### PR TITLE
Handle month-only upcoming rows in monthly view

### DIFF
--- a/docs/specs/mobile/calendar-screen.md
+++ b/docs/specs/mobile/calendar-screen.md
@@ -44,11 +44,25 @@
   - 상단 좌측: 날짜 숫자
   - 하단 영역: 팀 배지 최대 2개
   - 초과 시 마지막 줄에 `+N`
+- 날짜 셀에 들어가는 예정 컴백은 `exact date`가 있는 항목만 허용한다.
 - 선택 셀은 같은 월 안에서 1개만 활성
 
-### 4.5 List Mode
+### 4.5 Month-only Bucket
+- 캘린더 그리드 바로 아래 월 컨텍스트 섹션
+- 대상: `scheduled_month`는 있지만 `scheduled_date`는 없는 예정 신호
+- 표현:
+  - 팀 배지/팀명
+  - headline
+  - 상태 칩
+  - `2026년 4월 · 날짜 미정` 같은 월 단위 라벨
+  - Primary `팀 페이지`
+  - Meta `기사/공식 공지`
+- day cell이나 date detail sheet 안의 날짜별 row로 밀어 넣지 않는다.
+
+### 4.6 List Mode
 - 캘린더 그리드 위치를 카드 리스트가 대체
 - 상단 월/필터/요약 컨텍스트는 유지
+- `예정` 리스트는 `exact date`와 `month_only`를 분리해 보여주고, `month_only`에는 항상 `날짜 미정` 라벨을 붙인다.
 
 ## 5. 컴포넌트 인벤토리
 | 영역 | 컴포넌트 | 위치 | 필수 여부 | 탭 동작 |
@@ -61,6 +75,7 @@
 | Summary | Monthly Summary Strip | App Bar 아래 | 필수 | 없음 |
 | Segment | View Toggle | Summary 아래 | 필수 | 캘린더/리스트 전환 |
 | Calendar | Day Cell | 그리드 본문 | 필수 | Date Detail Sheet 오픈 |
+| Monthly Context | Month-only Bucket | Calendar 아래 | 조건부 | 각 행 액션 처리 |
 | Sheet | Verified Section | Sheet 상단 | 조건부 | 각 행 액션 처리 |
 | Sheet | Scheduled Section | Verified 아래 | 조건부 | 각 행 액션 처리 |
 
@@ -77,6 +92,7 @@
 - 발매/예정 없는 날짜는 숫자만 표시
 - 발매/예정 있는 날짜는 배지 노출
 - 배지는 `공식 배지 -> 대표 이미지 크롭 -> 모노그램` 순서의 fallback 허용
+- `month_only` 또는 `unknown` 예정 신호는 날짜 셀 배지 대상이 아니다.
 
 ### 7.2 선택 상태
 - border + background + ring 중 최소 2개 이상 변화
@@ -106,6 +122,10 @@
 1. `Verified releases`
 2. `Scheduled comebacks`
 
+### 8.4.a 제외 규칙
+- Date Detail Sheet의 `Scheduled comebacks`에는 `exact date` 항목만 넣는다.
+- `month_only` 항목은 sheet가 아니라 월 컨텍스트의 Month-only Bucket으로 보낸다.
+
 ### 8.5 Verified Release Row
 - 좌측: 팀 배지 + 팀명
 - 본문: 릴리즈명, 형식 칩, 발매일
@@ -134,12 +154,14 @@
 ### 9.3 카드 규칙
 - 발매 카드: 팀명, 릴리즈명, 대표곡(optional), 형식, 발매일, 상세/서비스 액션
 - 예정 카드: 팀명, 예정명, 상태, 예정일, confidence, 팀 페이지, 출처
+- `month_only` 예정 카드는 예정일 대신 `월 라벨 + 날짜 미정`을 표시한다.
 
 ## 10. 데이터 바인딩
 - 월간 발매 수: `releases.json` month filter
 - 예정 컴백 수: `upcomingCandidates.json` month filter
