### PR TITLE
Backfill Korean search aliases across artist profiles

### DIFF
--- a/docs/specs/mobile/content-governance-spec.md
+++ b/docs/specs/mobile/content-governance-spec.md
@@ -42,6 +42,12 @@
 
 ## 6. Alias 운영 원칙
 - 공식명, 한글명, 약칭, 표기 변형을 search alias로 유지한다.
+- tracked team 신규 추가 시 `search_aliases`에는 최소 1개의 Korean-searchable alias를 같이 넣는다.
+- 공식 한글명이 없으면 아래 우선순위로 fallback을 정한다.
+  1. 국내 기사/커뮤니티에서 널리 쓰는 한글 표기
+  2. 발음 기반 Hangul rendering
+  3. 제품 내에서 일관되게 쓰는 보수적 transcription
+- 약칭/닉네임은 널리 쓰이고 다른 팀과 충돌 위험이 낮을 때만 추가한다.
 - 사용자 체감 검색 실패를 유발하는 케이스는 큐레이션 우선순위가 높다.
 - alias는 장르 판정 라벨이 아니라 검색 편의 자산이다.
 

--- a/web/src/data/artistProfiles.json
+++ b/web/src/data/artistProfiles.json
@@ -10,7 +10,9 @@
     "official_instagram_url": "https://www.instagram.com/andteam_official/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "앤팀"
