### PR TITLE
Track comeback schedule and release-state changes

### DIFF
--- a/build_release_change_log.py
+++ b/build_release_change_log.py
@@ -1,0 +1,452 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+
+ROOT = Path(__file__).resolve().parent
+UPCOMING_PATH = "web/src/data/upcomingCandidates.json"
+RELEASES_PATH = "web/src/data/releases.json"
+OUTPUT_PATH = ROOT / "web/src/data/releaseChangeLog.json"
+VERIFIED_RELEASE_WINDOW_DAYS = 30
+
+
+@dataclass(frozen=True)
+class SnapshotState:
+    group: str
+    scheduled_date: str
+    date_status: str
+    headline: str
+    source_type: str
+    source_url: str
+    published_at: str
+    confidence: float
+
+
+@dataclass(frozen=True)
+class ReleaseState:
+    title: str
+    date: str
+    release_kind: str
+    source: str
+
+
+def run_git(*args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+def load_json_at_ref(ref: str, path: str) -> Any:
+    return json.loads(run_git("show", f"{ref}:{path}"))
+
+
+def get_history_refs(path: str) -> list[str]:
+    refs = [line.strip() for line in run_git("log", "--format=%H", "--follow", "--", path).splitlines()]
+    refs.reverse()
+    return refs
+
+
+def get_commit_date(ref: str) -> str:
+    return run_git("show", "-s", "--format=%cI", ref).strip()
+
+
+def is_exact_date(value: str) -> bool:
+    try:
+        datetime.strptime(value, "%Y-%m-%d")
+        return True
+    except ValueError:
+        return False
+
+
+def parse_datetime(value: str) -> datetime | None:
+    if not value:
+        return None
+
+    if is_exact_date(value):
+        return datetime.strptime(value, "%Y-%m-%d")
+
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        pass
+
+    for pattern in ("%a, %d %b %Y %H:%M:%S %Z", "%a, %d %b %Y %H:%M:%S %z"):
+        try:
+            return datetime.strptime(value, pattern)
+        except ValueError:
+            continue
+
+    return None
+
+
+def published_sort_value(value: str) -> float:
+    parsed = parse_datetime(value)
+    return parsed.timestamp() if parsed else -1
+
+
+def source_rank(source_type: str) -> int:
+    if source_type in {"agency_notice", "weverse_notice"}:
+        return 0
+    if source_type == "news_rss":
+        return 1
+    return 2
+
+
+def date_status_rank(date_status: str) -> int:
+    return {"confirmed": 0, "scheduled": 1, "rumor": 2}.get(date_status, 9)
+
+
+def compare_state_priority(left: SnapshotState, right: SnapshotState) -> tuple[Any, ...]:
+    return (
+        0 if is_exact_date(left.scheduled_date) else 1,
+        source_rank(left.source_type),
+        date_status_rank(left.date_status),
+        -(left.confidence or 0),
+        -published_sort_value(left.published_at),
+        left.headline,
+    ) < (
+        0 if is_exact_date(right.scheduled_date) else 1,
+        source_rank(right.source_type),
+        date_status_rank(right.date_status),
+        -(right.confidence or 0),
+        -published_sort_value(right.published_at),
+        right.headline,
+    )
+
+
+def select_group_states(rows: list[dict[str, Any]]) -> dict[str, SnapshotState]:
+    selected: dict[str, SnapshotState] = {}
+
+    for row in rows:
+        state = SnapshotState(
+            group=row.get("group", ""),
+            scheduled_date=row.get("scheduled_date", "") or "",
+            date_status=row.get("date_status", "") or "",
+            headline=row.get("headline", "") or "",
+            source_type=row.get("source_type", "") or "",
+            source_url=row.get("source_url", "") or "",
+            published_at=row.get("published_at", "") or "",
+            confidence=float(row.get("confidence", 0) or 0),
+        )
+        current = selected.get(state.group)
+        if current is None or compare_state_priority(state, current):
+            selected[state.group] = state
+
+    return selected
+
+
+def latest_release_states(rows: list[dict[str, Any]]) -> dict[str, ReleaseState]:
+    releases: dict[str, ReleaseState] = {}
+
+    for row in rows:
+        candidates: list[dict[str, Any]] = []
+        if row.get("latest_song"):
+            candidates.append(row["latest_song"])
+        if row.get("latest_album"):
+            candidates.append(row["latest_album"])
+        if not candidates:
+            continue
+
+        latest = max(candidates, key=lambda item: item.get("date", ""))
+        releases[row["group"]] = ReleaseState(
+            title=latest.get("title", "") or "",
+            date=latest.get("date", "") or "",
+            release_kind=latest.get("release_kind", "") or "",
+            source=latest.get("source", "") or "",
+        )
+
+    return releases
+
+
+def hash_state(value: dict[str, Any] | None) -> str:
+    if value is None:
+        return "none"
+    serialized = json.dumps(value, ensure_ascii=True, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha1(serialized.encode("utf-8")).hexdigest()[:12]
+
+
+def normalize_state(state: SnapshotState | None) -> dict[str, Any] | None:
+    if state is None:
+        return None
+    return {
+        "scheduled_date": state.scheduled_date,
+        "date_status": state.date_status,
+        "headline": state.headline,
+        "source_type": state.source_type,
+        "source_url": state.source_url,
+        "published_at": state.published_at,
+    }
+
+
+def normalize_release(release: ReleaseState | None) -> dict[str, Any] | None:
+    if release is None:
+        return None
+    return {
+        "title": release.title,
+        "date": release.date,
+        "release_kind": release.release_kind,
+        "source": release.source,
+    }
+
+
+def days_between(left: str, right: str) -> int | None:
+    if not is_exact_date(left) or not is_exact_date(right):
+        return None
+    left_date = datetime.strptime(left, "%Y-%m-%d")
+    right_date = datetime.strptime(right, "%Y-%m-%d")
+    return (left_date - right_date).days
+
+
+def get_source_url(change_type: str, next_state: SnapshotState | None, previous_state: SnapshotState | None, release: ReleaseState | None) -> str:
+    if change_type == "verified_release_detected" and release:
+        return release.source
+    if next_state and next_state.source_url:
+        return next_state.source_url
+    if previous_state and previous_state.source_url:
+        return previous_state.source_url
+    return ""
+
+
+def get_source_domain(source_url: str) -> str:
+    if not source_url:
+        return ""
+    return urlparse(source_url).netloc
+
+
+def get_change_occurred_at(change_type: str, next_state: SnapshotState | None, release: ReleaseState | None, next_commit_date: str) -> str:
+    if change_type == "verified_release_detected" and release and release.date:
+        return release.date
+    if next_state and next_state.published_at:
+        return next_state.published_at
+    if next_state and next_state.scheduled_date:
+        return next_state.scheduled_date
+    return next_commit_date
+
+
+def build_summary(change_type: str, previous_state: SnapshotState | None, next_state: SnapshotState | None, release: ReleaseState | None) -> str:
+    if change_type == "scheduled_date_added" and next_state:
+        return f"Scheduled date was filled in as {next_state.scheduled_date}."
+    if change_type == "scheduled_date_changed" and previous_state and next_state:
+        return f"Scheduled date moved from {previous_state.scheduled_date} to {next_state.scheduled_date}."
+    if change_type == "date_status_changed" and previous_state and next_state:
+        return f"Signal status changed from {previous_state.date_status} to {next_state.date_status}."
+    if change_type == "headline_changed" and previous_state and next_state:
+        return f'Primary tracked headline changed from "{previous_state.headline}" to "{next_state.headline}".'
+    if change_type == "verified_release_detected" and release:
+        return f'Verified release "{release.title}" landed on {release.date}.'
+    return ""
+
+
+def build_event(
+    *,
+    group: str,
+    change_type: str,
+    previous_state: SnapshotState | None,
+    next_state: SnapshotState | None,
+    next_release: ReleaseState | None,
+    next_commit_date: str,
+    previous_ref: str,
+    next_ref: str,
+) -> dict[str, Any]:
+    previous_payload = normalize_state(previous_state)
+    next_payload = normalize_state(next_state)
+    previous_hash = hash_state(previous_payload)
+    next_hash = hash_state(next_payload or normalize_release(next_release))
+    diff_key = f"{group}:{previous_hash}:{next_hash}"
+    source_url = get_source_url(change_type, next_state, previous_state, next_release)
+
+    return {
+        "key": f"{diff_key}:{change_type}",
+        "diff_key": diff_key,
+        "group": group,
+        "change_type": change_type,
+        "occurred_at": get_change_occurred_at(change_type, next_state, next_release, next_commit_date),
+        "summary": build_summary(change_type, previous_state, next_state, next_release),
+        "source_url": source_url,
+        "source_domain": get_source_domain(source_url),
+        "previous_state_hash": previous_hash,
+        "next_state_hash": next_hash,
+        "previous": previous_payload,
+        "next": next_payload,
+        "verified_release": normalize_release(next_release) if change_type == "verified_release_detected" else None,
+        "snapshot": {
+            "previous_ref": previous_ref[:7],
+            "next_ref": next_ref[:7],
+        },
+    }
+
+
+def compare_snapshots(
+    previous_ref: str,
+    next_ref: str,
+    previous_states: dict[str, SnapshotState],
+    next_states: dict[str, SnapshotState],
+    previous_releases: dict[str, ReleaseState],
+    next_releases: dict[str, ReleaseState],
+    next_commit_date: str,
+) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    all_groups = sorted(set(previous_states) | set(next_states))
+
+    for group in all_groups:
+        previous_state = previous_states.get(group)
+        next_state = next_states.get(group)
+        previous_release = previous_releases.get(group)
+        next_release = next_releases.get(group)
+
+        if previous_state and next_state:
+            if not previous_state.scheduled_date and is_exact_date(next_state.scheduled_date):
+                events.append(
+                    build_event(
+                        group=group,
+                        change_type="scheduled_date_added",
+                        previous_state=previous_state,
+                        next_state=next_state,
+                        next_release=None,
+                        next_commit_date=next_commit_date,
+                        previous_ref=previous_ref,
+                        next_ref=next_ref,
+                    )
+                )
+
+            if (
+                is_exact_date(previous_state.scheduled_date)
+                and is_exact_date(next_state.scheduled_date)
+                and previous_state.scheduled_date != next_state.scheduled_date
+            ):
+                events.append(
+                    build_event(
+                        group=group,
+                        change_type="scheduled_date_changed",
+                        previous_state=previous_state,
+                        next_state=next_state,
+                        next_release=None,
+                        next_commit_date=next_commit_date,
+                        previous_ref=previous_ref,
+                        next_ref=next_ref,
+                    )
+                )
+
+            if (
+                previous_state.date_status
+                and next_state.date_status
+                and previous_state.date_status != next_state.date_status
+            ):
+                events.append(
+                    build_event(
+                        group=group,
+                        change_type="date_status_changed",
+                        previous_state=previous_state,
+                        next_state=next_state,
+                        next_release=None,
+                        next_commit_date=next_commit_date,
+                        previous_ref=previous_ref,
+                        next_ref=next_ref,
+                    )
+                )
+
+            if previous_state.headline and next_state.headline and previous_state.headline != next_state.headline:
+                events.append(
+                    build_event(
+                        group=group,
+                        change_type="headline_changed",
+                        previous_state=previous_state,
+                        next_state=next_state,
+                        next_release=None,
+                        next_commit_date=next_commit_date,
+                        previous_ref=previous_ref,
+                        next_ref=next_ref,
+                    )
+                )
+
+        if previous_state and next_release:
+            release_changed = previous_release != next_release
+            release_near_scheduled = False
+            if is_exact_date(previous_state.scheduled_date) and is_exact_date(next_release.date):
+                difference = days_between(next_release.date, previous_state.scheduled_date)
+                release_near_scheduled = difference is not None and abs(difference) <= VERIFIED_RELEASE_WINDOW_DAYS
+
+            if release_changed and release_near_scheduled:
+                events.append(
+                    build_event(
+                        group=group,
+                        change_type="verified_release_detected",
+                        previous_state=previous_state,
+                        next_state=next_state,
+                        next_release=next_release,
+                        next_commit_date=next_commit_date,
+                        previous_ref=previous_ref,
+                        next_ref=next_ref,
+                    )
+                )
+
+    return events
+
+
+def occurred_sort_value(value: str) -> tuple[int, str]:
+    parsed = parse_datetime(value)
+    if parsed is None:
+        return (0, value)
+    return (1, parsed.isoformat())
+
+
+def main() -> None:
+    refs = get_history_refs(UPCOMING_PATH)
+    if len(refs) < 2:
+        raise SystemExit("Need at least two snapshot revisions to build release change log.")
+
+    snapshots: list[dict[str, Any]] = []
+    for ref in refs:
+        states = select_group_states(load_json_at_ref(ref, UPCOMING_PATH))
+        if not states:
+            continue
+        snapshots.append(
+            {
+                "ref": ref,
+                "commit_date": get_commit_date(ref),
+                "states": states,
+                "releases": latest_release_states(load_json_at_ref(ref, RELEASES_PATH)),
+            }
+        )
+
+    events: list[dict[str, Any]] = []
+    for previous_snapshot, next_snapshot in zip(snapshots, snapshots[1:]):
+        events.extend(
+            compare_snapshots(
+                previous_ref=previous_snapshot["ref"],
+                next_ref=next_snapshot["ref"],
+                previous_states=previous_snapshot["states"],
+                next_states=next_snapshot["states"],
+                previous_releases=previous_snapshot["releases"],
+                next_releases=next_snapshot["releases"],
+                next_commit_date=next_snapshot["commit_date"],
+            )
+        )
+
+    deduped = {event["key"]: event for event in events}
+    ordered = sorted(
+        deduped.values(),
+        key=lambda item: (occurred_sort_value(item["occurred_at"]), item["group"], item["change_type"]),
+        reverse=True,
+    )
+
+    OUTPUT_PATH.write_text(json.dumps(ordered, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    print(f"Wrote {len(ordered)} change events to {OUTPUT_PATH.relative_to(ROOT)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -686,6 +686,27 @@
   color: var(--accent-deep);
 }
 
+.signal-badge-change-scheduled_date_added,
+.signal-badge-change-scheduled_date_changed {
+  background: rgba(215, 229, 252, 0.96);
+  color: #244c88;
+}
+
+.signal-badge-change-date_status_changed {
+  background: rgba(195, 224, 204, 0.92);
+  color: #27543a;
+}
+
+.signal-badge-change-headline_changed {
+  background: rgba(236, 221, 255, 0.94);
+  color: #60428f;
+}
+
+.signal-badge-change-verified_release_detected {
+  background: rgba(217, 233, 179, 0.9);
+  color: #4b5a17;
+}
+
 .signal-meta {
   margin: 8px 0 0;
   font-size: 0.82rem;
@@ -891,6 +912,48 @@
   margin: 0;
   font-size: 0.82rem;
   color: var(--text-soft);
+}
+
+.change-log-list {
+  display: grid;
+  gap: 12px;
+}
+
+.change-log-item {
+  border: 1px solid rgba(27, 42, 65, 0.08);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.82);
+  padding: 16px;
+}
+
+.change-log-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.change-log-head h4,
+.change-log-summary {
+  margin: 0;
+}
+
+.change-log-head h4 {
+  margin-top: 6px;
+  font-size: 0.98rem;
+  color: var(--text-strong);
+}
+
+.change-log-date {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--text-soft);
+}
+
+.change-log-summary {
+  margin-top: 10px;
+  font-size: 0.86rem;
+  color: var(--text-strong);
 }
 
 .source-timeline {
@@ -1361,6 +1424,10 @@
   }
 
   .source-timeline-head {
+    flex-direction: column;
+  }
+
+  .change-log-head {
     flex-direction: column;
   }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,6 +6,7 @@ import releaseDetailRows from './data/releaseDetails.json'
 import releaseRows from './data/releases.json'
 import unresolvedRows from './data/unresolved.json'
 import upcomingCandidateRows from './data/upcomingCandidates.json'
+import releaseChangeLogRows from './data/releaseChangeLog.json'
 import watchlistRows from './data/watchlist.json'
 
 type ReleaseFact = {
@@ -138,6 +139,49 @@ type SourceTimelineItem = {
   sortValue: number
 }
 
+type ReleaseChangeType =
+  | 'scheduled_date_added'
+  | 'scheduled_date_changed'
+  | 'date_status_changed'
+  | 'headline_changed'
+  | 'verified_release_detected'
+
+type ReleaseChangeSnapshotState = {
+  scheduled_date: string
+  date_status: string
+  headline: string
+  source_type: string
+  source_url: string
+  published_at: string
+}
+
+type ReleaseChangeVerifiedRelease = {
+  title: string
+  date: string
+  release_kind: string
+  source: string
+}
+
+type ReleaseChangeLogRow = {
+  key: string
+  diff_key: string
+  group: string
+  change_type: ReleaseChangeType
+  occurred_at: string
+  summary: string
+  source_url: string
+  source_domain: string
+  previous_state_hash: string
+  next_state_hash: string
+  previous: ReleaseChangeSnapshotState | null
+  next: ReleaseChangeSnapshotState | null
+  verified_release: ReleaseChangeVerifiedRelease | null
+  snapshot: {
+    previous_ref: string
+    next_ref: string
+  }
+}
+
 type WatchlistRow = {
   group: string
   tier: string
@@ -211,6 +255,7 @@ type TeamProfile = {
   recentAlbums: VerifiedRelease[]
   upcomingSignals: UpcomingCandidateRow[]
   sourceTimeline: SourceTimelineItem[]
+  changeLog: ReleaseChangeLogRow[]
   nextUpcomingSignal: UpcomingCandidateRow | null
 }
 
@@ -338,6 +383,13 @@ const TRANSLATIONS = {
       medium: '보통',
       low: '낮음',
     },
+    changeTypeLabels: {
+      scheduled_date_added: '날짜 추가',
+      scheduled_date_changed: '날짜 변경',
+      date_status_changed: '상태 변경',
+      headline_changed: '헤드라인 변경',
+      verified_release_detected: '검증 발매 감지',
+    },
     timelineEventLabels: {
       first_signal: '첫 신호',
       official_announcement: '공식 공지',
@@ -453,6 +505,13 @@ const TRANSLATIONS = {
       medium: 'medium',
       low: 'low',
     },
+    changeTypeLabels: {
+      scheduled_date_added: 'Date added',
+      scheduled_date_changed: 'Date changed',
+      date_status_changed: 'Status changed',
+      headline_changed: 'Headline changed',
+      verified_release_detected: 'Verified release',
+    },
     timelineEventLabels: {
       first_signal: 'First signal',
       official_announcement: 'Official announcement',
@@ -502,6 +561,11 @@ const TEAM_COPY = {
     timelineIntro: '예정 신호와 검증된 발매를 같은 타임라인에서 봅니다.',
     timelineEmptyTitle: '타임라인 근거 없음',
     timelineEmpty: '예정 신호나 검증된 발매 출처가 아직 충분하지 않습니다.',
+    changeLogLabel: '변경 로그',
+    changeLogTitle: '최근 일정/상태 변동',
+    changeLogIntro: '스냅샷 비교로 감지한 최근 변경입니다.',
+    changeLogEmptyTitle: '최근 변동 없음',
+    changeLogEmpty: '기록된 일정/상태 변경이 아직 없습니다.',
     pagesPanelLabel: '팀 페이지',
     pagesPanelTitle: '추적 팀 열기',
     noTeamMatch: '이 검색어와 일치하는 추적 팀이 없습니다.',
@@ -559,6 +623,11 @@ const TEAM_COPY = {
     timelineIntro: 'Scheduled signals and verified releases share one evidence trail.',
     timelineEmptyTitle: 'No timeline evidence yet',
     timelineEmpty: 'There is not enough scheduled or verified source evidence for this team yet.',
+    changeLogLabel: 'Change log',
+    changeLogTitle: 'Recent schedule and state changes',
+    changeLogIntro: 'Detected from snapshot-to-snapshot comparisons.',
+    changeLogEmptyTitle: 'No recent changes',
+    changeLogEmpty: 'No schedule or state change has been recorded for this team yet.',
     pagesPanelLabel: 'Team pages',
     pagesPanelTitle: 'Open a tracked team',
     noTeamMatch: 'No tracked team matches this search.',
@@ -597,6 +666,7 @@ const releases = releaseCatalog
 const unresolved = unresolvedRows as UnresolvedRow[]
 const watchlist = watchlistRows as WatchlistRow[]
 const upcomingCandidates = upcomingCandidateRows as UpcomingCandidateRow[]
+const releaseChangeLog = releaseChangeLogRows as ReleaseChangeLogRow[]
 
 const dateFormatter = new Intl.DateTimeFormat('en-CA', {
   year: 'numeric',
@@ -621,6 +691,10 @@ const releaseDetailsByKey = new Map(
 const releaseGroups = groupReleasesByGroup(releases)
 const watchlistByGroup = new Map(watchlist.map((row) => [row.group, row]))
 const upcomingByGroup = groupUpcomingCandidatesByGroup(upcomingCandidates)
+const releaseChangeLogByGroup = groupReleaseChangeLogByGroup(releaseChangeLog)
+const latestReleaseChangeByGroup = new Map(
+  Array.from(releaseChangeLogByGroup, ([group, changes]) => [group, changes[0] ?? null]),
+)
 const searchIndexByGroup = buildSearchIndexByGroup()
 const teamProfiles = buildTeamProfiles()
 const teamProfileMap = new Map(teamProfiles.map((team) => [team.group, team]))
@@ -961,6 +1035,7 @@ function App() {
                               >
                                 {formatConfidenceTone(getConfidenceTone(item.confidence), language)}
                               </span>
+                              <ReleaseChangeBadge group={item.group} language={language} />
                               <ReleaseClassificationBadges
                                 releaseFormat={item.release_format}
                                 contextTags={item.context_tags}
@@ -991,6 +1066,23 @@ function App() {
                     ))
                   ) : (
                     <p className="empty-copy">{teamCopy.upcomingEmpty}</p>
+                  )}
+                </div>
+
+                <div className="team-subsection">
+                  <div className="team-subsection-head">
+                    <p className="panel-label">{teamCopy.changeLogLabel}</p>
+                    <h3>{selectedTeam.changeLog.length ? teamCopy.changeLogTitle : teamCopy.changeLogEmptyTitle}</h3>
+                    <p className="team-subsection-copy">{teamCopy.changeLogIntro}</p>
+                  </div>
+                  {selectedTeam.changeLog.length ? (
+                    <ReleaseChangeLogList
+                      changes={selectedTeam.changeLog.slice(0, 3)}
+                      language={language}
+                      formatter={timelineDateFormatter}
+                    />
+                  ) : (
+                    <p className="empty-copy">{teamCopy.changeLogEmpty}</p>
                   )}
                 </div>
 
@@ -1386,6 +1478,7 @@ function App() {
                             >
                               {formatConfidenceTone(getConfidenceTone(item.confidence), language)}
                             </span>
+                            <ReleaseChangeBadge group={item.group} language={language} />
                             <ReleaseClassificationBadges
                               releaseFormat={item.release_format}
                               contextTags={item.context_tags}
@@ -1768,6 +1861,68 @@ function UpcomingCountdownBadge({
   )
 }
 
+function ReleaseChangeBadge({
+  group,
+  language,
+}: {
+  group: string
+  language: Language
+}) {
+  const latestChange = latestReleaseChangeByGroup.get(group)
+  if (!latestChange) {
+    return null
+  }
+
+  return (
+    <span className={`signal-badge signal-badge-change signal-badge-change-${latestChange.change_type}`}>
+      {formatReleaseChangeType(latestChange.change_type, language)}
+    </span>
+  )
+}
+
+function ReleaseChangeLogList({
+  changes,
+  language,
+  formatter,
+}: {
+  changes: ReleaseChangeLogRow[]
+  language: Language
+  formatter: Intl.DateTimeFormat
+}) {
+  const copy = TRANSLATIONS[language]
+
+  return (
+    <div className="change-log-list">
+      {changes.map((change) => (
+        <article key={change.key} className="change-log-item">
+          <div className="change-log-head">
+            <div>
+              <p className="change-log-date">
+                {formatSourceTimelineDate(change.occurred_at, formatter, copy.none)}
+              </p>
+              <h4>{formatReleaseChangeType(change.change_type, language)}</h4>
+            </div>
+            <span className={`signal-badge signal-badge-change signal-badge-change-${change.change_type}`}>
+              {change.snapshot.previous_ref} {'->'} {change.snapshot.next_ref}
+            </span>
+          </div>
+          <p className="signal-meta">{change.source_domain || copy.sourceTypeLabels.pending}</p>
+          <p className="change-log-summary">{change.summary}</p>
+          <div className="detail-links detail-links-stack">
+            {change.source_url ? (
+              <a href={change.source_url} target="_blank" rel="noreferrer">
+                {copy.sourceLink}
+              </a>
+            ) : (
+              <span className="signal-link-muted">{copy.noSourceLink}</span>
+            )}
+          </div>
+        </article>
+      ))}
+    </div>
+  )
+}
+
 function ReleaseClassificationBadges({
   releaseFormat,
   contextTags,
@@ -1891,6 +2046,7 @@ function SelectedDayPanel({
                         >
                           {formatConfidenceTone(getConfidenceTone(item.confidence), language)}
                         </span>
+                        <ReleaseChangeBadge group={item.group} language={language} />
                         <ReleaseClassificationBadges
                           releaseFormat={item.release_format}
                           contextTags={item.context_tags}
@@ -2080,6 +2236,10 @@ function formatTrackingStatus(status: string, language: Language) {
 
 function formatConfidenceTone(tone: ReturnType<typeof getConfidenceTone>, language: Language) {
   return TRANSLATIONS[language].confidenceToneLabels[tone]
+}
+
+function formatReleaseChangeType(changeType: ReleaseChangeType, language: Language) {
+  return TRANSLATIONS[language].changeTypeLabels[changeType]
 }
 
 function formatTimelineEventType(eventType: SourceTimelineEventType, language: Language) {
@@ -2294,6 +2454,7 @@ function buildTeamProfiles() {
       const artistProfile = artistProfileByGroup.get(group)
       const groupReleases = releaseGroups.get(group) ?? []
       const upcomingSignals = [...(upcomingByGroup.get(group) ?? [])].sort(compareUpcomingSignals)
+      const changeLog = releaseChangeLogByGroup.get(group) ?? []
       const sourceTimeline = buildSourceTimeline(group, upcomingByGroup.get(group) ?? [], groupReleases)
       const latestRelease = deriveLatestRelease(groupReleases, watchRow, releaseRow)
 
@@ -2316,6 +2477,7 @@ function buildTeamProfiles() {
         recentAlbums: groupReleases.filter((item) => item.stream === 'album'),
         upcomingSignals,
         sourceTimeline,
+        changeLog,
         nextUpcomingSignal: upcomingSignals[0] ?? null,
       }
     })
@@ -2451,6 +2613,16 @@ function compareUpcomingSignals(
   }
 
   return left.headline.localeCompare(right.headline)
+}
+
+function compareReleaseChanges(left: ReleaseChangeLogRow, right: ReleaseChangeLogRow) {
+  const leftValue = getSourceTimelineSortValue(left.occurred_at)
+  const rightValue = getSourceTimelineSortValue(right.occurred_at)
+  if (leftValue !== rightValue) {
+    return rightValue - leftValue
+  }
+
+  return left.group.localeCompare(right.group)
 }
 
 function buildSourceTimeline(
@@ -2682,6 +2854,16 @@ function groupUpcomingCandidatesByGroup(rows: UpcomingCandidateRow[]) {
   return rows.reduce<Map<string, UpcomingCandidateRow[]>>((map, row) => {
     const bucket = map.get(row.group) ?? []
     bucket.push(row)
+    map.set(row.group, bucket)
+    return map
+  }, new Map())
+}
+
+function groupReleaseChangeLogByGroup(rows: ReleaseChangeLogRow[]) {
+  return rows.reduce<Map<string, ReleaseChangeLogRow[]>>((map, row) => {
+    const bucket = map.get(row.group) ?? []
+    bucket.push(row)
+    bucket.sort(compareReleaseChanges)
     map.set(row.group, bucket)
     return map
   }, new Map())

--- a/web/src/data/releaseChangeLog.json
+++ b/web/src/data/releaseChangeLog.json
@@ -1,0 +1,495 @@
+[
+  {
+    "key": "TOMORROW X TOGETHER:af0eca0adba7:3f5265bb8f47:headline_changed",
+    "diff_key": "TOMORROW X TOGETHER:af0eca0adba7:3f5265bb8f47",
+    "group": "TOMORROW X TOGETHER",
+    "change_type": "headline_changed",
+    "occurred_at": "2026-04-13",
+    "summary": "Primary tracked headline changed from \"TOMORROW X TOGETHER mark comeback after contract renewal with April 13 showcase in Korea - CHOSUNBIZ - Chosunbiz\" to \"[NOTICE] Comeback Showcase to Celebrate the Release of TOMORROW X TOGETHER “7TH YEAR: A Moment of Stillness in the Thorns”\".",
+    "source_url": "https://weverse.io/txt/notice/34002",
+    "source_domain": "weverse.io",
+    "previous_state_hash": "af0eca0adba7",
+    "next_state_hash": "3f5265bb8f47",
+    "previous": {
+      "scheduled_date": "2026-04-13",
+      "date_status": "scheduled",
+      "headline": "TOMORROW X TOGETHER mark comeback after contract renewal with April 13 showcase in Korea - CHOSUNBIZ - Chosunbiz",
+      "source_type": "news_rss",
+      "source_url": "https://news.google.com/rss/articles/CBMinAFBVV95cUxNSmltcVJ1REJzQTE5Rm9fV3JmSl9RRWdRdk1Yb2Jwc2UtYTNaOFhWbGRfS0dXTVk3LTUyRG5YWmVaVkNjWTNMMHIzaDVUX0ZBcW5OTGx0QWRJM2dKRGpQTTVrUnB6ZDdGLUpxZnljcFBPaW9nRE5qT1d2dnpmLTJhRi04LUNHM24tRktoSDVORzdfenF0VS1uSnU0T0bSAZwBQVVfeXFMTUppbXFSdURCc0ExOUZvX1dyZkpfUUVnUXZNWG9icHNlLWEzWjhYVmxkX0tHV01ZNy01MkRuWFplWlZDY1kzTDByM2g1VF9GQXFuTkxsdEFkSTNnSkRqUE01a1JwemQ3Ri1KcWZ5Y3BQT2lvZ0ROak9XdnZ6Zi0yYUYtOC1DRzNuLUZLaEg1Tkc3X3pxdFUtbkp1NE9G?oc=5",
+      "published_at": "Wed, 04 Mar 2026 03:29:00 GMT"
+    },
+    "next": {
+      "scheduled_date": "2026-04-13",
+      "date_status": "confirmed",
+      "headline": "[NOTICE] Comeback Showcase to Celebrate the Release of TOMORROW X TOGETHER “7TH YEAR: A Moment of Stillness in the Thorns”",
+      "source_type": "weverse_notice",
+      "source_url": "https://weverse.io/txt/notice/34002",
+      "published_at": ""
+    },
+    "verified_release": null,
+    "snapshot": {
+      "previous_ref": "78d3b91",
+      "next_ref": "95f5db3"
+    }
+  },
+  {
+    "key": "TOMORROW X TOGETHER:af0eca0adba7:3f5265bb8f47:date_status_changed",
+    "diff_key": "TOMORROW X TOGETHER:af0eca0adba7:3f5265bb8f47",
+    "group": "TOMORROW X TOGETHER",
+    "change_type": "date_status_changed",
+    "occurred_at": "2026-04-13",
+    "summary": "Signal status changed from scheduled to confirmed.",
+    "source_url": "https://weverse.io/txt/notice/34002",
+    "source_domain": "weverse.io",
+    "previous_state_hash": "af0eca0adba7",
+    "next_state_hash": "3f5265bb8f47",
+    "previous": {
+      "scheduled_date": "2026-04-13",
+      "date_status": "scheduled",
+      "headline": "TOMORROW X TOGETHER mark comeback after contract renewal with April 13 showcase in Korea - CHOSUNBIZ - Chosunbiz",
+      "source_type": "news_rss",
+      "source_url": "https://news.google.com/rss/articles/CBMinAFBVV95cUxNSmltcVJ1REJzQTE5Rm9fV3JmSl9RRWdRdk1Yb2Jwc2UtYTNaOFhWbGRfS0dXTVk3LTUyRG5YWmVaVkNjWTNMMHIzaDVUX0ZBcW5OTGx0QWRJM2dKRGpQTTVrUnB6ZDdGLUpxZnljcFBPaW9nRE5qT1d2dnpmLTJhRi04LUNHM24tRktoSDVORzdfenF0VS1uSnU0T0bSAZwBQVVfeXFMTUppbXFSdURCc0ExOUZvX1dyZkpfUUVnUXZNWG9icHNlLWEzWjhYVmxkX0tHV01ZNy01MkRuWFplWlZDY1kzTDByM2g1VF9GQXFuTkxsdEFkSTNnSkRqUE01a1JwemQ3Ri1KcWZ5Y3BQT2lvZ0ROak9XdnZ6Zi0yYUYtOC1DRzNuLUZLaEg1Tkc3X3pxdFUtbkp1NE9G?oc=5",
+      "published_at": "Wed, 04 Mar 2026 03:29:00 GMT"
+    },
+    "next": {
+      "scheduled_date": "2026-04-13",
+      "date_status": "confirmed",
+      "headline": "[NOTICE] Comeback Showcase to Celebrate the Release of TOMORROW X TOGETHER “7TH YEAR: A Moment of Stillness in the Thorns”",
+      "source_type": "weverse_notice",
+      "source_url": "https://weverse.io/txt/notice/34002",
+      "published_at": ""
+    },
+    "verified_release": null,
+    "snapshot": {
+      "previous_ref": "78d3b91",
+      "next_ref": "95f5db3"
+    }
+  },
+  {
+    "key": "TWS:eea81a76964e:ed272a7287bd:headline_changed",
+    "diff_key": "TWS:eea81a76964e:ed272a7287bd",
+    "group": "TWS",
+    "change_type": "headline_changed",
+    "occurred_at": "Fri, 06 Mar 2026 06:15:24 GMT",
+    "summary": "Primary tracked headline changed from \"TWS Unveils Comeback Schedule Ahead of April 21 Release - K-en News\" to \"TWS Set for a High-Energy Spring Comeback Confirmed for April - OtakuKart\".",
+    "source_url": "https://news.google.com/rss/articles/CBMijAFBVV95cUxQZzJ5VkxoOGhGVS1GUEVVV0dMUnR1RkJHQlBqR2tGOGpWNUh2SXEwUzJ0czNVVHdlb1h3SzBMZnhPNXJHSWdaNlk5ajlOYy1wYTZYNDE2UUJmX3NpXzlhc1BXR0Q4SWR0ZXZqb2xja0lFYzhmQ2FKSS05cWZ0ZEkzZmJzMlFJRmstYVhfcA?oc=5",
+    "source_domain": "news.google.com",
+    "previous_state_hash": "eea81a76964e",
+    "next_state_hash": "ed272a7287bd",
+    "previous": {
+      "scheduled_date": "2026-04-21",
+      "date_status": "",
+      "headline": "TWS Unveils Comeback Schedule Ahead of April 21 Release - K-en News",
+      "source_type": "",
+      "source_url": "https://news.google.com/rss/articles/CBMiaEFVX3lxTE12eDU4MUN4NmFIRXNQekVySDVQbUZ2bmdweU1PYnNVRDZ4M3VGS2VYQUh2QVFEcUgwQm1EUFB6dEJJTE9KWGNUcG5PT25VZHZYRXBFeGU0cXF3LWd6V0dZNG1OM1JGOUJy0gFsQVVfeXFMTUhmdkZkQTJzUW1oZF9WQks3RGFFQXIxWHhoNl9IWHE5TEN0d0EwVGliZ2Q2blVmRUtaMjZlSk1ubTRYQW10Y2hCYXdSVzJ6dU5qWlhMcERPSjRpUm9Lai0tTC02WkNGSDNDd2N3?oc=5",
+      "published_at": "Tue, 25 Mar 2025 07:00:00 GMT"
+    },
+    "next": {
+      "scheduled_date": "",
+      "date_status": "scheduled",
+      "headline": "TWS Set for a High-Energy Spring Comeback Confirmed for April - OtakuKart",
+      "source_type": "news_rss",
+      "source_url": "https://news.google.com/rss/articles/CBMijAFBVV95cUxQZzJ5VkxoOGhGVS1GUEVVV0dMUnR1RkJHQlBqR2tGOGpWNUh2SXEwUzJ0czNVVHdlb1h3SzBMZnhPNXJHSWdaNlk5ajlOYy1wYTZYNDE2UUJmX3NpXzlhc1BXR0Q4SWR0ZXZqb2xja0lFYzhmQ2FKSS05cWZ0ZEkzZmJzMlFJRmstYVhfcA?oc=5",
+      "published_at": "Fri, 06 Mar 2026 06:15:24 GMT"
+    },
+    "verified_release": null,
+    "snapshot": {
+      "previous_ref": "6bf3920",
+      "next_ref": "78d3b91"
+    }
+  },
+  {
+    "key": "LE SSERAFIM:1268e7f24760:7060b5ac157c:headline_changed",
+    "diff_key": "LE SSERAFIM:1268e7f24760:7060b5ac157c",
+    "group": "LE SSERAFIM",
+    "change_type": "headline_changed",
+    "occurred_at": "Fri, 06 Mar 2026 01:00:00 GMT",
+    "summary": "Primary tracked headline changed from \"Le Sserafim announces return with new single 'Spaghetti' set for October 24 release - The Times of India\" to \"LE SSERAFIM and TWS Set for April Comebacks as K-Pop Return Rush Intensifies - DIPE.CO.KR\".",
+    "source_url": "https://news.google.com/rss/articles/CBMiREFVX3lxTE9aMUtzSDlQa2FxSG9TZjNlMF9fcU9PYmE3WE1lUmJFaWhzOW5aaDQ4VVpXZkJxYkNLcEJhSkZCNlZUWFE1?oc=5",
+    "source_domain": "news.google.com",
+    "previous_state_hash": "1268e7f24760",
+    "next_state_hash": "7060b5ac157c",
+    "previous": {
+      "scheduled_date": "2026-10-24",
+      "date_status": "",
+      "headline": "Le Sserafim announces return with new single 'Spaghetti' set for October 24 release - The Times of India",
+      "source_type": "",
+      "source_url": "https://news.google.com/rss/articles/CBMihAJBVV95cUxNTy1kelMyaUFONUhFdW14RXpkajRLbC1sMHVNNnJ1MjExaXo1bHBuRENvSS10WWduYWN2T1h4RXNMemRVZnVJS1ZsSE94TGFiRUhtQnhheGhoLUtHVGY5NjlyRlNCekJkamxEamVjU3BvSDlLUUdyTjJDY2JvdTBjQ3VFbTg4eDhueUpDV1JKRUtHTUJVUnZOb1FsQkk0YmZWbUlPb1k1NVdGQkFlWmhaQ09BaWFwY3B5bFp4dW5KV2V4Z2FPcW5vVjFadDZxbVJhbk5uSnl4ZGpQVkVMLUllLV9YWVVTUzNva2ZwWkdrSjJQUnFSbnZrLUNPV3NZLXowdWdTYdIBigJBVV95cUxNNGNLYzV3ZjdpZFlEYkNTbWkyY005cG50TVdCWDFlaEtaSWJBd0t4eVZBY0QweGp4ZmdPdDNRRlJwSGJ2RGFXcU8zdmRBRmtvUTFXTzZrUFpaaWh3N1E0Rlpzd3dYc21oaldDb0FiVnNBLW9NWE1JX2NQYnREQl9SVDhSNkpIbV9OelNnVDN3V0hEay1TOHduRVd5SkxHcDhaQy1wQXdKRlRZLUFaVjItZTg4TkhOejRiaDl3T0N6WlNUd0h5N2NoQWJtWVJKZzlpcUxwUktmbEhRUkxIcGZzQ0JhUzM0RXRrR0xGamdXTm5Hc2hXM29Vekc1WlNQc053QTU2UTBmOVF1Zw?oc=5",
+      "published_at": "Mon, 29 Sep 2025 07:00:00 GMT"
+    },
+    "next": {
+      "scheduled_date": "",
+      "date_status": "scheduled",
+      "headline": "LE SSERAFIM and TWS Set for April Comebacks as K-Pop Return Rush Intensifies - DIPE.CO.KR",
+      "source_type": "news_rss",
+      "source_url": "https://news.google.com/rss/articles/CBMiREFVX3lxTE9aMUtzSDlQa2FxSG9TZjNlMF9fcU9PYmE3WE1lUmJFaWhzOW5aaDQ4VVpXZkJxYkNLcEJhSkZCNlZUWFE1?oc=5",
+      "published_at": "Fri, 06 Mar 2026 01:00:00 GMT"
+    },
+    "verified_release": null,
+    "snapshot": {
+      "previous_ref": "6bf3920",
+      "next_ref": "78d3b91"
+    }
+  },
+  {
+    "key": "BABYMONSTER:671881e4f2b8:5eb7d69c1523:headline_changed",
+    "diff_key": "BABYMONSTER:671881e4f2b8:5eb7d69c1523",
+    "group": "BABYMONSTER",
+    "change_type": "headline_changed",
+    "occurred_at": "Wed, 04 Mar 2026 04:00:00 GMT",
+    "summary": "Primary tracked headline changed from \"BABYMONSTER to Host Global Comeback Live on October 10 with ‘WE GO UP’ - KbizoOm\" to \"YG Entertainment confirms BABYMONSTER World Tour & BIGBANG's Global - bandwagon.asia\".",
+    "source_url": "https://news.google.com/rss/articles/CBMi2gFBVV95cUxOZWI5YWpSUmd6bk1rYS1VM1o3bXU4aFNhaTRfLUhvYjBKSUN5S1ZSc0NPalNBZVlMaDI0UE9EVVktaWlPZ0RHWEd1SFN4MVcwM1IzaEY2VkpxcUViUDZEQVFaV3BSbmFHbXhmejZFTXpLQ2hMV3BzS1Foc0ZoNHdJZ0xkaGJnZXZYczNrY3d2b3dJb2EzNVROZy1DRlIyUFBPTU9UU2FKVTlvVVV5cTIyRjZfdl9WSFNCWXo2dUwzQzE5ZnluSGQ5X29BVGRZZXZVTUE4N1U3a29nQQ?oc=5",
+    "source_domain": "news.google.com",
+    "previous_state_hash": "671881e4f2b8",
+    "next_state_hash": "5eb7d69c1523",
+    "previous": {
+      "scheduled_date": "2026-10-10",
+      "date_status": "",
+      "headline": "BABYMONSTER to Host Global Comeback Live on October 10 with ‘WE GO UP’ - KbizoOm",
+      "source_type": "",
+      "source_url": "https://news.google.com/rss/articles/CBMibEFVX3lxTE01VlNTME1iczI3YTQwYVplVXdzQVlpeFBHdTBRTVpGVkVQZUFqUkg0UlZTNGdacUtXQk0xZHNVTWx5eDR6bkQ0TnFsbjhxejRjRGVabTF1U2Q0ck1waXIwX010MDFMdWROTFFhcQ?oc=5",
+      "published_at": "Fri, 03 Oct 2025 07:00:00 GMT"
+    },
+    "next": {
+      "scheduled_date": "",
+      "date_status": "rumor",
+      "headline": "YG Entertainment confirms BABYMONSTER World Tour & BIGBANG's Global - bandwagon.asia",
+      "source_type": "news_rss",
+      "source_url": "https://news.google.com/rss/articles/CBMi2gFBVV95cUxOZWI5YWpSUmd6bk1rYS1VM1o3bXU4aFNhaTRfLUhvYjBKSUN5S1ZSc0NPalNBZVlMaDI0UE9EVVktaWlPZ0RHWEd1SFN4MVcwM1IzaEY2VkpxcUViUDZEQVFaV3BSbmFHbXhmejZFTXpLQ2hMV3BzS1Foc0ZoNHdJZ0xkaGJnZXZYczNrY3d2b3dJb2EzNVROZy1DRlIyUFBPTU9UU2FKVTlvVVV5cTIyRjZfdl9WSFNCWXo2dUwzQzE5ZnluSGQ5X29BVGRZZXZVTUE4N1U3a29nQQ?oc=5",
+      "published_at": "Wed, 04 Mar 2026 04:00:00 GMT"
+    },
+    "verified_release": null,
+    "snapshot": {
+      "previous_ref": "6bf3920",
+      "next_ref": "78d3b91"
+    }
+  },
+  {
+    "key": "KickFlip:38fc5dc10088:b6fb18f801c4:headline_changed",
+    "diff_key": "KickFlip:38fc5dc10088:b6fb18f801c4",
+    "group": "KickFlip",
+    "change_type": "headline_changed",
+    "occurred_at": "Mon, 02 Mar 2026 18:54:14 GMT",
+    "summary": "Primary tracked headline changed from \"KickFlip announces first comeback with 'Kick Out, Flip Now!' on May 26 - CHOSUNBIZ - Chosunbiz\" to \"KickFlip announces April comeback - Music Mundial\".",
+    "source_url": "https://news.google.com/rss/articles/CBMidEFVX3lxTE1vRVlPU0xVRUlFSlN6SU1oNWQ1VWQxYWNpYUpXaDl6MFVHZWtVSElyTVFIZGZKaU51OFZDRlVTX2R4VmdVZWVzbmVpeEtxb3BrYXkwV3VWb282SVd6dDdlakdaczlVcmtpbWFxWTdOY2NqRS1Z0gF6QVVfeXFMTU5XU1lfWnpuclpnWTlfZm9aVGxocmVnYXN1bzhNenRBUlF2VnJQMzBsZVk5M2RmbklQdnRvUzZneW9qclJ4c29qcTUtSDFPMlNwbk1qUERuVDUtOGpMMldaU25hdVo5MHR3ZnRYYmlSeGNOdnVlOFliUlE?oc=5",
+    "source_domain": "news.google.com",
+    "previous_state_hash": "38fc5dc10088",
+    "next_state_hash": "b6fb18f801c4",
+    "previous": {
+      "scheduled_date": "2026-05-26",
+      "date_status": "",
+      "headline": "KickFlip announces first comeback with 'Kick Out, Flip Now!' on May 26 - CHOSUNBIZ - Chosunbiz",
+      "source_type": "",
+      "source_url": "https://news.google.com/rss/articles/CBMiiAFBVV95cUxNSkVXeVB3R295ckVZMmg1WHo1TFU3Qm5wTmNnN2pvcWRPS0hFcEhwYVhQVjRTQW5Rek9pdFh2QjM0WHN5N1VqV0FFSzNTMUNZeWpsdnZUNkZKejhScmR4MGNhZTIxeGV6X3o1bTZsUmpOX2o1VUYtZDU3M1Q5WXIwek1iWl9neXBy0gGcAUFVX3lxTFBuam1XYkJHRG1ibWx1Zi1MTWVyeC1xSTNWa2I4OE94dkFYZFdoR3E1bnZXRGszUm5RdTR6dDRPOGoyMmg2Y3hUMkJFZFAyNjBrdTZTSFlnLTlZd2wyQzQwU2d4WFRZQ2prZGliTVhZNjJHUEFndVVXS1ZWckZQTTFmOWVXd200OFdzS3E1U1NwZ0xQei1Ccy1ZX1ZSYg?oc=5",
+      "published_at": "Fri, 02 May 2025 07:00:00 GMT"
+    },
+    "next": {
+      "scheduled_date": "",
+      "date_status": "scheduled",
+      "headline": "KickFlip announces April comeback - Music Mundial",
+      "source_type": "news_rss",
+      "source_url": "https://news.google.com/rss/articles/CBMidEFVX3lxTE1vRVlPU0xVRUlFSlN6SU1oNWQ1VWQxYWNpYUpXaDl6MFVHZWtVSElyTVFIZGZKaU51OFZDRlVTX2R4VmdVZWVzbmVpeEtxb3BrYXkwV3VWb282SVd6dDdlakdaczlVcmtpbWFxWTdOY2NqRS1Z0gF6QVVfeXFMTU5XU1lfWnpuclpnWTlfZm9aVGxocmVnYXN1bzhNenRBUlF2VnJQMzBsZVk5M2RmbklQdnRvUzZneW9qclJ4c29qcTUtSDFPMlNwbk1qUERuVDUtOGpMMldaU25hdVo5MHR3ZnRYYmlSeGNOdnVlOFliUlE?oc=5",
+      "published_at": "Mon, 02 Mar 2026 18:54:14 GMT"
+    },
+    "verified_release": null,
+    "snapshot": {
+      "previous_ref": "6bf3920",
+      "next_ref": "78d3b91"
+    }
+  },
+  {
+    "key": "ITZY:ecc1633d5f57:f0a672c666d8:headline_changed",
+    "diff_key": "ITZY:ecc1633d5f57:f0a672c666d8",
+    "group": "ITZY",
+    "change_type": "headline_changed",
+    "occurred_at": "Sun, 01 Mar 2026 15:13:14 GMT",
+    "summary": "Primary tracked headline changed from \"ITZY Announces Comeback with Mini Album 'TUNNEL VISION' Dropping November 10 - K-en News\" to \"ITZY’s YUNA Announces Debut Solo Album ‘Ice Cream’ - inmusicblog.com\".",
+    "source_url": "https://news.google.com/rss/articles/CBMidkFVX3lxTFBXZmRPV244dzlYNDlKZGhGZ1h4QmxOTTBkUU0zN1BlYng0NlQ3QzVfTEdDOVRXWlNEeVRrYXBHdXRQYjBDOWVHVTdGMVBqU0NPcUxKTW1aUWZHQk52M2RNYlNEaG9HV2N2TkZPTzJsLTFrZzUxY0E?oc=5",
+    "source_domain": "news.google.com",
+    "previous_state_hash": "ecc1633d5f57",
+    "next_state_hash": "f0a672c666d8",
+    "previous": {
+      "scheduled_date": "2026-11-10",
+      "date_status": "",
+      "headline": "ITZY Announces Comeback with Mini Album 'TUNNEL VISION' Dropping November 10 - K-en News",
+      "source_type": "",
+      "source_url": "https://news.google.com/rss/articles/CBMiakFVX3lxTE43bDVkTXJ5Q0g2QzZVUjRUVFA3Zll1dU5MM1JVc3lfMWZWd0Y1N0JGYkZtOG9oZ1EtR0ZQcHJCaHBrcTh0UjlvalUza19nMVdNRnF0ZjdfOXFkbU5SVF92YWQ1Y2FtZGZlbmfSAW5BVV95cUxNdXpXUkdwOERzNnR2NmRVS1hpc0xyUWZqTG51MWh2eUpvbm45cTNfM25YUGpyQ2lhRXRBLUtpTTdmZjZISjY1QS1jYkdfTGdZdGhTQTkzdV8zbHE4Z3c0eEhwMDAwRERQdUp6cWt1QQ?oc=5",
+      "published_at": "Fri, 17 Oct 2025 07:00:00 GMT"
+    },
+    "next": {
+      "scheduled_date": "",
+      "date_status": "rumor",
+      "headline": "ITZY’s YUNA Announces Debut Solo Album ‘Ice Cream’ - inmusicblog.com",
+      "source_type": "news_rss",
+      "source_url": "https://news.google.com/rss/articles/CBMidkFVX3lxTFBXZmRPV244dzlYNDlKZGhGZ1h4QmxOTTBkUU0zN1BlYng0NlQ3QzVfTEdDOVRXWlNEeVRrYXBHdXRQYjBDOWVHVTdGMVBqU0NPcUxKTW1aUWZHQk52M2RNYlNEaG9HV2N2TkZPTzJsLTFrZzUxY0E?oc=5",
+      "published_at": "Sun, 01 Mar 2026 15:13:14 GMT"
+    },
+    "verified_release": null,
+    "snapshot": {
+      "previous_ref": "6bf3920",
+      "next_ref": "78d3b91"
+    }
+  },
+  {
+    "key": "NMIXX:b8dec1896121:7dfc4b694e07:verified_release_detected",
+    "diff_key": "NMIXX:b8dec1896121:7dfc4b694e07",
+    "group": "NMIXX",
+    "change_type": "verified_release_detected",
+    "occurred_at": "2026-02-26",
+    "summary": "Verified release \"TIC TIC\" landed on 2026-02-26.",
+    "source_url": "https://musicbrainz.org/release-group/b71aa2e7-c4a3-44ea-a577-f9459bf6456f",
+    "source_domain": "musicbrainz.org",
+    "previous_state_hash": "b8dec1896121",
+    "next_state_hash": "7dfc4b694e07",
+    "previous": {
+      "scheduled_date": "2026-03-17",
+      "date_status": "",
+      "headline": "NMIXX confirms March 17 comeback with ‘Fe3O4: FORWARD’—final chapter in trilogy - allkpop",
+      "source_type": "",
+      "source_url": "https://news.google.com/rss/articles/CBMitgFBVV95cUxQSzJjVE83NU5CRVBnYzQyQTYtWHI2dk90dnlsMGE4enRualhXNjMydmJ1djhXQ2Rsd01mOEpabzhUS2xXZ3UxSHZsRUFGVUtrcERXRmh3VUVYd0Y4aTRMaXhJalpvdFNQdW9sQ0h0UTR1bnZiUjdNallMLURhMVU4ZzNrT19uRjkzVFF1d010clZNek8ydGxuWGVMSm1GVDBNV1hUa2lXRC1JWG5OYkNVSnF1VTk3UQ?oc=5",
+      "published_at": "Tue, 18 Feb 2025 08:00:00 GMT"
+    },
+    "next": null,
+    "verified_release": {
+      "title": "TIC TIC",
+      "date": "2026-02-26",
+      "release_kind": "single",
+      "source": "https://musicbrainz.org/release-group/b71aa2e7-c4a3-44ea-a577-f9459bf6456f"
+    },
+    "snapshot": {
+      "previous_ref": "6bf3920",
+      "next_ref": "78d3b91"
+    }
+  },
+  {
+    "key": "H1-KEY:d23f9c941edf:3af0c3d72b42:headline_changed",
+    "diff_key": "H1-KEY:d23f9c941edf:3af0c3d72b42",
+    "group": "H1-KEY",
+    "change_type": "headline_changed",
+    "occurred_at": "Mon, 16 Feb 2026 07:01:55 GMT",
+    "summary": "Primary tracked headline changed from \"Girl group H1-KEY to release new album on June 26 - Korea JoongAng Daily\" to \"H1-KEY announces a comeback with their 5th mini album 'LOVE CHAPTER' - allkpop\".",
+    "source_url": "https://news.google.com/rss/articles/CBMiqgFBVV95cUxNXzdveG1oNkJmUXlwOUdGZGttWXdGNVBiVUJtcnB0MVJ1MmJPaHloLXVFQXc4S0pfU1NQRnVqZlF4ODY3OGFxbDNfQU9HbGVwZndGOWluRmtpTU9SMV9pME1BdnJJcWduNm9VbFVkTzBuWmdzelFmNV9CQnhORUt5U0dySmtSMV9Iak1Ebk1aemNDOW9qUzNKV1ppZXZ1eDVUZG1iWGFvdUNQQQ?oc=5",
+    "source_domain": "news.google.com",
+    "previous_state_hash": "d23f9c941edf",
+    "next_state_hash": "3af0c3d72b42",
+    "previous": {
+      "scheduled_date": "2026-06-26",
+      "date_status": "",
+      "headline": "Girl group H1-KEY to release new album on June 26 - Korea JoongAng Daily",
+      "source_type": "",
+      "source_url": "https://news.google.com/rss/articles/CBMixwFBVV95cUxNU3FKdE9VZTE3azRmV2toSjlCbVNsNWd1RmNVaXN0b2FRNGFzMG1wRTI4SnhFNmt0cTBhOVppcWxQcGFCSl9ibTVRQzZFSS1XdVN4R2I2WDNWQmhQV2xyNTFTWmRQYTNfeURCdlBCY3d3QzJxd1AySTc3SnNPaVJSV3VFUUJwS05sTU1CMlZMQlFHa2ZkTkRnalRZY1A2N1pNNlBmQlFmVFlEQXpya0RXUzNUTVRKTFRtb3V5Vzg4ZkVtS3hhZ0RJ?oc=5",
+      "published_at": "Mon, 02 Jun 2025 07:00:00 GMT"
+    },
+    "next": {
+      "scheduled_date": "",
+      "date_status": "rumor",
+      "headline": "H1-KEY announces a comeback with their 5th mini album 'LOVE CHAPTER' - allkpop",
+      "source_type": "news_rss",
+      "source_url": "https://news.google.com/rss/articles/CBMiqgFBVV95cUxNXzdveG1oNkJmUXlwOUdGZGttWXdGNVBiVUJtcnB0MVJ1MmJPaHloLXVFQXc4S0pfU1NQRnVqZlF4ODY3OGFxbDNfQU9HbGVwZndGOWluRmtpTU9SMV9pME1BdnJJcWduNm9VbFVkTzBuWmdzelFmNV9CQnhORUt5U0dySmtSMV9Iak1Ebk1aemNDOW9qUzNKV1ppZXZ1eDVUZG1iWGFvdUNQQQ?oc=5",
+      "published_at": "Mon, 16 Feb 2026 07:01:55 GMT"
+    },
+    "verified_release": null,
+    "snapshot": {
+      "previous_ref": "6bf3920",
+      "next_ref": "78d3b91"
+    }
+  },
+  {
+    "key": "BLACKPINK:314a54142779:acdf98c3adc8:headline_changed",
+    "diff_key": "BLACKPINK:314a54142779:acdf98c3adc8",
+    "group": "BLACKPINK",
+    "change_type": "headline_changed",
+    "occurred_at": "Fri, 06 Feb 2026 00:00:00 GMT",
+    "summary": "Primary tracked headline changed from \"Blackpink's DEADLINE sells 1.46 million copies on day of release, sets new K-pop girl group record - The Korea Economic Daily Global Edition\" to \"BLACKPINK’s New Title Track Is ‘GO’.. YG “Created with Great Care”\".",
+    "source_url": "https://www.ygfamily.com/en/news/report/7378",
+    "source_domain": "www.ygfamily.com",
+    "previous_state_hash": "314a54142779",
+    "next_state_hash": "acdf98c3adc8",
+    "previous": {
+      "scheduled_date": "",
+      "date_status": "rumor",
+      "headline": "Blackpink's DEADLINE sells 1.46 million copies on day of release, sets new K-pop girl group record - The Korea Economic Daily Global Edition",
+      "source_type": "news_rss",
+      "source_url": "https://news.google.com/rss/articles/CBMiZ0FVX3lxTE94bmhvU2RuMVBXTGNpS1VMaExLUXN6c0lCekxVbm1KTy1McTNvTkUycE1KNUl1c0U3b2c5ajh3cE9WSEs0TGJwNlgyZU9LX3JHam55VVhGX3h2SDBoaUdtcGYwWmdGdHc?oc=5",
+      "published_at": "Sun, 01 Mar 2026 17:47:48 GMT"
+    },
+    "next": {
+      "scheduled_date": "",
+      "date_status": "rumor",
+      "headline": "BLACKPINK’s New Title Track Is ‘GO’.. YG “Created with Great Care”",
+      "source_type": "agency_notice",
+      "source_url": "https://www.ygfamily.com/en/news/report/7378",
+      "published_at": "Fri, 06 Feb 2026 00:00:00 GMT"
+    },
+    "verified_release": null,
+    "snapshot": {
+      "previous_ref": "78d3b91",
+      "next_ref": "95f5db3"
+    }
+  },
+  {
+    "key": "BABYMONSTER:5eb7d69c1523:3c768cd8c88a:headline_changed",
+    "diff_key": "BABYMONSTER:5eb7d69c1523:3c768cd8c88a",
+    "group": "BABYMONSTER",
+    "change_type": "headline_changed",
+    "occurred_at": "Tue, 03 Feb 2026 00:00:00 GMT",
+    "summary": "Primary tracked headline changed from \"YG Entertainment confirms BABYMONSTER World Tour & BIGBANG's Global - bandwagon.asia\" to \"BABYMONSTER’s B-Side Track From Two Years Ago Makes a Reverse Chart Run… Reappears on ‘M Countdown’ → Live Clip Released\".",
+    "source_url": "https://www.ygfamily.com/en/news/report/7372",
+    "source_domain": "www.ygfamily.com",
+    "previous_state_hash": "5eb7d69c1523",
+    "next_state_hash": "3c768cd8c88a",
+    "previous": {
+      "scheduled_date": "",
+      "date_status": "rumor",
+      "headline": "YG Entertainment confirms BABYMONSTER World Tour & BIGBANG's Global - bandwagon.asia",
+      "source_type": "news_rss",
+      "source_url": "https://news.google.com/rss/articles/CBMi2gFBVV95cUxOZWI5YWpSUmd6bk1rYS1VM1o3bXU4aFNhaTRfLUhvYjBKSUN5S1ZSc0NPalNBZVlMaDI0UE9EVVktaWlPZ0RHWEd1SFN4MVcwM1IzaEY2VkpxcUViUDZEQVFaV3BSbmFHbXhmejZFTXpLQ2hMV3BzS1Foc0ZoNHdJZ0xkaGJnZXZYczNrY3d2b3dJb2EzNVROZy1DRlIyUFBPTU9UU2FKVTlvVVV5cTIyRjZfdl9WSFNCWXo2dUwzQzE5ZnluSGQ5X29BVGRZZXZVTUE4N1U3a29nQQ?oc=5",
+      "published_at": "Wed, 04 Mar 2026 04:00:00 GMT"
+    },
+    "next": {
+      "scheduled_date": "",
+      "date_status": "rumor",
+      "headline": "BABYMONSTER’s B-Side Track From Two Years Ago Makes a Reverse Chart Run… Reappears on ‘M Countdown’ → Live Clip Released",
+      "source_type": "agency_notice",
+      "source_url": "https://www.ygfamily.com/en/news/report/7372",
+      "published_at": "Tue, 03 Feb 2026 00:00:00 GMT"
+    },
+    "verified_release": null,
+    "snapshot": {
+      "previous_ref": "78d3b91",
+      "next_ref": "95f5db3"
+    }
+  },
+  {
+    "key": "ATEEZ:e71be4c334b3:53436cf75180:headline_changed",
+    "diff_key": "ATEEZ:e71be4c334b3:53436cf75180",
+    "group": "ATEEZ",
+    "change_type": "headline_changed",
+    "occurred_at": "Mon, 12 Jan 2026 08:00:00 GMT",
+    "summary": "Primary tracked headline changed from \"ATEEZ to make a comeback with 'Golden Hour: Part.2' on November 15 - DIPE.CO.KR\" to \"ATEEZ’s ‘GOLDEN HOUR: Part 4’ Drops Feb. 6 - 조선일보\".",
+    "source_url": "https://news.google.com/rss/articles/CBMijgFBVV95cUxOZ1QwQUN0VU5HMU51RFhteEs0eXpiTTV3QzRsQXozM01IbGNRb3ZOdFkyTVUzRGxYdmlWVGtkZ2hyekhyYVJMb3ZadlpoQXpscWFwVG1STGlQeGdDZTc0elNEMzFCQk54MENBNnJ4Z0hsS2FjcnZCZjZFbTZoZkhkOGNtVGRwU0x1cVotN3F3?oc=5",
+    "source_domain": "news.google.com",
+    "previous_state_hash": "e71be4c334b3",
+    "next_state_hash": "53436cf75180",
+    "previous": {
+      "scheduled_date": "2026-11-15",
+      "date_status": "",
+      "headline": "ATEEZ to make a comeback with 'Golden Hour: Part.2' on November 15 - DIPE.CO.KR",
+      "source_type": "",
+      "source_url": "https://news.google.com/rss/articles/CBMiREFVX3lxTE9UVzdIZV9rUmYwZ0dzc2RTaXBnRTktZmFIRFBYRGJTTERxeUlqZkFUMjlUSWFnanpNb2t1dGFNQzdVSmxh?oc=5",
+      "published_at": "Thu, 24 Oct 2024 07:00:00 GMT"
+    },
+    "next": {
+      "scheduled_date": "",
+      "date_status": "rumor",
+      "headline": "ATEEZ’s ‘GOLDEN HOUR: Part 4’ Drops Feb. 6 - 조선일보",
+      "source_type": "news_rss",
+      "source_url": "https://news.google.com/rss/articles/CBMijgFBVV95cUxOZ1QwQUN0VU5HMU51RFhteEs0eXpiTTV3QzRsQXozM01IbGNRb3ZOdFkyTVUzRGxYdmlWVGtkZ2hyekhyYVJMb3ZadlpoQXpscWFwVG1STGlQeGdDZTc0elNEMzFCQk54MENBNnJ4Z0hsS2FjcnZCZjZFbTZoZkhkOGNtVGRwU0x1cVotN3F3?oc=5",
+      "published_at": "Mon, 12 Jan 2026 08:00:00 GMT"
+    },
+    "verified_release": null,
+    "snapshot": {
+      "previous_ref": "6bf3920",
+      "next_ref": "78d3b91"
+    }
+  },
+  {
+    "key": "ENHYPEN:fc4fac186f56:2a871faa1f26:headline_changed",
+    "diff_key": "ENHYPEN:fc4fac186f56:2a871faa1f26",
+    "group": "ENHYPEN",
+    "change_type": "headline_changed",
+    "occurred_at": "Fri, 09 Jan 2026 08:00:00 GMT",
+    "summary": "Primary tracked headline changed from \"ENHYPEN Announces June 5 Comeback — Coachella + 6th Mini Album Combo! - DIPE.CO.KR\" to \"ENHYPEN's 'Knife' Reveals Sharp-Fanged Vampires - 조선일보\".",
+    "source_url": "https://news.google.com/rss/articles/CBMijgFBVV95cUxPblZfVHkyVDBQVmZPY0pJaGFqNEd3RTVrQUtXejJEOEE0d0RlaXRteml5TEJuYm44Y0tSb2paeXBHeXI1MlpISTJPUkJld01oWFduVTlIVERpRXpIRWdaeklOWS1nSXpSQTNYZWdCU1d5am9TWFRxV1U4X3BDRWJTcDNoekUxYnNrVXlZYWpR?oc=5",
+    "source_domain": "news.google.com",
+    "previous_state_hash": "fc4fac186f56",
+    "next_state_hash": "2a871faa1f26",
+    "previous": {
+      "scheduled_date": "2026-06-05",
+      "date_status": "",
+      "headline": "ENHYPEN Announces June 5 Comeback — Coachella + 6th Mini Album Combo! - DIPE.CO.KR",
+      "source_type": "",
+      "source_url": "https://news.google.com/rss/articles/CBMiREFVX3lxTE1paTFuVUdaZEQtTERYX0JEWW04VUFEZGlERDFmS1VUVDRiOUdPcFhhTUhPdW9ZMTh4Rkd3NUtsbXdpMWJK?oc=5",
+      "published_at": "Mon, 14 Apr 2025 07:00:00 GMT"
+    },
+    "next": {
+      "scheduled_date": "",
+      "date_status": "rumor",
+      "headline": "ENHYPEN's 'Knife' Reveals Sharp-Fanged Vampires - 조선일보",
+      "source_type": "news_rss",
+      "source_url": "https://news.google.com/rss/articles/CBMijgFBVV95cUxPblZfVHkyVDBQVmZPY0pJaGFqNEd3RTVrQUtXejJEOEE0d0RlaXRteml5TEJuYm44Y0tSb2paeXBHeXI1MlpISTJPUkJld01oWFduVTlIVERpRXpIRWdaeklOWS1nSXpSQTNYZWdCU1d5am9TWFRxV1U4X3BDRWJTcDNoekUxYnNrVXlZYWpR?oc=5",
+      "published_at": "Fri, 09 Jan 2026 08:00:00 GMT"
+    },
+    "verified_release": null,
+    "snapshot": {
+      "previous_ref": "6bf3920",
+      "next_ref": "78d3b91"
+    }
+  },
+  {
+    "key": "ONEUS:0742c5492bab:ac6dca984aae:headline_changed",
+    "diff_key": "ONEUS:0742c5492bab:ac6dca984aae",
+    "group": "ONEUS",
+    "change_type": "headline_changed",
+    "occurred_at": "Wed, 07 Jan 2026 08:00:00 GMT",
+    "summary": "Primary tracked headline changed from \"ONEUS to return on June 30 with 11th mini album ‘5x’ - allkpop\" to \"ONEUS reveals the tracks for their upcoming single album ‘原 (Won)’ - allkpop\".",
+    "source_url": "https://news.google.com/rss/articles/CBMinAFBVV95cUxOeHlXTUR3OFozMFR2U0xuZWVaNUtPWmc2Y1ZkTFFYZFh6OHN5ekZfRWxGWXduYjAzbDZBYXh5NS0tZjJOSWdYdnRwc0NjQXhCSV9hYV9JRDJnWUJ6ekNXWGVBTUtiUDNGZFR5QnVoYTMybi04Y3ByMC00eHRZZlI3c2RFSHVPRS1ULS1YblplQjVCeWROanBETlJyMlo?oc=5",
+    "source_domain": "news.google.com",
+    "previous_state_hash": "0742c5492bab",
+    "next_state_hash": "ac6dca984aae",
+    "previous": {
+      "scheduled_date": "2026-06-30",
+      "date_status": "",
+      "headline": "ONEUS to return on June 30 with 11th mini album ‘5x’ - allkpop",
+      "source_type": "",
+      "source_url": "https://news.google.com/rss/articles/CBMilAFBVV95cUxNbS1BYXFxVE1sT1c5QlNqWnE2ZXV2Y1A5N01uT2NrWlZmNEt4eGVqUVlCbTBPbXZCUkktUVF3eGNyOW4zTy1XZDFSaVg4czFyMEhWd1o5VmV4X0tMWTRqNll6MDZOakE4OWE1NGVZcjdsZ014WUl4ckNRbDZLODFyTWxhbHI4REFGZ0Rta1hHRzQ2MVZN?oc=5",
+      "published_at": "Mon, 09 Jun 2025 07:00:00 GMT"
+    },
+    "next": {
+      "scheduled_date": "",
+      "date_status": "rumor",
+      "headline": "ONEUS reveals the tracks for their upcoming single album ‘原 (Won)’ - allkpop",
+      "source_type": "news_rss",
+      "source_url": "https://news.google.com/rss/articles/CBMinAFBVV95cUxOeHlXTUR3OFozMFR2U0xuZWVaNUtPWmc2Y1ZkTFFYZFh6OHN5ekZfRWxGWXduYjAzbDZBYXh5NS0tZjJOSWdYdnRwc0NjQXhCSV9hYV9JRDJnWUJ6ekNXWGVBTUtiUDNGZFR5QnVoYTMybi04Y3ByMC00eHRZZlI3c2RFSHVPRS1ULS1YblplQjVCeWROanBETlJyMlo?oc=5",
+      "published_at": "Wed, 07 Jan 2026 08:00:00 GMT"
+    },
+    "verified_release": null,
+    "snapshot": {
+      "previous_ref": "6bf3920",
+      "next_ref": "78d3b91"
+    }
+  },
+  {
+    "key": "ZEROBASEONE:6610213246bf:1463cb22d3c2:headline_changed",
+    "diff_key": "ZEROBASEONE:6610213246bf:1463cb22d3c2",
+    "group": "ZEROBASEONE",
+    "change_type": "headline_changed",
+    "occurred_at": "Tue, 06 Jan 2026 08:00:00 GMT",
+    "summary": "Primary tracked headline changed from \"ZEROBASEONE announces global comeback show 'WHO MADE THIS!' for September 1 - CHOSUNBIZ - Chosunbiz\" to \"ZEROBASEONE Drops Track Poster for ‘Running To Future’ Ahead of Comeback - K-en News\".",
+    "source_url": "https://news.google.com/rss/articles/CBMiakFVX3lxTE9BeUhpZUhiSnN5QkdyX0s2WG83X0htbHdlNkl3UXdYcmlDbHA2eUNOQjhoeUFHWDN0R2E3YUhjejRtdkk2NUFjVHUzYnhwWm5mOHRob3RKZGZCMnVSZXVkdlk3T2pvVmQ4QWfSAW5BVV95cUxOMmFwRWhrTkE3QS1ORkR2X01fVHdTU0I1dU1fMmxMTlpiRFFENnVOMnBSRHJjdEQ2dDAxV2pKY3dSb2NHdF9jSEN6ZW51SW8wV1hEU191WXBIZ1BwdXZEQWg4S0lpai1aNV9Gbi1RZw?oc=5",
+    "source_domain": "news.google.com",
+    "previous_state_hash": "6610213246bf",
+    "next_state_hash": "1463cb22d3c2",
+    "previous": {
+      "scheduled_date": "2026-09-01",
+      "date_status": "",
+      "headline": "ZEROBASEONE announces global comeback show 'WHO MADE THIS!' for September 1 - CHOSUNBIZ - Chosunbiz",
+      "source_type": "",
+      "source_url": "https://news.google.com/rss/articles/CBMiiAFBVV95cUxPMG0yVGJZcUNUZWp2ME5MWGJaMWlseFNCTnRDX09KTVRXamlCTnNjU1luMzFhX1QtcXAwektpcmN4UThXZF9WeGpyd3R3NkdiUXN3QjNDVG9YRlROUHFfOWZ6by1SelBvb05hNHBmV1NuYWxJb0ZJRkZWbUM0aEMycHhVUjNoZEQx0gGcAUFVX3lxTE11a0hYTVhoZnpFa1pDMjRYcW5CM0dabFNVNDVmREN2LUU2Y3JDa0o2MDZDREVlUWxsV21JWHNHTm9Kb1VLWFFUUVV4N21PWVNyejdvckR0ek5pZHRTNDVpQlhqWVVkWDkwM2xRSmNQUVRRWDZUSVBpa0otd180UWVuampuYTVqeG1JdFQwOU95RTNPaDRUZU1GM28ycA?oc=5",
+      "published_at": "Wed, 06 Aug 2025 07:00:00 GMT"
+    },
+    "next": {
+      "scheduled_date": "",
+      "date_status": "rumor",
+      "headline": "ZEROBASEONE Drops Track Poster for ‘Running To Future’ Ahead of Comeback - K-en News",
+      "source_type": "news_rss",
+      "source_url": "https://news.google.com/rss/articles/CBMiakFVX3lxTE9BeUhpZUhiSnN5QkdyX0s2WG83X0htbHdlNkl3UXdYcmlDbHA2eUNOQjhoeUFHWDN0R2E3YUhjejRtdkk2NUFjVHUzYnhwWm5mOHRob3RKZGZCMnVSZXVkdlk3T2pvVmQ4QWfSAW5BVV95cUxOMmFwRWhrTkE3QS1ORkR2X01fVHdTU0I1dU1fMmxMTlpiRFFENnVOMnBSRHJjdEQ2dDAxV2pKY3dSb2NHdF9jSEN6ZW51SW8wV1hEU191WXBIZ1BwdXZEQWg4S0lpai1aNV9Gbi1RZw?oc=5",
+      "published_at": "Tue, 06 Jan 2026 08:00:00 GMT"
+    },
+    "verified_release": null,
+    "snapshot": {
+      "previous_ref": "6bf3920",
+      "next_ref": "78d3b91"
+    }
+  }
+]


### PR DESCRIPTION
## Summary\n- add a snapshot diff generator that writes  from historical upcoming/release snapshots\n- surface recent change events inside the team page upcoming block\n- show optional change badges on future signal cards across the app\n\n## Verification\n- python3 build_release_change_log.py\n- npm run build\n- npm run lint\n\nCloses #36