-- 가장 가까운 일정: filtered upcoming 중 earliest
-- 날짜 셀 배지: releases/upcoming grouped by iso day
+- 가장 가까운 일정: filtered upcoming 중 earliest `exact date`
+- 날짜 셀 배지: releases + exact-date upcoming grouped by iso day
+- month-only bucket: `upcomingCandidates.json` 중 `date_precision = month_only` and `scheduled_month = active month`
 - verified row artwork: optional `releaseArtwork.json`
 
 ## 11. 상태 매트릭스
@@ -156,6 +178,7 @@
 - 월 제목은 `2026년 4월` 형식을 우선한다.
 - Summary 라벨은 `이번 달 발매`, `예정 컴백`, `가장 가까운 일정`으로 고정한다.
 - Empty Day 시트 문구는 `이 날짜에는 등록된 일정이 없습니다.`로 고정한다.
+- `month_only` 라벨은 `2026년 4월 · 날짜 미정` 형식을 우선한다.
 
 ## 13. 제스처 계약
 - 날짜 셀 탭은 sheet open만 수행한다.
@@ -178,5 +201,6 @@
 ## 16. QA 핵심 포인트
 - 날짜 탭 -> sheet 오픈 -> 팀 상세 이동 흐름 확인
 - empty day, multi-item day, partial-data day 확인
+- month-only만 있는 월에서 날짜 셀은 비어 있고, 별도 월 버킷에는 항목이 보이는지 확인
 - `캘린더/리스트` 전환 시 월 상태 유지 확인
 - 서비스 버튼과 Meta 링크가 시각적으로 구분되는지 확인

--- a/docs/specs/mobile/radar-screen.md
+++ b/docs/specs/mobile/radar-screen.md
@@ -70,6 +70,8 @@
   - 예정일
   - 상태
   - 대표 source
+- 제외:
+  - `month_only`, `unknown` 예정 신호는 이 카드 후보에 넣지 않는다.
 - 액션 순서:
   1. `팀 페이지`(Primary)
   2. source(Meta)
@@ -84,6 +86,8 @@
   - 예정일
   - 상태
   - confidence
+- 제외:
+  - `month_only`, `unknown` 예정 신호는 주간 카드 후보에 넣지 않는다.
 - 액션 순서:
   1. `팀 페이지`(Primary)
   2. source(Meta)
@@ -133,11 +137,12 @@
 
 ## 9. 데이터 바인딩
 - Featured Comeback: `upcomingCandidates.json`에서 exact/future date 기준 가장 가까운 항목
-- Weekly Events: 현재 주 범위 필터된 upcoming
+- Weekly Events: 현재 주 범위의 exact-date upcoming
 - Change Feed: `change-tracked` 데이터 또는 derived diff feed
 - Long-gap: `watchlist.json` + latest release recency
 - Rookie: `artistProfiles.json`의 debut_year 또는 manual rookie tags
 - Team badge/image: `artistProfiles.json` 우선, 없으면 fallback
+- `month_only` 신호는 Radar의 featured/weekly date slot이 아니라 Calendar 월 컨텍스트에서 소비한다.
 
 ## 10. 상태 매트릭스
 | 상태 | Featured | Weekly | Change | Long-gap/Rookie |
@@ -152,6 +157,7 @@
 - 섹션 제목은 `가장 가까운 컴백`, `이번 주 예정`, `일정 변경`, `장기 공백 레이더`, `루키 레이더`로 고정한다.
 - D-day 표기는 `D-3`, `오늘`, `내일` 규칙을 따른다.
 - source 라벨은 `기사 원문`, `공식 공지`, `소스 보기`만 사용한다.
+- 날짜가 없는 월 단위 신호는 이 화면에서 날짜 카드처럼 보이면 안 된다.
 
 ## 12. 제스처 및 전환
 - Featured/Weekly/Change/Long-gap/Rookie 카드 탭은 기본적으로 Team Detail push다.

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1098,6 +1098,27 @@
   margin-top: 4px;
 }
 
