### PR TITLE
fix: narrow long-gap radar eligibility

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5489,7 +5489,7 @@ function buildLongGapRadarEntries() {
   return teamProfiles
     .flatMap((team) => {
       const watchRow = watchlistByGroup.get(team.group)
-      if (!watchRow || !isLongGapRadarWatchReason(watchRow.watch_reason)) {
+      if (!watchRow || watchRow.watch_reason !== 'long_gap') {
         return []
       }
 
@@ -5498,7 +5498,7 @@ function buildLongGapRadarEntries() {
       }
 
       const gapDays = getElapsedDaysSinceDate(team.latestRelease.date)
-      if (watchRow.watch_reason === 'long_gap' && gapDays < LONG_GAP_THRESHOLD_DAYS) {
+      if (gapDays < LONG_GAP_THRESHOLD_DAYS) {
         return []
       }
 
@@ -5615,10 +5615,6 @@ function compareLatestRadarSignals(left: UpcomingCandidateRow, right: UpcomingCa
   }
 
   return compareUpcomingSignals(left, right)
-}
-
-function isLongGapRadarWatchReason(reason: WatchReason) {
-  return reason === 'long_gap' || reason === 'manual_watch'
 }
 
 function isRookieEligible(profile: ArtistProfileRow) {


### PR DESCRIPTION
## Summary
- stop treating `manual_watch` acts as eligible long-gap radar entries
- require the dormant threshold check only for `watch_reason === long_gap`
- keep the long-gap radar focused on genuinely dormant acts instead of recent or manually watched exceptions

## Verification
- cd web && npm run build
- cd web && npm run lint
- git diff --check -- web/src/App.tsx
- data-level selector check: long-gap entries now resolve to `Weeekly` and `woo!ah!`
- data-level selector check: `ALLDAY PROJECT` no longer appears in long-gap radar candidates

Fixes #95
