### PR TITLE
Add in-scope solo artists to tracked datasets

### DIFF
--- a/docs/specs/mobile/content-governance-spec.md
+++ b/docs/specs/mobile/content-governance-spec.md
@@ -59,6 +59,19 @@
   - `tracking_watchlist.json`과 `web/src/data/watchlist.json`의 최소 watchlist row
 - verified release나 upcoming fact가 아직 없어도, team search와 team navigation이 되도록 profile/watchlist 기준 엔트리를 우선 연다.
 
+## 6.b Solo Artist Inclusion
+- 솔로 아티스트도 K-pop release/upcoming 탐색 대상이면 group/unit와 같은 tracked entity로 취급한다.
+- 우선 포함 기준은 아래를 모두 만족하는 경우다.
+  - K-pop idol ecosystem 안에서 활동하는 명확한 stage name이 있다.
+  - 국내 사용자가 실제로 검색할 영어명 또는 한글명이 있다.
+  - onboarding 시점에 방어 가능한 official link를 최소 1개 이상 붙일 수 있다.
+- 아래 케이스는 기본 포함 대상에서 제외한다.
+  - 배우/예능인 중심으로만 소비되고 music-tracking 목적이 약한 케이스
+  - OST/feature 중심으로만 드문드문 등장해 독립 comeback tracking 가치가 낮은 케이스
+  - official identity link가 전혀 없어 name-only placeholder밖에 만들 수 없는 케이스
+- 솔로 아티스트 onboarding 최소 세트는 team missing triage와 동일하되, `search_aliases`에는 Korean-searchable 표기를 반드시 1개 이상 넣는다.
+- 2026-03-07 초기 pass 기준 tracked solo set은 `YENA`, `CHUU`, `Yves`, `JEON SOMI`, `KWON EUNBI`, `CHUNG HA`, `YUJU`를 포함한다.
+
 ## 7. 브랜드 자산 운영 원칙
 - 공식 배지/대표 이미지가 있으면 우선 사용
 - 없으면 representative image

