### PR TITLE
Add YENA to tracked datasets

### DIFF
--- a/tracking_watchlist.json
+++ b/tracking_watchlist.json
@@ -1477,6 +1477,22 @@
     ]
   },
   {
+    "group": "YENA",
+    "tier": "longtail",
+    "watch_reason": "manual_watch",
+    "tracking_status": "watch_only",
+    "latest_release_title": "",
+    "latest_release_date": "",
+    "latest_release_kind": "",
+    "x_url": "https://x.com/YENA_OFFICIAL",
+    "instagram_url": "https://www.instagram.com/yena.jigumina/",
+    "search_terms": [
+      "\"YENA\" kpop comeback",
+      "\"최예나\" 컴백",
+      "\"YENA\" teaser"
+    ]
+  },
+  {
     "group": "YOUNG POSSE",
     "tier": "longtail",
     "watch_reason": "recent_release",

--- a/web/src/data/artistProfiles.json
+++ b/web/src/data/artistProfiles.json
@@ -1691,5 +1691,20 @@
     "search_aliases": [
       "싸이커스"
     ]
+  },
+  {
+    "slug": "yena",
+    "group": "YENA",
+    "display_name": "YENA",
+    "aliases": [],
+    "agency": null,
+    "official_youtube_url": "https://www.youtube.com/@yena_official",
+    "official_x_url": "https://x.com/YENA_OFFICIAL",
+    "official_instagram_url": "https://www.instagram.com/yena.jigumina/",
+    "representative_image_url": null,
+    "representative_image_source": null,
+    "search_aliases": [
+      "최예나"
+    ]
   }
 ]

--- a/web/src/data/watchlist.json
+++ b/web/src/data/watchlist.json
@@ -1477,6 +1477,22 @@
     ]
   },
   {
+    "group": "YENA",
+    "tier": "longtail",
+    "watch_reason": "manual_watch",
+    "tracking_status": "watch_only",
+    "latest_release_title": "",
+    "latest_release_date": "",
+    "latest_release_kind": "",
+    "x_url": "https://x.com/YENA_OFFICIAL",
+    "instagram_url": "https://www.instagram.com/yena.jigumina/",
+    "search_terms": [
+      "\"YENA\" kpop comeback",
+      "\"최예나\" 컴백",
+      "\"YENA\" teaser"
+    ]
+  },
+  {
     "group": "YOUNG POSSE",
     "tier": "longtail",
     "watch_reason": "recent_release",


### PR DESCRIPTION
## Summary
- onboard YENA into artist profiles with Korean alias coverage and official YouTube/X/Instagram links
- add YENA to the root and web watchlists as a watch-only tracked solo act for future upcoming and MV workflows
- keep alias coverage focused on the required `최예나` form to avoid noisy bare-name search collisions

## Verification
- confirm baseline absence via local dataset grep
- verify `YENA` and `최예나` both resolve to the YENA entity in the search index model
- cd web && npm run build
- cd web && npm run lint
- git diff --check

Closes #137