### PR TITLE
#89 Compact the calendar header and filter UI

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -116,42 +116,50 @@
 
 .context-header {
   display: grid;
-  gap: 18px;
-  margin-bottom: 24px;
+  gap: 14px;
+  margin-bottom: 18px;
 }
 
 .context-header-top {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(320px, 420px);
-  gap: 24px;
-  align-items: start;
+  gap: 18px;
+  align-items: stretch;
+}
+
+.context-header-copy,
+.context-header-controls,
+.context-filter-stack {
+  display: grid;
+  gap: 12px;
 }
 
 .context-header-copy h1 {
   margin: 0;
   max-width: 12ch;
-  font-size: clamp(2rem, 4vw, 3.4rem);
+  font-size: clamp(1.8rem, 3.6vw, 2.9rem);
   line-height: 0.96;
 }
 
-.context-header-controls {
+.context-header-search-row {
   display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
   gap: 12px;
-}
-
-.context-header-utility-row {
-  display: flex;
-  justify-content: flex-end;
+  align-items: end;
 }
 
 .context-filter-grid,
 .context-summary-grid {
   display: grid;
-  gap: 14px;
+  gap: 10px;
 }
 
 .context-filter-grid {
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.context-filter-grid-primary {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
 .context-summary-grid {
@@ -166,10 +174,10 @@
 
 .context-summary-card {
   display: grid;
-  gap: 8px;
-  min-height: 112px;
+  gap: 6px;
+  min-height: 92px;
   border-radius: 20px;
-  padding: 16px 18px;
+  padding: 14px 16px;
 }
 
 .context-summary-card span {
@@ -191,9 +199,9 @@
 
 .context-highlight-card {
   display: grid;
-  gap: 14px;
+  gap: 12px;
   border-radius: 24px;
-  padding: 18px 20px;
+  padding: 16px 18px;
   background:
     radial-gradient(circle at top right, rgba(255, 170, 138, 0.18), transparent 40%),
     rgba(255, 255, 255, 0.76);
@@ -277,7 +285,7 @@
 
 .filter-group {
   display: grid;
-  gap: 8px;
+  gap: 6px;
 }
 
 .filter-group span {
@@ -285,18 +293,45 @@
   color: var(--text-soft);
 }
 
+.filter-group-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
 .filter-row {
   display: flex;
   flex-wrap: wrap;
-  gap: 10px;
+  gap: 8px;
 }
 
 .filter-chip {
   border: 1px solid rgba(27, 42, 65, 0.12);
   border-radius: 999px;
-  padding: 10px 14px;
+  padding: 8px 12px;
   background: rgba(255, 255, 255, 0.84);
   color: var(--text-soft);
+  font-size: 0.82rem;
+}
+
+.filter-group-agency {
+  gap: 10px;
+}
+
+.filter-row-agency {
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  padding-bottom: 4px;
+  scrollbar-width: thin;
+}
+
+.filter-row-agency-expanded {
+  flex-wrap: wrap;
+  max-height: 120px;
+  overflow-x: hidden;
+  overflow-y: auto;
+  padding-right: 4px;
 }
 
 .filter-chip-active {
@@ -322,7 +357,7 @@
   border: 1px solid rgba(27, 42, 65, 0.12);
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.88);
-  padding: 14px 18px;
+  padding: 12px 16px;
   font: inherit;
   color: var(--text-strong);
 }
@@ -2565,16 +2600,11 @@
     max-width: none;
   }
 
-  .hero-topline {
+  .hero-topline,
+  .monthly-dashboard-head,
+  .context-header-search-row {
+    grid-template-columns: 1fr;
     flex-direction: column;
-  }
-
-  .monthly-dashboard-head {
-    flex-direction: column;
-  }
-
-  .context-header-utility-row {
-    justify-content: flex-start;
   }
 
   .sidebar-upcoming-panel {
@@ -2602,6 +2632,7 @@
   .toolbar,
   .context-highlight-head,
   .context-highlight-body,
+  .filter-group-head,
   .daily-share-head,
   .daily-share-brand-row,
   .daily-share-date-row {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -438,6 +438,8 @@ const TRANSLATIONS = {
       status: '표시 상태',
       agency: '소속사',
     },
+    agencyFilterExpand: '전체 소속사 보기',
+    agencyFilterCollapse: '접기',
     filterOptions: {
       all: '전체',
       single: '싱글',
@@ -644,6 +646,8 @@ const TRANSLATIONS = {
       status: 'Status',
       agency: 'Agency',
     },
+    agencyFilterExpand: 'Browse all agencies',
+    agencyFilterCollapse: 'Collapse',
     filterOptions: {
       all: 'All',
       single: 'Single',
@@ -1428,18 +1432,39 @@ function App() {
           <div className="context-header-copy">
             <p className="panel-label">{copy.monthlyContextLabel}</p>
             <h1>{monthlyContextTitle}</h1>
+            <div className="context-summary-grid">
+              <article className="context-summary-card">
+                <span>{copy.monthlySummaryLabels.verified}</span>
+                <strong>{monthReleases.length}</strong>
+              </article>
+              <article className="context-summary-card">
+                <span>{copy.monthlySummaryLabels.scheduled}</span>
+                <strong>{monthScheduledDashboardRows.length}</strong>
+              </article>
+              <article className="context-summary-card">
+                <span>{copy.monthlySummaryLabels.nearest}</span>
+                <strong>
+                  {nearestMonthlySignal
+                    ? formatOptionalDate(nearestMonthlySignal.scheduled_date, displayDateFormatter, copy.none)
+                    : copy.monthlyNearestEmpty}
+                </strong>
+                <p className="context-summary-meta">
+                  {nearestMonthlySignal ? getTeamDisplayName(nearestMonthlySignal.group) : copy.none}
+                </p>
+              </article>
+            </div>
           </div>
 
           <div className="context-header-controls">
-            <label className="search-field">
-              <span>{copy.searchLabel}</span>
-              <input
-                value={search}
-                onChange={(event) => setSearch(event.target.value)}
-                placeholder={copy.searchPlaceholder}
-              />
-            </label>
-            <div className="context-header-utility-row">
+            <div className="context-header-search-row">
+              <label className="search-field">
+                <span>{copy.searchLabel}</span>
+                <input
+                  value={search}
+                  onChange={(event) => setSearch(event.target.value)}
+                  placeholder={copy.searchPlaceholder}
+                />
+              </label>
               <div className="language-switch" role="group" aria-label={copy.languageLabel}>
                 {LANGUAGE_OPTIONS.map((option) => (
                   <button
@@ -1455,32 +1480,82 @@ function App() {
                 ))}
               </div>
             </div>
+
+            <article className="context-highlight-card">
+              <div className="context-highlight-head">
+                <div>
+                  <p className="panel-label">{copy.monthlyHighlightLabel}</p>
+                  <h2>{nearestMonthlySignal ? nearestMonthlySignal.headline : copy.monthlyNearestEmpty}</h2>
+                </div>
+                {nearestMonthlySignal ? (
+                  <div className="signal-tags">
+                    <UpcomingCountdownBadge item={nearestMonthlySignal} formatter={shortDateFormatter} />
+                    <span className={`signal-badge signal-badge-date-${nearestMonthlySignal.date_status}`}>
+                      {formatDateStatus(nearestMonthlySignal.date_status, language)}
+                    </span>
+                  </div>
+                ) : null}
+              </div>
+
+              {nearestMonthlySignal ? (
+                <div className="context-highlight-body">
+                  <div>
+                    <TeamIdentity group={nearestMonthlySignal.group} variant="list" />
+                    <p className="signal-meta">
+                      {formatOptionalDate(nearestMonthlySignal.scheduled_date, displayDateFormatter, copy.none)} ·{' '}
+                      {formatSourceType(nearestMonthlySignal.source_type, language)} ·{' '}
+                      {nearestMonthlySignal.source_domain || copy.sourceTypeLabels.pending}
+                    </p>
+                    {formatUpcomingEvidenceMeta(nearestMonthlySignal, language) ? (
+                      <p className="signal-meta">{formatUpcomingEvidenceMeta(nearestMonthlySignal, language)}</p>
+                    ) : null}
+                  </div>
+                  <div className="context-highlight-actions">
+                    <button type="button" className="inline-button" onClick={() => openTeamPage(nearestMonthlySignal.group)}>
+                      {teamCopy.action}
+                    </button>
+                    {nearestMonthlySignal.source_url ? (
+                      <a href={nearestMonthlySignal.source_url} target="_blank" rel="noreferrer">
+                        {copy.open}
+                      </a>
+                    ) : (
+                      <span className="signal-link-muted">{copy.noSourceLink}</span>
+                    )}
+                  </div>
+                </div>
+              ) : (
+                <p className="empty-copy">{copy.monthlyHighlightEmpty}</p>
+              )}
+            </article>
           </div>
         </div>
 
-        <div className="context-filter-grid">
-          <FilterGroup
-            label={copy.filterLabels.releaseKind}
-            options={releaseKindOptions}
-            selected={selectedReleaseKind}
-            language={language}
-            onSelect={(value) => setSelectedReleaseKind(value)}
-          />
-          <FilterGroup
-            label={copy.filterLabels.actType}
-            options={actTypeOptions}
-            selected={selectedActType}
-            language={language}
-            onSelect={(value) => setSelectedActType(value)}
-          />
-          <FilterGroup
-            label={copy.filterLabels.status}
-            options={dashboardStatusOptions}
-            selected={selectedDashboardStatus}
-            language={language}
-            onSelect={(value) => setSelectedDashboardStatus(value)}
-          />
-          <FilterGroup
+        <div className="context-filter-stack">
+          <div className="context-filter-grid context-filter-grid-primary">
+            <FilterGroup
+              label={copy.filterLabels.releaseKind}
+              options={releaseKindOptions}
+              selected={selectedReleaseKind}
+              language={language}
+              onSelect={(value) => setSelectedReleaseKind(value)}
+            />
+            <FilterGroup
+              label={copy.filterLabels.actType}
+              options={actTypeOptions}
+              selected={selectedActType}
+              language={language}
+              onSelect={(value) => setSelectedActType(value)}
+            />
+            <FilterGroup
+              label={copy.filterLabels.status}
+              options={dashboardStatusOptions}
+              selected={selectedDashboardStatus}
+              language={language}
+              onSelect={(value) => setSelectedDashboardStatus(value)}
+            />
+          </div>
+
+          <AgencyFilterGroup
             label={copy.filterLabels.agency}
             options={agencyFilterOptions}
             selected={selectedAgency}
@@ -1488,79 +1563,6 @@ function App() {
             onSelect={setSelectedAgency}
           />
         </div>
-
-        <div className="context-summary-grid">
-          <article className="context-summary-card">
-            <span>{copy.monthlySummaryLabels.verified}</span>
-            <strong>{monthReleases.length}</strong>
-          </article>
-          <article className="context-summary-card">
-            <span>{copy.monthlySummaryLabels.scheduled}</span>
-            <strong>{monthScheduledDashboardRows.length}</strong>
-          </article>
-          <article className="context-summary-card">
-            <span>{copy.monthlySummaryLabels.nearest}</span>
-            <strong>
-              {nearestMonthlySignal
-                ? formatOptionalDate(nearestMonthlySignal.scheduled_date, displayDateFormatter, copy.none)
-                : copy.monthlyNearestEmpty}
-            </strong>
-            <p className="context-summary-meta">
-              {nearestMonthlySignal ? getTeamDisplayName(nearestMonthlySignal.group) : copy.none}
-            </p>
-          </article>
-        </div>
-
-        <article className="context-highlight-card">
-          <div className="context-highlight-head">
-            <div>
-              <p className="panel-label">{copy.monthlyHighlightLabel}</p>
-              <h2>
-                {nearestMonthlySignal ? nearestMonthlySignal.headline : copy.monthlyNearestEmpty}
-              </h2>
-            </div>
-            {nearestMonthlySignal ? (
-              <div className="signal-tags">
-                <UpcomingCountdownBadge item={nearestMonthlySignal} formatter={shortDateFormatter} />
-                <span className={`signal-badge signal-badge-date-${nearestMonthlySignal.date_status}`}>
-                  {formatDateStatus(nearestMonthlySignal.date_status, language)}
-                </span>
-              </div>
-            ) : null}
-          </div>
-
-          {nearestMonthlySignal ? (
-            <>
-              <div className="context-highlight-body">
-                <div>
-                  <TeamIdentity group={nearestMonthlySignal.group} variant="list" />
-                  <p className="signal-meta">
-                    {formatOptionalDate(nearestMonthlySignal.scheduled_date, displayDateFormatter, copy.none)} ·{' '}
-                    {formatSourceType(nearestMonthlySignal.source_type, language)} ·{' '}
-                    {nearestMonthlySignal.source_domain || copy.sourceTypeLabels.pending}
-                  </p>
-                  {formatUpcomingEvidenceMeta(nearestMonthlySignal, language) ? (
-                    <p className="signal-meta">{formatUpcomingEvidenceMeta(nearestMonthlySignal, language)}</p>
-                  ) : null}
-                </div>
-                <div className="context-highlight-actions">
-                  <button type="button" className="inline-button" onClick={() => openTeamPage(nearestMonthlySignal.group)}>
-                    {teamCopy.action}
-                  </button>
-                  {nearestMonthlySignal.source_url ? (
-                    <a href={nearestMonthlySignal.source_url} target="_blank" rel="noreferrer">
-                      {copy.open}
-                    </a>
-                  ) : (
-                    <span className="signal-link-muted">{copy.noSourceLink}</span>
-                  )}
-                </div>
-              </div>
-            </>
-          ) : (
-            <p className="empty-copy">{copy.monthlyHighlightEmpty}</p>
-          )}
-        </article>
       </header>
 
       {selectedTeam ? (
@@ -4338,6 +4340,50 @@ function FilterGroup<T extends string>({
       <span>{label}</span>
       <div className="filter-row">
         {options.map((option) => (
+          <button
+            type="button"
+            key={option}
+            className={`filter-chip ${selected === option ? 'filter-chip-active' : ''}`}
+            onClick={() => onSelect(option)}
+          >
+            {formatFilterOption(option, language)}
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function AgencyFilterGroup<T extends string>({
+  label,
+  options,
+  selected,
+  language,
+  onSelect,
+}: {
+  label: string
+  options: readonly T[]
+  selected: T
+  language: Language
+  onSelect: (value: T) => void
+}) {
+  const copy = TRANSLATIONS[language]
+  const [expanded, setExpanded] = useState(selected !== 'all')
+  const collapsedOptions = Array.from(
+    new Set([options[0], selected, ...options.filter((option) => option !== options[0]).slice(0, 4)]),
+  ).filter(Boolean) as T[]
+  const visibleOptions = expanded ? options : collapsedOptions
+
+  return (
+    <div className="filter-group filter-group-agency">
+      <div className="filter-group-head">
+        <span>{label}</span>
+        <button type="button" className="inline-button" onClick={() => setExpanded((value) => !value)}>
+          {expanded ? copy.agencyFilterCollapse : copy.agencyFilterExpand}
+        </button>
+      </div>
+      <div className={`filter-row filter-row-agency ${expanded ? 'filter-row-agency-expanded' : ''}`}>
+        {visibleOptions.map((option) => (
           <button
             type="button"
             key={option}


### PR DESCRIPTION
## Summary
- restructure the monthly context header so summary cards and the nearest-signal highlight sit inside the top compact band
- keep release kind, act type, and status filters in a tighter primary row
- move agency filtering into a collapsed/scrollable rail so it no longer expands the full header height

## Verification
- npm run build
- npm run lint
- git diff --check

## Notes
- desktop/mobile browser QA was not run directly in this environment
- agency overflow now uses a collapsed preview rail plus an expanded scroll area

Closes #89