### PR TITLE
chore(repo): add delivery issue and pr templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,72 @@
+name: Bug Report
+description: 버그, 회귀, 오작동 문제를 등록합니다.
+title: "[Bug] "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        추측 대신 재현 정보를 남깁니다.
+        심각도와 영향 범위가 크면 `p0` 라벨을 추가합니다.
+  - type: textarea
+    id: summary
+    attributes:
+      label: 문제 요약
+      description: 무엇이 잘못됐는지 한두 문장으로 적습니다.
+      placeholder: 예) BLACKPINK 최신 컴백이 싱글 기준으로만 노출되고 앨범 발매가 반영되지 않는다.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: 재현 절차
+      description: QA가 그대로 따라 할 수 있게 적습니다.
+      placeholder: |
+        1. 웹 앱을 연다.
+        2. BLACKPINK 카드를 확인한다.
+        3. 최신 발매 제목과 날짜를 본다.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: 기대 결과
+      placeholder: 예) 최신 앨범과 타이틀곡 정보가 분리되어 표시된다.
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: 실제 결과
+      placeholder: 예) 선공개 싱글만 최신값으로 남아 있어 컴백 전체 정보가 보이지 않는다.
+    validations:
+      required: true
+  - type: textarea
+    id: impact
+    attributes:
+      label: 영향 범위
+      description: 사용자 영향, 데이터 오류 범위, 회귀 가능성을 적습니다.
+      placeholder: 예) 최신 컴백 노출 정확도에 직접 영향. 여러 팀에 동일 패턴이 있을 수 있음.
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: 증거 / 링크
+      description: 스크린샷, 기사, 공식 공지, 로그 등을 적습니다.
+      placeholder: 예) https://...
+    validations:
+      required: false
+  - type: dropdown
+    id: area
+    attributes:
+      label: 주 영향 영역
+      options:
+        - web
+        - pipeline
+        - automation
+        - docs
+        - infra
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 서비스 페이지
+    url: https://iamsomething.github.io/idol-song-app/
+    about: 배포된 캘린더 화면과 현재 데이터를 확인합니다.
+  - name: 저장소
+    url: https://github.com/iAmSomething/idol-song-app
+    about: 코드, 워크플로, 이슈/PR 상태를 확인합니다.