--- a/tracking_watchlist.json
+++ b/tracking_watchlist.json
@@ -70,6 +70,102 @@
     ]
   },
   {
+    "group": "CHUNG HA",
+    "tier": "longtail",
+    "watch_reason": "manual_watch",
+    "tracking_status": "watch_only",
+    "latest_release_title": "",
+    "latest_release_date": "",
+    "latest_release_kind": "",
+    "x_url": "",
+    "instagram_url": "https://www.instagram.com/chungha.art/",
+    "search_terms": [
+      "\"CHUNG HA\" kpop comeback",
+      "\"청하\" 컴백",
+      "\"CHUNG HA\" teaser"
+    ]
+  },
+  {
+    "group": "CHUU",
+    "tier": "longtail",
+    "watch_reason": "manual_watch",
+    "tracking_status": "watch_only",
+    "latest_release_title": "",
+    "latest_release_date": "",
+    "latest_release_kind": "",
+    "x_url": "",
+    "instagram_url": "https://www.instagram.com/chuuo3o/",
+    "search_terms": [
+      "\"CHUU\" kpop comeback",
+      "\"츄\" 컴백",
+      "\"CHUU\" teaser"
+    ]
+  },
+  {
+    "group": "JEON SOMI",
+    "tier": "longtail",
+    "watch_reason": "manual_watch",
+    "tracking_status": "watch_only",
+    "latest_release_title": "",
+    "latest_release_date": "",
+    "latest_release_kind": "",
+    "x_url": "",
+    "instagram_url": "https://www.instagram.com/somsomi0309/",
+    "search_terms": [
+      "\"JEON SOMI\" kpop comeback",
+      "\"전소미\" 컴백",
+      "\"JEON SOMI\" teaser"
+    ]
+  },
+  {
+    "group": "KWON EUNBI",
+    "tier": "longtail",
+    "watch_reason": "manual_watch",
+    "tracking_status": "watch_only",
+    "latest_release_title": "",
+    "latest_release_date": "",
+    "latest_release_kind": "",
+    "x_url": "",
+    "instagram_url": "https://www.instagram.com/silver_rain.__/",
+    "search_terms": [
+      "\"KWON EUNBI\" kpop comeback",
+      "\"권은비\" 컴백",
+      "\"KWON EUNBI\" teaser"
+    ]
+  },
+  {
+    "group": "YUJU",
+    "tier": "longtail",
+    "watch_reason": "manual_watch",
+    "tracking_status": "watch_only",
+    "latest_release_title": "",
+    "latest_release_date": "",
+    "latest_release_kind": "",
+    "x_url": "",
+    "instagram_url": "https://www.instagram.com/yuuzth/",
+    "search_terms": [
+      "\"YUJU\" kpop comeback",
+      "\"유주\" 컴백",
+      "\"YUJU\" teaser"
+    ]
+  },
+  {
+    "group": "Yves",
+    "tier": "longtail",
+    "watch_reason": "manual_watch",
+    "tracking_status": "watch_only",
+    "latest_release_title": "",
+    "latest_release_date": "",
+    "latest_release_kind": "",
+    "x_url": "",
+    "instagram_url": "https://www.instagram.com/yvesntual/",
+    "search_terms": [
+      "\"Yves\" kpop comeback",
+      "\"이브\" 컴백",
+      "\"Yves\" teaser"
+    ]
+  },
+  {
     "group": "aespa",
     "tier": "core",
     "watch_reason": "recent_release",

--- a/web/src/data/artistProfiles.json
+++ b/web/src/data/artistProfiles.json
@@ -80,6 +80,96 @@
     ]
   },
   {
+    "slug": "chung-ha",
+    "group": "CHUNG HA",
+    "display_name": "CHUNG HA",
+    "aliases": [],
+    "agency": null,
+    "official_youtube_url": "https://www.youtube.com/@CHUNGHA_OFFICIAL",
+    "official_x_url": null,
+    "official_instagram_url": "https://www.instagram.com/chungha.art/",
+    "representative_image_url": null,
+    "representative_image_source": null,
+    "search_aliases": [
+      "청하"
+    ]
+  },
+  {
+    "slug": "chuu",
+    "group": "CHUU",
+    "display_name": "CHUU",
+    "aliases": [],
+    "agency": null,
+    "official_youtube_url": "https://www.youtube.com/@CHUUOfficial",
+    "official_x_url": null,
+    "official_instagram_url": "https://www.instagram.com/chuuo3o/",
+    "representative_image_url": null,
+    "representative_image_source": null,
+    "search_aliases": [
+      "츄"
+    ]
+  },
+  {
+    "slug": "jeon-somi",
+    "group": "JEON SOMI",
+    "display_name": "JEON SOMI",
+    "aliases": [],
+    "agency": null,
+    "official_youtube_url": "https://www.youtube.com/@JEONSOMIOFFICIAL",
+    "official_x_url": null,
+    "official_instagram_url": "https://www.instagram.com/somsomi0309/",
+    "representative_image_url": null,
+    "representative_image_source": null,
+    "search_aliases": [
+      "전소미"
+    ]
+  },
+  {
+    "slug": "kwon-eunbi",
+    "group": "KWON EUNBI",
+    "display_name": "KWON EUNBI",
+    "aliases": [],
+    "agency": null,
+    "official_youtube_url": "https://www.youtube.com/@KWONEUNBI",
+    "official_x_url": null,
+    "official_instagram_url": "https://www.instagram.com/silver_rain.__/",
+    "representative_image_url": null,
+    "representative_image_source": null,
+    "search_aliases": [
+      "권은비"
+    ]
+  },
+  {
+    "slug": "yuju",
+    "group": "YUJU",
+    "display_name": "YUJU",
+    "aliases": [],
+    "agency": null,
+    "official_youtube_url": "https://www.youtube.com/@YUJUofficial",
+    "official_x_url": null,
+    "official_instagram_url": "https://www.instagram.com/yuuzth/",
+    "representative_image_url": null,
+    "representative_image_source": null,
+    "search_aliases": [
+      "유주"
+    ]
+  },
+  {
+    "slug": "yves",
+    "group": "Yves",
+    "display_name": "Yves",
+    "aliases": [],
+    "agency": null,
+    "official_youtube_url": "https://www.youtube.com/@YVES_OFFICIAL",
+    "official_x_url": null,
+    "official_instagram_url": "https://www.instagram.com/yvesntual/",
+    "representative_image_url": null,
+    "representative_image_source": null,
+    "search_aliases": [
+      "이브"
+    ]
+  },
+  {
     "slug": "all-h-ours",
     "group": "ALL(H)OURS",
     "display_name": "ALL(H)OURS",

--- a/web/src/data/watchlist.json
+++ b/web/src/data/watchlist.json
@@ -70,6 +70,102 @@
     ]
   },
   {
+    "group": "CHUNG HA",
+    "tier": "longtail",
+    "watch_reason": "manual_watch",
+    "tracking_status": "watch_only",
+    "latest_release_title": "",
+    "latest_release_date": "",
+    "latest_release_kind": "",
+    "x_url": "",
+    "instagram_url": "https://www.instagram.com/chungha.art/",
+    "search_terms": [
+      "\"CHUNG HA\" kpop comeback",
+      "\"청하\" 컴백",
+      "\"CHUNG HA\" teaser"
+    ]
+  },
+  {
+    "group": "CHUU",
+    "tier": "longtail",
+    "watch_reason": "manual_watch",
+    "tracking_status": "watch_only",
+    "latest_release_title": "",
+    "latest_release_date": "",
+    "latest_release_kind": "",
+    "x_url": "",
+    "instagram_url": "https://www.instagram.com/chuuo3o/",
+    "search_terms": [
+      "\"CHUU\" kpop comeback",
+      "\"츄\" 컴백",
+      "\"CHUU\" teaser"
+    ]
+  },
+  {
+    "group": "JEON SOMI",
+    "tier": "longtail",
+    "watch_reason": "manual_watch",
+    "tracking_status": "watch_only",
+    "latest_release_title": "",
+    "latest_release_date": "",
+    "latest_release_kind": "",
+    "x_url": "",
+    "instagram_url": "https://www.instagram.com/somsomi0309/",
+    "search_terms": [
+      "\"JEON SOMI\" kpop comeback",
+      "\"전소미\" 컴백",
+      "\"JEON SOMI\" teaser"
+    ]
+  },
+  {
+    "group": "KWON EUNBI",
+    "tier": "longtail",
+    "watch_reason": "manual_watch",
+    "tracking_status": "watch_only",
+    "latest_release_title": "",
+    "latest_release_date": "",
+    "latest_release_kind": "",
+    "x_url": "",
+    "instagram_url": "https://www.instagram.com/silver_rain.__/",
+    "search_terms": [
+      "\"KWON EUNBI\" kpop comeback",
+      "\"권은비\" 컴백",
+      "\"KWON EUNBI\" teaser"
+    ]
+  },
+  {
+    "group": "YUJU",
+    "tier": "longtail",
+    "watch_reason": "manual_watch",
+    "tracking_status": "watch_only",
+    "latest_release_title": "",
+    "latest_release_date": "",
+    "latest_release_kind": "",
+    "x_url": "",
+    "instagram_url": "https://www.instagram.com/yuuzth/",
+    "search_terms": [
+      "\"YUJU\" kpop comeback",
+      "\"유주\" 컴백",
+      "\"YUJU\" teaser"
+    ]
+  },
+  {
+    "group": "Yves",
+    "tier": "longtail",
+    "watch_reason": "manual_watch",
+    "tracking_status": "watch_only",
+    "latest_release_title": "",
+    "latest_release_date": "",
+    "latest_release_kind": "",
+    "x_url": "",
+    "instagram_url": "https://www.instagram.com/yvesntual/",
+    "search_terms": [
+      "\"Yves\" kpop comeback",
+      "\"이브\" 컴백",
+      "\"Yves\" teaser"
+    ]
+  },
+  {
     "group": "aespa",
     "tier": "core",
     "watch_reason": "recent_release",


### PR DESCRIPTION
## Summary
- define a repeatable inclusion rule for in-scope K-pop solo artists in the content governance spec
- onboard CHUU, Yves, JEON SOMI, KWON EUNBI, CHUNG HA, and YUJU with Korean-searchable aliases plus official Instagram/YouTube links
- add matching watchlist seeds so solo artists participate in the same baseline search and tracking flows as other tracked entities

## Verification
- confirm baseline absence of CHUU, Yves, JEON SOMI, KWON EUNBI, CHUNG HA, and YUJU in HEAD tracked datasets
- verify representative queries `CHUU`, `츄`, `Yves`, `JEON SOMI`, `전소미`, `권은비`, `청하`, `유주`, `YENA`, `최예나` resolve in the search index model
- cd web && npm run build
- cd web && npm run lint
- git diff --check

Closes #138