### PR TITLE
Onboard CLOSE YOUR EYES into tracked search data

### DIFF
--- a/docs/specs/mobile/content-governance-spec.md
+++ b/docs/specs/mobile/content-governance-spec.md
@@ -51,6 +51,14 @@
 - 사용자 체감 검색 실패를 유발하는 케이스는 큐레이션 우선순위가 높다.
 - alias는 장르 판정 라벨이 아니라 검색 편의 자산이다.
 
+## 6.a Missing Entity Triage
+- 검색 실패 제보가 들어오면 먼저 `artistProfiles.json`, `watchlist.json`, `releases.json`, `upcomingCandidates.json`에 엔티티가 아예 없는지 확인한다.
+- 엔티티 부재가 원인이면 alias 이슈로 우회하지 않고 onboarding 이슈로 분리한다.
+- in-scope 팀으로 판단되면 최소 아래 세트를 같은 턴에 넣는다.
+  - `artistProfiles.json`의 canonical name, slug, Korean-searchable alias
+  - `tracking_watchlist.json`과 `web/src/data/watchlist.json`의 최소 watchlist row
+- verified release나 upcoming fact가 아직 없어도, team search와 team navigation이 되도록 profile/watchlist 기준 엔트리를 우선 연다.
+
 ## 7. 브랜드 자산 운영 원칙
 - 공식 배지/대표 이미지가 있으면 우선 사용
 - 없으면 representative image

--- a/tracking_watchlist.json
+++ b/tracking_watchlist.json
@@ -324,6 +324,21 @@
     ]
   },
   {
+    "group": "CLOSE YOUR EYES",
+    "tier": "longtail",
+    "watch_reason": "recent_release",
+    "tracking_status": "recent_release",
+    "latest_release_title": "ETERNALT",
+    "latest_release_date": "2025-04-02",
+    "latest_release_kind": "ep",
+    "x_url": "",
+    "instagram_url": "https://www.instagram.com/close.your.eyes.official/",
+    "search_terms": [
+      "\"CLOSE YOUR EYES\" kpop comeback",
+      "\"클로즈 유어 아이즈\" 컴백"
+    ]
+  },
+  {
     "group": "CLASS:y",
     "tier": "longtail",
     "watch_reason": "",

--- a/web/src/data/artistProfiles.json
+++ b/web/src/data/artistProfiles.json
@@ -337,6 +337,26 @@
     ]
   },
   {
+    "slug": "close-your-eyes",
+    "group": "CLOSE YOUR EYES",
+    "display_name": "CLOSE YOUR EYES",
+    "aliases": [
+      "CYE"
+    ],
+    "agency": "UNCORE",
+    "official_youtube_url": null,
+    "official_x_url": null,
+    "official_instagram_url": "https://www.instagram.com/close.your.eyes.official/",
+    "representative_image_url": null,
+    "representative_image_source": null,
+    "search_aliases": [
+      "클로즈 유어 아이즈",
+      "클로즈유어아이즈",
+      "클유아"
+    ],
+    "debut_year": 2025
+  },
+  {
     "slug": "class-y",
     "group": "CLASS:y",
     "display_name": "CLASS:y",

--- a/web/src/data/watchlist.json
+++ b/web/src/data/watchlist.json
@@ -324,6 +324,21 @@
     ]
   },
   {
+    "group": "CLOSE YOUR EYES",
+    "tier": "longtail",
+    "watch_reason": "recent_release",
+    "tracking_status": "recent_release",
+    "latest_release_title": "ETERNALT",
+    "latest_release_date": "2025-04-02",
+    "latest_release_kind": "ep",
+    "x_url": "",
+    "instagram_url": "https://www.instagram.com/close.your.eyes.official/",
+    "search_terms": [
+      "\"CLOSE YOUR EYES\" kpop comeback",
+      "\"클로즈 유어 아이즈\" 컴백"
+    ]
+  },
+  {
     "group": "CLASS:y",
     "tier": "longtail",
     "watch_reason": "",


### PR DESCRIPTION
## Summary\n- onboard CLOSE YOUR EYES into artist profile and watchlist search sources\n- add Korean-searchable aliases including 클로즈 유어 아이즈 and 클유아 at onboarding time\n- document a repeatable missing-entity triage rule for future search-gap reports\n\n## Verification\n- confirmed CLOSE YOUR EYES now exists in artistProfiles and watchlist while releases/upcoming remain absent\n- confirmed queries CLOSE YOUR EYES, 클로즈 유어 아이즈, 클로즈유어아이즈, 클유아 resolve to the same group\n- cd web && npm run build\n- cd web && npm run lint\n- git diff --check\n\nCloses #117