### PR TITLE
feat: add release detail seed data for album modals and team pages

### DIFF
--- a/build_release_details_musicbrainz.py
+++ b/build_release_details_musicbrainz.py
@@ -1,0 +1,251 @@
+import json
+import time
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+from urllib.parse import parse_qs, urlparse
+
+import requests
+
+ROOT = Path(__file__).resolve().parent
+RELEASES_PATH = ROOT / "web/src/data/releases.json"
+OUTPUT_PATH = ROOT / "web/src/data/releaseDetails.json"
+USER_AGENT = "idol-song-app/1.0 (https://github.com/iAmSomething/idol-song-app)"
+REQUEST_DELAY_SECONDS = 0.35
+MAX_RETRIES = 4
+
+
+def get_json(session: requests.Session, url: str, params: Dict[str, object]) -> Dict:
+    for attempt in range(MAX_RETRIES):
+        try:
+            response = session.get(url, params={**params, "fmt": "json"}, timeout=20)
+            response.raise_for_status()
+            time.sleep(REQUEST_DELAY_SECONDS)
+            return response.json()
+        except Exception:
+            if attempt == MAX_RETRIES - 1:
+                raise
+            time.sleep((attempt + 1) * 1.2)
+    raise RuntimeError("unreachable")
+
+
+def iter_release_items(rows: List[Dict]) -> List[Dict]:
+    items: List[Dict] = []
+    for row in rows:
+        for key, stream in (("latest_song", "song"), ("latest_album", "album")):
+            release = row.get(key)
+            if not release:
+                continue
+            items.append(
+                {
+                    "group": row["group"],
+                    "release_title": release["title"],
+                    "release_date": release["date"],
+                    "stream": stream,
+                    "release_kind": release["release_kind"],
+                    "release_group_id": release["source"].rsplit("/", 1)[-1],
+                }
+            )
+    return items
+
+
+def score_release(release: Dict, title: str, release_date: str) -> int:
+    score = 0
+    if release.get("title") == title:
+        score += 40
+    if release.get("date") == release_date:
+        score += 30
+    if release.get("status") == "Official":
+        score += 20
+    if release.get("country") == "XW":
+        score += 10
+    elif release.get("country") == "KR":
+        score += 6
+    if release.get("packaging") == "None":
+        score += 2
+    return score
+
+
+def select_candidate_releases(releases: List[Dict], title: str, release_date: str) -> List[Dict]:
+    return sorted(
+        releases,
+        key=lambda release: score_release(release, title, release_date),
+        reverse=True,
+    )
+
+
+def extract_tracks(release: Dict) -> List[Dict]:
+    tracks: List[Dict] = []
+    order = 1
+    for medium in release.get("media", []):
+        for track in medium.get("tracks", []):
+            title = track.get("title") or track.get("recording", {}).get("title")
+            if not title:
+                continue
+            tracks.append({"order": order, "title": title})
+            order += 1
+    return tracks
+
+
+def extract_youtube_video_id(resource: str) -> Optional[str]:
+    parsed = urlparse(resource)
+    host = parsed.netloc.lower()
+
+    if "youtu.be" in host:
+        return parsed.path.strip("/") or None
+    if "youtube.com" in host:
+        return parse_qs(parsed.query).get("v", [None])[0]
+    return None
+
+
+def extract_urls(relations: List[Dict]) -> Tuple[Optional[str], Optional[str], Optional[str]]:
+    spotify_url = None
+    youtube_music_url = None
+    youtube_video_id = None
+
+    for relation in relations:
+        resource = relation.get("url", {}).get("resource")
+        if not resource:
+            continue
+
+        lowered = resource.lower()
+        if spotify_url is None and "open.spotify.com/" in lowered:
+            spotify_url = resource
+        if youtube_music_url is None and "music.youtube.com/" in lowered:
+            youtube_music_url = resource
+        if youtube_video_id is None:
+            youtube_video_id = extract_youtube_video_id(resource)
+
+    return spotify_url, youtube_music_url, youtube_video_id
+
+
+def build_notes(track_count: int, release_kind: str, spotify_url: Optional[str], youtube_music_url: Optional[str]) -> str:
+    kind_label = release_kind.upper()
+    if track_count:
+        note = f"Representative MusicBrainz {kind_label} seed with {track_count} track"
+        if track_count != 1:
+            note += "s"
+        note += "."
+    else:
+        note = "Representative MusicBrainz seed without track rows."
+
+    linked_services = []
+    if spotify_url:
+        linked_services.append("Spotify")
+    if youtube_music_url:
+        linked_services.append("YouTube Music")
+    if linked_services:
+        note += f" Canonical links: {', '.join(linked_services)}."
+
+    return note
+
+
+def build_empty_detail(item: Dict) -> Dict:
+    return {
+        "group": item["group"],
+        "release_title": item["release_title"],
+        "release_date": item["release_date"],
+        "stream": item["stream"],
+        "release_kind": item["release_kind"],
+        "tracks": [],
+        "spotify_url": None,
+        "youtube_music_url": None,
+        "youtube_video_id": None,
+        "notes": "Release detail seed unavailable in MusicBrainz; UI fallback applies.",
+    }
+
+
+def build_detail_row(session: requests.Session, item: Dict) -> Dict:
+    release_group = get_json(
+        session,
+        f"https://musicbrainz.org/ws/2/release-group/{item['release_group_id']}",
+        {"inc": "releases+url-rels"},
+    )
+    candidate_releases = select_candidate_releases(
+        release_group.get("releases", []),
+        item["release_title"],
+        item["release_date"],
+    )
+
+    if not candidate_releases:
+        return build_empty_detail(item)
+
+    fallback_row = build_empty_detail(item)
+
+    for candidate in candidate_releases[:4]:
+        release = get_json(
+            session,
+            f"https://musicbrainz.org/ws/2/release/{candidate['id']}",
+            {"inc": "recordings+url-rels"},
+        )
+        tracks = extract_tracks(release)
+        spotify_url, youtube_music_url, youtube_video_id = extract_urls(release.get("relations", []))
+
+        if not tracks and not spotify_url and not youtube_music_url and not youtube_video_id:
+            continue
+
+        return {
+            "group": item["group"],
+            "release_title": item["release_title"],
+            "release_date": item["release_date"],
+            "stream": item["stream"],
+            "release_kind": item["release_kind"],
+            "tracks": tracks,
+            "spotify_url": spotify_url,
+            "youtube_music_url": youtube_music_url,
+            "youtube_video_id": youtube_video_id,
+            "notes": build_notes(len(tracks), item["release_kind"], spotify_url, youtube_music_url),
+        }
+
+    return fallback_row
+
+
+def main() -> None:
+    with RELEASES_PATH.open() as handle:
+        release_rows = json.load(handle)
+
+    items = iter_release_items(release_rows)
+    details: List[Dict] = []
+
+    session = requests.Session()
+    session.headers["User-Agent"] = USER_AGENT
+
+    for index, item in enumerate(items, start=1):
+        print(
+            f"[{index}/{len(items)}] {item['group']} · {item['release_title']} · {item['stream']}",
+            flush=True,
+        )
+        details.append(build_detail_row(session, item))
+
+    details.sort(
+        key=lambda row: (
+            row["group"].lower(),
+            row["release_date"],
+            row["stream"],
+            row["release_title"].lower(),
+        )
+    )
+
+    OUTPUT_PATH.write_text(json.dumps(details, ensure_ascii=False, indent=2) + "\n")
+
+    with_tracks = sum(1 for row in details if row["tracks"])
+    with_spotify = sum(1 for row in details if row["spotify_url"])
+    with_youtube_music = sum(1 for row in details if row["youtube_music_url"])
+    with_video = sum(1 for row in details if row["youtube_video_id"])
+
+    print(
+        json.dumps(
+            {
+                "count": len(details),
+                "with_tracks": with_tracks,
+                "with_spotify": with_spotify,
+                "with_youtube_music": with_youtube_music,
+                "with_video": with_video,
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import './App.css'
 import artistProfileRows from './data/artistProfiles.json'
 import releaseArtworkRows from './data/releaseArtwork.json'
+import releaseDetailRows from './data/releaseDetails.json'
 import releaseRows from './data/releases.json'
 import unresolvedRows from './data/unresolved.json'
 import upcomingCandidateRows from './data/upcomingCandidates.json'
@@ -50,6 +51,28 @@ type ReleaseArtworkRow = {
 
 type ResolvedReleaseArtwork = ReleaseArtworkRow & {
   isPlaceholder: boolean
+}
+
+type ReleaseDetailTrack = {
+  order: number
+  title: string
+}
+
+type ReleaseDetailRow = {
+  group: string
+  release_title: string
+  release_date: string
+  stream: 'song' | 'album'
+  release_kind: ReleaseFact['release_kind']
+  tracks: ReleaseDetailTrack[]
+  spotify_url: string | null
+  youtube_music_url: string | null
+  youtube_video_id: string | null
+  notes: string
+}
+
+type ResolvedReleaseDetail = ReleaseDetailRow & {
+  isFallback: boolean
 }
 
 type ActType = 'group' | 'solo' | 'unit'
@@ -396,7 +419,8 @@ const TEAM_COPY = {
     releaseDate: '발매일',
     stream: '스트림',
     trackPreview: '트랙 프리뷰',
-    trackPreviewHint: '트랙 정보는 v1 placeholder입니다. 전체 디스코그래피 파이프라인에서 실제 트랙 데이터로 대체됩니다.',
+    trackPreviewHint: '시드 데이터가 있으면 실제 트랙을, 없으면 placeholder 프리뷰를 표시합니다.',
+    releaseNotes: '릴리즈 메모',
     placeholderCover: '릴리즈 아트워크',
     drawerCopy:
       '앨범 상세는 팀 페이지 안 슬라이드오버로 유지해서 컴백 맥락을 잃지 않고 바로 돌아올 수 있습니다.',
@@ -447,7 +471,8 @@ const TEAM_COPY = {
     releaseDate: 'Release date',
     stream: 'Stream',
     trackPreview: 'Track preview',
-    trackPreviewHint: 'Track info is a v1 placeholder and will be replaced when the full discography pipeline lands.',
+    trackPreviewHint: 'Uses seeded track data when available and falls back to placeholder preview rows otherwise.',
+    releaseNotes: 'Release notes',
     placeholderCover: 'Release artwork',
     drawerCopy:
       'Album detail stays inside the team page so users can inspect the release and return to comeback context immediately.',
@@ -465,6 +490,7 @@ const RELEASE_ARTWORK_PLACEHOLDER_URL = '/release-placeholder.svg'
 
 const artistProfiles = artistProfileRows as ArtistProfileRow[]
 const releaseArtworkCatalog = releaseArtworkRows as ReleaseArtworkRow[]
+const releaseDetailsCatalog = releaseDetailRows as ReleaseDetailRow[]
 const releaseCatalog = releaseRows as ReleaseRow[]
 const releases = releaseCatalog
   .flatMap((row) => expandReleaseRow(row))
@@ -489,7 +515,10 @@ const releaseCatalogByGroup = new Map(releaseCatalog.map((row) => [row.group, ro
 const artistProfileByGroup = new Map(artistProfiles.map((row) => [row.group, row]))
 const artistProfileBySlug = new Map(artistProfiles.map((row) => [row.slug, row]))
 const releaseArtworkByKey = new Map(
-  releaseArtworkCatalog.map((row) => [getReleaseArtworkKey(row.group, row.release_title, row.release_date, row.stream), row]),
+  releaseArtworkCatalog.map((row) => [getReleaseLookupKey(row.group, row.release_title, row.release_date, row.stream), row]),
+)
+const releaseDetailsByKey = new Map(
+  releaseDetailsCatalog.map((row) => [getReleaseLookupKey(row.group, row.release_title, row.release_date, row.stream), row]),
 )
 const releaseGroups = groupReleasesByGroup(releases)
 const watchlistByGroup = new Map(watchlist.map((row) => [row.group, row]))
@@ -646,6 +675,20 @@ function App() {
     selectedTeam && selectedAlbumKey
       ? selectedTeam.recentAlbums.find((item) => getAlbumKey(item) === selectedAlbumKey) ?? null
       : null
+  const selectedTeamLatestDetail =
+    selectedTeam?.latestRelease
+      ? getReleaseDetail(
+          selectedTeam.group,
+          selectedTeam.latestRelease.title,
+          selectedTeam.latestRelease.date,
+          selectedTeam.latestRelease.stream,
+          selectedTeam.latestRelease.releaseKind,
+        )
+      : null
+  const selectedTeamLatestHandoffs =
+    selectedTeam?.latestRelease
+      ? buildReleaseDetailHandoffs(selectedTeamLatestDetail, selectedTeam.latestRelease.musicHandoffs)
+      : undefined
   const relatedTeams = filteredTeams.filter((team) => team.group !== selectedTeam?.group).slice(0, 8)
 
   function openTeamPage(group: string) {
@@ -848,6 +891,9 @@ function App() {
                         {selectedTeam.latestRelease.verified ? teamCopy.verifiedRelease : teamCopy.watchlistFallback} ·{' '}
                         {formatOptionalDate(selectedTeam.latestRelease.date, displayDateFormatter, copy.none)}
                       </p>
+                      {selectedTeamLatestDetail?.notes ? (
+                        <p className="signal-evidence">{selectedTeamLatestDetail.notes}</p>
+                      ) : null}
                       <div className="detail-links detail-links-stack">
                         {selectedTeam.latestRelease.source ? (
                           <a href={selectedTeam.latestRelease.source} target="_blank" rel="noreferrer">
@@ -865,7 +911,7 @@ function App() {
                       <MusicHandoffRow
                         group={selectedTeam.group}
                         title={selectedTeam.latestRelease.title}
-                        canonicalUrls={selectedTeam.latestRelease.musicHandoffs}
+                        canonicalUrls={selectedTeamLatestHandoffs}
                         language={language}
                         showHint
                       />
@@ -883,6 +929,13 @@ function App() {
                   <div className="album-grid">
                     {selectedTeam.recentAlbums.map((item) => {
                       const artwork = getReleaseArtwork(
+                        item.group,
+                        item.title,
+                        item.date,
+                        item.stream,
+                        item.release_kind,
+                      )
+                      const detail = getReleaseDetail(
                         item.group,
                         item.title,
                         item.date,
@@ -912,7 +965,7 @@ function App() {
                           <MusicHandoffRow
                             group={selectedTeam.group}
                             title={item.title}
-                            canonicalUrls={item.music_handoffs}
+                            canonicalUrls={buildReleaseDetailHandoffs(detail, item.music_handoffs)}
                             language={language}
                             compact
                           />
@@ -1351,9 +1404,13 @@ function AlbumDrawer({
 }) {
   const copy = TRANSLATIONS[language]
   const teamCopy = TEAM_COPY[language]
-  const previewTracks = buildAlbumPreviewTracks(album, group, language)
   const displayName = getTeamDisplayName(group)
   const artwork = getReleaseArtwork(group, album.title, album.date, album.stream, album.release_kind)
+  const releaseDetail = getReleaseDetail(group, album.title, album.date, album.stream, album.release_kind)
+  const previewTracks = releaseDetail.tracks.length
+    ? releaseDetail.tracks
+    : buildAlbumPreviewTracks(album, group, language).map((title, index) => ({ order: index + 1, title }))
+  const canonicalHandoffs = buildReleaseDetailHandoffs(releaseDetail, album.music_handoffs)
 
   return (
     <div className="drawer-backdrop" onClick={onClose} role="presentation">
@@ -1397,15 +1454,22 @@ function AlbumDrawer({
         <section className="track-preview">
           <p className="panel-label">{teamCopy.trackPreview}</p>
           <div className="track-list">
-            {previewTracks.map((track, index) => (
-              <div key={`${album.title}-${track}-${index + 1}`} className="track-row">
-                <span>{`${index + 1}`.padStart(2, '0')}</span>
-                <strong>{track}</strong>
+            {previewTracks.map((track) => (
+              <div key={`${album.title}-${track.title}-${track.order}`} className="track-row">
+                <span>{`${track.order}`.padStart(2, '0')}</span>
+                <strong>{track.title}</strong>
               </div>
             ))}
           </div>
           <p className="hero-text drawer-copy">{teamCopy.trackPreviewHint}</p>
         </section>
+
+        {releaseDetail.notes ? (
+          <section className="track-preview">
+            <p className="panel-label">{teamCopy.releaseNotes}</p>
+            <p className="hero-text drawer-copy">{releaseDetail.notes}</p>
+          </section>
+        ) : null}
 
         <p className="hero-text drawer-copy">{teamCopy.drawerCopy}</p>
         <div className="detail-links detail-links-stack">
@@ -1420,7 +1484,7 @@ function AlbumDrawer({
         <MusicHandoffRow
           group={group}
           title={album.title}
-          canonicalUrls={album.music_handoffs}
+          canonicalUrls={canonicalHandoffs}
           language={language}
           showHint
         />
@@ -1701,16 +1765,16 @@ function buildMusicSearchUrl(service: MusicService, query: string) {
   return `https://music.youtube.com/search?q=${encodedQuery}`
 }
 
-function getReleaseArtworkKey(
+function getReleaseLookupKey(
   group: string,
   releaseTitle: string,
   releaseDate: string,
-  stream: ReleaseArtworkRow['stream'],
+  stream: ReleaseArtworkRow['stream'] | ReleaseDetailRow['stream'],
 ) {
   return [group, releaseTitle, releaseDate, stream].join('::')
 }
 
-function normalizeArtworkStream(
+function normalizeReleaseStream(
   stream: TeamLatestRelease['stream'] | VerifiedRelease['stream'],
   releaseKind?: string,
 ): ReleaseArtworkRow['stream'] {
@@ -1734,7 +1798,7 @@ function buildPlaceholderReleaseArtwork(
     group,
     release_title: releaseTitle,
     release_date: releaseDate,
-    stream: normalizeArtworkStream(stream, releaseKind),
+    stream: normalizeReleaseStream(stream, releaseKind),
     cover_image_url: RELEASE_ARTWORK_PLACEHOLDER_URL,
     thumbnail_image_url: RELEASE_ARTWORK_PLACEHOLDER_URL,
     artwork_source_type: 'placeholder',
@@ -1750,9 +1814,9 @@ function getReleaseArtwork(
   stream: TeamLatestRelease['stream'] | VerifiedRelease['stream'],
   releaseKind?: string,
 ): ResolvedReleaseArtwork {
-  const normalizedStream = normalizeArtworkStream(stream, releaseKind)
+  const normalizedStream = normalizeReleaseStream(stream, releaseKind)
   const artwork = releaseArtworkByKey.get(
-    getReleaseArtworkKey(group, releaseTitle, releaseDate, normalizedStream),
+    getReleaseLookupKey(group, releaseTitle, releaseDate, normalizedStream),
   )
 
   if (!artwork) {
@@ -1763,6 +1827,66 @@ function getReleaseArtwork(
     ...artwork,
     isPlaceholder: artwork.artwork_source_type === 'placeholder',
   }
+}
+
+function buildFallbackReleaseDetail(
+  group: string,
+  releaseTitle: string,
+  releaseDate: string,
+  stream: TeamLatestRelease['stream'] | VerifiedRelease['stream'],
+  releaseKind?: string,
+): ResolvedReleaseDetail {
+  return {
+    group,
+    release_title: releaseTitle,
+    release_date: releaseDate,
+    stream: normalizeReleaseStream(stream, releaseKind),
+    release_kind: releaseKind === 'album' || releaseKind === 'ep' ? releaseKind : 'single',
+    tracks: [],
+    spotify_url: null,
+    youtube_music_url: null,
+    youtube_video_id: null,
+    notes: '',
+    isFallback: true,
+  }
+}
+
+function getReleaseDetail(
+  group: string,
+  releaseTitle: string,
+  releaseDate: string,
+  stream: TeamLatestRelease['stream'] | VerifiedRelease['stream'],
+  releaseKind?: string,
+): ResolvedReleaseDetail {
+  const normalizedStream = normalizeReleaseStream(stream, releaseKind)
+  const detail = releaseDetailsByKey.get(
+    getReleaseLookupKey(group, releaseTitle, releaseDate, normalizedStream),
+  )
+
+  if (!detail) {
+    return buildFallbackReleaseDetail(group, releaseTitle, releaseDate, stream, releaseKind)
+  }
+
+  return {
+    ...detail,
+    isFallback: false,
+  }
+}
+
+function buildReleaseDetailHandoffs(
+  detail: ResolvedReleaseDetail | null,
+  canonicalUrls?: MusicHandoffUrls,
+): MusicHandoffUrls | undefined {
+  const merged = {
+    spotify: detail?.spotify_url ?? canonicalUrls?.spotify,
+    youtube_music: detail?.youtube_music_url ?? canonicalUrls?.youtube_music,
+  }
+
+  if (!merged.spotify && !merged.youtube_music) {
+    return canonicalUrls
+  }
+
+  return merged
 }
 
 function buildTeamProfiles() {

--- a/web/src/data/releaseDetails.json
+++ b/web/src/data/releaseDetails.json
@@ -1,0 +1,3511 @@
+[
+  {
+    "group": "&TEAM",
+    "release_title": "Back to Life",
+    "release_date": "2025-10-28",
+    "stream": "album",
+    "release_kind": "ep",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "Back to Life"
+      },
+      {
+        "order": 2,
+        "title": "Lunatic"
+      },
+      {
+        "order": 3,
+        "title": "MISMATCH"
+      },
+      {
+        "order": 4,
+        "title": "Rush"
+      },
+      {
+        "order": 5,
+        "title": "Heartbreak Time Machine"
+      },
+      {
+        "order": 6,
+        "title": "Who am I"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/7g35iam7Zn7Kwc1ZpkWD8c",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz EP seed with 6 tracks. Canonical links: Spotify."
+  },
+  {
+    "group": "(G)I-DLE",
+    "release_title": "i‐dle",
+    "release_date": "2025-10-03",
+    "stream": "album",
+    "release_kind": "ep",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "どうしよっかな"
+      },
+      {
+        "order": 2,
+        "title": "Invincible"
+      },
+      {
+        "order": 3,
+        "title": "愛せなかった世界へ永遠にじゃあね"
+      },
+      {
+        "order": 4,
+        "title": "傷つくのは嫌いだから"
+      },
+      {
+        "order": 5,
+        "title": "Queencard (Japanese ver.)"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/prerelease/6dwb5r26FV8QM1q2VNfin6",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz EP seed with 5 tracks. Canonical links: Spotify."
+  },
+  {
+    "group": "(G)I-DLE",
+    "release_title": "Mono",
+    "release_date": "2026-01-27",
+    "stream": "song",
+    "release_kind": "single",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "Mono"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/4FbuxAECa56oJs71RE9acG",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz SINGLE seed with 1 track. Canonical links: Spotify."
+  },
+  {
+    "group": "82MAJOR",
+    "release_title": "Trophy",
+    "release_date": "2025-10-30",
+    "stream": "album",
+    "release_kind": "ep",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "TROPHY"
+      },
+      {
+        "order": 2,
+        "title": "Say more"
+      },
+      {
+        "order": 3,
+        "title": "Suspicious"
+      },
+      {
+        "order": 4,
+        "title": "Need That Bass"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/6oTUrlTjn5yEohEoQrXVTf",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz EP seed with 4 tracks. Canonical links: Spotify."
+  },
+  {
+    "group": "8TURN",
+    "release_title": "BRUISE",
+    "release_date": "2026-01-28",
+    "stream": "song",
+    "release_kind": "single",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "BRUISE"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/0Hnt6Uo4wPdBvh0Yb4oSrI",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz SINGLE seed with 1 track. Canonical links: Spotify."
+  },
+  {
+    "group": "aespa",
+    "release_title": "Rich Man",
+    "release_date": "2025-09-05",
+    "stream": "album",
+    "release_kind": "ep",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "Rich Man"
+      },
+      {
+        "order": 2,
+        "title": "Drift"
+      },
+      {
+        "order": 3,
+        "title": "Bubble"
+      },
+      {
+        "order": 4,
+        "title": "Count on Me"
+      },
+      {
+        "order": 5,
+        "title": "Angel #48"
+      },
+      {
+        "order": 6,
+        "title": "To the Girls"
+      }
+    ],
+    "spotify_url": null,
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz EP seed with 6 tracks."
+  },
+  {
+    "group": "aespa",
+    "release_title": "SYNK : aeXIS LINE",
+    "release_date": "2025-11-17",
+    "stream": "song",
+    "release_kind": "single",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "BLUE"
+      },
+      {
+        "order": 2,
+        "title": "Ketchup and Lemonade"
+      },
+      {
+        "order": 3,
+        "title": "Tornado"
+      },
+      {
+        "order": 4,
+        "title": "GOOD STUFF"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/74gHwFGwl4KWA3sD8ZmAbJ",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz SINGLE seed with 4 tracks. Canonical links: Spotify."
+  },
+  {
+    "group": "ALL(H)OURS",
+    "release_title": "VCF",
+    "release_date": "2025-09-09",
+    "stream": "album",
+    "release_kind": "ep",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "VCF"
+      },
+      {
+        "order": 2,
+        "title": "READY 2 RUMBLE"
+      },
+      {
+        "order": 3,
+        "title": "DO IT"
+      },
+      {
+        "order": 4,
+        "title": "GOOD JOB (KUNHO, XAYDEN, MASAMI, HYUNBIN)"
+      },
+      {
+        "order": 5,
+        "title": "La Vida Loca (YOUMIN, MINJE, ON:N, KUNHO)"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/3mNJ0XCdr6TbY3TPN0k0tn",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz EP seed with 5 tracks. Canonical links: Spotify."
+  },
+  {
+    "group": "AMPERS&ONE",
+    "release_title": "LOUD & PROUD",
+    "release_date": "2025-08-12",
+    "stream": "album",
+    "release_kind": "ep",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "That’s That"
+      },
+      {
+        "order": 2,
+        "title": "Seesaw"
+      },
+      {
+        "order": 3,
+        "title": "Get Famous"
+      },
+      {
+        "order": 4,
+        "title": "Move Out"
+      },
+      {
+        "order": 5,
+        "title": "Did It"
+      },
+      {
+        "order": 6,
+        "title": "I’m Down"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/4s6H9i2JkMF58sij9Xa26W",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz EP seed with 6 tracks. Canonical links: Spotify."
+  },
+  {
+    "group": "ARTMS",
+    "release_title": "<Club Icarus>",
+    "release_date": "2025-06-13",
+    "stream": "album",
+    "release_kind": "ep",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "Club for the Broken"
+      },
+      {
+        "order": 2,
+        "title": "Icarus"
+      },
+      {
+        "order": 3,
+        "title": "Obsessed"
+      },
+      {
+        "order": 4,
+        "title": "Goddess"
+      },
+      {
+        "order": 5,
+        "title": "Verified Beauty"
+      },
+      {
+        "order": 6,
+        "title": "BURN"
+      }
+    ],
+    "spotify_url": null,
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz EP seed with 6 tracks."
+  },
+  {
+    "group": "ATEEZ",
+    "release_title": "Choose",
+    "release_date": "2025-11-17",
+    "stream": "song",
+    "release_kind": "single",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "Choose"
+      }
+    ],
+    "spotify_url": null,
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz SINGLE seed with 1 track."
+  },
+  {
+    "group": "ATEEZ",
+    "release_title": "GOLDEN HOUR : Part.4",
+    "release_date": "2026-02-06",
+    "stream": "album",
+    "release_kind": "ep",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "Ghost"
+      },
+      {
+        "order": 2,
+        "title": "Adrenaline"
+      },
+      {
+        "order": 3,
+        "title": "NASA"
+      },
+      {
+        "order": 4,
+        "title": "On the Road"
+      },
+      {
+        "order": 5,
+        "title": "Choose"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/1FBxW4I6azDVjGallQ4wQk",
+    "youtube_music_url": "https://music.youtube.com/playlist?list=OLAK5uy_nZhevv94ART20ZjqYs_TTKb1oCyyreWL8",
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz EP seed with 5 tracks. Canonical links: Spotify, YouTube Music."
+  },
+  {
+    "group": "AtHeart",
+    "release_title": "Plot Twist",
+    "release_date": "2025-08-13",
+    "stream": "album",
+    "release_kind": "ep",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "Plot Twist"
+      },
+      {
+        "order": 2,
+        "title": "Push Back"
+      },
+      {
+        "order": 3,
+        "title": "Dot Dot Dot..."
+      },
+      {
+        "order": 4,
+        "title": "Knew Me"
+      },
+      {
+        "order": 5,
+        "title": "Good Girl (AtHeart)"
+      }
+    ],
+    "spotify_url": null,
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz EP seed with 5 tracks."
+  },
+  {
+    "group": "AtHeart",
+    "release_title": "Shut Up",
+    "release_date": "2026-02-26",
+    "stream": "song",
+    "release_kind": "single",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "Shut Up"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/13N8MLxKX3V8AiIRYVZC2q",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz SINGLE seed with 1 track. Canonical links: Spotify."
+  },
+  {
+    "group": "BABYMONSTER",
+    "release_title": "HOT SAUCE",
+    "release_date": "2025-07-01",
+    "stream": "song",
+    "release_kind": "single",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "HOT SAUCE"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/5kTDyVVuvyPJZX1MlXiBvW",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz SINGLE seed with 1 track. Canonical links: Spotify."
+  },
+  {
+    "group": "BABYMONSTER",
+    "release_title": "WE GO UP",
+    "release_date": "2025-10-10",
+    "stream": "album",
+    "release_kind": "ep",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "WE GO UP"
+      },
+      {
+        "order": 2,
+        "title": "PSYCHO"
+      },
+      {
+        "order": 3,
+        "title": "SUPA DUPA LUV"
+      },
+      {
+        "order": 4,
+        "title": "WILD"
+      }
+    ],
+    "spotify_url": null,
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz EP seed with 4 tracks."
+  },
+  {
+    "group": "BADVILLAIN",
+    "release_title": "THRILLER",
+    "release_date": "2025-09-15",
+    "stream": "song",
+    "release_kind": "single",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "THRILLER"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/3WDzrUo4IO2A3ScJh6LWTW",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz SINGLE seed with 1 track. Canonical links: Spotify."
+  },
+  {
+    "group": "BAE173",
+    "release_title": "What’s wrong?",
+    "release_date": "2025-10-03",
+    "stream": "song",
+    "release_kind": "single",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "What’s wrong?"
+      }
+    ],
+    "spotify_url": null,
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz SINGLE seed with 1 track."
+  },
+  {
+    "group": "BAE173",
+    "release_title": "NEW CHAPTER : DESEAR",
+    "release_date": "2025-10-14",
+    "stream": "album",
+    "release_kind": "ep",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "Turned Up"
+      },
+      {
+        "order": 2,
+        "title": "Snap"
+      },
+      {
+        "order": 3,
+        "title": "BLACKOUT"
+      },
+      {
+        "order": 4,
+        "title": "WHAT"
+      },
+      {
+        "order": 5,
+        "title": "NOBODY"
+      },
+      {
+        "order": 6,
+        "title": "BAE (Before Anyone Else)"
+      }
+    ],
+    "spotify_url": null,
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz EP seed with 6 tracks."
+  },
+  {
+    "group": "BLACKPINK",
+    "release_title": "뛰어 (JUMP)",
+    "release_date": "2025-07-11",
+    "stream": "song",
+    "release_kind": "single",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "뛰어 (JUMP)"
+      }
+    ],
+    "spotify_url": null,
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz SINGLE seed with 1 track."
+  },
+  {
+    "group": "BLACKPINK",
+    "release_title": "DEADLINE",
+    "release_date": "2026-02-26",
+    "stream": "album",
+    "release_kind": "ep",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "JUMP"
+      },
+      {
+        "order": 2,
+        "title": "GO"
+      },
+      {
+        "order": 3,
+        "title": "Me and my"
+      },
+      {
+        "order": 4,
+        "title": "Champion"
+      },
+      {
+        "order": 5,
+        "title": "Fxxxboy"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/0al74j1n8XIEkZMMFRfsbx",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz EP seed with 5 tracks. Canonical links: Spotify."
+  },
+  {
+    "group": "BOYNEXTDOOR",
+    "release_title": "BOYLIFE",
+    "release_date": "2025-08-20",
+    "stream": "song",
+    "release_kind": "single",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "Count To Love"
+      },
+      {
+        "order": 2,
+        "title": "I Feel Good (Japanese Ver.)"
+      },
+      {
+        "order": 3,
+        "title": "Nice Guy (Japanese Ver.)"
+      },
+      {
+        "order": 4,
+        "title": "Dangerous (Japanese Ver.)"
+      }
+    ],
+    "spotify_url": null,
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz SINGLE seed with 4 tracks."
+  },
+  {
+    "group": "BOYNEXTDOOR",
+    "release_title": "The Action",
+    "release_date": "2025-10-20",
+    "stream": "album",
+    "release_kind": "ep",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "Live In Paris"
+      },
+      {
+        "order": 2,
+        "title": "Hollywood Action"
+      },
+      {
+        "order": 3,
+        "title": "JAM!"
+      },
+      {
+        "order": 4,
+        "title": "Bathroom"
+      },
+      {
+        "order": 5,
+        "title": "As Time Goes By"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/6NKAKKTVPPE85NIDY9u6QD",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz EP seed with 5 tracks. Canonical links: Spotify."
+  },
+  {
+    "group": "CIX",
+    "release_title": "GO Chapter 1: GO Together",
+    "release_date": "2025-09-08",
+    "stream": "album",
+    "release_kind": "ep",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "S.O.S"
+      },
+      {
+        "order": 2,
+        "title": "WONDER YOU"
+      },
+      {
+        "order": 3,
+        "title": "UPSTANDER"
+      },
+      {
+        "order": 4,
+        "title": "IN MY DREAMS"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/5dhQSeZvL4WtRwi4CaQBb6",
+    "youtube_music_url": "https://music.youtube.com/playlist?list=OLAK5uy_k9wDCgWNvMX8z-De0Y4xpSUxoiCi52XMk",
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz EP seed with 4 tracks. Canonical links: Spotify, YouTube Music."
+  },
+  {
+    "group": "CRAVITY",
+    "release_title": "Dare to Crave",
+    "release_date": "2025-06-23",
+    "stream": "album",
+    "release_kind": "album",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "On My Way"
+      },
+      {
+        "order": 2,
+        "title": "SWISH"
+      },
+      {
+        "order": 3,
+        "title": "SET NET G0?!"
+      },
+      {
+        "order": 4,
+        "title": "Rendez‐vous"
+      },
+      {
+        "order": 5,
+        "title": "PARANOIA"
+      },
+      {
+        "order": 6,
+        "title": "Straight Up to Heaven (Sung by JUNGMO, WOOBIN, SEONGMIN)"
+      },
+      {
+        "order": 7,
+        "title": "Stadium (Sung by ALLEN, WONJIN, HYEONGJUN)"
+      },
+      {
+        "order": 8,
+        "title": "Marionette (Sung by SERIM, MINHEE, TAEYOUNG)"
+      },
+      {
+        "order": 9,
+        "title": "Underdog"
+      },
+      {
+        "order": 10,
+        "title": "Click, Flash, Pow"
+      },
+      {
+        "order": 11,
+        "title": "Love Me Again"
+      },
+      {
+        "order": 12,
+        "title": "Wish Upon a Star"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/5dsLiHjDY0eNIN8iEhNuy5",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz ALBUM seed with 12 tracks. Canonical links: Spotify."
+  },
+  {
+    "group": "DAY6",
+    "release_title": "The DECADE",
+    "release_date": "2025-09-05",
+    "stream": "album",
+    "release_kind": "album",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "꿈의 버스"
+      },
+      {
+        "order": 2,
+        "title": "INSIDE OUT"
+      },
+      {
+        "order": 3,
+        "title": "해야 뜨지 말아 줘"
+      },
+      {
+        "order": 4,
+        "title": "Disco Day"
+      },
+      {
+        "order": 5,
+        "title": "My Way"
+      },
+      {
+        "order": 6,
+        "title": "별들 앞에서"
+      },
+      {
+        "order": 7,
+        "title": "Take All My Heart"
+      },
+      {
+        "order": 8,
+        "title": "날아라! 드림라이더"
+      },
+      {
+        "order": 9,
+        "title": "드디어 끝나갑니다"
+      },
+      {
+        "order": 10,
+        "title": "우리의 계절"
+      }
+    ],
+    "spotify_url": null,
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz ALBUM seed with 10 tracks."
+  },
+  {
+    "group": "DKB",
+    "release_title": "Emotion",
+    "release_date": "2025-10-23",
+    "stream": "album",
+    "release_kind": "ep",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "Irony"
+      },
+      {
+        "order": 2,
+        "title": "Snake"
+      },
+      {
+        "order": 3,
+        "title": "Weekend"
+      },
+      {
+        "order": 4,
+        "title": "Cinderella"
+      },
+      {
+        "order": 5,
+        "title": "Hello, Goodbye (Rollercoaster)"
+      }
+    ],
+    "spotify_url": null,
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz EP seed with 5 tracks."
+  },
+  {
+    "group": "ENHYPEN",
+    "release_title": "宵 -YOI-",
+    "release_date": "2025-07-27",
+    "stream": "song",
+    "release_kind": "single",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "Shine on Me"
+      },
+      {
+        "order": 2,
+        "title": "Echoes"
+      },
+      {
+        "order": 3,
+        "title": "Bad Desire (With or Without You) (Japanese Ver.)"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/3SbFks7Ke2crP3O0RpfDEF",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz SINGLE seed with 3 tracks. Canonical links: Spotify."
+  },
+  {
+    "group": "ENHYPEN",
+    "release_title": "THE SIN : VANISH",
+    "release_date": "2026-01-16",
+    "stream": "album",
+    "release_kind": "ep",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "The Beginning"
+      },
+      {
+        "order": 2,
+        "title": "No Way Back"
+      },
+      {
+        "order": 3,
+        "title": "The Fugitives"
+      },
+      {
+        "order": 4,
+        "title": "Knife"
+      },
+      {
+        "order": 5,
+        "title": "Stealer"
+      },
+      {
+        "order": 6,
+        "title": "The Voice"
+      },
+      {
+        "order": 7,
+        "title": "Witnesses"
+      },
+      {
+        "order": 8,
+        "title": "Big Girls Don't Cry"
+      },
+      {
+        "order": 9,
+        "title": "Lost Island"
+      },
+      {
+        "order": 10,
+        "title": "Sleep Tight"
+      },
+      {
+        "order": 11,
+        "title": "The Beyond"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/4h3umvQDxwVMlZ7Adtc8Ad",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz EP seed with 11 tracks. Canonical links: Spotify."
+  },
+  {
+    "group": "EPEX",
+    "release_title": "Youth Chapter 3 : ROMANTIC YOUTH",
+    "release_date": "2025-07-28",
+    "stream": "album",
+    "release_kind": "album",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "Waffle"
+      },
+      {
+        "order": 2,
+        "title": "Bang"
+      },
+      {
+        "order": 3,
+        "title": "Picasso"
+      },
+      {
+        "order": 4,
+        "title": "Grateful to Tears"
+      },
+      {
+        "order": 5,
+        "title": "Dances with Wolves"
+      },
+      {
+        "order": 6,
+        "title": "Morning to midnight"
+      },
+      {
+        "order": 7,
+        "title": "Whale fall"
+      },
+      {
+        "order": 8,
+        "title": "Pluto"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/4ifOrn2Qb0xwCTY44o7XCQ",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz ALBUM seed with 8 tracks. Canonical links: Spotify."
+  },
+  {
+    "group": "EVNNE",
+    "release_title": "LOVE ANECDOTE(S)",
+    "release_date": "2025-08-04",
+    "stream": "album",
+    "release_kind": "ep",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "dirtybop"
+      },
+      {
+        "order": 2,
+        "title": "How Can I Do"
+      },
+      {
+        "order": 3,
+        "title": "Mako"
+      },
+      {
+        "order": 4,
+        "title": "love chat"
+      },
+      {
+        "order": 5,
+        "title": "PUT IT ON ME"
+      },
+      {
+        "order": 6,
+        "title": "Newest"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/0hffupnkBt5Q4tP7kf2713",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz EP seed with 6 tracks. Canonical links: Spotify."
+  },
+  {
+    "group": "EXO",
+    "release_title": "I'm Home",
+    "release_date": "2025-12-13",
+    "stream": "song",
+    "release_kind": "single",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "I'm Home"
+      }
+    ],
+    "spotify_url": null,
+    "youtube_music_url": null,
+    "youtube_video_id": "7hTbNeHqGD8",
+    "notes": "Representative MusicBrainz SINGLE seed with 1 track."
+  },
+  {
+    "group": "EXO",
+    "release_title": "REVERXE",
+    "release_date": "2026-01-19",
+    "stream": "album",
+    "release_kind": "album",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "Crown"
+      },
+      {
+        "order": 2,
+        "title": "Back It Up"
+      },
+      {
+        "order": 3,
+        "title": "Crazy"
+      },
+      {
+        "order": 4,
+        "title": "Suffocate"
+      },
+      {
+        "order": 5,
+        "title": "Moonlight Shadows"
+      },
+      {
+        "order": 6,
+        "title": "Back Pocket"
+      },
+      {
+        "order": 7,
+        "title": "Touch & Go"
+      },
+      {
+        "order": 8,
+        "title": "Flatline"
+      },
+      {
+        "order": 9,
+        "title": "I’m Home"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/4ZXDMoZKLnkxFyqRGmCLnB",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz ALBUM seed with 9 tracks. Canonical links: Spotify."
+  },
+  {
+    "group": "FIFTY FIFTY",
+    "release_title": "TAKE MY HAND",
+    "release_date": "2025-08-22",
+    "stream": "song",
+    "release_kind": "single",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "TAKE MY HAND"
+      },
+      {
+        "order": 2,
+        "title": "TAKE MY HAND (instrumental)"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/03AsWUHNl2Hh9JPF3Y66ds",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz SINGLE seed with 2 tracks. Canonical links: Spotify."
+  },
+  {
+    "group": "FIFTY FIFTY",
+    "release_title": "Too Much Part 1",
+    "release_date": "2025-11-04",
+    "stream": "album",
+    "release_kind": "ep",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "가위바위보 (Eeny meeny miny moe)"
+      },
+      {
+        "order": 2,
+        "title": "Skittlez"
+      },
+      {
+        "order": 3,
+        "title": "가위바위보 (Eeny meeny miny moe) (Eng ver.)"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/0spXOvUlUo1EUDs13nlXki",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz EP seed with 3 tracks. Canonical links: Spotify."
+  },
+  {
+    "group": "fromis_9",
+    "release_title": "From Our 20’s",
+    "release_date": "2025-06-25",
+    "stream": "album",
+    "release_kind": "ep",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "LIKE YOU BETTER"
+      },
+      {
+        "order": 2,
+        "title": "REBELUTIONAL"
+      },
+      {
+        "order": 3,
+        "title": "Love=Disaster"
+      },
+      {
+        "order": 4,
+        "title": "Strawberry Mimosa"
+      },
+      {
+        "order": 5,
+        "title": "Twisted Love"
+      },
+      {
+        "order": 6,
+        "title": "Merry Go Round"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/3jGURiEnUi4OoN879bBz0V",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz EP seed with 6 tracks. Canonical links: Spotify."
+  },
+  {
+    "group": "fromis_9",
+    "release_title": "White Memories",
+    "release_date": "2025-12-02",
+    "stream": "song",
+    "release_kind": "single",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "White Memories"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/4vnA4ZWgxrhxy5doVCGv9u",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz SINGLE seed with 1 track. Canonical links: Spotify."
+  },
+  {
+    "group": "H1-KEY",
+    "release_title": "Lovestruck",
+    "release_date": "2025-06-26",
+    "stream": "album",
+    "release_kind": "ep",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "Good for U"
+      },
+      {
+        "order": 2,
+        "title": "Summer Was You"
+      },
+      {
+        "order": 3,
+        "title": "One, Two, Three, Four"
+      },
+      {
+        "order": 4,
+        "title": "Let Me Be Your Sea"
+      },
+      {
+        "order": 5,
+        "title": "Summer Was You (instrumental)"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/21oMWx3BnmfTOy2zqzxJwt",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz EP seed with 5 tracks. Canonical links: Spotify."
+  },
+  {
+    "group": "H1-KEY",
+    "release_title": "세상은 영화 같지 않더라",
+    "release_date": "2026-01-05",
+    "stream": "song",
+    "release_kind": "single",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "세상은 영화 같지 않더라"
+      }
+    ],
+    "spotify_url": null,
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz SINGLE seed with 1 track."
+  },
+  {
+    "group": "Hearts2Hearts",
+    "release_title": "FOCUS",
+    "release_date": "2025-10-20",
+    "stream": "album",
+    "release_kind": "ep",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "FOCUS"
+      },
+      {
+        "order": 2,
+        "title": "Apple Pie"
+      },
+      {
+        "order": 3,
+        "title": "Pretty Please"
+      },
+      {
+        "order": 4,
+        "title": "Flutter"
+      },
+      {
+        "order": 5,
+        "title": "Blue Moon"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/0SVlu6q116wFO1m4EZ088b",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz EP seed with 5 tracks. Canonical links: Spotify."
+  },
+  {
+    "group": "Hearts2Hearts",
+    "release_title": "RUDE!",
+    "release_date": "2026-02-20",
+    "stream": "song",
+    "release_kind": "single",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "RUDE!"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/3053E9tumiU5rqbAPWF06s",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz SINGLE seed with 1 track. Canonical links: Spotify."
+  },
+  {
+    "group": "ifeye",
+    "release_title": "sweet tang",
+    "release_date": "2025-07-16",
+    "stream": "album",
+    "release_kind": "ep",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "loverboy"
+      },
+      {
+        "order": 2,
+        "title": "friend like me"
+      },
+      {
+        "order": 3,
+        "title": "round and round"
+      },
+      {
+        "order": 4,
+        "title": "ifeye (interlude)"
+      },
+      {
+        "order": 5,
+        "title": "r u ok?"
+      },
+      {
+        "order": 6,
+        "title": "say moo!"
+      },
+      {
+        "order": 7,
+        "title": "echo"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/464og3a6TdySFWC2hEq1TW",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz EP seed with 7 tracks. Canonical links: Spotify."
+  },
+  {
+    "group": "ITZY",
+    "release_title": "TUNNEL VISION",
+    "release_date": "2025-11-10",
+    "stream": "album",
+    "release_kind": "ep",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "Focus"
+      },
+      {
+        "order": 2,
+        "title": "TUNNEL VISION"
+      },
+      {
+        "order": 3,
+        "title": "DYT"
+      },
+      {
+        "order": 4,
+        "title": "Flicker"
+      },
+      {
+        "order": 5,
+        "title": "Nocturne"
+      },
+      {
+        "order": 6,
+        "title": "8‐BIT HEART"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/7CD7NdEDOMY5Owl9MEzgRw",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz EP seed with 6 tracks. Canonical links: Spotify."
+  },
+  {
+    "group": "IVE",
+    "release_title": "BANG BANG",
+    "release_date": "2026-02-09",
+    "stream": "song",
+    "release_kind": "single",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "BANG BANG"
+      }
+    ],
+    "spotify_url": null,
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz SINGLE seed with 1 track."
+  },
+  {
+    "group": "IVE",
+    "release_title": "REVIVE+",
+    "release_date": "2026-02-23",
+    "stream": "album",
+    "release_kind": "album",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "BLACKHOLE"
+      },
+      {
+        "order": 2,
+        "title": "BANG BANG"
+      },
+      {
+        "order": 3,
+        "title": "숨바꼭질 (Hush)"
+      },
+      {
+        "order": 4,
+        "title": "악성코드 (Stuck in Your Head)"
+      },
+      {
+        "order": 5,
+        "title": "Fireworks"
+      },
+      {
+        "order": 6,
+        "title": "HOT COFFEE"
+      },
+      {
+        "order": 7,
+        "title": "8"
+      },
+      {
+        "order": 8,
+        "title": "Odd"
+      },
+      {
+        "order": 9,
+        "title": "Super ICY"
+      },
+      {
+        "order": 10,
+        "title": "Unreal"
+      },
+      {
+        "order": 11,
+        "title": "In Your Heart"
+      },
+      {
+        "order": 12,
+        "title": "Force"
+      }
+    ],
+    "spotify_url": null,
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz ALBUM seed with 12 tracks."
+  },
+  {
+    "group": "izna",
+    "release_title": "BEEP",
+    "release_date": "2025-06-09",
+    "stream": "song",
+    "release_kind": "single",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "BEEP"
+      },
+      {
+        "order": 2,
+        "title": "BEEP (Japan Edition)"
+      }
+    ],
+    "spotify_url": null,
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz SINGLE seed with 2 tracks."
+  },
+  {
+    "group": "izna",
+    "release_title": "Not Just Pretty",
+    "release_date": "2025-09-30",
+    "stream": "album",
+    "release_kind": "ep",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "Supercrush"
+      },
+      {
+        "order": 2,
+        "title": "Mamma Mia"
+      },
+      {
+        "order": 3,
+        "title": "Racecar"
+      },
+      {
+        "order": 4,
+        "title": "In the Rain"
+      },
+      {
+        "order": 5,
+        "title": "SIGN (remix)"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/5GbFWsdf0iAbLvg2nMwxHG",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz EP seed with 5 tracks. Canonical links: Spotify."
+  },
+  {
+    "group": "KARD",
+    "release_title": "DRIFT",
+    "release_date": "2025-07-02",
+    "stream": "album",
+    "release_kind": "ep",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "BETCHA"
+      },
+      {
+        "order": 2,
+        "title": "Touch"
+      },
+      {
+        "order": 3,
+        "title": "Before We Go"
+      },
+      {
+        "order": 4,
+        "title": "Top Down"
+      },
+      {
+        "order": 5,
+        "title": "Pivot"
+      },
+      {
+        "order": 6,
+        "title": "Touch (instrumental)"
+      },
+      {
+        "order": 7,
+        "title": "Pivot (instrumental)"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/20n7NJgj2ZOi1YJ85KEkhq",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz EP seed with 7 tracks. Canonical links: Spotify."
+  },
+  {
+    "group": "Kep1er",
+    "release_title": "BUBBLE GUM",
+    "release_date": "2025-08-19",
+    "stream": "album",
+    "release_kind": "ep",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "Taste Better"
+      },
+      {
+        "order": 2,
+        "title": "BUBBLE GUM"
+      },
+      {
+        "order": 3,
+        "title": "Don′t Be Dumb"
+      },
+      {
+        "order": 4,
+        "title": "Ice Tea"
+      },
+      {
+        "order": 5,
+        "title": "Yum (KOR ver.)"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/3pKcgDJmV3GZwgElcupVrg",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz EP seed with 5 tracks. Canonical links: Spotify."
+  },
+  {
+    "group": "KickFlip",
+    "release_title": "My First Flip",
+    "release_date": "2025-09-22",
+    "stream": "album",
+    "release_kind": "ep",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "My First Love Song"
+      },
+      {
+        "order": 2,
+        "title": "Band‐Aid"
+      },
+      {
+        "order": 3,
+        "title": "Crush"
+      },
+      {
+        "order": 4,
+        "title": "Tiki‐taka"
+      },
+      {
+        "order": 5,
+        "title": "Gas on It"
+      },
+      {
+        "order": 6,
+        "title": "404: Not Found"
+      },
+      {
+        "order": 7,
+        "title": "Secret Nightmare"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/2oPgsxzvXORR8pnYv9mYdz",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz EP seed with 7 tracks. Canonical links: Spotify."
+  },
+  {
+    "group": "KickFlip",
+    "release_title": "From KickFlip, To WeFlip",
+    "release_date": "2026-01-20",
+    "stream": "song",
+    "release_kind": "single",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "Hyper Slide"
+      },
+      {
+        "order": 2,
+        "title": "Good Night"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/4VtPAHPKZD2KEgtlkG7zP1",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz SINGLE seed with 2 tracks. Canonical links: Spotify."
+  },
+  {
+    "group": "KiiiKiii",
+    "release_title": "To Me From Me",
+    "release_date": "2025-11-04",
+    "stream": "song",
+    "release_kind": "single",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "To Me From Me"
+      }
+    ],
+    "spotify_url": null,
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz SINGLE seed with 1 track."
+  },
+  {
+    "group": "KiiiKiii",
+    "release_title": "Delulu Pack",
+    "release_date": "2026-01-25",
+    "stream": "album",
+    "release_kind": "ep",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "Delulu"
+      },
+      {
+        "order": 2,
+        "title": "404 (New Era)"
+      },
+      {
+        "order": 3,
+        "title": "UNDERDOGS"
+      },
+      {
+        "order": 4,
+        "title": "MUNGNYANG"
+      },
+      {
+        "order": 5,
+        "title": "Dizzy"
+      },
+      {
+        "order": 6,
+        "title": "To Me From Me"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/09YZd8EhjQjGDJbc8EUuKq",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz EP seed with 6 tracks. Canonical links: Spotify."
+  },
+  {
+    "group": "KISS OF LIFE",
+    "release_title": "TOKYO MISSION START",
+    "release_date": "2025-11-05",
+    "stream": "album",
+    "release_kind": "ep",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "Lucky"
+      },
+      {
+        "order": 2,
+        "title": "Sticky (Japanese ver.)"
+      },
+      {
+        "order": 3,
+        "title": "Midas Touch (Japanese ver.)"
+      },
+      {
+        "order": 4,
+        "title": "Shhh (Japanese ver.)"
+      },
+      {
+        "order": 5,
+        "title": "Nobody Knows (remix)"
+      },
+      {
+        "order": 6,
+        "title": "R.E.M (remix)"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/3isrBYAYBxBerWHVtjD8gE",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz EP seed with 6 tracks. Canonical links: Spotify."
+  },
+  {
+    "group": "LE SSERAFIM",
+    "release_title": "SPAGHETTI",
+    "release_date": "2025-10-24",
+    "stream": "song",
+    "release_kind": "single",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "SPAGHETTI"
+      },
+      {
+        "order": 2,
+        "title": "Pearlies (My oyster is the world)"
+      },
+      {
+        "order": 3,
+        "title": "SPAGHETTI (Member ver.)"
+      },
+      {
+        "order": 4,
+        "title": "SPAGHETTI (English ver.)"
+      },
+      {
+        "order": 5,
+        "title": "SPAGHETTI"
+      },
+      {
+        "order": 6,
+        "title": "Pearlies (My oyster is the world)"
+      },
+      {
+        "order": 7,
+        "title": "SPAGHETTI (Member ver.)"
+      },
+      {
+        "order": 8,
+        "title": "SPAGHETTI (English ver.)"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/2yUrwTLHDWBrW74Ewuw6RX",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz SINGLE seed with 8 tracks. Canonical links: Spotify."
+  },
+  {
+    "group": "LIGHTSUM",
+    "release_title": "Beautiful Pain (SANGAH, CHOWON, JUHYEON)",
+    "release_date": "2026-01-15",
+    "stream": "song",
+    "release_kind": "single",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "Beautiful Pain (SANGAH, CHOWON, JUHYEON)"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/5pPLGQ9xQA7PvD6RTLxOef",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz SINGLE seed with 1 track. Canonical links: Spotify."
+  },
+  {
+    "group": "LUN8",
+    "release_title": "LOST",
+    "release_date": "2025-09-17",
+    "stream": "song",
+    "release_kind": "single",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "Bad Girl"
+      },
+      {
+        "order": 2,
+        "title": "Lost"
+      },
+      {
+        "order": 3,
+        "title": "Nauty"
+      }
+    ],
+    "spotify_url": null,
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz SINGLE seed with 3 tracks."
+  },
+  {
+    "group": "MEOVV",
+    "release_title": "BURNING UP",
+    "release_date": "2025-10-14",
+    "stream": "song",
+    "release_kind": "single",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "BURNING UP"
+      }
+    ],
+    "spotify_url": null,
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz SINGLE seed with 1 track."
+  },
+  {
+    "group": "MONSTA X",
+    "release_title": "THE X",
+    "release_date": "2025-09-01",
+    "stream": "album",
+    "release_kind": "ep",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "Do What I Want"
+      },
+      {
+        "order": 2,
+        "title": "N the Front"
+      },
+      {
+        "order": 3,
+        "title": "Savior"
+      },
+      {
+        "order": 4,
+        "title": "Tuscan Leather"
+      },
+      {
+        "order": 5,
+        "title": "Catch Me Now"
+      },
+      {
+        "order": 6,
+        "title": "Fire & Ice"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/3BUEab50RO1tf709W4EMcL",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz EP seed with 6 tracks. Canonical links: Spotify."
+  },
+  {
+    "group": "MONSTA X",
+    "release_title": "growing pains",
+    "release_date": "2026-02-06",
+    "stream": "song",
+    "release_kind": "single",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "growing pains"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/6eH7d6D70X0IbAGHBFP9yj",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz SINGLE seed with 1 track. Canonical links: Spotify."
+  },
+  {
+    "group": "NCT DREAM",
+    "release_title": "Beat It Up",
+    "release_date": "2025-11-17",
+    "stream": "album",
+    "release_kind": "ep",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "Beat It Up"
+      },
+      {
+        "order": 2,
+        "title": "Rush"
+      },
+      {
+        "order": 3,
+        "title": "Cold Coffee"
+      },
+      {
+        "order": 4,
+        "title": "Butterflies"
+      },
+      {
+        "order": 5,
+        "title": "Tempo"
+      },
+      {
+        "order": 6,
+        "title": "TRICKY"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/7jd5hUsxFPUsM0dqfpRjmp",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz EP seed with 6 tracks. Canonical links: Spotify."
+  },
+  {
+    "group": "NCT WISH",
+    "release_title": "WISHLIST",
+    "release_date": "2026-01-14",
+    "stream": "album",
+    "release_kind": "ep",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "Hello Mellow"
+      },
+      {
+        "order": 2,
+        "title": "ZONE"
+      },
+      {
+        "order": 3,
+        "title": "BUBBLE GUM"
+      },
+      {
+        "order": 4,
+        "title": "Dreamcatcher"
+      },
+      {
+        "order": 5,
+        "title": "SOMEDAY"
+      },
+      {
+        "order": 6,
+        "title": "Good Morning"
+      },
+      {
+        "order": 7,
+        "title": "poppop (Japanese ver.)"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/0AbenVXd5ypXotWe1z0ytw",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz EP seed with 7 tracks. Canonical links: Spotify."
+  },
+  {
+    "group": "NCT WISH",
+    "release_title": "Same Sky",
+    "release_date": "2026-02-27",
+    "stream": "song",
+    "release_kind": "single",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "Same Sky"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/5w10bOkr3HsPSp0nl1R0ff",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz SINGLE seed with 1 track. Canonical links: Spotify."
+  },
+  {
+    "group": "NEXZ",
+    "release_title": "Beat‐Boxer",
+    "release_date": "2025-10-27",
+    "stream": "album",
+    "release_kind": "ep",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "Legacy"
+      },
+      {
+        "order": 2,
+        "title": "Beat‐Boxer"
+      },
+      {
+        "order": 3,
+        "title": "I’m Him"
+      },
+      {
+        "order": 4,
+        "title": "Co‐Star"
+      },
+      {
+        "order": 5,
+        "title": "Next to Me"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/2iI33V0gbSII6iuEfq65fE",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz EP seed with 5 tracks. Canonical links: Spotify."
+  },
+  {
+    "group": "NMIXX",
+    "release_title": "Blue Valentine",
+    "release_date": "2025-10-13",
+    "stream": "album",
+    "release_kind": "album",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "Blue Valentine"
+      },
+      {
+        "order": 2,
+        "title": "SPINNIN’ ON IT"
+      },
+      {
+        "order": 3,
+        "title": "Phoenix"
+      },
+      {
+        "order": 4,
+        "title": "Reality Hurts"
+      },
+      {
+        "order": 5,
+        "title": "RICO"
+      },
+      {
+        "order": 6,
+        "title": "Game Face"
+      },
+      {
+        "order": 7,
+        "title": "PODIUM"
+      },
+      {
+        "order": 8,
+        "title": "Crush on You"
+      },
+      {
+        "order": 9,
+        "title": "ADORE U"
+      },
+      {
+        "order": 10,
+        "title": "Shape of Love"
+      },
+      {
+        "order": 11,
+        "title": "O.O, Part 1 (Baila)"
+      },
+      {
+        "order": 12,
+        "title": "O.O, Part 2 (Superhero)"
+      }
+    ],
+    "spotify_url": null,
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz ALBUM seed with 12 tracks."
+  },
+  {
+    "group": "NMIXX",
+    "release_title": "TIC TIC",
+    "release_date": "2026-02-26",
+    "stream": "song",
+    "release_kind": "single",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "TIC TIC"
+      }
+    ],
+    "spotify_url": null,
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz SINGLE seed with 1 track."
+  },
+  {
+    "group": "ONEUS",
+    "release_title": "5x",
+    "release_date": "2025-06-30",
+    "stream": "album",
+    "release_kind": "ep",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "X"
+      },
+      {
+        "order": 2,
+        "title": "LOVE ME or LOSER"
+      },
+      {
+        "order": 3,
+        "title": "RELOAD"
+      },
+      {
+        "order": 4,
+        "title": "BAD"
+      },
+      {
+        "order": 5,
+        "title": "TIME MACHINE (Korean ver.)"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/549FaK4UMSSCdbxKVLWaYL",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz EP seed with 5 tracks. Canonical links: Spotify."
+  },
+  {
+    "group": "ONEUS",
+    "release_title": "原",
+    "release_date": "2026-01-20",
+    "stream": "song",
+    "release_kind": "single",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "Grenade"
+      },
+      {
+        "order": 2,
+        "title": "STOP & MOVE"
+      },
+      {
+        "order": 3,
+        "title": "When you're close to me"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/4qTTzaU30PLhLJmD6lLzFm",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz SINGLE seed with 3 tracks. Canonical links: Spotify."
+  },
+  {
+    "group": "ONEWE",
+    "release_title": "MAZE : AD ASTRA",
+    "release_date": "2025-10-07",
+    "stream": "album",
+    "release_kind": "ep",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "Lucky 12"
+      },
+      {
+        "order": 2,
+        "title": "MAZE"
+      },
+      {
+        "order": 3,
+        "title": "UFO"
+      },
+      {
+        "order": 4,
+        "title": "Hide & Seek"
+      },
+      {
+        "order": 5,
+        "title": "Trace"
+      },
+      {
+        "order": 6,
+        "title": "Diary"
+      },
+      {
+        "order": 7,
+        "title": "Beyond the Storm"
+      }
+    ],
+    "spotify_url": null,
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz EP seed with 7 tracks."
+  },
+  {
+    "group": "ONF",
+    "release_title": "Summer Light",
+    "release_date": "2025-08-03",
+    "stream": "song",
+    "release_kind": "single",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "Summer Light"
+      },
+      {
+        "order": 2,
+        "title": "Summer Light (Inst.)"
+      }
+    ],
+    "spotify_url": null,
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz SINGLE seed with 2 tracks."
+  },
+  {
+    "group": "P1Harmony",
+    "release_title": "EX",
+    "release_date": "2025-09-26",
+    "stream": "album",
+    "release_kind": "ep",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "EX"
+      },
+      {
+        "order": 2,
+        "title": "Dancing Queen"
+      },
+      {
+        "order": 3,
+        "title": "Stupid Brain"
+      },
+      {
+        "order": 4,
+        "title": "Night of My Life"
+      },
+      {
+        "order": 5,
+        "title": "EX (Spanish version)"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/4fUrVp1xhJvcJfxYLlJiNm",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz EP seed with 5 tracks. Canonical links: Spotify."
+  },
+  {
+    "group": "PLAVE",
+    "release_title": "PLBBUU",
+    "release_date": "2025-11-10",
+    "stream": "song",
+    "release_kind": "single",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "BBUU!"
+      },
+      {
+        "order": 2,
+        "title": "숨바꼭질 (Hide and Seek)"
+      },
+      {
+        "order": 3,
+        "title": "Bongsoong-a"
+      }
+    ],
+    "spotify_url": null,
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz SINGLE seed with 3 tracks."
+  },
+  {
+    "group": "POW",
+    "release_title": "Wall Flowers",
+    "release_date": "2025-09-29",
+    "stream": "song",
+    "release_kind": "single",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "Wall Flowers"
+      }
+    ],
+    "spotify_url": null,
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz SINGLE seed with 1 track."
+  },
+  {
+    "group": "Purple Kiss",
+    "release_title": "OUR NOW",
+    "release_date": "2025-08-31",
+    "stream": "album",
+    "release_kind": "album",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "DOREMI (English ver.)"
+      },
+      {
+        "order": 2,
+        "title": "WANT U BACK"
+      },
+      {
+        "order": 3,
+        "title": "Unhappily Ever After"
+      },
+      {
+        "order": 4,
+        "title": "Ponzona (English ver.)"
+      },
+      {
+        "order": 5,
+        "title": "Zombie (English ver.)"
+      },
+      {
+        "order": 6,
+        "title": "memeM (English ver.)"
+      },
+      {
+        "order": 7,
+        "title": "Sweet Juice (English ver.)"
+      },
+      {
+        "order": 8,
+        "title": "7HEAVEN (English ver.)"
+      }
+    ],
+    "spotify_url": null,
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz ALBUM seed with 8 tracks."
+  },
+  {
+    "group": "Purple Kiss",
+    "release_title": "A Violet to Remember",
+    "release_date": "2025-11-16",
+    "stream": "song",
+    "release_kind": "single",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "Breath"
+      },
+      {
+        "order": 2,
+        "title": "Breath (inst.)"
+      }
+    ],
+    "spotify_url": null,
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz SINGLE seed with 2 tracks."
+  },
+  {
+    "group": "QWER",
+    "release_title": "In a million noises, I’ll be your harmony",
+    "release_date": "2025-06-09",
+    "stream": "album",
+    "release_kind": "ep",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "눈물참기"
+      },
+      {
+        "order": 2,
+        "title": "행복해져라"
+      },
+      {
+        "order": 3,
+        "title": "검색어는 QWER"
+      },
+      {
+        "order": 4,
+        "title": "OVERDRIVE"
+      },
+      {
+        "order": 5,
+        "title": "D‐Day"
+      },
+      {
+        "order": 6,
+        "title": "Yours Sincerely"
+      }
+    ],
+    "spotify_url": null,
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz EP seed with 6 tracks."
+  },
+  {
+    "group": "QWER",
+    "release_title": "흰수염고래",
+    "release_date": "2025-10-06",
+    "stream": "song",
+    "release_kind": "single",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "흰수염고래"
+      }
+    ],
+    "spotify_url": null,
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz SINGLE seed with 1 track."
+  },
+  {
+    "group": "RESCENE",
+    "release_title": "lip bomb",
+    "release_date": "2025-11-25",
+    "stream": "album",
+    "release_kind": "ep",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "Heart Drop"
+      },
+      {
+        "order": 2,
+        "title": "Bloom"
+      },
+      {
+        "order": 3,
+        "title": "Love Echo"
+      },
+      {
+        "order": 4,
+        "title": "Hello XO"
+      },
+      {
+        "order": 5,
+        "title": "MVP"
+      }
+    ],
+    "spotify_url": null,
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz EP seed with 5 tracks."
+  },
+  {
+    "group": "RESCENE",
+    "release_title": "[RESCENE X ???]",
+    "release_date": "2026-02-27",
+    "stream": "song",
+    "release_kind": "single",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "Busy boy"
+      },
+      {
+        "order": 2,
+        "title": "Busy boy - inst."
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/0dbuXh0XcMsrgQsVep3jAk",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz SINGLE seed with 2 tracks. Canonical links: Spotify."
+  },
+  {
+    "group": "RIIZE",
+    "release_title": "All of You",
+    "release_date": "2026-02-09",
+    "stream": "song",
+    "release_kind": "single",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "All of You"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/2BOIZjVSfiQDntgqzE94PI",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz SINGLE seed with 1 track. Canonical links: Spotify."
+  },
+  {
+    "group": "SAY MY NAME",
+    "release_title": "iLy",
+    "release_date": "2025-08-01",
+    "stream": "song",
+    "release_kind": "single",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "iLy"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/3fbsZjl86xqxaDmuXCDmV0",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz SINGLE seed with 1 track. Canonical links: Spotify."
+  },
+  {
+    "group": "SAY MY NAME",
+    "release_title": "&Our Vibe",
+    "release_date": "2025-12-29",
+    "stream": "album",
+    "release_kind": "ep",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "Bad Idea"
+      },
+      {
+        "order": 2,
+        "title": "UFO (ATTENT!ON)"
+      },
+      {
+        "order": 3,
+        "title": "Delulu Solulu"
+      },
+      {
+        "order": 4,
+        "title": "Hard to Love"
+      },
+      {
+        "order": 5,
+        "title": "SAY MY NAME"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/52f4wYBg1SDSaMMwZ5u3OF",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz EP seed with 5 tracks. Canonical links: Spotify."
+  },
+  {
+    "group": "SEVENTEEN",
+    "release_title": "Where love passed",
+    "release_date": "2025-07-14",
+    "stream": "song",
+    "release_kind": "single",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "Where love passed"
+      }
+    ],
+    "spotify_url": null,
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz SINGLE seed with 1 track."
+  },
+  {
+    "group": "STAYC",
+    "release_title": "I WANT IT",
+    "release_date": "2025-07-23",
+    "stream": "song",
+    "release_kind": "single",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "I WANT IT"
+      },
+      {
+        "order": 2,
+        "title": "BOY"
+      },
+      {
+        "order": 3,
+        "title": "반칙(Honestly)"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/252AHBq3W65lTnnELHIi4y",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz SINGLE seed with 3 tracks. Canonical links: Spotify."
+  },
+  {
+    "group": "STAYC",
+    "release_title": "STAY ALIVE",
+    "release_date": "2026-02-11",
+    "stream": "album",
+    "release_kind": "album",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "MWUAH"
+      },
+      {
+        "order": 2,
+        "title": "I WANT IT (Japanese ver.)"
+      },
+      {
+        "order": 3,
+        "title": "BEBE (Japanese ver.)"
+      },
+      {
+        "order": 4,
+        "title": "POPPY (Japanese ver.)"
+      },
+      {
+        "order": 5,
+        "title": "Teddy Bear (Japanese ver.)"
+      },
+      {
+        "order": 6,
+        "title": "ASAP (Japanese ver.)"
+      },
+      {
+        "order": 7,
+        "title": "LIT"
+      },
+      {
+        "order": 8,
+        "title": "STEREOTYPE (Japanese ver.)"
+      },
+      {
+        "order": 9,
+        "title": "Tell Me Now"
+      },
+      {
+        "order": 10,
+        "title": "Satellite"
+      },
+      {
+        "order": 11,
+        "title": "Lover, Killer"
+      },
+      {
+        "order": 12,
+        "title": "Say My Name"
+      },
+      {
+        "order": 13,
+        "title": "MEOW"
+      },
+      {
+        "order": 14,
+        "title": "GPT (Japanese ver.)"
+      },
+      {
+        "order": 15,
+        "title": "Bubble (Japanese ver.)"
+      },
+      {
+        "order": 16,
+        "title": "Cheeky Icy Thang (Japanese ver.)"
+      },
+      {
+        "order": 17,
+        "title": "Stay WITH me (Japanese ver.)"
+      }
+    ],
+    "spotify_url": null,
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz ALBUM seed with 17 tracks."
+  },
+  {
+    "group": "Stray Kids",
+    "release_title": "In The Dark",
+    "release_date": "2025-11-06",
+    "stream": "song",
+    "release_kind": "single",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "In The Dark"
+      }
+    ],
+    "spotify_url": null,
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz SINGLE seed with 1 track."
+  },
+  {
+    "group": "Stray Kids",
+    "release_title": "DO IT",
+    "release_date": "2025-11-21",
+    "stream": "album",
+    "release_kind": "ep",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "Do It"
+      },
+      {
+        "order": 2,
+        "title": "DIVINE"
+      },
+      {
+        "order": 3,
+        "title": "Holiday"
+      },
+      {
+        "order": 4,
+        "title": "Photobook"
+      },
+      {
+        "order": 5,
+        "title": "Do It (festival version)"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/4lkJ6i3LDK8HvcU2tPWX9k",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz EP seed with 5 tracks. Canonical links: Spotify."
+  },
+  {
+    "group": "TEMPEST",
+    "release_title": "As I am",
+    "release_date": "2025-10-27",
+    "stream": "album",
+    "release_kind": "ep",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "In the Dark"
+      },
+      {
+        "order": 2,
+        "title": "nocturnal"
+      },
+      {
+        "order": 3,
+        "title": "CHILL"
+      },
+      {
+        "order": 4,
+        "title": "Silly Kid"
+      },
+      {
+        "order": 5,
+        "title": "How deep is your love?"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/173YgSJe4F1sZG6pABL2zm",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz EP seed with 5 tracks. Canonical links: Spotify."
+  },
+  {
+    "group": "TEMPEST",
+    "release_title": "In the Dark (暮色独白)",
+    "release_date": "2025-11-03",
+    "stream": "song",
+    "release_kind": "single",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "In the Dark (暮色独白)"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/3lBfxuIUiLqa03MhYXpr6m",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz SINGLE seed with 1 track. Canonical links: Spotify."
+  },
+  {
+    "group": "THE BOYZ",
+    "release_title": "a;effect",
+    "release_date": "2025-07-28",
+    "stream": "album",
+    "release_kind": "ep",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "Stylish"
+      },
+      {
+        "order": 2,
+        "title": "Talk"
+      },
+      {
+        "order": 3,
+        "title": "You and I"
+      },
+      {
+        "order": 4,
+        "title": "함께라서 눈부셨던, 서툴지만 아름다운 (Constellation)"
+      },
+      {
+        "order": 5,
+        "title": "AURA"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/3NLbROSjvh9Qo0Esb3aTX0",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz EP seed with 5 tracks. Canonical links: Spotify."
+  },
+  {
+    "group": "THE BOYZ",
+    "release_title": "Still Love You",
+    "release_date": "2025-12-06",
+    "stream": "song",
+    "release_kind": "single",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "The Season"
+      },
+      {
+        "order": 2,
+        "title": "Still Love You"
+      },
+      {
+        "order": 3,
+        "title": "Together Forever"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/5NJHeBJzOo41F03PAdSBiP",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz SINGLE seed with 3 tracks. Canonical links: Spotify."
+  },
+  {
+    "group": "The KingDom",
+    "release_title": "the flower of the moon",
+    "release_date": "2025-09-23",
+    "stream": "album",
+    "release_kind": "ep",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "Last Flower"
+      },
+      {
+        "order": 2,
+        "title": "Festival"
+      },
+      {
+        "order": 3,
+        "title": "Forget"
+      },
+      {
+        "order": 4,
+        "title": "Last Flower (Instrumental)"
+      }
+    ],
+    "spotify_url": null,
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz EP seed with 4 tracks."
+  },
+  {
+    "group": "TIOT",
+    "release_title": "Run Run Barefoot",
+    "release_date": "2025-07-07",
+    "stream": "song",
+    "release_kind": "single",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "Run Run Barefoot"
+      },
+      {
+        "order": 2,
+        "title": "Run Run Barefoot (Instrumental)"
+      },
+      {
+        "order": 3,
+        "title": "Run Run Barefoot (Fast Ver.)"
+      }
+    ],
+    "spotify_url": null,
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz SINGLE seed with 3 tracks."
+  },
+  {
+    "group": "TIOT",
+    "release_title": "MY PRIDE",
+    "release_date": "2025-09-23",
+    "stream": "album",
+    "release_kind": "ep",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "I’m the One"
+      },
+      {
+        "order": 2,
+        "title": "MY PRIDE"
+      },
+      {
+        "order": 3,
+        "title": "I Don’t Wanna Wait (IDWW)"
+      },
+      {
+        "order": 4,
+        "title": "Every Ten Minutes"
+      }
+    ],
+    "spotify_url": null,
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz EP seed with 4 tracks."
+  },
+  {
+    "group": "TNX",
+    "release_title": "CALL ME BACK",
+    "release_date": "2026-01-22",
+    "stream": "song",
+    "release_kind": "single",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "CALL ME BACK"
+      },
+      {
+        "order": 2,
+        "title": "Love letter"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/4x65qm15EE2YTLUIJLX4b5",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz SINGLE seed with 2 tracks. Canonical links: Spotify."
+  },
+  {
+    "group": "TOMORROW X TOGETHER",
+    "release_title": "butterflies",
+    "release_date": "2025-07-10",
+    "stream": "song",
+    "release_kind": "single",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "butterflies"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/1Ct91vpCofv1WLTmhNeFK7",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz SINGLE seed with 1 track. Canonical links: Spotify."
+  },
+  {
+    "group": "TOMORROW X TOGETHER",
+    "release_title": "Starkissed",
+    "release_date": "2025-10-19",
+    "stream": "album",
+    "release_kind": "album",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "Intro : SPARK"
+      },
+      {
+        "order": 2,
+        "title": "Can’t Stop"
+      },
+      {
+        "order": 3,
+        "title": "Beautiful Strangers - Japanese Ver."
+      },
+      {
+        "order": 4,
+        "title": "Where Do You Go?"
+      },
+      {
+        "order": 5,
+        "title": "Deja Vu - Japanese Ver."
+      },
+      {
+        "order": 6,
+        "title": "ひとつの誓い (We’ll Never Change)"
+      },
+      {
+        "order": 7,
+        "title": "SSS (Sending Secret Signals)"
+      },
+      {
+        "order": 8,
+        "title": "きっとずっと (Kitto Zutto)"
+      },
+      {
+        "order": 9,
+        "title": "Step by Step"
+      },
+      {
+        "order": 10,
+        "title": "Rise"
+      },
+      {
+        "order": 11,
+        "title": "星の詩 - Japanese Ver."
+      },
+      {
+        "order": 12,
+        "title": "Outro : GLOW"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/6iPNWX9dibeWPMaVuhRKEw",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz ALBUM seed with 12 tracks. Canonical links: Spotify."
+  },
+  {
+    "group": "TREASURE",
+    "release_title": "LOVE PULSE",
+    "release_date": "2025-09-01",
+    "stream": "album",
+    "release_kind": "ep",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "EVERYTHING"
+      },
+      {
+        "order": 2,
+        "title": "PARADISE"
+      },
+      {
+        "order": 3,
+        "title": "NOW FOREVER"
+      },
+      {
+        "order": 4,
+        "title": "BETTER THAN ME"
+      }
+    ],
+    "spotify_url": null,
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz EP seed with 4 tracks."
+  },
+  {
+    "group": "TRENDZ",
+    "release_title": "Kart Racer",
+    "release_date": "2026-02-13",
+    "stream": "song",
+    "release_kind": "single",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "Kart Racer"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/1p3Mq5paEBsbHmv1DT55Kx",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz SINGLE seed with 1 track. Canonical links: Spotify."
+  },
+  {
+    "group": "tripleS",
+    "release_title": "msnz <Beyond Beauty>",
+    "release_date": "2025-11-24",
+    "stream": "album",
+    "release_kind": "ep",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "Magic Shine New Zone"
+      },
+      {
+        "order": 2,
+        "title": "Fly Up"
+      },
+      {
+        "order": 3,
+        "title": "Cameo Love"
+      },
+      {
+        "order": 4,
+        "title": "Bubble Gum Girl"
+      },
+      {
+        "order": 5,
+        "title": "Q&A"
+      },
+      {
+        "order": 6,
+        "title": "Christmas Alone"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/281B8RLDzA7mufE1ccVxrM",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz EP seed with 6 tracks. Canonical links: Spotify."
+  },
+  {
+    "group": "tripleS",
+    "release_title": "トキメティック",
+    "release_date": "2026-02-05",
+    "stream": "song",
+    "release_kind": "single",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "トキメティック"
+      },
+      {
+        "order": 2,
+        "title": "トキメティック Shin Sakiura Remix"
+      },
+      {
+        "order": 3,
+        "title": "トキメティック TV Edit"
+      }
+    ],
+    "spotify_url": null,
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz SINGLE seed with 3 tracks."
+  },
+  {
+    "group": "TWICE",
+    "release_title": "Like 1",
+    "release_date": "2025-08-20",
+    "stream": "song",
+    "release_kind": "single",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "Like 1"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/6m1tTBNtQtBtNeDLhVm3bO",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz SINGLE seed with 1 track. Canonical links: Spotify."
+  },
+  {
+    "group": "TWICE",
+    "release_title": "TEN: The Story Goes On",
+    "release_date": "2025-10-10",
+    "stream": "album",
+    "release_kind": "album",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "ME+YOU"
+      },
+      {
+        "order": 2,
+        "title": "MEEEEEE"
+      },
+      {
+        "order": 3,
+        "title": "FIX A DRINK"
+      },
+      {
+        "order": 4,
+        "title": "MOVE LIKE THAT"
+      },
+      {
+        "order": 5,
+        "title": "DECAFFEINATED"
+      },
+      {
+        "order": 6,
+        "title": "ATM"
+      },
+      {
+        "order": 7,
+        "title": "STONE COLD"
+      },
+      {
+        "order": 8,
+        "title": "CHESS"
+      },
+      {
+        "order": 9,
+        "title": "IN MY ROOM"
+      },
+      {
+        "order": 10,
+        "title": "DIVE IN"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/7zyibWit2LeHvy5h9utbfg",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz ALBUM seed with 10 tracks. Canonical links: Spotify."
+  },
+  {
+    "group": "TWS",
+    "release_title": "Head Shoulders Knees Toes",
+    "release_date": "2025-09-22",
+    "stream": "song",
+    "release_kind": "single",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "Head Shoulders Knees Toes"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/3D8vj2pQwvS2tIzgmgAuZN",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz SINGLE seed with 1 track. Canonical links: Spotify."
+  },
+  {
+    "group": "TWS",
+    "release_title": "play hard",
+    "release_date": "2025-10-13",
+    "stream": "album",
+    "release_kind": "ep",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "Head Shoulders Knees Toes"
+      },
+      {
+        "order": 2,
+        "title": "OVERDRIVE"
+      },
+      {
+        "order": 3,
+        "title": "HOT BLUE SHOES"
+      },
+      {
+        "order": 4,
+        "title": "Caffeine Rush"
+      },
+      {
+        "order": 5,
+        "title": "overthinking"
+      },
+      {
+        "order": 6,
+        "title": "Here for You"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/6RBnUYZIGKGDdgEnf3ta1U",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz EP seed with 6 tracks. Canonical links: Spotify."
+  },
+  {
+    "group": "UNIS",
+    "release_title": "幸せになんかならないでね",
+    "release_date": "2025-12-17",
+    "stream": "song",
+    "release_kind": "single",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "幸せになんかならないでね"
+      }
+    ],
+    "spotify_url": null,
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz SINGLE seed with 1 track."
+  },
+  {
+    "group": "VERIVERY",
+    "release_title": "Lost and Found",
+    "release_date": "2025-12-01",
+    "stream": "song",
+    "release_kind": "single",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "RED (Beggin’)"
+      },
+      {
+        "order": 2,
+        "title": "empty"
+      },
+      {
+        "order": 3,
+        "title": "Blame us"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/4j6qWUx1OjrrR59XdT6gcU",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz SINGLE seed with 3 tracks. Canonical links: Spotify."
+  },
+  {
+    "group": "VIVIZ",
+    "release_title": "A Montage of ( )",
+    "release_date": "2025-07-08",
+    "stream": "album",
+    "release_kind": "album",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "La La Love Me"
+      },
+      {
+        "order": 2,
+        "title": "Hands Off My Heart"
+      },
+      {
+        "order": 3,
+        "title": "Citrus"
+      },
+      {
+        "order": 4,
+        "title": "Sticker"
+      },
+      {
+        "order": 5,
+        "title": "Toxic"
+      },
+      {
+        "order": 6,
+        "title": "Hipnotic"
+      },
+      {
+        "order": 7,
+        "title": "Love Language"
+      },
+      {
+        "order": 8,
+        "title": "Milky Way"
+      },
+      {
+        "order": 9,
+        "title": "Wildflower"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/7hc0DjpDJHNvVNF7a9PDNq",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz ALBUM seed with 9 tracks. Canonical links: Spotify."
+  },
+  {
+    "group": "WEi",
+    "release_title": "Wonderland",
+    "release_date": "2025-10-29",
+    "stream": "album",
+    "release_kind": "ep",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "HOME"
+      },
+      {
+        "order": 2,
+        "title": "DOMINO"
+      },
+      {
+        "order": 3,
+        "title": "One in A Million"
+      },
+      {
+        "order": 4,
+        "title": "Gravity"
+      },
+      {
+        "order": 5,
+        "title": "Everglow"
+      }
+    ],
+    "spotify_url": null,
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz EP seed with 5 tracks."
+  },
+  {
+    "group": "Xdinary Heroes",
+    "release_title": "FiRE (My Sweet Misery)",
+    "release_date": "2025-07-07",
+    "stream": "song",
+    "release_kind": "single",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "FiRE (My Sweet Misery)"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/6ZqZFhhTiwscyLwyoEq8ku",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz SINGLE seed with 1 track. Canonical links: Spotify."
+  },
+  {
+    "group": "Xdinary Heroes",
+    "release_title": "LXVE to DEATH",
+    "release_date": "2025-10-24",
+    "stream": "album",
+    "release_kind": "ep",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "Lost and Found"
+      },
+      {
+        "order": 2,
+        "title": "ICU"
+      },
+      {
+        "order": 3,
+        "title": "Fire (My Sweet Misery)"
+      },
+      {
+        "order": 4,
+        "title": "Ashes to Ashes"
+      },
+      {
+        "order": 5,
+        "title": "Spoiler!!!"
+      },
+      {
+        "order": 6,
+        "title": "Love Tug of War"
+      },
+      {
+        "order": 7,
+        "title": "LOVE ME 2 DEATH"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/04WcDHoLelHf9ajNp6HXkD",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz EP seed with 7 tracks. Canonical links: Spotify."
+  },
+  {
+    "group": "xikers",
+    "release_title": "ICONIC",
+    "release_date": "2025-08-01",
+    "stream": "song",
+    "release_kind": "single",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "ICONIC"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/5Boa7YknUbdFy87sIxQ2vG",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz SINGLE seed with 1 track. Canonical links: Spotify."
+  },
+  {
+    "group": "xikers",
+    "release_title": "HOUSE OF TRICKY : WRECKING THE HOUSE",
+    "release_date": "2025-10-31",
+    "stream": "album",
+    "release_kind": "ep",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "ICONIC"
+      },
+      {
+        "order": 2,
+        "title": "See You Play (S’il vous plaît)"
+      },
+      {
+        "order": 3,
+        "title": "SUPERPOWER (Peak)"
+      },
+      {
+        "order": 4,
+        "title": "Blurry"
+      },
+      {
+        "order": 5,
+        "title": "Right in"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/0BWWwBPmMDLnhvi2SJX8CV",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz EP seed with 5 tracks. Canonical links: Spotify."
+  },
+  {
+    "group": "YOUNG POSSE",
+    "release_title": "Growing Pain pt.1 : FREE",
+    "release_date": "2025-08-14",
+    "stream": "album",
+    "release_kind": "ep",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "YSSR"
+      },
+      {
+        "order": 2,
+        "title": "FREESTYLE"
+      },
+      {
+        "order": 3,
+        "title": "ADHD"
+      },
+      {
+        "order": 4,
+        "title": "School’s Out"
+      },
+      {
+        "order": 5,
+        "title": "MON3Y 8ANK"
+      },
+      {
+        "order": 6,
+        "title": "soju"
+      },
+      {
+        "order": 7,
+        "title": "Same Shit, Another One"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/5Nfxo1U4jKI13JB4nPimOJ",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz EP seed with 7 tracks. Canonical links: Spotify."
+  },
+  {
+    "group": "YOUNG POSSE",
+    "release_title": "VISA / Pilot3",
+    "release_date": "2026-01-27",
+    "stream": "song",
+    "release_kind": "single",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "VISA"
+      },
+      {
+        "order": 2,
+        "title": "Pilot3"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/7BYBKfbZxXgJkZ82GYp3MI",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz SINGLE seed with 2 tracks. Canonical links: Spotify."
+  },
+  {
+    "group": "ZEROBASEONE",
+    "release_title": "ROSES",
+    "release_date": "2026-01-23",
+    "stream": "song",
+    "release_kind": "single",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "ROSES"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/3bIZ5FREocfX2tLIUnnOdr",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz SINGLE seed with 1 track. Canonical links: Spotify."
+  },
+  {
+    "group": "ZEROBASEONE",
+    "release_title": "RE-FLOW",
+    "release_date": "2026-02-02",
+    "stream": "album",
+    "release_kind": "ep",
+    "tracks": [
+      {
+        "order": 1,
+        "title": "Running to Future"
+      },
+      {
+        "order": 2,
+        "title": "ROSES"
+      },
+      {
+        "order": 3,
+        "title": "LOVEPOCALYPSE"
+      }
+    ],
+    "spotify_url": "https://open.spotify.com/album/2IhQYBuoaZmcXRQJqwFGQg",
+    "youtube_music_url": null,
+    "youtube_video_id": null,
+    "notes": "Representative MusicBrainz EP seed with 3 tracks. Canonical links: Spotify."
+  }
+]


### PR DESCRIPTION
## Summary
- add a MusicBrainz-backed `releaseDetails.json` seed dataset plus a regeneration script
- wire release detail seed data into team-page latest release cards, album card handoff links, and album drawer tracklists/notes
- keep missing detail lookups on the existing safe fallback path

## Verification
- .venv/bin/python build_release_details_musicbrainz.py
- npm run lint
- npm run build
- manual spot-check of 10+ release detail rows and key lookup/fallback behavior