+.dashboard-subsection-stack,
+.dashboard-subsection {
+  display: grid;
+  gap: 14px;
+}
+
+.dashboard-subsection {
+  padding-top: 6px;
+  border-top: 1px solid rgba(27, 42, 65, 0.08);
+}
+
+.dashboard-subsection:first-child {
+  padding-top: 0;
+  border-top: 0;
+}
+
+.dashboard-subsection-head h4 {
+  margin: 0;
+  font-size: 0.96rem;
+}
+
 .dashboard-table-actions {
   display: grid;
   gap: 8px;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -459,9 +459,10 @@ const TRANSLATIONS = {
       scheduled: '예정 컴백',
       nearest: '가장 가까운 일정',
     },
-    monthlyNearestEmpty: '일정 없음',
+    monthlyNearestEmpty: '정확한 날짜 없음',
     monthlyHighlightLabel: '가장 가까운 일정',
-    monthlyHighlightEmpty: '현재 월과 필터 기준으로 표시할 예정 컴백이 없습니다.',
+    monthlyHighlightEmpty: '현재 월과 필터 기준으로 정확한 날짜가 있는 예정 컴백이 없습니다.',
+    monthlyHighlightUndatedOnly: '현재 월에는 날짜 미정 월 단위 신호만 있습니다. 아래 월간 목록에서 확인하세요.',
     stats: {
       verifiedReleases: '검증된 발매',
       watchTargets: '추적 대상',
@@ -552,6 +553,9 @@ const TRANSLATIONS = {
     monthlyDashboardSort: '정렬',
     monthlyDashboardVerifiedTitle: 'Verified releases',
     monthlyDashboardScheduledTitle: 'Scheduled comebacks',
+    monthlyDashboardScheduledExactTitle: '날짜가 잡힌 예정',
+    monthlyDashboardScheduledMonthOnlyTitle: '월 단위 신호 · 날짜 미정',
+    monthlyDashboardDatePending: '날짜 미정',
     monthlyDashboardVerifiedEmpty: '이 월에 표시할 검증 발매가 없습니다.',
     monthlyDashboardScheduledEmpty: '이 월에 표시할 예정 컴백이 없습니다.',
     agencyView: '소속사 뷰',
@@ -691,9 +695,10 @@ const TRANSLATIONS = {
       scheduled: 'Scheduled comebacks',
       nearest: 'Closest schedule',
     },
-    monthlyNearestEmpty: 'No schedule',
+    monthlyNearestEmpty: 'No exact date',
     monthlyHighlightLabel: 'Closest schedule',
-    monthlyHighlightEmpty: 'No scheduled comebacks match this month and filter state.',
+    monthlyHighlightEmpty: 'No exact-date scheduled comebacks match this month and filter state.',
+    monthlyHighlightUndatedOnly: 'Only month-level undated signals remain for this month. Check the monthly list below.',
     stats: {
       verifiedReleases: 'Verified releases',
       watchTargets: 'Watch targets',
@@ -784,6 +789,9 @@ const TRANSLATIONS = {
     monthlyDashboardSort: 'Sort',
     monthlyDashboardVerifiedTitle: 'Verified releases',
     monthlyDashboardScheduledTitle: 'Scheduled comebacks',
+    monthlyDashboardScheduledExactTitle: 'Exact-date comebacks',
+    monthlyDashboardScheduledMonthOnlyTitle: 'Month-only signals',
+    monthlyDashboardDatePending: 'Date TBA',
     monthlyDashboardVerifiedEmpty: 'No verified releases to show for this month.',
     monthlyDashboardScheduledEmpty: 'No scheduled comebacks to show for this month.',
     agencyView: 'Agency view',
@@ -1365,7 +1373,13 @@ function App() {
 
   const todayIso = dateFormatter.format(new Date())
   const todayMonthKey = todayIso.slice(0, 7)
-  const visibleMonthKeys = getVisibleMonthKeys(filteredReleases, filteredUpcomingSignals, [todayMonthKey])
+  const filteredUpcomingMonthKeys = Array.from(
+    new Set(filteredUpcoming.map((item) => getUpcomingMonthKey(item)).filter(Boolean)),
+  ).sort()
+  const visibleMonthKeys = getVisibleMonthKeys(filteredReleases, filteredUpcomingSignals, [
+    todayMonthKey,
+    ...filteredUpcomingMonthKeys,
+  ])
   const effectiveMonthKey = visibleMonthKeys.includes(selectedMonthKey)
     ? selectedMonthKey
     : visibleMonthKeys.at(-1) ?? selectedMonthKey
@@ -1377,8 +1391,15 @@ function App() {
   const monthUpcomingSignals = filteredUpcomingSignals.filter(
     (item) => getMonthKey(item.dateValue) === effectiveMonthKey,
   )
+  const monthMonthOnlyUpcomingRows = filteredUpcoming
+    .filter(
+      (item) =>
+        getUpcomingDatePrecisionValue(item) === 'month_only' && getUpcomingMonthKey(item) === effectiveMonthKey,
+    )
+    .sort(compareUpcomingSignals)
   const monthVerifiedDashboardRows = [...monthReleases].sort(compareMonthlyDashboardVerified)
   const monthScheduledDashboardRows = [...monthUpcomingSignals].sort(compareMonthlyDashboardUpcoming)
+  const monthScheduledCount = monthScheduledDashboardRows.length + monthMonthOnlyUpcomingRows.length
   const dashboardFilterSummary = buildMonthlyDashboardFilterSummary(
     {
       search,
@@ -1413,7 +1434,8 @@ function App() {
       : []
   const visibleDayIsos = new Set(monthDays.map((day) => day.iso))
   const isSelectedDayVisible = visibleDayIsos.has(selectedDayIso)
-  const hasNoReleaseMatches = filteredReleases.length === 0 && filteredUpcomingSignals.length === 0
+  const hasNoMonthMatches =
+    monthReleases.length === 0 && monthUpcomingSignals.length === 0 && monthMonthOnlyUpcomingRows.length === 0
 
   const effectiveSelectedDayIso =
     isSelectedDayVisible
@@ -1473,6 +1495,8 @@ function App() {
   const nearestJumpSourceLabel = nearestCalendarJumpTarget
     ? copy.calendarQuickJumpSourceLabels[nearestCalendarJumpTarget.source]
     : copy.calendarQuickJumpUnavailable
+  const monthlyHighlightEmptyCopy =
+    monthMonthOnlyUpcomingRows.length > 0 ? copy.monthlyHighlightUndatedOnly : copy.monthlyHighlightEmpty
   const selectedTeam = selectedGroup ? teamProfileMap.get(selectedGroup) ?? null : null
   const compareTeam = activeCompareGroup ? teamProfileMap.get(activeCompareGroup) ?? null : null
   const compareTeamOptions = selectedTeam ? teamProfiles.filter((team) => team.group !== selectedTeam.group) : []
@@ -1728,7 +1752,7 @@ function App() {
               </article>
               <article className="context-summary-card">
                 <span>{copy.monthlySummaryLabels.scheduled}</span>
-                <strong>{monthScheduledDashboardRows.length}</strong>
+                <strong>{monthScheduledCount}</strong>
               </article>
               <article className="context-summary-card">
                 <span>{copy.monthlySummaryLabels.nearest}</span>
@@ -1813,7 +1837,7 @@ function App() {
                   </div>
                 </div>
               ) : (
-                <p className="empty-copy">{copy.monthlyHighlightEmpty}</p>
+                <p className="empty-copy">{monthlyHighlightEmptyCopy}</p>
               )}
             </article>
           </div>
@@ -2379,7 +2403,7 @@ function App() {
                   </div>
                 </div>
 
-                {hasNoReleaseMatches ? (
+                {hasNoMonthMatches ? (
                   <div className="empty-state">
                     {copy.noFilteredMatches}
                   </div>
@@ -2464,6 +2488,7 @@ function App() {
               monthLabel={monthFormatter.format(selectedMonthDate)}
               verifiedRows={monthVerifiedDashboardRows}
               scheduledRows={monthScheduledDashboardRows}
+              monthOnlyRows={monthMonthOnlyUpcomingRows}
               activeFilters={dashboardFilterSummary}
               language={language}
               displayDateFormatter={displayDateFormatter}
@@ -3939,11 +3964,143 @@ function CompareCountCard({ count }: { count: number }) {
   )
 }
 
+function DashboardScheduledBucket({
+  title,
+  rows,
+  language,
+  displayDateFormatter,
+  onOpenTeamPage,
+}: {
+  title: string
+  rows: UpcomingCandidateRow[]
+  language: Language
+  displayDateFormatter: Intl.DateTimeFormat
+  onOpenTeamPage: (group: string) => void
+}) {
+  const copy = TRANSLATIONS[language]
+
+  return (
+    <section className="dashboard-subsection">
+      <div className="selected-day-panel-head dashboard-subsection-head">
+        <h4>{title}</h4>
+        <span className="selected-day-panel-count">{rows.length}</span>
+      </div>
+      <div className="dashboard-table-shell">
+        <table className="dashboard-table">
+          <thead>
+            <tr>
+              <th>{copy.dashboardTeam}</th>
+              <th>{copy.dashboardScheduledTitle}</th>
+              <th>{copy.dashboardStatus}</th>
+              <th>{copy.dashboardFormat}</th>
+              <th>{copy.dashboardDate}</th>
+              <th>{copy.dashboardConfidence}</th>
+              <th>{copy.dashboardSource}</th>
+              <th>{copy.dashboardActions}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((item) => (
+              <tr key={getUpcomingDashboardRowKey(item)}>
+                <td>
+                  <TeamIdentity group={item.group} variant="list" />
+                </td>
+                <td>
+                  <strong>{item.headline}</strong>
+                  {formatUpcomingEvidenceMeta(item, language) ? (
+                    <p className="signal-meta">{formatUpcomingEvidenceMeta(item, language)}</p>
+                  ) : null}
+                </td>
+                <td>
+                  <span className={`signal-badge signal-badge-date-${item.date_status}`}>
+                    {formatDateStatus(item.date_status, language)}
+                  </span>
+                </td>
+                <td>{formatReleaseFormat(item.release_format, language) || copy.none}</td>
+                <td>{formatScheduledDashboardTimingLabel(item, language, displayDateFormatter, copy.none)}</td>
+                <td>
+                  <span className={`signal-badge signal-badge-confidence-${getConfidenceTone(item.confidence)}`}>
+                    {formatConfidenceTone(getConfidenceTone(item.confidence), language)}
+                  </span>
+                </td>
+                <td>
+                  {item.source_url ? (
+                    <a href={item.source_url} target="_blank" rel="noreferrer" className="dashboard-source-link">
+                      {item.source_domain || copy.sourceLink}
+                    </a>
+                  ) : (
+                    <span className="signal-link-muted">{copy.noSourceLink}</span>
+                  )}
+                </td>
+                <td>
+                  <div className="dashboard-table-actions">
+                    <ActionButton variant="primary" onClick={() => onOpenTeamPage(item.group)}>
+                      {TEAM_COPY[language].action}
+                    </ActionButton>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <div className="dashboard-mobile-list">
+        {rows.map((item) => (
+          <article
+            key={`mobile-${getUpcomingDashboardRowKey(item)}`}
+            className={`detail-card dashboard-mobile-card detail-card-signal detail-card-signal-${item.date_status}`}
+          >
+            <div className="signal-head">
+              <TeamIdentity group={item.group} variant="list" />
+              <div className="signal-tags">
+                <span className={`signal-badge signal-badge-date-${item.date_status}`}>
+                  {formatDateStatus(item.date_status, language)}
+                </span>
+                <span className={`signal-badge signal-badge-confidence-${getConfidenceTone(item.confidence)}`}>
+                  {formatConfidenceTone(getConfidenceTone(item.confidence), language)}
+                </span>
+              </div>
+            </div>
+            <h3>{item.headline}</h3>
+            <p className="signal-meta">
+              {formatReleaseFormat(item.release_format, language) || copy.none} ·{' '}
+              {formatScheduledDashboardTimingLabel(item, language, displayDateFormatter, copy.none)}
+            </p>
+            <p className="signal-meta">
+              {formatSourceType(item.source_type, language)} · {item.source_domain || copy.sourceTypeLabels.pending}
+            </p>
+            {formatUpcomingEvidenceMeta(item, language) ? (
+              <p className="signal-meta">{formatUpcomingEvidenceMeta(item, language)}</p>
+            ) : null}
+            <div className="action-stack">
+              <div className="action-row">
+                <ActionButton variant="primary" onClick={() => onOpenTeamPage(item.group)}>
+                  {TEAM_COPY[language].action}
+                </ActionButton>
+              </div>
+              <div className="meta-links">
+                {item.source_url ? (
+                  <a href={item.source_url} target="_blank" rel="noreferrer" className="meta-link">
+                    {copy.sourceLink}
+                  </a>
+                ) : (
+                  <span className="signal-link-muted">{copy.noSourceLink}</span>
+                )}
+              </div>
+            </div>
+          </article>
+        ))}
+      </div>
+    </section>
+  )
+}
+
 function MonthlyReleaseDashboard({
   sectionId,
   monthLabel,
   verifiedRows,
   scheduledRows,
+  monthOnlyRows,
   activeFilters,
   language,
   displayDateFormatter,
@@ -3954,6 +4111,7 @@ function MonthlyReleaseDashboard({
   monthLabel: string
   verifiedRows: VerifiedRelease[]
   scheduledRows: DatedUpcomingSignal[]
+  monthOnlyRows: UpcomingCandidateRow[]
   activeFilters: string[]
   language: Language
   displayDateFormatter: Intl.DateTimeFormat
@@ -3977,6 +4135,8 @@ function MonthlyReleaseDashboard({
   ]
   const sortedVerifiedRows = sortVerifiedDashboardRows(verifiedRows, verifiedSortKey, verifiedSortDirection)
   const sortedScheduledRows = sortScheduledDashboardRows(scheduledRows, scheduledSortKey, scheduledSortDirection)
+  const sortedMonthOnlyRows = sortScheduledDashboardRows(monthOnlyRows, scheduledSortKey, scheduledSortDirection)
+  const totalScheduledRows = sortedScheduledRows.length + sortedMonthOnlyRows.length
 
   function handleVerifiedSortChange(key: VerifiedDashboardSortKey) {
     if (verifiedSortKey === key) {
@@ -4152,7 +4312,7 @@ function MonthlyReleaseDashboard({
         <section className="monthly-dashboard-section">
           <div className="selected-day-panel-head">
             <h3>{copy.monthlyDashboardScheduledTitle}</h3>
-            <span className="selected-day-panel-count">{sortedScheduledRows.length}</span>
+            <span className="selected-day-panel-count">{totalScheduledRows}</span>
           </div>
           <div className="dashboard-section-toolbar">
             <span className="dashboard-toolbar-label">{copy.monthlyDashboardSort}</span>
@@ -4176,115 +4336,27 @@ function MonthlyReleaseDashboard({
               ))}
             </div>
           </div>
-          {sortedScheduledRows.length ? (
-            <>
-              <div className="dashboard-table-shell">
-                <table className="dashboard-table">
-                  <thead>
-                    <tr>
-                      <th>{copy.dashboardTeam}</th>
-                      <th>{copy.dashboardScheduledTitle}</th>
-                      <th>{copy.dashboardStatus}</th>
-                      <th>{copy.dashboardFormat}</th>
-                      <th>{copy.dashboardDate}</th>
-                      <th>{copy.dashboardConfidence}</th>
-                      <th>{copy.dashboardSource}</th>
-                      <th>{copy.dashboardActions}</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {sortedScheduledRows.map((item) => (
-                      <tr key={`${item.group}-${item.scheduled_date}-${item.headline}`}>
-                        <td>
-                          <TeamIdentity group={item.group} variant="list" />
-                        </td>
-                        <td>
-                          <strong>{item.headline}</strong>
-                          {formatUpcomingEvidenceMeta(item, language) ? (
-                            <p className="signal-meta">{formatUpcomingEvidenceMeta(item, language)}</p>
-                          ) : null}
-                        </td>
-                        <td>
-                          <span className={`signal-badge signal-badge-date-${item.date_status}`}>
-                            {formatDateStatus(item.date_status, language)}
-                          </span>
-                        </td>
-                        <td>{formatReleaseFormat(item.release_format, language) || copy.none}</td>
-                        <td>{formatUpcomingTimingLabel(item, language, displayDateFormatter, copy.none)}</td>
-                        <td>
-                          <span className={`signal-badge signal-badge-confidence-${getConfidenceTone(item.confidence)}`}>
-                            {formatConfidenceTone(getConfidenceTone(item.confidence), language)}
-                          </span>
-                        </td>
-                        <td>
-                          {item.source_url ? (
-                            <a href={item.source_url} target="_blank" rel="noreferrer" className="dashboard-source-link">
-                              {item.source_domain || copy.sourceLink}
-                            </a>
-                          ) : (
-                            <span className="signal-link-muted">{copy.noSourceLink}</span>
-                          )}
-                        </td>
-                        <td>
-                          <div className="dashboard-table-actions">
-                            <ActionButton variant="primary" onClick={() => onOpenTeamPage(item.group)}>
-                              {TEAM_COPY[language].action}
-                            </ActionButton>
-                          </div>
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-              <div className="dashboard-mobile-list">
-                {sortedScheduledRows.map((item) => (
-                  <article
-                    key={`mobile-${item.group}-${item.scheduled_date}-${item.headline}`}
-                    className={`detail-card dashboard-mobile-card detail-card-signal detail-card-signal-${item.date_status}`}
-                  >
-                    <div className="signal-head">
-                      <TeamIdentity group={item.group} variant="list" />
-                      <div className="signal-tags">
-                        <span className={`signal-badge signal-badge-date-${item.date_status}`}>
-                          {formatDateStatus(item.date_status, language)}
-                        </span>
-                        <span className={`signal-badge signal-badge-confidence-${getConfidenceTone(item.confidence)}`}>
-                          {formatConfidenceTone(getConfidenceTone(item.confidence), language)}
-                        </span>
-                      </div>
-                    </div>
-                    <h3>{item.headline}</h3>
-                    <p className="signal-meta">
-                      {formatReleaseFormat(item.release_format, language) || copy.none} ·{' '}
-                      {formatUpcomingTimingLabel(item, language, displayDateFormatter, copy.none)}
-                    </p>
-                    <p className="signal-meta">
-                      {formatSourceType(item.source_type, language)} · {item.source_domain || copy.sourceTypeLabels.pending}
-                    </p>
-                    {formatUpcomingEvidenceMeta(item, language) ? (
-                      <p className="signal-meta">{formatUpcomingEvidenceMeta(item, language)}</p>
-                    ) : null}
-                    <div className="action-stack">
-                      <div className="action-row">
-                        <ActionButton variant="primary" onClick={() => onOpenTeamPage(item.group)}>
-                          {TEAM_COPY[language].action}
-                        </ActionButton>
-                      </div>
-                      <div className="meta-links">
-                        {item.source_url ? (
-                          <a href={item.source_url} target="_blank" rel="noreferrer" className="meta-link">
-                            {copy.sourceLink}
-                          </a>
-                        ) : (
-                          <span className="signal-link-muted">{copy.noSourceLink}</span>
-                        )}
-                      </div>
-                    </div>
-                  </article>
-                ))}
-              </div>
-            </>
+          {totalScheduledRows ? (
+            <div className="dashboard-subsection-stack">
+              {sortedScheduledRows.length ? (
+                <DashboardScheduledBucket
+                  title={copy.monthlyDashboardScheduledExactTitle}
+                  rows={sortedScheduledRows}
+                  language={language}
+                  displayDateFormatter={displayDateFormatter}
+                  onOpenTeamPage={onOpenTeamPage}
+                />
+              ) : null}
+              {sortedMonthOnlyRows.length ? (
+                <DashboardScheduledBucket
+                  title={copy.monthlyDashboardScheduledMonthOnlyTitle}
+                  rows={sortedMonthOnlyRows}
+                  language={language}
+                  displayDateFormatter={displayDateFormatter}
+                  onOpenTeamPage={onOpenTeamPage}
+                />
+              ) : null}
+            </div>
           ) : (
             <p className="empty-copy">{copy.monthlyDashboardScheduledEmpty}</p>
           )}
@@ -6135,8 +6207,8 @@ function sortVerifiedDashboardRows(
   })
 }
 
-function sortScheduledDashboardRows(
-  rows: DatedUpcomingSignal[],
+function sortScheduledDashboardRows<T extends UpcomingSignalBase>(
+  rows: T[],
   sortKey: ScheduledDashboardSortKey,
   direction: DashboardSortDirection,
 ) {
@@ -6151,11 +6223,11 @@ function sortScheduledDashboardRows(
     } else if (sortKey === 'confidence') {
       comparison = left.confidence - right.confidence
     } else {
-      comparison = left.dateValue.getTime() - right.dateValue.getTime()
+      comparison = compareScheduledDashboardDate(left, right)
     }
 
     if (comparison === 0) {
-      comparison = left.dateValue.getTime() - right.dateValue.getTime()
+      comparison = compareScheduledDashboardDate(left, right)
     }
 
     if (comparison === 0) {
@@ -6170,7 +6242,28 @@ function sortScheduledDashboardRows(
   })
 }
 
-function compareDashboardStatus(left: DatedUpcomingSignal['date_status'], right: DatedUpcomingSignal['date_status']) {
+function compareScheduledDashboardDate(left: UpcomingSignalBase, right: UpcomingSignalBase) {
+  const leftHasDate = hasExactUpcomingDate(left)
+  const rightHasDate = hasExactUpcomingDate(right)
+  if (leftHasDate && rightHasDate) {
+    const dateCompare = parseDateValue(left.scheduled_date) - parseDateValue(right.scheduled_date)
+    if (dateCompare !== 0) {
+      return dateCompare
+    }
+  } else if (leftHasDate !== rightHasDate) {
+    return leftHasDate ? -1 : 1
+  }
+
+  const leftMonthKey = getUpcomingMonthKey(left)
+  const rightMonthKey = getUpcomingMonthKey(right)
+  if (leftMonthKey && rightMonthKey && leftMonthKey !== rightMonthKey) {
+    return leftMonthKey.localeCompare(rightMonthKey)
+  }
+
+  return 0
+}
+
+function compareDashboardStatus(left: UpcomingSignalBase['date_status'], right: UpcomingSignalBase['date_status']) {
   const rank = { confirmed: 0, scheduled: 1, rumor: 2 }
   return rank[left] - rank[right]
 }
@@ -7014,6 +7107,10 @@ function getAlbumKey(item: VerifiedRelease) {
   return `${item.group}-${item.stream}-${item.title}-${item.date}`
 }
 
+function getUpcomingDashboardRowKey(item: UpcomingCandidateRow) {
+  return item.event_key ?? [item.group, item.scheduled_date || item.scheduled_month || 'undated', item.headline].join('::')
+}
+
 function findVerifiedReleaseByKey(group: string, albumKey: string) {
   return (verifiedReleaseHistoryByGroup.get(group) ?? []).find((item) => getAlbumKey(item) === albumKey) ?? null
 }
@@ -7391,6 +7488,21 @@ function formatUpcomingTimingLabel(
   }
 
   return fallback
+}
+
+function formatScheduledDashboardTimingLabel(
+  item: Pick<UpcomingSignalBase, 'scheduled_date' | 'scheduled_month' | 'date_precision'>,
+  language: Language,
+  formatter: Intl.DateTimeFormat,
+  fallback: string,
+) {
+  const copy = TRANSLATIONS[language]
+  const timingLabel = formatUpcomingTimingLabel(item, language, formatter, fallback)
+  if (getUpcomingDatePrecisionValue(item) !== 'month_only') {
+    return timingLabel
+  }
+
+  return timingLabel === fallback ? copy.monthlyDashboardDatePending : `${timingLabel} · ${copy.monthlyDashboardDatePending}`
 }
 
 function getMonthKey(date: Date) {


### PR DESCRIPTION
## Summary\n- keep exact-date upcoming rows in calendar cells and day drill-ins only\n- expose month-only upcoming signals in the monthly dashboard as a separate undated bucket\n- update mobile specs so calendar/radar exact-date rules match the new contract\n\nCloses #113