--- a/.github/ISSUE_TEMPLATE/data.yml
+++ b/.github/ISSUE_TEMPLATE/data.yml
@@ -1,0 +1,69 @@
+name: Data / Source Update
+description: 데이터 누락, 매핑 보정, 소스 반영 작업을 등록합니다.
+title: "[Data] "
+labels:
+  - data
+body:
+  - type: markdown
+    attributes:
+      value: |
+        데이터 이슈는 대상 그룹/아티스트, 근거 링크, 기대 출력 형식을 명확히 적습니다.
+  - type: textarea
+    id: target
+    attributes:
+      label: 대상
+      description: 그룹, 아티스트, 파일, 수집 소스를 적습니다.
+      placeholder: |
+        - 대상 그룹: WJSN
+        - 대상 파일: tracking_watchlist.json
+        - 대상 소스: agency notice / Weverse / Google News RSS
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: 현재 문제
+      description: 누락, 오탐, 오매핑 내용을 적습니다.
+      placeholder: 예) 장기 공백 그룹이 watchlist에서 빠져 주간 스캔 대상에 포함되지 않는다.
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: 근거 링크
+      description: 공식 SNS, 기획사 공지, 기사, 데이터 소스 링크를 적습니다.
+      placeholder: |
+        - https://...
+        - https://...
+    validations:
+      required: true
+  - type: textarea
+    id: expected_output
+    attributes:
+      label: 기대 결과
+      description: 수정 후 데이터가 어떤 형태여야 하는지 적습니다.
+      placeholder: 예) watch_status=watch_only, search_terms에 우주소녀/ Cosmic Girls 조합이 포함된다.
+    validations:
+      required: true
+  - type: textarea
+    id: verification
+    attributes:
+      label: 검증 방법
+      description: 스크립트 실행이나 샘플 확인 방법을 적습니다.
+      placeholder: |
+        - python build_tracking_watchlist.py
+        - 산출 JSON에서 대상 팀 확인
+    validations:
+      required: true
+  - type: dropdown
+    id: source_type
+    attributes:
+      label: 주요 소스 유형
+      options:
+        - official notice
+        - official sns
+        - news article
+        - api / database
+        - manual review
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,89 @@
+name: Feature / Task
+description: 기능 추가, 개선, 구현 작업을 등록합니다.
+title: "[Feature] "
+labels:
+  - feature
+body:
+  - type: markdown
+    attributes:
+      value: |
+        작업은 체크 가능한 문장으로 적습니다.
+        우선순위(`p0/p1/p2`)와 영역(`web/pipeline/automation/docs/infra`)은 생성 후 라벨로 맞춥니다.
+  - type: textarea
+    id: background
+    attributes:
+      label: 배경
+      description: 왜 이 작업이 필요한지 적습니다.
+      placeholder: 예) 캘린더에서 발매 종류를 구분할 수 없어 사용자가 원하는 목록만 보기 어렵다.
+    validations:
+      required: true
+  - type: textarea
+    id: goal
+    attributes:
+      label: 목표
+      description: 이 이슈가 끝났을 때 달라져야 하는 결과를 적습니다.
+      placeholder: 예) release kind 필터를 추가해 싱글/앨범/선공개곡을 구분해서 볼 수 있게 한다.
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: 범위
+      description: 수정 대상 파일, 화면, 스크립트, 데이터 구조를 적습니다.
+      placeholder: |
+        - web/src/App.tsx
+        - web/src/App.css
+        - web/src/data/releases.json
+    validations:
+      required: true
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: 제외 범위
+      description: 이번 작업에 포함하지 않을 항목을 적습니다.
+      placeholder: 예) 서버 API 추가, 알림 기능 구현
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: 수용 기준
+      description: QA가 그대로 확인할 수 있는 조건을 적습니다.
+      placeholder: |
+        - 사용자가 release kind를 1개 이상 선택할 수 있다.
+        - 모바일과 데스크톱에서 모두 동작한다.
+        - 선택 결과가 빈 경우 empty state가 보인다.
+    validations:
+      required: true
+  - type: textarea
+    id: verification
+    attributes:
+      label: 검증 방법
+      description: 개발자 self-check와 QA 검증 기준을 적습니다.
+      placeholder: |
+        - npm run build
+        - 주요 필터 조합 수동 확인
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: 주 작업 영역
+      options:
+        - web
+        - pipeline
+        - automation
+        - docs
+        - infra
+    validations:
+      required: true
+  - type: dropdown
+    id: priority
+    attributes:
+      label: 우선순위
+      options:
+        - p1
+        - p0
+        - p2
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+## Related Issue
+- Closes #
+
+## What Changed
+- 
+
+## Out of Scope
+- 
+
+## Acceptance Checklist
+- [ ] 이슈의 수용 기준을 다시 확인했다.
+- [ ] 범위 밖 변경이 없다. 있으면 PM 승인을 받았다.
+- [ ] UI 변경이면 스크린샷을 첨부했다.
+
+## Verification
+```bash
+# 실행한 명령을 적습니다.
+```
+
+## Result
+- 
+
+## Risk / Follow-up
+- 
+
+## Screenshots
+- N/A


### PR DESCRIPTION
## Related Issue
- Closes #1

## What Changed
- GitHub issue form 3종(feature, bug, data) 추가
- blank issue 비활성화 및 기본 contact link 추가
- PR 본문 템플릿 추가

## Out of Scope
- 제품 기능 변경
- 데이터 파이프라인 로직 변경

## Acceptance Checklist
- [x] 저장소에 이슈 템플릿 3종이 존재한다.
- [x] PR 템플릿이 존재한다.
- [x] 템플릿 YAML이 파싱된다.

## Verification
```bash
ruby -e 'require "yaml"; Dir[".github/ISSUE_TEMPLATE/*.yml"].sort.each { |f| YAML.load_file(f); puts "ok #{f}" }'\ngit diff --check\n```\n\n## Result\n- GitHub 이슈 작성과 PR 작성 형식을 저장소 차원에서 고정했다.\n\n## Risk / Follow-up\n- 라벨 자동 적용은 템플릿 기본 라벨까지만 처리한다.\n- priority/area 라벨은 이슈 생성 직후 PM이 정리해야 한다.\n\n## Screenshots\n- N/A