### PR TITLE
feat: add release artwork dataset for latest releases and album cards

### DIFF
--- a/web/public/release-placeholder.svg
+++ b/web/public/release-placeholder.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="1200" viewBox="0 0 1200 1200" role="img" aria-labelledby="title desc">
+  <title id="title">Release placeholder artwork</title>
+  <desc id="desc">Placeholder image used when release cover art is unavailable.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#f7d2a0" />
+      <stop offset="55%" stop-color="#c35831" />
+      <stop offset="100%" stop-color="#1b2a41" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="1200" fill="url(#bg)" rx="120" />
+  <circle cx="920" cy="260" r="210" fill="rgba(255,255,255,0.16)" />
+  <circle cx="220" cy="960" r="240" fill="rgba(255,255,255,0.12)" />
+  <g fill="#fffaf3" font-family="Georgia, serif">
+    <text x="120" y="420" font-size="84" letter-spacing="18">IDOL SONG APP</text>
+    <text x="120" y="585" font-size="230" font-weight="700">NO COVER</text>
+    <text x="120" y="700" font-size="72" letter-spacing="10">PLACEHOLDER ARTWORK</text>
+  </g>
+</svg>

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -745,7 +745,16 @@
 
 .detail-card-feature {
   display: grid;
+  grid-template-columns: 132px minmax(0, 1fr);
+  align-items: start;
   gap: 16px;
+}
+
+.detail-card-feature-body,
+.album-card-copy {
+  min-width: 0;
+  display: grid;
+  gap: 8px;
 }
 
 .handoff-row {
@@ -839,13 +848,13 @@
 .album-card {
   border: 1px solid rgba(27, 42, 65, 0.08);
   border-radius: 22px;
-  padding: 18px;
+  padding: 14px;
   background:
     radial-gradient(circle at top right, rgba(255, 214, 153, 0.34), transparent 38%),
     rgba(255, 255, 255, 0.82);
   text-align: left;
   display: grid;
-  gap: 8px;
+  gap: 12px;
 }
 
 .album-card strong {
@@ -891,6 +900,44 @@
   gap: 18px;
   align-items: center;
   margin: 22px 0;
+}
+
+.release-artwork {
+  position: relative;
+  overflow: hidden;
+  border-radius: 26px;
+  background:
+    radial-gradient(circle at 25% 20%, rgba(255, 214, 153, 0.9), transparent 34%),
+    linear-gradient(160deg, rgba(195, 88, 49, 0.9), rgba(27, 42, 65, 0.96));
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.2);
+}
+
+.release-artwork-feature {
+  width: 132px;
+  aspect-ratio: 1;
+}
+
+.release-artwork-card {
+  width: 100%;
+  aspect-ratio: 1;
+  border-radius: 20px;
+}
+
+.release-artwork-drawer {
+  width: 112px;
+  aspect-ratio: 1;
+  border-radius: 28px;
+}
+
+.release-artwork-image {
+  width: 100%;
+  height: 100%;
+  display: block;
+  object-fit: cover;
+}
+
+.release-artwork-placeholder .release-artwork-image {
+  object-fit: cover;
 }
 
 .album-drawer-art {
@@ -1041,6 +1088,10 @@
     align-items: stretch;
   }
 
+  .detail-card-feature {
+    grid-template-columns: 1fr;
+  }
+
   .signal-tags {
     justify-content: flex-start;
   }
@@ -1088,5 +1139,11 @@
     height: 88px;
     border-radius: 22px;
     font-size: 1.4rem;
+  }
+
+  .release-artwork-feature,
+  .release-artwork-drawer {
+    width: 88px;
+    border-radius: 22px;
   }
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import './App.css'
 import artistProfileRows from './data/artistProfiles.json'
+import releaseArtworkRows from './data/releaseArtwork.json'
 import releaseRows from './data/releases.json'
 import unresolvedRows from './data/unresolved.json'
 import upcomingCandidateRows from './data/upcomingCandidates.json'
@@ -34,6 +35,21 @@ type ArtistProfileRow = {
   official_instagram_url: string | null
   representative_image_url: string | null
   representative_image_source: string | null
+}
+
+type ReleaseArtworkRow = {
+  group: string
+  release_title: string
+  release_date: string
+  stream: 'song' | 'album'
+  cover_image_url: string
+  thumbnail_image_url: string
+  artwork_source_type: string
+  artwork_source_url: string
+}
+
+type ResolvedReleaseArtwork = ReleaseArtworkRow & {
+  isPlaceholder: boolean
 }
 
 type ActType = 'group' | 'solo' | 'unit'