+    ]
   },
   {
     "slug": "g-i-dle",
@@ -26,7 +28,10 @@
     "official_instagram_url": "https://www.instagram.com/i_dle_official/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "아이들",
+      "여자아이들"
+    ]
   },
   {
     "slug": "82major",
@@ -39,7 +44,10 @@
     "official_instagram_url": "https://www.instagram.com/82major_official/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "에이티투메이저",
+      "에이티투 메이저"
+    ]
   },
   {
     "slug": "8turn",
@@ -52,7 +60,9 @@
     "official_instagram_url": "https://www.instagram.com/8turn.official/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "에잇턴"
+    ]
   },
   {
     "slug": "ab6ix",
@@ -65,7 +75,9 @@
     "official_instagram_url": "https://www.instagram.com/ab6ix_official/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "에이비식스"
+    ]
   },
   {
     "slug": "all-h-ours",
@@ -78,7 +90,9 @@
     "official_instagram_url": "https://www.instagram.com/all_h_ours/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "올아워즈"
+    ]
   },
   {
     "slug": "allday-project",
@@ -93,7 +107,8 @@
     "representative_image_source": null,
     "search_aliases": [
       "올데이 프로젝트",
-      "올데프"
+      "올데프",
+      "올데이프로젝트"
     ],
     "debut_year": 2025,
     "radar_tags": [
@@ -111,7 +126,9 @@
     "official_instagram_url": "https://www.instagram.com/ampersandone_official/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "앰퍼샌드원"
+    ]
   },
   {
     "slug": "artms",
@@ -124,7 +141,9 @@
     "official_instagram_url": "https://www.instagram.com/official_artms/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "아르테미스"
+    ]
   },
   {
     "slug": "atbo",
@@ -137,7 +156,9 @@
     "official_instagram_url": "https://www.instagram.com/atboground/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "에이티비오"
+    ]
   },
   {
     "slug": "ateez",
@@ -150,7 +171,9 @@
     "official_instagram_url": "https://www.instagram.com/ateez_official_/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "에이티즈"
+    ]
   },
   {
     "slug": "atheart",
@@ -163,7 +186,9 @@
     "official_instagram_url": "https://www.instagram.com/atheart__official/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": [],
+    "search_aliases": [
+      "앳하트"
+    ],
     "debut_year": 2025
   },
   {
@@ -195,7 +220,9 @@
     "official_instagram_url": "https://www.instagram.com/badvillain_bpm/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "배드빌런"
+    ]
   },
   {
     "slug": "bae173",
@@ -208,7 +235,9 @@
     "official_instagram_url": "https://www.instagram.com/official_pocketdolz/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "비에이이173"
+    ]
   },
   {
     "slug": "blackpink",
@@ -237,7 +266,9 @@
     "official_instagram_url": "https://www.instagram.com/official_blitzers/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "블리처스"
+    ]
   },
   {
     "slug": "boynextdoor",
@@ -268,7 +299,9 @@
     "official_instagram_url": "https://www.instagram.com/official_btob/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "비투비"
+    ]
   },
   {
     "slug": "bts",
@@ -299,7 +332,9 @@
     "official_instagram_url": "https://www.instagram.com/cix.official/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "씨아이엑스"
+    ]
   },
   {
     "slug": "class-y",
@@ -312,7 +347,9 @@
     "official_instagram_url": "https://www.instagram.com/m25_classy/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "클라씨"
+    ]
   },
   {
     "slug": "cravity",
@@ -325,7 +362,9 @@
     "official_instagram_url": "https://www.instagram.com/cravity_official/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "크래비티"
+    ]
   },
   {
     "slug": "csr",
@@ -338,7 +377,10 @@
     "official_instagram_url": "https://www.instagram.com/csr.offcl/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "첫사랑",
+      "씨에스알"
+    ]
   },
   {
     "slug": "day6",
@@ -351,7 +393,9 @@
     "official_instagram_url": "https://www.instagram.com/day6kilogram/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "데이식스"
+    ]
   },
   {
     "slug": "dkb",
@@ -364,7 +408,9 @@
     "official_instagram_url": "https://www.instagram.com/official.dkb/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "다크비"
+    ]
   },
   {
     "slug": "drippin",
@@ -377,7 +423,9 @@
     "official_instagram_url": "https://www.instagram.com/wearedrippin/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "드리핀"
+    ]
   },
   {
     "slug": "dxmon",
@@ -390,7 +438,9 @@
     "official_instagram_url": "https://www.instagram.com/dxmon_hm/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "다이몬"
+    ]
   },
   {
     "slug": "dreamcatcher",
@@ -403,7 +453,9 @@
     "official_instagram_url": "https://www.instagram.com/hf_dreamcatcher/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "드림캐쳐"
+    ]
   },
   {
     "slug": "enhypen",
@@ -432,7 +484,9 @@
     "official_instagram_url": "https://www.instagram.com/epex.official/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "이펙스"
+    ]
   },
   {
     "slug": "evnne",
@@ -445,7 +499,9 @@
     "official_instagram_url": "https://www.instagram.com/evnne_official/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "이븐"
+    ]
   },
   {
     "slug": "exo",
@@ -473,7 +529,9 @@
     "official_instagram_url": "https://www.instagram.com/we_fiftyfifty/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "피프티피프티"
+    ]
   },
   {
     "slug": "ghost9",
@@ -486,7 +544,9 @@
     "official_instagram_url": "https://www.instagram.com/official.ghost9/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "고스트나인"
+    ]
   },
   {
     "slug": "h1-key",
@@ -499,7 +559,9 @@
     "official_instagram_url": "https://www.instagram.com/h1key_official/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "하이키"
+    ]
   },
   {
     "slug": "hearts2hearts",
@@ -532,7 +594,9 @@
     "official_instagram_url": "https://www.instagram.com/official_ifnt_/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "인피니트"
+    ]
   },
   {
     "slug": "itzy",
@@ -545,7 +609,9 @@
     "official_instagram_url": "https://www.instagram.com/itzy.all.in.us/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "있지"
+    ]
   },
   {
     "slug": "ive",
@@ -573,7 +639,9 @@
     "official_instagram_url": "https://www.instagram.com/justb_ig_official/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "저스트비"
+    ]
   },
   {
     "slug": "kard",
@@ -586,7 +654,9 @@
     "official_instagram_url": "https://www.instagram.com/official_kard/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "카드"
+    ]
   },
   {
     "slug": "kiss-of-life",
@@ -617,7 +687,9 @@
     "official_instagram_url": "https://www.instagram.com/official.kep1er/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "케플러"
+    ]
   },
   {
     "slug": "kickflip",
@@ -630,7 +702,9 @@
     "official_instagram_url": "https://www.instagram.com/kickflip_jype/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": [],
+    "search_aliases": [
+      "킥플립"
+    ],
     "debut_year": 2025
   },
   {
@@ -644,7 +718,9 @@
     "official_instagram_url": "https://www.instagram.com/we_kiiikiii/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": [],
+    "search_aliases": [
+      "키키"
+    ],
     "debut_year": 2025
   },
   {
@@ -674,7 +750,9 @@
     "official_instagram_url": "https://www.instagram.com/cube_lightsum/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "라잇썸"
+    ]
   },
   {
     "slug": "lun8",
@@ -687,7 +765,9 @@
     "official_instagram_url": "https://www.instagram.com/lun8_official/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "루네이트"
+    ]
   },
   {
     "slug": "loossemble",
@@ -700,7 +780,9 @@
     "official_instagram_url": "https://www.instagram.com/loossemble.official/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "루셈블"
+    ]
   },
   {
     "slug": "mamamoo",
@@ -713,7 +795,9 @@
     "official_instagram_url": "https://www.instagram.com/mamamoo_official/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "마마무"
+    ]
   },
   {
     "slug": "mcnd",
@@ -726,7 +810,9 @@
     "official_instagram_url": "https://www.instagram.com/mcnd_official/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "엠씨엔디"
+    ]
   },
   {
     "slug": "meovv",
@@ -739,7 +825,9 @@
     "official_instagram_url": "https://www.instagram.com/meovv/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "미야오"
+    ]
   },
   {
     "slug": "monsta-x",
@@ -752,7 +840,10 @@
     "official_instagram_url": "https://www.instagram.com/official_monsta_x/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "몬스타엑스",
+      "몬엑"
+    ]
   },
   {
     "slug": "nct-127",
@@ -768,7 +859,8 @@
     "search_aliases": [
       "엔시티 127",
       "엔시티일이칠",
-      "일이칠"
+      "일이칠",
+      "엔시티127"
     ]
   },
   {
@@ -784,7 +876,8 @@
     "representative_image_source": null,
     "search_aliases": [
       "엔시티 드림",
-      "엔드림"
+      "엔드림",
+      "엔시티드림"
     ]
   },
   {
@@ -800,7 +893,8 @@
     "representative_image_source": null,
     "search_aliases": [
       "엔시티 위시",
-      "엔위시"
+      "엔위시",
+      "엔시티위시"
     ]
   },
   {
@@ -814,7 +908,9 @@
     "official_instagram_url": "https://www.instagram.com/real_nexz/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "넥스지"
+    ]
   },
   {
     "slug": "nmixx",
@@ -827,7 +923,9 @@
     "official_instagram_url": "https://www.instagram.com/nmixx_official/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "엔믹스"
+    ]
   },
   {
     "slug": "nomad",
@@ -840,7 +938,9 @@
     "official_instagram_url": "https://www.instagram.com/nomadaish88/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "노매드"
+    ]
   },
   {
     "slug": "newjeans",
@@ -853,7 +953,9 @@
     "official_instagram_url": "https://www.instagram.com/newjeans_official/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "뉴진스"
+    ]
   },
   {
     "slug": "oneus",
@@ -866,7 +968,9 @@
     "official_instagram_url": "https://www.instagram.com/official_oneus/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "원어스"
+    ]
   },
   {
     "slug": "onewe",
@@ -879,7 +983,9 @@
     "official_instagram_url": "https://www.instagram.com/official_onewe/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "원위"
+    ]
   },
   {
     "slug": "onf",
@@ -892,7 +998,9 @@
     "official_instagram_url": "https://www.instagram.com/wm_onoff/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "온앤오프"
+    ]
   },
   {
     "slug": "p1harmony",
@@ -921,7 +1029,9 @@
     "official_instagram_url": "https://www.instagram.com/plave_official/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "플레이브"
+    ]
   },
   {
     "slug": "pow",
@@ -934,7 +1044,9 @@
     "official_instagram_url": "https://www.instagram.com/pow_grid/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "파우"
+    ]
   },
   {
     "slug": "purple-kiss",
@@ -947,7 +1059,9 @@
     "official_instagram_url": "https://www.instagram.com/purplekiss_official/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "퍼플키스"
+    ]
   },
   {
     "slug": "qwer",
@@ -960,7 +1074,9 @@
     "official_instagram_url": "https://www.instagram.com/qwerband_official/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "큐더블유이알"
+    ]
   },
   {
     "slug": "rescene",
@@ -973,7 +1089,9 @@
     "official_instagram_url": "https://www.instagram.com/rescene.official/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "리센느"
+    ]
   },
   {
     "slug": "riize",
@@ -1017,7 +1135,9 @@
     "official_instagram_url": "https://www.instagram.com/sa2m2nam3/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "세이마이네임"
+    ]
   },
   {
     "slug": "seventeen",
@@ -1048,7 +1168,9 @@
     "official_instagram_url": "https://www.instagram.com/shinee/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "샤이니"
+    ]
   },
   {
     "slug": "stayc",
@@ -1061,7 +1183,9 @@
     "official_instagram_url": "https://www.instagram.com/stayc_highup/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "스테이씨"
+    ]
   },
   {
     "slug": "stray-kids",
@@ -1074,7 +1198,11 @@
     "official_instagram_url": "https://www.instagram.com/realstraykids/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "스트레이 키즈",
+      "스트레이키즈",
+      "스키즈"
+    ]
   },
   {
     "slug": "tempest",
@@ -1087,7 +1215,9 @@
     "official_instagram_url": "https://www.instagram.com/tpst__official/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "템페스트"
+    ]
   },
   {
     "slug": "the-boyz",
@@ -1100,7 +1230,9 @@
     "official_instagram_url": "https://www.instagram.com/official_theboyz/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "더보이즈"
+    ]
   },
   {
     "slug": "tiot",
@@ -1113,7 +1245,9 @@
     "official_instagram_url": "https://www.instagram.com/tiot_now/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "티아이오티"
+    ]
   },
   {
     "slug": "tnx",
@@ -1126,7 +1260,9 @@
     "official_instagram_url": "https://www.instagram.com/official.tnx/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "티엔엑스"
+    ]
   },
   {
     "slug": "tomorrow-x-together",
@@ -1158,7 +1294,9 @@
     "official_instagram_url": "https://www.instagram.com/yg_treasure_official/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "트레저"
+    ]
   },
   {
     "slug": "trendz",
@@ -1171,7 +1309,9 @@
     "official_instagram_url": "https://www.instagram.com/trendz_offcl/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "트렌드지"
+    ]
   },
   {
     "slug": "twice",
@@ -1217,7 +1357,9 @@
     "official_instagram_url": "https://www.instagram.com/kingdom_gfent/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "더킹덤"
+    ]
   },
   {
     "slug": "unis",
@@ -1230,7 +1372,9 @@
     "official_instagram_url": "https://www.instagram.com/unis_offcl/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "유니스"
+    ]
   },
   {
     "slug": "verivery",
@@ -1243,7 +1387,9 @@
     "official_instagram_url": "https://www.instagram.com/the_verivery/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "베리베리"
+    ]
   },
   {
     "slug": "viviz",
@@ -1256,7 +1402,9 @@
     "official_instagram_url": "https://www.instagram.com/viviz_official/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "비비지"
+    ]
   },
   {
     "slug": "wei",
@@ -1269,7 +1417,9 @@
     "official_instagram_url": "https://www.instagram.com/wei_official/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "위아이"
+    ]
   },
   {
     "slug": "whib",
@@ -1282,7 +1432,9 @@
     "official_instagram_url": "https://www.instagram.com/whib_official/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "휘브"
+    ]
   },
   {
     "slug": "wjsn",
@@ -1299,7 +1451,8 @@
     "representative_image_url": null,
     "representative_image_source": null,
     "search_aliases": [
-      "우소"
+      "우소",
+      "우주소녀"
     ]
   },
   {
@@ -1313,7 +1466,10 @@
     "official_instagram_url": "https://www.instagram.com/wayvofficial/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "웨이션브이",
+      "웨이션v"
+    ]
   },
   {
     "slug": "weeekly",
@@ -1326,7 +1482,9 @@
     "official_instagram_url": "https://www.instagram.com/_weeekly/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "위클리"
+    ]
   },
   {
     "slug": "xdinary-heroes",
@@ -1339,7 +1497,10 @@
     "official_instagram_url": "https://www.instagram.com/xdinaryheroes_official/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "엑스디너리 히어로즈",
+      "엑디즈"
+    ]
   },
   {
     "slug": "young-posse",
@@ -1352,7 +1513,9 @@
     "official_instagram_url": "https://www.instagram.com/youngposseup/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "영파씨"
+    ]
   },
   {
     "slug": "younite",
@@ -1365,7 +1528,9 @@
     "official_instagram_url": "https://www.instagram.com/younite_bnm/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "유나이트"
+    ]
   },
   {
     "slug": "zerobaseone",
@@ -1411,7 +1576,9 @@
     "official_instagram_url": "https://www.instagram.com/cignature_j9/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "시그니처"
+    ]
   },
   {
     "slug": "fromis-9",
@@ -1424,7 +1591,10 @@
     "official_instagram_url": "https://www.instagram.com/officialfromis_9/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "프로미스나인",
+      "프로미스9"
+    ]
   },
   {
     "slug": "ifeye",
@@ -1437,7 +1607,9 @@
     "official_instagram_url": "https://www.instagram.com/ifeye.official/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": [],
+    "search_aliases": [
+      "이프아이"
+    ],
     "debut_year": 2025
   },
   {
@@ -1451,7 +1623,9 @@
     "official_instagram_url": "https://www.instagram.com/izna_offcl/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "이즈나"
+    ]
   },
   {
     "slug": "triples",
@@ -1464,7 +1638,9 @@
     "official_instagram_url": "https://www.instagram.com/triplescosmos/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "트리플에스"
+    ]
   },
   {
     "slug": "woo-ah",
@@ -1477,7 +1653,9 @@
     "official_instagram_url": "https://www.instagram.com/wooah_nv/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "우아"
+    ]
   },
   {
     "slug": "xikers",
@@ -1490,6 +1668,8 @@
     "official_instagram_url": "https://www.instagram.com/xikers_official/",
     "representative_image_url": null,
     "representative_image_source": null,
-    "search_aliases": []
+    "search_aliases": [
+      "싸이커스"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary\n- backfill Korean-searchable aliases across all tracked artist profiles\n- strengthen shorthand coverage for common team nicknames without adding fuzzy initials\n- document the fallback order for future alias curation\n\n## Verification\n- confirmed artist profiles with non-empty search aliases increased from 24 to 107\n- manually checked queries such as 키오프, 스키즈, 엔믹스, 트리플에스, 우주소녀, 보넥도, 영파씨, 앤팀\n- cd web && npm run build\n- cd web && npm run lint\n- git diff --check\n\nCloses #116