@@ -110,6 +126,7 @@ type TeamLatestRelease = {
   date: string
   releaseKind: string
   streamLabel: string
+  stream: 'song' | 'album' | 'watchlist'
   source: string
   artistSource: string
   musicHandoffs?: MusicHandoffUrls
@@ -380,7 +397,7 @@ const TEAM_COPY = {
     stream: '스트림',
     trackPreview: '트랙 프리뷰',
     trackPreviewHint: '트랙 정보는 v1 placeholder입니다. 전체 디스코그래피 파이프라인에서 실제 트랙 데이터로 대체됩니다.',
-    placeholderCover: '임시 커버',
+    placeholderCover: '릴리즈 아트워크',
     drawerCopy:
       '앨범 상세는 팀 페이지 안 슬라이드오버로 유지해서 컴백 맥락을 잃지 않고 바로 돌아올 수 있습니다.',
     appleMusicNext: 'Apple Music 다음 이슈',
@@ -431,7 +448,7 @@ const TEAM_COPY = {
     stream: 'Stream',
     trackPreview: 'Track preview',
     trackPreviewHint: 'Track info is a v1 placeholder and will be replaced when the full discography pipeline lands.',
-    placeholderCover: 'Placeholder cover',
+    placeholderCover: 'Release artwork',
     drawerCopy:
       'Album detail stays inside the team page so users can inspect the release and return to comeback context immediately.',
     appleMusicNext: 'Apple Music next',
@@ -444,8 +461,10 @@ const releaseKindOptions = ['all', 'single', 'album', 'ep'] as const
 const actTypeOptions = ['all', 'group', 'solo', 'unit'] as const
 const unitGroups = new Set(['ARTMS', 'NCT DREAM', 'NCT WISH', 'VIVIZ'])
 const MUSIC_HANDOFF_SERVICES: MusicService[] = ['spotify', 'youtube_music']
+const RELEASE_ARTWORK_PLACEHOLDER_URL = '/release-placeholder.svg'
 
 const artistProfiles = artistProfileRows as ArtistProfileRow[]
+const releaseArtworkCatalog = releaseArtworkRows as ReleaseArtworkRow[]
 const releaseCatalog = releaseRows as ReleaseRow[]
 const releases = releaseCatalog
   .flatMap((row) => expandReleaseRow(row))
@@ -469,6 +488,9 @@ const watchStatusCounts = watchlist.reduce<Record<string, number>>((counts, row)
 const releaseCatalogByGroup = new Map(releaseCatalog.map((row) => [row.group, row]))
 const artistProfileByGroup = new Map(artistProfiles.map((row) => [row.group, row]))
 const artistProfileBySlug = new Map(artistProfiles.map((row) => [row.slug, row]))
+const releaseArtworkByKey = new Map(
+  releaseArtworkCatalog.map((row) => [getReleaseArtworkKey(row.group, row.release_title, row.release_date, row.stream), row]),
+)
 const releaseGroups = groupReleasesByGroup(releases)
 const watchlistByGroup = new Map(watchlist.map((row) => [row.group, row]))
 const upcomingByGroup = groupUpcomingCandidatesByGroup(upcomingCandidates)
@@ -803,7 +825,18 @@ function App() {
                 <h2>{selectedTeam.latestRelease?.title ?? teamCopy.latestEmptyTitle}</h2>
                 {selectedTeam.latestRelease ? (
                   <article className="detail-card detail-card-feature">
-                    <div>
+                    <ReleaseArtworkFigure
+                      artwork={getReleaseArtwork(
+                        selectedTeam.group,
+                        selectedTeam.latestRelease.title,
+                        selectedTeam.latestRelease.date,
+                        selectedTeam.latestRelease.stream,
+                        selectedTeam.latestRelease.releaseKind,
+                      )}
+                      alt={`${selectedTeam.displayName} ${selectedTeam.latestRelease.title} cover artwork`}
+                      variant="feature"
+                    />
+                    <div className="detail-card-feature-body">
                       <div className="signal-head">
                         <TeamIdentity group={selectedTeam.group} variant="list" />
                         <span className="signal-badge">
@@ -815,28 +848,28 @@ function App() {
                         {selectedTeam.latestRelease.verified ? teamCopy.verifiedRelease : teamCopy.watchlistFallback} ·{' '}
                         {formatOptionalDate(selectedTeam.latestRelease.date, displayDateFormatter, copy.none)}
                       </p>
+                      <div className="detail-links detail-links-stack">
+                        {selectedTeam.latestRelease.source ? (
+                          <a href={selectedTeam.latestRelease.source} target="_blank" rel="noreferrer">
+                            {copy.releaseSource}
+                          </a>
+                        ) : (
+                          <span className="signal-link-muted">{teamCopy.releaseSourcePending}</span>
+                        )}
+                        {selectedTeam.latestRelease.artistSource ? (
+                          <a href={selectedTeam.latestRelease.artistSource} target="_blank" rel="noreferrer">
+                            {copy.artistSource}
+                          </a>
+                        ) : null}
+                      </div>
+                      <MusicHandoffRow
+                        group={selectedTeam.group}
+                        title={selectedTeam.latestRelease.title}
+                        canonicalUrls={selectedTeam.latestRelease.musicHandoffs}
+                        language={language}
+                        showHint
+                      />
                     </div>
-                    <div className="detail-links detail-links-stack">
-                      {selectedTeam.latestRelease.source ? (
-                        <a href={selectedTeam.latestRelease.source} target="_blank" rel="noreferrer">
-                          {copy.releaseSource}
-                        </a>
-                      ) : (
-                        <span className="signal-link-muted">{teamCopy.releaseSourcePending}</span>
-                      )}
-                      {selectedTeam.latestRelease.artistSource ? (
-                        <a href={selectedTeam.latestRelease.artistSource} target="_blank" rel="noreferrer">
-                          {copy.artistSource}
-                        </a>
-                      ) : null}
-                    </div>
-                    <MusicHandoffRow
-                      group={selectedTeam.group}
-                      title={selectedTeam.latestRelease.title}
-                      canonicalUrls={selectedTeam.latestRelease.musicHandoffs}
-                      language={language}
-                      showHint
-                    />
                   </article>
                 ) : (
                   <p className="empty-copy">{teamCopy.latestEmptyTitle}</p>
@@ -848,27 +881,44 @@ function App() {
                 <h2>{selectedTeam.recentAlbums.length ? teamCopy.recentAlbumsTitle : teamCopy.recentAlbumsEmptyTitle}</h2>
                 {selectedTeam.recentAlbums.length ? (
                   <div className="album-grid">
-                    {selectedTeam.recentAlbums.map((item) => (
-                      <article key={getAlbumKey(item)} className="album-card-shell">
-                        <button
-                          type="button"
-                          className="album-card"
-                          onClick={() => setSelectedAlbumKey(getAlbumKey(item))}
-                        >
-                          <span className="album-card-kicker">{item.release_kind}</span>
-                          <strong>{item.title}</strong>
-                          <span>{formatOptionalDate(item.date, displayDateFormatter, copy.none)}</span>
-                          <span className="album-card-meta">{teamCopy.openAlbumDetail}</span>
-                        </button>
-                        <MusicHandoffRow
-                          group={selectedTeam.group}
-                          title={item.title}
-                          canonicalUrls={item.music_handoffs}
-                          language={language}
-                          compact
-                        />
-                      </article>
-                    ))}
+                    {selectedTeam.recentAlbums.map((item) => {
+                      const artwork = getReleaseArtwork(
+                        item.group,
+                        item.title,
+                        item.date,
+                        item.stream,
+                        item.release_kind,
+                      )
+
+                      return (
+                        <article key={getAlbumKey(item)} className="album-card-shell">
+                          <button
+                            type="button"
+                            className="album-card"
+                            onClick={() => setSelectedAlbumKey(getAlbumKey(item))}
+                          >
+                            <ReleaseArtworkFigure
+                              artwork={artwork}
+                              alt={`${selectedTeam.displayName} ${item.title} cover artwork`}
+                              variant="card"
+                            />
+                            <div className="album-card-copy">
+                              <span className="album-card-kicker">{item.release_kind}</span>
+                              <strong>{item.title}</strong>
+                              <span>{formatOptionalDate(item.date, displayDateFormatter, copy.none)}</span>
+                              <span className="album-card-meta">{teamCopy.openAlbumDetail}</span>
+                            </div>
+                          </button>
+                          <MusicHandoffRow
+                            group={selectedTeam.group}
+                            title={item.title}
+                            canonicalUrls={item.music_handoffs}
+                            language={language}
+                            compact
+                          />
+                        </article>
+                      )
+                    })}
                   </div>
                 ) : (
                   <p className="empty-copy">{teamCopy.recentAlbumsEmpty}</p>
@@ -1303,6 +1353,7 @@ function AlbumDrawer({
   const teamCopy = TEAM_COPY[language]
   const previewTracks = buildAlbumPreviewTracks(album, group, language)
   const displayName = getTeamDisplayName(group)
+  const artwork = getReleaseArtwork(group, album.title, album.date, album.stream, album.release_kind)
 
   return (
     <div className="drawer-backdrop" onClick={onClose} role="presentation">
@@ -1318,9 +1369,11 @@ function AlbumDrawer({
         </div>
 
         <div className="album-drawer-cover">
-          <div className="album-drawer-art" aria-hidden="true">
-            {getTeamMonogram(group)}
-          </div>
+          <ReleaseArtworkFigure
+            artwork={artwork}
+            alt={`${displayName} ${album.title} cover artwork`}
+            variant="drawer"
+          />
           <div>
             <p className="panel-label">{teamCopy.placeholderCover}</p>
             <h3>{displayName}</h3>
@@ -1452,6 +1505,36 @@ function TeamIdentity({
       </span>
       <span className="team-label">{label}</span>
     </span>
+  )
+}
+
+function ReleaseArtworkFigure({
+  artwork,
+  alt,
+  variant,
+}: {
+  artwork: ResolvedReleaseArtwork
+  alt: string
+  variant: 'feature' | 'card' | 'drawer'
+}) {
+  return (
+    <div
+      className={[
+        'release-artwork',
+        `release-artwork-${variant}`,
+        artwork.isPlaceholder ? 'release-artwork-placeholder' : '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+    >
+      <img
+        className="release-artwork-image"
+        src={variant === 'drawer' ? artwork.cover_image_url : artwork.thumbnail_image_url}
+        alt={alt}
+        loading={variant === 'drawer' ? 'eager' : 'lazy'}
+        decoding="async"
+      />
+    </div>
   )
 }
 
@@ -1618,6 +1701,70 @@ function buildMusicSearchUrl(service: MusicService, query: string) {
   return `https://music.youtube.com/search?q=${encodedQuery}`
 }
 
+function getReleaseArtworkKey(
+  group: string,
+  releaseTitle: string,
+  releaseDate: string,
+  stream: ReleaseArtworkRow['stream'],
+) {
+  return [group, releaseTitle, releaseDate, stream].join('::')
+}
+
+function normalizeArtworkStream(
+  stream: TeamLatestRelease['stream'] | VerifiedRelease['stream'],
+  releaseKind?: string,
+): ReleaseArtworkRow['stream'] {
+  if (stream === 'album') {
+    return 'album'
+  }
+  if (stream === 'song') {
+    return 'song'
+  }
+  return releaseKind === 'album' || releaseKind === 'ep' ? 'album' : 'song'
+}
+
+function buildPlaceholderReleaseArtwork(
+  group: string,
+  releaseTitle: string,
+  releaseDate: string,
+  stream: TeamLatestRelease['stream'] | VerifiedRelease['stream'],
+  releaseKind?: string,
+): ResolvedReleaseArtwork {
+  return {
+    group,
+    release_title: releaseTitle,
+    release_date: releaseDate,
+    stream: normalizeArtworkStream(stream, releaseKind),
+    cover_image_url: RELEASE_ARTWORK_PLACEHOLDER_URL,
+    thumbnail_image_url: RELEASE_ARTWORK_PLACEHOLDER_URL,
+    artwork_source_type: 'placeholder',
+    artwork_source_url: RELEASE_ARTWORK_PLACEHOLDER_URL,
+    isPlaceholder: true,
+  }
+}
+
+function getReleaseArtwork(
+  group: string,
+  releaseTitle: string,
+  releaseDate: string,
+  stream: TeamLatestRelease['stream'] | VerifiedRelease['stream'],
+  releaseKind?: string,
+): ResolvedReleaseArtwork {
+  const normalizedStream = normalizeArtworkStream(stream, releaseKind)
+  const artwork = releaseArtworkByKey.get(
+    getReleaseArtworkKey(group, releaseTitle, releaseDate, normalizedStream),
+  )
+
+  if (!artwork) {
+    return buildPlaceholderReleaseArtwork(group, releaseTitle, releaseDate, stream, releaseKind)
+  }
+
+  return {
+    ...artwork,
+    isPlaceholder: artwork.artwork_source_type === 'placeholder',
+  }
+}
+
 function buildTeamProfiles() {
   return Array.from(
     new Set([
@@ -1670,6 +1817,7 @@ function deriveLatestRelease(
       date: latestVerified.date,
       releaseKind: latestVerified.release_kind,
       streamLabel: latestVerified.stream,
+      stream: latestVerified.stream,
       source: latestVerified.source,
       artistSource: latestVerified.artist_source,
       musicHandoffs: latestVerified.music_handoffs,
@@ -1686,6 +1834,7 @@ function deriveLatestRelease(
     date: watchRow.latest_release_date || '',
     releaseKind: watchRow.latest_release_kind || 'unknown',
     streamLabel: 'watchlist',
+    stream: 'watchlist',
     source: '',
     artistSource: releaseRow?.artist_source ?? '',
     verified: false,

--- a/web/src/data/releaseArtwork.json
+++ b/web/src/data/releaseArtwork.json
@@ -1,0 +1,1172 @@
+[
+  {
+    "group": "&TEAM",
+    "release_title": "Back to Life",
+    "release_date": "2025-10-28",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/159eca09-5a9a-4ee2-a1ea-56a08269229f/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/159eca09-5a9a-4ee2-a1ea-56a08269229f/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/159eca09-5a9a-4ee2-a1ea-56a08269229f"
+  },
+  {
+    "group": "(G)I-DLE",
+    "release_title": "Mono",
+    "release_date": "2026-01-27",
+    "stream": "song",
+    "cover_image_url": "https://coverartarchive.org/release-group/c669f230-9b65-46c3-808c-99a26d44b464/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/c669f230-9b65-46c3-808c-99a26d44b464/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/c669f230-9b65-46c3-808c-99a26d44b464"
+  },
+  {
+    "group": "(G)I-DLE",
+    "release_title": "i‐dle",
+    "release_date": "2025-10-03",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/91518b35-2567-4b2d-95f9-135361183fe5/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/91518b35-2567-4b2d-95f9-135361183fe5/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/91518b35-2567-4b2d-95f9-135361183fe5"
+  },
+  {
+    "group": "82MAJOR",
+    "release_title": "Trophy",
+    "release_date": "2025-10-30",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/6981db36-66ea-42a5-9f19-5d42eb7ead2c/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/6981db36-66ea-42a5-9f19-5d42eb7ead2c/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/6981db36-66ea-42a5-9f19-5d42eb7ead2c"
+  },
+  {
+    "group": "8TURN",
+    "release_title": "BRUISE",
+    "release_date": "2026-01-28",
+    "stream": "song",
+    "cover_image_url": "https://coverartarchive.org/release-group/7ede4c86-fc66-46fd-86ac-90062118583d/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/7ede4c86-fc66-46fd-86ac-90062118583d/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/7ede4c86-fc66-46fd-86ac-90062118583d"
+  },
+  {
+    "group": "aespa",
+    "release_title": "SYNK : aeXIS LINE",
+    "release_date": "2025-11-17",
+    "stream": "song",
+    "cover_image_url": "https://coverartarchive.org/release-group/71d978c6-775d-4327-aca5-517a62cc4626/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/71d978c6-775d-4327-aca5-517a62cc4626/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/71d978c6-775d-4327-aca5-517a62cc4626"
+  },
+  {
+    "group": "aespa",
+    "release_title": "Rich Man",
+    "release_date": "2025-09-05",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/f014b273-c609-4f05-9c72-f3ff93a4c25b/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/f014b273-c609-4f05-9c72-f3ff93a4c25b/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/f014b273-c609-4f05-9c72-f3ff93a4c25b"
+  },
+  {
+    "group": "ALL(H)OURS",
+    "release_title": "VCF",
+    "release_date": "2025-09-09",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/140ca1e8-718c-47a6-9f34-22179a66ed3e/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/140ca1e8-718c-47a6-9f34-22179a66ed3e/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/140ca1e8-718c-47a6-9f34-22179a66ed3e"
+  },
+  {
+    "group": "AMPERS&ONE",
+    "release_title": "LOUD & PROUD",
+    "release_date": "2025-08-12",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/5c07db0b-4bd5-453c-9258-082d9599de19/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/5c07db0b-4bd5-453c-9258-082d9599de19/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/5c07db0b-4bd5-453c-9258-082d9599de19"
+  },
+  {
+    "group": "ARTMS",
+    "release_title": "<Club Icarus>",
+    "release_date": "2025-06-13",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/46b396ea-dee3-4c62-b8db-2bd84bc70b08/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/46b396ea-dee3-4c62-b8db-2bd84bc70b08/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/46b396ea-dee3-4c62-b8db-2bd84bc70b08"
+  },
+  {
+    "group": "ATEEZ",
+    "release_title": "Choose",
+    "release_date": "2025-11-17",
+    "stream": "song",
+    "cover_image_url": "https://coverartarchive.org/release-group/c193acdc-c046-4e77-98e5-986edc72ba12/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/c193acdc-c046-4e77-98e5-986edc72ba12/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/c193acdc-c046-4e77-98e5-986edc72ba12"
+  },
+  {
+    "group": "ATEEZ",
+    "release_title": "GOLDEN HOUR : Part.4",
+    "release_date": "2026-02-06",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/8072d29d-f779-404e-b5cc-0cc01e442444/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/8072d29d-f779-404e-b5cc-0cc01e442444/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/8072d29d-f779-404e-b5cc-0cc01e442444"
+  },
+  {
+    "group": "AtHeart",
+    "release_title": "Shut Up",
+    "release_date": "2026-02-26",
+    "stream": "song",
+    "cover_image_url": "https://coverartarchive.org/release-group/16cf36c1-5330-4078-bb8d-4be324d27250/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/16cf36c1-5330-4078-bb8d-4be324d27250/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/16cf36c1-5330-4078-bb8d-4be324d27250"
+  },
+  {
+    "group": "AtHeart",
+    "release_title": "Plot Twist",
+    "release_date": "2025-08-13",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/546efe73-cb05-49af-a513-e3fc116b2df3/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/546efe73-cb05-49af-a513-e3fc116b2df3/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/546efe73-cb05-49af-a513-e3fc116b2df3"
+  },
+  {
+    "group": "BABYMONSTER",
+    "release_title": "HOT SAUCE",
+    "release_date": "2025-07-01",
+    "stream": "song",
+    "cover_image_url": "https://coverartarchive.org/release-group/29d2346a-b87d-4fe7-886a-77021f945abf/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/29d2346a-b87d-4fe7-886a-77021f945abf/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/29d2346a-b87d-4fe7-886a-77021f945abf"
+  },
+  {
+    "group": "BABYMONSTER",
+    "release_title": "WE GO UP",
+    "release_date": "2025-10-10",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/ffe2b6b8-2d2c-44e7-af71-e5aac4a23dd5/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/ffe2b6b8-2d2c-44e7-af71-e5aac4a23dd5/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/ffe2b6b8-2d2c-44e7-af71-e5aac4a23dd5"
+  },
+  {
+    "group": "BADVILLAIN",
+    "release_title": "THRILLER",
+    "release_date": "2025-09-15",
+    "stream": "song",
+    "cover_image_url": "https://coverartarchive.org/release-group/d739e8f9-6575-41ae-910e-ddc45cad2bd9/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/d739e8f9-6575-41ae-910e-ddc45cad2bd9/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/d739e8f9-6575-41ae-910e-ddc45cad2bd9"
+  },
+  {
+    "group": "BAE173",
+    "release_title": "What’s wrong?",
+    "release_date": "2025-10-03",
+    "stream": "song",
+    "cover_image_url": "https://coverartarchive.org/release-group/c33d7fab-bcc5-4bc2-bd1b-f2a880b1504b/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/c33d7fab-bcc5-4bc2-bd1b-f2a880b1504b/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/c33d7fab-bcc5-4bc2-bd1b-f2a880b1504b"
+  },
+  {
+    "group": "BAE173",
+    "release_title": "NEW CHAPTER : DESEAR",
+    "release_date": "2025-10-14",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/77b28a76-cd4c-4a58-b4be-ec10e6fedd7b/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/77b28a76-cd4c-4a58-b4be-ec10e6fedd7b/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/77b28a76-cd4c-4a58-b4be-ec10e6fedd7b"
+  },
+  {
+    "group": "BLACKPINK",
+    "release_title": "뛰어 (JUMP)",
+    "release_date": "2025-07-11",
+    "stream": "song",
+    "cover_image_url": "https://coverartarchive.org/release-group/173ec0cf-52e9-4ca6-bf30-408ccafd61d7/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/173ec0cf-52e9-4ca6-bf30-408ccafd61d7/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/173ec0cf-52e9-4ca6-bf30-408ccafd61d7"
+  },
+  {
+    "group": "BLACKPINK",
+    "release_title": "DEADLINE",
+    "release_date": "2026-02-26",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/38204997-b295-4d09-a946-f7e119725031/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/38204997-b295-4d09-a946-f7e119725031/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/38204997-b295-4d09-a946-f7e119725031"
+  },
+  {
+    "group": "BOYNEXTDOOR",
+    "release_title": "BOYLIFE",
+    "release_date": "2025-08-20",
+    "stream": "song",
+    "cover_image_url": "https://coverartarchive.org/release-group/7f3e5d77-9ad8-4de6-8dcc-3ea29c6208ae/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/7f3e5d77-9ad8-4de6-8dcc-3ea29c6208ae/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/7f3e5d77-9ad8-4de6-8dcc-3ea29c6208ae"
+  },
+  {
+    "group": "BOYNEXTDOOR",
+    "release_title": "The Action",
+    "release_date": "2025-10-20",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/79e7f180-0f4a-4d87-98dd-0a39991823fa/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/79e7f180-0f4a-4d87-98dd-0a39991823fa/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/79e7f180-0f4a-4d87-98dd-0a39991823fa"
+  },
+  {
+    "group": "CIX",
+    "release_title": "GO Chapter 1: GO Together",
+    "release_date": "2025-09-08",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/fa27cf7c-9d03-4857-87b4-c7be5ffcfd2f/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/fa27cf7c-9d03-4857-87b4-c7be5ffcfd2f/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/fa27cf7c-9d03-4857-87b4-c7be5ffcfd2f"
+  },
+  {
+    "group": "CRAVITY",
+    "release_title": "Dare to Crave",
+    "release_date": "2025-06-23",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/44e36813-a852-401d-ad33-a23e11357a06/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/44e36813-a852-401d-ad33-a23e11357a06/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/44e36813-a852-401d-ad33-a23e11357a06"
+  },
+  {
+    "group": "DAY6",
+    "release_title": "The DECADE",
+    "release_date": "2025-09-05",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/213758ae-0a4a-452a-867f-5b65b4dcfc08/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/213758ae-0a4a-452a-867f-5b65b4dcfc08/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/213758ae-0a4a-452a-867f-5b65b4dcfc08"
+  },
+  {
+    "group": "DKB",
+    "release_title": "Emotion",
+    "release_date": "2025-10-23",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/18922c4e-7b46-429f-a5b7-c1087a796663/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/18922c4e-7b46-429f-a5b7-c1087a796663/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/18922c4e-7b46-429f-a5b7-c1087a796663"
+  },
+  {
+    "group": "ENHYPEN",
+    "release_title": "宵 -YOI-",
+    "release_date": "2025-07-27",
+    "stream": "song",
+    "cover_image_url": "https://coverartarchive.org/release-group/79df3384-8d5c-45fa-b53d-8f173e4a5171/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/79df3384-8d5c-45fa-b53d-8f173e4a5171/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/79df3384-8d5c-45fa-b53d-8f173e4a5171"
+  },
+  {
+    "group": "ENHYPEN",
+    "release_title": "THE SIN : VANISH",
+    "release_date": "2026-01-16",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/b07a4bc8-9edc-47e9-bfd9-8d3a85d0c080/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/b07a4bc8-9edc-47e9-bfd9-8d3a85d0c080/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/b07a4bc8-9edc-47e9-bfd9-8d3a85d0c080"
+  },
+  {
+    "group": "EPEX",
+    "release_title": "Youth Chapter 3 : ROMANTIC YOUTH",
+    "release_date": "2025-07-28",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/cd7b898e-80a2-4257-b2bb-3a2c8d550f1e/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/cd7b898e-80a2-4257-b2bb-3a2c8d550f1e/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/cd7b898e-80a2-4257-b2bb-3a2c8d550f1e"
+  },
+  {
+    "group": "EVNNE",
+    "release_title": "LOVE ANECDOTE(S)",
+    "release_date": "2025-08-04",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/9ba34369-e9f0-4adf-9c23-cbbbeeec01b1/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/9ba34369-e9f0-4adf-9c23-cbbbeeec01b1/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/9ba34369-e9f0-4adf-9c23-cbbbeeec01b1"
+  },
+  {
+    "group": "EXO",
+    "release_title": "I'm Home",
+    "release_date": "2025-12-13",
+    "stream": "song",
+    "cover_image_url": "/release-placeholder.svg",
+    "thumbnail_image_url": "/release-placeholder.svg",
+    "artwork_source_type": "placeholder",
+    "artwork_source_url": "/release-placeholder.svg"
+  },
+  {
+    "group": "EXO",
+    "release_title": "REVERXE",
+    "release_date": "2026-01-19",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/d9a5d58f-6520-4718-b46c-dabc26e152f1/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/d9a5d58f-6520-4718-b46c-dabc26e152f1/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/d9a5d58f-6520-4718-b46c-dabc26e152f1"
+  },
+  {
+    "group": "FIFTY FIFTY",
+    "release_title": "TAKE MY HAND",
+    "release_date": "2025-08-22",
+    "stream": "song",
+    "cover_image_url": "https://coverartarchive.org/release-group/ec762b26-8c09-4bcb-bafc-dd205ca59f55/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/ec762b26-8c09-4bcb-bafc-dd205ca59f55/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/ec762b26-8c09-4bcb-bafc-dd205ca59f55"
+  },
+  {
+    "group": "FIFTY FIFTY",
+    "release_title": "Too Much Part 1",
+    "release_date": "2025-11-04",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/10fc1795-de3f-4a73-8b52-ae882d3b895d/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/10fc1795-de3f-4a73-8b52-ae882d3b895d/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/10fc1795-de3f-4a73-8b52-ae882d3b895d"
+  },
+  {
+    "group": "fromis_9",
+    "release_title": "White Memories",
+    "release_date": "2025-12-02",
+    "stream": "song",
+    "cover_image_url": "https://coverartarchive.org/release-group/8ceecddf-94b4-40a4-b77a-592fae34fc65/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/8ceecddf-94b4-40a4-b77a-592fae34fc65/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/8ceecddf-94b4-40a4-b77a-592fae34fc65"
+  },
+  {
+    "group": "fromis_9",
+    "release_title": "From Our 20’s",
+    "release_date": "2025-06-25",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/8b4a8c41-9c53-4930-8c90-512bf8e56eee/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/8b4a8c41-9c53-4930-8c90-512bf8e56eee/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/8b4a8c41-9c53-4930-8c90-512bf8e56eee"
+  },
+  {
+    "group": "H1-KEY",
+    "release_title": "세상은 영화 같지 않더라",
+    "release_date": "2026-01-05",
+    "stream": "song",
+    "cover_image_url": "https://coverartarchive.org/release-group/4e4e27fa-97fe-42ac-9c4d-801d31d7de6a/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/4e4e27fa-97fe-42ac-9c4d-801d31d7de6a/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/4e4e27fa-97fe-42ac-9c4d-801d31d7de6a"
+  },
+  {
+    "group": "H1-KEY",
+    "release_title": "Lovestruck",
+    "release_date": "2025-06-26",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/a9d2d1a0-f332-41be-b45a-5555d937a892/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/a9d2d1a0-f332-41be-b45a-5555d937a892/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/a9d2d1a0-f332-41be-b45a-5555d937a892"
+  },
+  {
+    "group": "Hearts2Hearts",
+    "release_title": "RUDE!",
+    "release_date": "2026-02-20",
+    "stream": "song",
+    "cover_image_url": "https://coverartarchive.org/release-group/5209edba-458a-4f37-8863-ec663b51fc6b/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/5209edba-458a-4f37-8863-ec663b51fc6b/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/5209edba-458a-4f37-8863-ec663b51fc6b"
+  },
+  {
+    "group": "Hearts2Hearts",
+    "release_title": "FOCUS",
+    "release_date": "2025-10-20",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/158311ee-7ed5-46a3-89e5-0e2ed6416a5c/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/158311ee-7ed5-46a3-89e5-0e2ed6416a5c/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/158311ee-7ed5-46a3-89e5-0e2ed6416a5c"
+  },
+  {
+    "group": "ifeye",
+    "release_title": "sweet tang",
+    "release_date": "2025-07-16",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/e00021e9-f5fb-4a4a-8332-498ebaa2da76/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/e00021e9-f5fb-4a4a-8332-498ebaa2da76/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/e00021e9-f5fb-4a4a-8332-498ebaa2da76"
+  },
+  {
+    "group": "ITZY",
+    "release_title": "TUNNEL VISION",
+    "release_date": "2025-11-10",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/ed339807-5313-4773-91cd-3f770c3a9d10/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/ed339807-5313-4773-91cd-3f770c3a9d10/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/ed339807-5313-4773-91cd-3f770c3a9d10"
+  },
+  {
+    "group": "IVE",
+    "release_title": "BANG BANG",
+    "release_date": "2026-02-09",
+    "stream": "song",
+    "cover_image_url": "https://coverartarchive.org/release-group/af154a09-c742-4dc1-86ec-af8a25b24c6a/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/af154a09-c742-4dc1-86ec-af8a25b24c6a/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/af154a09-c742-4dc1-86ec-af8a25b24c6a"
+  },
+  {
+    "group": "IVE",
+    "release_title": "REVIVE+",
+    "release_date": "2026-02-23",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/5a37b657-9f1d-4bce-b85f-9b1f5b72feca/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/5a37b657-9f1d-4bce-b85f-9b1f5b72feca/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/5a37b657-9f1d-4bce-b85f-9b1f5b72feca"
+  },
+  {
+    "group": "izna",
+    "release_title": "BEEP",
+    "release_date": "2025-06-09",
+    "stream": "song",
+    "cover_image_url": "https://coverartarchive.org/release-group/9f1d1ec9-da05-4b38-9c16-545347ecc169/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/9f1d1ec9-da05-4b38-9c16-545347ecc169/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/9f1d1ec9-da05-4b38-9c16-545347ecc169"
+  },
+  {
+    "group": "izna",
+    "release_title": "Not Just Pretty",
+    "release_date": "2025-09-30",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/b1cc1d3d-2f6f-4dd1-836d-e29b3869f5ae/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/b1cc1d3d-2f6f-4dd1-836d-e29b3869f5ae/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/b1cc1d3d-2f6f-4dd1-836d-e29b3869f5ae"
+  },
+  {
+    "group": "KARD",
+    "release_title": "DRIFT",
+    "release_date": "2025-07-02",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/94d7a1a2-136f-4645-b3de-80540fd5cfc4/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/94d7a1a2-136f-4645-b3de-80540fd5cfc4/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/94d7a1a2-136f-4645-b3de-80540fd5cfc4"
+  },
+  {
+    "group": "Kep1er",
+    "release_title": "BUBBLE GUM",
+    "release_date": "2025-08-19",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/cefd55a0-2cd7-4bfa-bae8-c05e741109fd/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/cefd55a0-2cd7-4bfa-bae8-c05e741109fd/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/cefd55a0-2cd7-4bfa-bae8-c05e741109fd"
+  },
+  {
+    "group": "KickFlip",
+    "release_title": "From KickFlip, To WeFlip",
+    "release_date": "2026-01-20",
+    "stream": "song",
+    "cover_image_url": "https://coverartarchive.org/release-group/41e161d0-e355-479c-849f-b2a63f68fb00/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/41e161d0-e355-479c-849f-b2a63f68fb00/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/41e161d0-e355-479c-849f-b2a63f68fb00"
+  },
+  {
+    "group": "KickFlip",
+    "release_title": "My First Flip",
+    "release_date": "2025-09-22",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/d834a7cf-efa3-4a5d-bcf8-d40cbcc2a434/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/d834a7cf-efa3-4a5d-bcf8-d40cbcc2a434/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/d834a7cf-efa3-4a5d-bcf8-d40cbcc2a434"
+  },
+  {
+    "group": "KiiiKiii",
+    "release_title": "To Me From Me",
+    "release_date": "2025-11-04",
+    "stream": "song",
+    "cover_image_url": "https://coverartarchive.org/release-group/3964ffdb-8ba8-4b39-bc6a-b09d4d40d26d/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/3964ffdb-8ba8-4b39-bc6a-b09d4d40d26d/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/3964ffdb-8ba8-4b39-bc6a-b09d4d40d26d"
+  },
+  {
+    "group": "KiiiKiii",
+    "release_title": "Delulu Pack",
+    "release_date": "2026-01-25",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/9abb5e1d-54f9-49cc-b973-d7d561f7c181/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/9abb5e1d-54f9-49cc-b973-d7d561f7c181/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/9abb5e1d-54f9-49cc-b973-d7d561f7c181"
+  },
+  {
+    "group": "KISS OF LIFE",
+    "release_title": "TOKYO MISSION START",
+    "release_date": "2025-11-05",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/78752bd0-8be7-4be8-9973-9ed52f054743/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/78752bd0-8be7-4be8-9973-9ed52f054743/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/78752bd0-8be7-4be8-9973-9ed52f054743"
+  },
+  {
+    "group": "LE SSERAFIM",
+    "release_title": "SPAGHETTI",
+    "release_date": "2025-10-24",
+    "stream": "song",
+    "cover_image_url": "https://coverartarchive.org/release-group/8fecf07e-3715-4df4-9f47-1f7204f71b94/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/8fecf07e-3715-4df4-9f47-1f7204f71b94/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/8fecf07e-3715-4df4-9f47-1f7204f71b94"
+  },
+  {
+    "group": "LIGHTSUM",
+    "release_title": "Beautiful Pain (SANGAH, CHOWON, JUHYEON)",
+    "release_date": "2026-01-15",
+    "stream": "song",
+    "cover_image_url": "/release-placeholder.svg",
+    "thumbnail_image_url": "/release-placeholder.svg",
+    "artwork_source_type": "placeholder",
+    "artwork_source_url": "/release-placeholder.svg"
+  },
+  {
+    "group": "LUN8",
+    "release_title": "LOST",
+    "release_date": "2025-09-17",
+    "stream": "song",
+    "cover_image_url": "https://coverartarchive.org/release-group/c1bfa152-a517-4bf8-9753-a366541d3c67/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/c1bfa152-a517-4bf8-9753-a366541d3c67/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/c1bfa152-a517-4bf8-9753-a366541d3c67"
+  },
+  {
+    "group": "MEOVV",
+    "release_title": "BURNING UP",
+    "release_date": "2025-10-14",
+    "stream": "song",
+    "cover_image_url": "https://coverartarchive.org/release-group/87bcfee4-b8fc-438b-8e4b-241ec21c3895/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/87bcfee4-b8fc-438b-8e4b-241ec21c3895/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/87bcfee4-b8fc-438b-8e4b-241ec21c3895"
+  },
+  {
+    "group": "MONSTA X",
+    "release_title": "growing pains",
+    "release_date": "2026-02-06",
+    "stream": "song",
+    "cover_image_url": "https://coverartarchive.org/release-group/d77e44ee-aa20-498d-8606-db1f4ac5d481/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/d77e44ee-aa20-498d-8606-db1f4ac5d481/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/d77e44ee-aa20-498d-8606-db1f4ac5d481"
+  },
+  {
+    "group": "MONSTA X",
+    "release_title": "THE X",
+    "release_date": "2025-09-01",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/ca8e0811-5f61-4cd5-b9d8-354f4f9b5f28/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/ca8e0811-5f61-4cd5-b9d8-354f4f9b5f28/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/ca8e0811-5f61-4cd5-b9d8-354f4f9b5f28"
+  },
+  {
+    "group": "NCT DREAM",
+    "release_title": "Beat It Up",
+    "release_date": "2025-11-17",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/1d8b6f46-e52b-43a8-912d-0c7cee7a5c5a/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/1d8b6f46-e52b-43a8-912d-0c7cee7a5c5a/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/1d8b6f46-e52b-43a8-912d-0c7cee7a5c5a"
+  },
+  {
+    "group": "NCT WISH",
+    "release_title": "Same Sky",
+    "release_date": "2026-02-27",
+    "stream": "song",
+    "cover_image_url": "https://coverartarchive.org/release-group/44a5498a-7844-4ad3-891f-831eaa143b5d/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/44a5498a-7844-4ad3-891f-831eaa143b5d/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/44a5498a-7844-4ad3-891f-831eaa143b5d"
+  },
+  {
+    "group": "NCT WISH",
+    "release_title": "WISHLIST",
+    "release_date": "2026-01-14",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/aa6bead7-4507-41db-8d27-0a8a46d5db75/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/aa6bead7-4507-41db-8d27-0a8a46d5db75/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/aa6bead7-4507-41db-8d27-0a8a46d5db75"
+  },
+  {
+    "group": "NEXZ",
+    "release_title": "Beat‐Boxer",
+    "release_date": "2025-10-27",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/78518e14-605e-4abe-b030-b2ec4fcd1440/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/78518e14-605e-4abe-b030-b2ec4fcd1440/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/78518e14-605e-4abe-b030-b2ec4fcd1440"
+  },
+  {
+    "group": "NMIXX",
+    "release_title": "TIC TIC",
+    "release_date": "2026-02-26",
+    "stream": "song",
+    "cover_image_url": "https://coverartarchive.org/release-group/b71aa2e7-c4a3-44ea-a577-f9459bf6456f/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/b71aa2e7-c4a3-44ea-a577-f9459bf6456f/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/b71aa2e7-c4a3-44ea-a577-f9459bf6456f"
+  },
+  {
+    "group": "NMIXX",
+    "release_title": "Blue Valentine",
+    "release_date": "2025-10-13",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/fbdd1a42-b8fe-47a6-8bf4-927b61e567f0/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/fbdd1a42-b8fe-47a6-8bf4-927b61e567f0/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/fbdd1a42-b8fe-47a6-8bf4-927b61e567f0"
+  },
+  {
+    "group": "ONEUS",
+    "release_title": "原",
+    "release_date": "2026-01-20",
+    "stream": "song",
+    "cover_image_url": "https://coverartarchive.org/release-group/7ec53d25-cf70-4e7e-a0e7-3ce79bf619f7/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/7ec53d25-cf70-4e7e-a0e7-3ce79bf619f7/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/7ec53d25-cf70-4e7e-a0e7-3ce79bf619f7"
+  },
+  {
+    "group": "ONEUS",
+    "release_title": "5x",
+    "release_date": "2025-06-30",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/bf41a2c3-75ef-4c6b-aab6-0c8874163e8a/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/bf41a2c3-75ef-4c6b-aab6-0c8874163e8a/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/bf41a2c3-75ef-4c6b-aab6-0c8874163e8a"
+  },
+  {
+    "group": "ONEWE",
+    "release_title": "MAZE : AD ASTRA",
+    "release_date": "2025-10-07",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/9b82559f-d786-4418-a8b9-066bb90c8484/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/9b82559f-d786-4418-a8b9-066bb90c8484/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/9b82559f-d786-4418-a8b9-066bb90c8484"
+  },
+  {
+    "group": "ONF",
+    "release_title": "Summer Light",
+    "release_date": "2025-08-03",
+    "stream": "song",
+    "cover_image_url": "https://coverartarchive.org/release-group/017dac05-b448-4199-93a0-0d4415f90936/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/017dac05-b448-4199-93a0-0d4415f90936/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/017dac05-b448-4199-93a0-0d4415f90936"
+  },
+  {
+    "group": "P1Harmony",
+    "release_title": "EX",
+    "release_date": "2025-09-26",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/a32e5d1a-a665-4cca-beeb-ccd5e2424a91/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/a32e5d1a-a665-4cca-beeb-ccd5e2424a91/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/a32e5d1a-a665-4cca-beeb-ccd5e2424a91"
+  },
+  {
+    "group": "PLAVE",
+    "release_title": "PLBBUU",
+    "release_date": "2025-11-10",
+    "stream": "song",
+    "cover_image_url": "https://coverartarchive.org/release-group/e33697d4-87e8-4aab-8af7-f9b058a8cd98/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/e33697d4-87e8-4aab-8af7-f9b058a8cd98/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/e33697d4-87e8-4aab-8af7-f9b058a8cd98"
+  },
+  {
+    "group": "POW",
+    "release_title": "Wall Flowers",
+    "release_date": "2025-09-29",
+    "stream": "song",
+    "cover_image_url": "https://coverartarchive.org/release-group/a77ad515-51b9-4bef-a0dc-786a8b55f783/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/a77ad515-51b9-4bef-a0dc-786a8b55f783/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/a77ad515-51b9-4bef-a0dc-786a8b55f783"
+  },
+  {
+    "group": "Purple Kiss",
+    "release_title": "A Violet to Remember",
+    "release_date": "2025-11-16",
+    "stream": "song",
+    "cover_image_url": "https://coverartarchive.org/release-group/90a2d86d-ad0e-42db-bf20-fdf6cc5d915d/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/90a2d86d-ad0e-42db-bf20-fdf6cc5d915d/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/90a2d86d-ad0e-42db-bf20-fdf6cc5d915d"
+  },
+  {
+    "group": "Purple Kiss",
+    "release_title": "OUR NOW",
+    "release_date": "2025-08-31",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/8c6eab4a-ea6f-45db-ab2f-cadeb9f3b31d/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/8c6eab4a-ea6f-45db-ab2f-cadeb9f3b31d/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/8c6eab4a-ea6f-45db-ab2f-cadeb9f3b31d"
+  },
+  {
+    "group": "QWER",
+    "release_title": "흰수염고래",
+    "release_date": "2025-10-06",
+    "stream": "song",
+    "cover_image_url": "https://coverartarchive.org/release-group/f6027192-7e1d-4e68-a82b-b43cab18efea/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/f6027192-7e1d-4e68-a82b-b43cab18efea/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/f6027192-7e1d-4e68-a82b-b43cab18efea"
+  },
+  {
+    "group": "QWER",
+    "release_title": "In a million noises, I’ll be your harmony",
+    "release_date": "2025-06-09",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/3d34baf6-f1f9-4dac-879d-4b37d58c9958/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/3d34baf6-f1f9-4dac-879d-4b37d58c9958/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/3d34baf6-f1f9-4dac-879d-4b37d58c9958"
+  },
+  {
+    "group": "RESCENE",
+    "release_title": "[RESCENE X ???]",
+    "release_date": "2026-02-27",
+    "stream": "song",
+    "cover_image_url": "https://coverartarchive.org/release-group/4f3f5594-e38f-4e46-bef1-2d2cfc28182e/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/4f3f5594-e38f-4e46-bef1-2d2cfc28182e/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/4f3f5594-e38f-4e46-bef1-2d2cfc28182e"
+  },
+  {
+    "group": "RESCENE",
+    "release_title": "lip bomb",
+    "release_date": "2025-11-25",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/0854eb50-8966-441c-80be-74b10eb11c6f/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/0854eb50-8966-441c-80be-74b10eb11c6f/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/0854eb50-8966-441c-80be-74b10eb11c6f"
+  },
+  {
+    "group": "RIIZE",
+    "release_title": "All of You",
+    "release_date": "2026-02-09",
+    "stream": "song",
+    "cover_image_url": "https://coverartarchive.org/release-group/4dc1c060-7c99-408b-8ffe-2afb1a9032bb/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/4dc1c060-7c99-408b-8ffe-2afb1a9032bb/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/4dc1c060-7c99-408b-8ffe-2afb1a9032bb"
+  },
+  {
+    "group": "SAY MY NAME",
+    "release_title": "iLy",
+    "release_date": "2025-08-01",
+    "stream": "song",
+    "cover_image_url": "https://coverartarchive.org/release-group/440ca3df-b629-4455-b67d-d44cf488a6e3/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/440ca3df-b629-4455-b67d-d44cf488a6e3/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/440ca3df-b629-4455-b67d-d44cf488a6e3"
+  },
+  {
+    "group": "SAY MY NAME",
+    "release_title": "&Our Vibe",
+    "release_date": "2025-12-29",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/46627fda-0c83-491f-89dd-19b93b6c7c46/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/46627fda-0c83-491f-89dd-19b93b6c7c46/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/46627fda-0c83-491f-89dd-19b93b6c7c46"
+  },
+  {
+    "group": "SEVENTEEN",
+    "release_title": "Where love passed",
+    "release_date": "2025-07-14",
+    "stream": "song",
+    "cover_image_url": "https://coverartarchive.org/release-group/bc14070e-4c6f-44c9-bf30-ae20b6d44b96/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/bc14070e-4c6f-44c9-bf30-ae20b6d44b96/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/bc14070e-4c6f-44c9-bf30-ae20b6d44b96"
+  },
+  {
+    "group": "STAYC",
+    "release_title": "I WANT IT",
+    "release_date": "2025-07-23",
+    "stream": "song",
+    "cover_image_url": "https://coverartarchive.org/release-group/0eaf3023-4c83-45ea-94fe-25efd4c61830/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/0eaf3023-4c83-45ea-94fe-25efd4c61830/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/0eaf3023-4c83-45ea-94fe-25efd4c61830"
+  },
+  {
+    "group": "STAYC",
+    "release_title": "STAY ALIVE",
+    "release_date": "2026-02-11",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/d441bac9-17d5-47db-97cb-65b9000e3f76/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/d441bac9-17d5-47db-97cb-65b9000e3f76/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/d441bac9-17d5-47db-97cb-65b9000e3f76"
+  },
+  {
+    "group": "Stray Kids",
+    "release_title": "In The Dark",
+    "release_date": "2025-11-06",
+    "stream": "song",
+    "cover_image_url": "https://coverartarchive.org/release-group/6fc9a1f5-709d-4180-a01a-aa75c35558d4/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/6fc9a1f5-709d-4180-a01a-aa75c35558d4/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/6fc9a1f5-709d-4180-a01a-aa75c35558d4"
+  },
+  {
+    "group": "Stray Kids",
+    "release_title": "DO IT",
+    "release_date": "2025-11-21",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/ce29b685-a98d-411e-b68f-78c6b4e963c6/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/ce29b685-a98d-411e-b68f-78c6b4e963c6/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/ce29b685-a98d-411e-b68f-78c6b4e963c6"
+  },
+  {
+    "group": "TEMPEST",
+    "release_title": "In the Dark (暮色独白)",
+    "release_date": "2025-11-03",
+    "stream": "song",
+    "cover_image_url": "https://coverartarchive.org/release-group/cc31d9d5-c80d-4984-9b7a-599594c81fad/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/cc31d9d5-c80d-4984-9b7a-599594c81fad/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/cc31d9d5-c80d-4984-9b7a-599594c81fad"
+  },
+  {
+    "group": "TEMPEST",
+    "release_title": "As I am",
+    "release_date": "2025-10-27",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/2e01370d-bfb6-4ddc-838f-db1447399533/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/2e01370d-bfb6-4ddc-838f-db1447399533/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/2e01370d-bfb6-4ddc-838f-db1447399533"
+  },
+  {
+    "group": "THE BOYZ",
+    "release_title": "Still Love You",
+    "release_date": "2025-12-06",
+    "stream": "song",
+    "cover_image_url": "https://coverartarchive.org/release-group/01e6d59b-8166-40b7-bb26-881c033deb14/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/01e6d59b-8166-40b7-bb26-881c033deb14/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/01e6d59b-8166-40b7-bb26-881c033deb14"
+  },
+  {
+    "group": "THE BOYZ",
+    "release_title": "a;effect",
+    "release_date": "2025-07-28",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/ad2aabda-8449-449b-ab23-76e57f7857ee/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/ad2aabda-8449-449b-ab23-76e57f7857ee/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/ad2aabda-8449-449b-ab23-76e57f7857ee"
+  },
+  {
+    "group": "The KingDom",
+    "release_title": "the flower of the moon",
+    "release_date": "2025-09-23",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/326d8498-e340-4cad-a02f-5ea369e6ec49/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/326d8498-e340-4cad-a02f-5ea369e6ec49/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/326d8498-e340-4cad-a02f-5ea369e6ec49"
+  },
+  {
+    "group": "TIOT",
+    "release_title": "Run Run Barefoot",
+    "release_date": "2025-07-07",
+    "stream": "song",
+    "cover_image_url": "https://coverartarchive.org/release-group/8d092aa5-b63e-4892-8dbd-b29ab089b040/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/8d092aa5-b63e-4892-8dbd-b29ab089b040/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/8d092aa5-b63e-4892-8dbd-b29ab089b040"
+  },
+  {
+    "group": "TIOT",
+    "release_title": "MY PRIDE",
+    "release_date": "2025-09-23",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/25a28c0e-f4b4-420c-b80f-bcca8c7d5fc4/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/25a28c0e-f4b4-420c-b80f-bcca8c7d5fc4/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/25a28c0e-f4b4-420c-b80f-bcca8c7d5fc4"
+  },
+  {
+    "group": "TNX",
+    "release_title": "CALL ME BACK",
+    "release_date": "2026-01-22",
+    "stream": "song",
+    "cover_image_url": "https://coverartarchive.org/release-group/284125ec-d04c-4023-9977-666ca826b284/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/284125ec-d04c-4023-9977-666ca826b284/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/284125ec-d04c-4023-9977-666ca826b284"
+  },
+  {
+    "group": "TOMORROW X TOGETHER",
+    "release_title": "butterflies",
+    "release_date": "2025-07-10",
+    "stream": "song",
+    "cover_image_url": "https://coverartarchive.org/release-group/ffca8aaa-b0bd-49f5-9800-9d273f4735a7/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/ffca8aaa-b0bd-49f5-9800-9d273f4735a7/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/ffca8aaa-b0bd-49f5-9800-9d273f4735a7"
+  },
+  {
+    "group": "TOMORROW X TOGETHER",
+    "release_title": "Starkissed",
+    "release_date": "2025-10-19",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/f7ce84d1-8d9e-4674-98e5-8987db78cb86/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/f7ce84d1-8d9e-4674-98e5-8987db78cb86/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/f7ce84d1-8d9e-4674-98e5-8987db78cb86"
+  },
+  {
+    "group": "TREASURE",
+    "release_title": "LOVE PULSE",
+    "release_date": "2025-09-01",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/a33fa122-f703-4e2d-8cf9-93f93c506dc5/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/a33fa122-f703-4e2d-8cf9-93f93c506dc5/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/a33fa122-f703-4e2d-8cf9-93f93c506dc5"
+  },
+  {
+    "group": "TRENDZ",
+    "release_title": "Kart Racer",
+    "release_date": "2026-02-13",
+    "stream": "song",
+    "cover_image_url": "https://coverartarchive.org/release-group/d44c9809-e64b-4038-8993-a0ff75f67986/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/d44c9809-e64b-4038-8993-a0ff75f67986/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/d44c9809-e64b-4038-8993-a0ff75f67986"
+  },
+  {
+    "group": "tripleS",
+    "release_title": "トキメティック",
+    "release_date": "2026-02-05",
+    "stream": "song",
+    "cover_image_url": "https://coverartarchive.org/release-group/e55e3345-ef7c-44f3-9b99-a25b06df7cf8/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/e55e3345-ef7c-44f3-9b99-a25b06df7cf8/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/e55e3345-ef7c-44f3-9b99-a25b06df7cf8"
+  },
+  {
+    "group": "tripleS",
+    "release_title": "msnz <Beyond Beauty>",
+    "release_date": "2025-11-24",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/3c02e3dc-a991-4721-9252-c9b3cb2c9290/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/3c02e3dc-a991-4721-9252-c9b3cb2c9290/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/3c02e3dc-a991-4721-9252-c9b3cb2c9290"
+  },
+  {
+    "group": "TWICE",
+    "release_title": "Like 1",
+    "release_date": "2025-08-20",
+    "stream": "song",
+    "cover_image_url": "https://coverartarchive.org/release-group/ec115903-eb42-4437-925e-ad64f0a2d818/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/ec115903-eb42-4437-925e-ad64f0a2d818/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/ec115903-eb42-4437-925e-ad64f0a2d818"
+  },
+  {
+    "group": "TWICE",
+    "release_title": "TEN: The Story Goes On",
+    "release_date": "2025-10-10",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/3670fec6-643a-4a88-a623-900ff5fdd43b/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/3670fec6-643a-4a88-a623-900ff5fdd43b/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/3670fec6-643a-4a88-a623-900ff5fdd43b"
+  },
+  {
+    "group": "TWS",
+    "release_title": "Head Shoulders Knees Toes",
+    "release_date": "2025-09-22",
+    "stream": "song",
+    "cover_image_url": "https://coverartarchive.org/release-group/2ebe300e-b96c-4678-8bb8-03a0e3a32262/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/2ebe300e-b96c-4678-8bb8-03a0e3a32262/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/2ebe300e-b96c-4678-8bb8-03a0e3a32262"
+  },
+  {
+    "group": "TWS",
+    "release_title": "play hard",
+    "release_date": "2025-10-13",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/5be26f41-0605-41a6-a7a0-06f85305f1c9/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/5be26f41-0605-41a6-a7a0-06f85305f1c9/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/5be26f41-0605-41a6-a7a0-06f85305f1c9"
+  },
+  {
+    "group": "UNIS",
+    "release_title": "幸せになんかならないでね",
+    "release_date": "2025-12-17",
+    "stream": "song",
+    "cover_image_url": "https://coverartarchive.org/release-group/6c4f751d-053e-4d6e-970c-24bd12985f3b/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/6c4f751d-053e-4d6e-970c-24bd12985f3b/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/6c4f751d-053e-4d6e-970c-24bd12985f3b"
+  },
+  {
+    "group": "VERIVERY",
+    "release_title": "Lost and Found",
+    "release_date": "2025-12-01",
+    "stream": "song",
+    "cover_image_url": "https://coverartarchive.org/release-group/109571b5-c2ef-4bb1-a3ec-dff21ad2d31c/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/109571b5-c2ef-4bb1-a3ec-dff21ad2d31c/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/109571b5-c2ef-4bb1-a3ec-dff21ad2d31c"
+  },
+  {
+    "group": "VIVIZ",
+    "release_title": "A Montage of ( )",
+    "release_date": "2025-07-08",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/06428a95-ee6f-40dc-9310-36b74a9c112d/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/06428a95-ee6f-40dc-9310-36b74a9c112d/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/06428a95-ee6f-40dc-9310-36b74a9c112d"
+  },
+  {
+    "group": "WEi",
+    "release_title": "Wonderland",
+    "release_date": "2025-10-29",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/252b4761-926f-479f-86bc-a0999710321b/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/252b4761-926f-479f-86bc-a0999710321b/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/252b4761-926f-479f-86bc-a0999710321b"
+  },
+  {
+    "group": "Xdinary Heroes",
+    "release_title": "FiRE (My Sweet Misery)",
+    "release_date": "2025-07-07",
+    "stream": "song",
+    "cover_image_url": "https://coverartarchive.org/release-group/a59a689a-c57f-4691-8ef0-c87e5fd2b418/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/a59a689a-c57f-4691-8ef0-c87e5fd2b418/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/a59a689a-c57f-4691-8ef0-c87e5fd2b418"
+  },
+  {
+    "group": "Xdinary Heroes",
+    "release_title": "LXVE to DEATH",
+    "release_date": "2025-10-24",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/25bb96b9-3470-4923-bb05-7cf734d5775c/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/25bb96b9-3470-4923-bb05-7cf734d5775c/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/25bb96b9-3470-4923-bb05-7cf734d5775c"
+  },
+  {
+    "group": "xikers",
+    "release_title": "ICONIC",
+    "release_date": "2025-08-01",
+    "stream": "song",
+    "cover_image_url": "https://coverartarchive.org/release-group/d53e958d-4e4e-44cf-8942-75f793e187c6/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/d53e958d-4e4e-44cf-8942-75f793e187c6/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/d53e958d-4e4e-44cf-8942-75f793e187c6"
+  },
+  {
+    "group": "xikers",
+    "release_title": "HOUSE OF TRICKY : WRECKING THE HOUSE",
+    "release_date": "2025-10-31",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/f2c83a31-4bcb-4e5e-b40e-59478ccc77ba/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/f2c83a31-4bcb-4e5e-b40e-59478ccc77ba/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/f2c83a31-4bcb-4e5e-b40e-59478ccc77ba"
+  },
+  {
+    "group": "YOUNG POSSE",
+    "release_title": "VISA / Pilot3",
+    "release_date": "2026-01-27",
+    "stream": "song",
+    "cover_image_url": "https://coverartarchive.org/release-group/a3dca638-6256-40be-b501-692f3e371ba4/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/a3dca638-6256-40be-b501-692f3e371ba4/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/a3dca638-6256-40be-b501-692f3e371ba4"
+  },
+  {
+    "group": "YOUNG POSSE",
+    "release_title": "Growing Pain pt.1 : FREE",
+    "release_date": "2025-08-14",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/f894d3a6-0225-4269-bb58-8947719d2f5d/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/f894d3a6-0225-4269-bb58-8947719d2f5d/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/f894d3a6-0225-4269-bb58-8947719d2f5d"
+  },
+  {
+    "group": "ZEROBASEONE",
+    "release_title": "ROSES",
+    "release_date": "2026-01-23",
+    "stream": "song",
+    "cover_image_url": "https://coverartarchive.org/release-group/6656b493-ef15-4aee-a142-4fc2656294d3/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/6656b493-ef15-4aee-a142-4fc2656294d3/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/6656b493-ef15-4aee-a142-4fc2656294d3"
+  },
+  {
+    "group": "ZEROBASEONE",
+    "release_title": "RE-FLOW",
+    "release_date": "2026-02-02",
+    "stream": "album",
+    "cover_image_url": "https://coverartarchive.org/release-group/901f64ef-586f-4061-86f6-3ec3fb156d5b/front",
+    "thumbnail_image_url": "https://coverartarchive.org/release-group/901f64ef-586f-4061-86f6-3ec3fb156d5b/front-250",
+    "artwork_source_type": "cover_art_archive",
+    "artwork_source_url": "https://coverartarchive.org/release-group/901f64ef-586f-4061-86f6-3ec3fb156d5b"
+  }
+]


### PR DESCRIPTION
## Summary\n- add  with release-level artwork keys, source provenance, and placeholder fallback\n- wire release artwork into the team page latest release card, recent album cards, and album drawer\n- add a reusable placeholder artwork asset for missing covers\n\n## Verification\n- npm run lint\n- npm run build\n- manual data spot check for 10+ release artwork rows and placeholder fallback cases