### PR TITLE
Add canonical schema migration baseline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__/
 
 web/node_modules/
 web/dist/
+backend/node_modules/
 
 .idea/
 .vscode/

--- a/README.md
+++ b/README.md
@@ -117,6 +117,11 @@ python build_release_change_log.py
 python -m unittest test_youtube_mv_candidate_scoring.py
 ```
 
+### 백엔드 migration baseline
+
+- migration location: `backend/sql/migrations/`
+- run note: `backend/sql/README.md`
+
 Hydration dry-run 예시:
 
 ```bash

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,18 @@
+# Backend Area
+
+이 디렉터리는 backend migration 관련 자산을 둔다.
+
+현재 포함 범위:
+
+- `sql/migrations/`
+  - Neon baseline schema migration
+- `sql/README.md`
+  - migration apply / verify run note
+- `scripts/`
+  - plain SQL migration apply / schema verify helper
+
+원칙:
+
+- ORM이나 무거운 migration framework는 도입하지 않는다.
+- 정본 schema는 plain SQL로 관리한다.
+- apply / verify 도구는 SQL 실행 보조에만 사용한다.

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,0 +1,159 @@
+{
+  "name": "idol-song-app-backend",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "idol-song-app-backend",
+      "dependencies": {
+        "pg": "^8.13.3"
+      }
+    },
+    "node_modules/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    }
+  }
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "idol-song-app-backend",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "migrate:apply": "node ./scripts/apply-migration.mjs ./sql/migrations/0001_canonical_schema.sql",
+    "schema:verify": "node ./scripts/verify-canonical-schema.mjs"
+  },
+  "dependencies": {
+    "pg": "^8.13.3"
+  }
+}

--- a/backend/scripts/apply-migration.mjs
+++ b/backend/scripts/apply-migration.mjs
@@ -1,0 +1,84 @@
+import { readFile } from 'node:fs/promises';
+import { basename, resolve } from 'node:path';
+import { createHash } from 'node:crypto';
+import pg from 'pg';
+
+const { Client } = pg;
+
+function requiredEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
+
+async function main() {
+  const migrationArg = process.argv[2];
+
+  if (!migrationArg) {
+    throw new Error('usage: node ./scripts/apply-migration.mjs ./sql/migrations/0001_canonical_schema.sql');
+  }
+
+  const migrationPath = resolve(process.cwd(), migrationArg);
+  const version = basename(migrationPath);
+  const sql = await readFile(migrationPath, 'utf8');
+  const checksum = createHash('sha256').update(sql).digest('hex');
+  const connectionString = requiredEnv('DATABASE_URL');
+
+  const client = new Client({
+    connectionString,
+    application_name: 'idol-song-app-backend-migrate',
+    ssl: { rejectUnauthorized: false },
+  });
+
+  await client.connect();
+
+  try {
+    await client.query(`
+      create table if not exists schema_migrations (
+        version text primary key,
+        checksum text not null,
+        applied_at timestamptz not null default now()
+      )
+    `);
+
+    const existing = await client.query(
+      'select checksum from schema_migrations where version = $1',
+      [version]
+    );
+
+    if (existing.rowCount === 1) {
+      if (existing.rows[0].checksum !== checksum) {
+        throw new Error(`migration ${version} already applied with a different checksum`);
+      }
+
+      console.log(`skip: ${version} already applied`);
+      return;
+    }
+
+    await client.query('begin');
+    await client.query(sql);
+    await client.query(
+      'insert into schema_migrations (version, checksum) values ($1, $2)',
+      [version, checksum]
+    );
+    await client.query('commit');
+
+    console.log(`applied: ${version}`);
+  } catch (error) {
+    try {
+      await client.query('rollback');
+    } catch {
+      // noop
+    }
+    throw error;
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});

--- a/backend/scripts/verify-canonical-schema.mjs
+++ b/backend/scripts/verify-canonical-schema.mjs
@@ -1,0 +1,105 @@
+import pg from 'pg';
+
+const { Client } = pg;
+
+const REQUIRED_TABLES = [
+  'entities',
+  'entity_aliases',
+  'entity_official_links',
+  'youtube_channels',
+  'entity_youtube_channels',
+  'releases',
+  'release_artwork',
+  'tracks',
+  'release_service_links',
+  'track_service_links',
+  'upcoming_signals',
+  'upcoming_signal_sources',
+  'entity_tracking_state',
+  'review_tasks',
+  'release_link_overrides',
+];
+
+const REQUIRED_CONSTRAINTS = [
+  ['entities', 'entities_slug_key'],
+  ['entity_aliases', 'entity_aliases_entity_id_alias_key'],
+  ['entity_official_links', 'entity_official_links_entity_id_link_type_url_key'],
+  ['youtube_channels', 'youtube_channels_canonical_channel_url_key'],
+  ['entity_youtube_channels', 'entity_youtube_channels_pkey'],
+  ['releases', 'releases_entity_id_normalized_release_title_release_date_stream'],
+  ['tracks', 'tracks_release_id_track_order_key'],
+  ['release_service_links', 'release_service_links_release_id_service_type_key'],
+  ['track_service_links', 'track_service_links_track_id_service_type_key'],
+  ['upcoming_signal_sources', 'upcoming_signal_sources_upcoming_signal_id_source_url_key'],
+  ['release_link_overrides', 'release_link_overrides_release_id_service_type_key'],
+];
+
+function requiredEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
+
+async function main() {
+  const connectionString = requiredEnv('DATABASE_URL');
+  const client = new Client({
+    connectionString,
+    application_name: 'idol-song-app-backend-verify',
+    ssl: { rejectUnauthorized: false },
+  });
+
+  await client.connect();
+
+  try {
+    const tableRows = await client.query(
+      `
+        select table_name
+        from information_schema.tables
+        where table_schema = 'public'
+          and table_name = any($1::text[])
+      `,
+      [REQUIRED_TABLES]
+    );
+
+    const existingTables = new Set(tableRows.rows.map((row) => row.table_name));
+    const missingTables = REQUIRED_TABLES.filter((name) => !existingTables.has(name));
+
+    if (missingTables.length > 0) {
+      throw new Error(`missing tables: ${missingTables.join(', ')}`);
+    }
+
+    const constraintRows = await client.query(
+      `
+        select table_name, constraint_name
+        from information_schema.table_constraints
+        where table_schema = 'public'
+          and constraint_name = any($1::text[])
+      `,
+      [REQUIRED_CONSTRAINTS.map(([, constraint]) => constraint)]
+    );
+
+    const existingConstraints = new Set(
+      constraintRows.rows.map((row) => `${row.table_name}.${row.constraint_name}`)
+    );
+
+    const missingConstraints = REQUIRED_CONSTRAINTS
+      .map(([table, constraint]) => `${table}.${constraint}`)
+      .filter((entry) => !existingConstraints.has(entry));
+
+    if (missingConstraints.length > 0) {
+      throw new Error(`missing constraints: ${missingConstraints.join(', ')}`);
+    }
+
+    console.log(`verified tables: ${REQUIRED_TABLES.length}`);
+    console.log(`verified constraints: ${REQUIRED_CONSTRAINTS.length}`);
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});

--- a/backend/sql/README.md
+++ b/backend/sql/README.md
@@ -1,0 +1,34 @@
+# SQL Migration Run Note
+
+이 디렉터리는 Neon canonical schema baseline migration을 둔다.
+
+## 위치
+
+- migration folder: `backend/sql/migrations/`
+- current baseline: `backend/sql/migrations/0001_canonical_schema.sql`
+
+## 요구사항
+
+- `DATABASE_URL` 환경 변수
+- Node.js
+- `backend/package.json`에 정의된 `pg` dependency
+
+## 권장 실행 순서
+
+```bash
+set -a
+source ~/.config/idol-song-app/neon.env
+set +a
+
+cd backend
+npm install
+npm run migrate:apply
+npm run schema:verify
+```
+
+## 규칙
+
+- migration은 plain SQL 파일을 추가 번호로 누적한다.
+- apply helper는 `schema_migrations` 메타 테이블로 재적용을 막는다.
+- direct connection string인 `DATABASE_URL`을 우선 사용한다.
+- pooler URL은 migration보다 read traffic 용도에 가깝다.

--- a/backend/sql/migrations/0001_canonical_schema.sql
+++ b/backend/sql/migrations/0001_canonical_schema.sql
@@ -1,0 +1,238 @@
+create extension if not exists pgcrypto;
+
+create table if not exists entities (
+  id uuid primary key default gen_random_uuid(),
+  slug text not null unique,
+  canonical_name text not null,
+  display_name text not null,
+  entity_type text not null check (entity_type in ('group', 'solo', 'unit', 'project')),
+  agency_name text,
+  debut_year integer check (debut_year is null or debut_year between 1900 and 2100),
+  representative_image_url text,
+  representative_image_source text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists entity_aliases (
+  id uuid primary key default gen_random_uuid(),
+  entity_id uuid not null references entities(id) on delete cascade,
+  alias text not null,
+  alias_type text not null check (alias_type in ('official_ko', 'common_ko', 'shorthand', 'nickname', 'romanized', 'legacy', 'search_seed')),
+  normalized_alias text not null,
+  is_primary boolean not null default false,
+  created_at timestamptz not null default now(),
+  constraint entity_aliases_entity_id_alias_key unique (entity_id, alias)
+);
+
+create table if not exists entity_official_links (
+  id uuid primary key default gen_random_uuid(),
+  entity_id uuid not null references entities(id) on delete cascade,
+  link_type text not null check (link_type in ('youtube', 'x', 'instagram', 'website', 'artist_source')),
+  url text not null,
+  is_primary boolean not null default false,
+  provenance text,
+  created_at timestamptz not null default now(),
+  constraint entity_official_links_entity_id_link_type_url_key unique (entity_id, link_type, url)
+);
+
+create table if not exists youtube_channels (
+  id uuid primary key default gen_random_uuid(),
+  canonical_channel_url text not null unique,
+  channel_label text not null,
+  owner_type text not null check (owner_type in ('team', 'label', 'distributor', 'other_official')),
+  display_in_team_links boolean not null default false,
+  allow_mv_uploads boolean not null default false,
+  provenance text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists entity_youtube_channels (
+  entity_id uuid not null references entities(id) on delete cascade,
+  youtube_channel_id uuid not null references youtube_channels(id) on delete cascade,
+  channel_role text not null check (channel_role in ('primary_team_channel', 'mv_allowlist', 'both')),
+  created_at timestamptz not null default now(),
+  primary key (entity_id, youtube_channel_id)
+);
+
+create table if not exists releases (
+  id uuid primary key default gen_random_uuid(),
+  entity_id uuid not null references entities(id) on delete cascade,
+  release_title text not null,
+  normalized_release_title text not null,
+  release_date date not null,
+  stream text not null check (stream in ('song', 'album')),
+  release_kind text,
+  release_format text,
+  source_url text,
+  artist_source_url text,
+  musicbrainz_artist_id text,
+  musicbrainz_release_group_id text,
+  notes text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint releases_entity_id_normalized_release_title_release_date_stream_key
+    unique (entity_id, normalized_release_title, release_date, stream)
+);
+
+create table if not exists release_artwork (
+  release_id uuid primary key references releases(id) on delete cascade,
+  cover_image_url text,
+  thumbnail_image_url text,
+  artwork_source_type text,
+  artwork_source_url text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists tracks (
+  id uuid primary key default gen_random_uuid(),
+  release_id uuid not null references releases(id) on delete cascade,
+  track_order integer not null check (track_order > 0),
+  track_title text not null,
+  normalized_track_title text not null,
+  is_title_track boolean,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint tracks_release_id_track_order_key unique (release_id, track_order)
+);
+
+create table if not exists release_service_links (
+  id uuid primary key default gen_random_uuid(),
+  release_id uuid not null references releases(id) on delete cascade,
+  service_type text not null check (service_type in ('spotify', 'youtube_music', 'youtube_mv')),
+  url text,
+  status text not null check (status in ('canonical', 'manual_override', 'relation_match', 'needs_review', 'unresolved', 'no_link')),
+  provenance text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint release_service_links_release_id_service_type_key unique (release_id, service_type)
+);
+
+create table if not exists track_service_links (
+  id uuid primary key default gen_random_uuid(),
+  track_id uuid not null references tracks(id) on delete cascade,
+  service_type text not null check (service_type in ('spotify', 'youtube_music')),
+  url text,
+  status text not null check (status in ('canonical', 'unresolved', 'no_link')),
+  provenance text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint track_service_links_track_id_service_type_key unique (track_id, service_type)
+);
+
+create table if not exists upcoming_signals (
+  id uuid primary key default gen_random_uuid(),
+  entity_id uuid not null references entities(id) on delete cascade,
+  headline text not null,
+  normalized_headline text not null,
+  scheduled_date date,
+  scheduled_month date,
+  date_precision text not null check (date_precision in ('exact', 'month_only', 'unknown')),
+  date_status text not null check (date_status in ('confirmed', 'scheduled', 'rumor')),
+  release_format text,
+  confidence_score numeric(4,2) check (confidence_score is null or (confidence_score >= 0 and confidence_score <= 1)),
+  tracking_status text,
+  first_seen_at timestamptz,
+  latest_seen_at timestamptz,
+  is_active boolean not null default true,
+  dedupe_key text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  check (
+    (date_precision = 'exact' and scheduled_date is not null and scheduled_month is null) or
+    (
+      date_precision = 'month_only'
+      and scheduled_date is null
+      and scheduled_month is not null
+      and scheduled_month = date_trunc('month', scheduled_month::timestamp)::date
+    ) or
+    (date_precision = 'unknown' and scheduled_date is null and scheduled_month is null)
+  )
+);
+
+create table if not exists upcoming_signal_sources (
+  id uuid primary key default gen_random_uuid(),
+  upcoming_signal_id uuid not null references upcoming_signals(id) on delete cascade,
+  source_type text not null check (source_type in ('news_rss', 'weverse_notice', 'agency_notice', 'official_social', 'manual')),
+  source_url text not null,
+  source_domain text,
+  published_at timestamptz,
+  search_term text,
+  evidence_summary text,
+  created_at timestamptz not null default now(),
+  constraint upcoming_signal_sources_upcoming_signal_id_source_url_key
+    unique (upcoming_signal_id, source_url)
+);
+
+create table if not exists entity_tracking_state (
+  entity_id uuid primary key references entities(id) on delete cascade,
+  tier text not null,
+  watch_reason text not null,
+  tracking_status text not null,
+  latest_verified_release_id uuid references releases(id) on delete set null,
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists review_tasks (
+  id uuid primary key default gen_random_uuid(),
+  review_type text not null check (review_type in ('upcoming_signal', 'mv_candidate', 'entity_onboarding', 'alias_gap')),
+  status text not null check (status in ('open', 'resolved', 'dismissed')),
+  entity_id uuid references entities(id) on delete set null,
+  release_id uuid references releases(id) on delete set null,
+  upcoming_signal_id uuid references upcoming_signals(id) on delete set null,
+  review_reason text[],
+  recommended_action text,
+  payload jsonb,
+  created_at timestamptz not null default now(),
+  resolved_at timestamptz
+);
+
+create table if not exists release_link_overrides (
+  id uuid primary key default gen_random_uuid(),
+  release_id uuid not null references releases(id) on delete cascade,
+  service_type text not null check (service_type in ('youtube_music', 'youtube_mv')),
+  override_url text,
+  override_video_id text,
+  provenance text not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint release_link_overrides_release_id_service_type_key unique (release_id, service_type)
+);
+
+create index if not exists idx_entity_aliases_normalized_alias
+  on entity_aliases (normalized_alias);
+
+create index if not exists idx_entity_official_links_entity_id
+  on entity_official_links (entity_id);
+
+create index if not exists idx_releases_entity_id_release_date
+  on releases (entity_id, release_date desc);
+
+create index if not exists idx_releases_release_date
+  on releases (release_date desc);
+
+create index if not exists idx_releases_musicbrainz_release_group_id
+  on releases (musicbrainz_release_group_id);
+
+create index if not exists idx_upcoming_signals_entity_id
+  on upcoming_signals (entity_id);
+
+create index if not exists idx_upcoming_signals_scheduled_date
+  on upcoming_signals (scheduled_date);
+
+create index if not exists idx_upcoming_signals_scheduled_month
+  on upcoming_signals (scheduled_month);
+
+create index if not exists idx_upcoming_signals_dedupe_key
+  on upcoming_signals (dedupe_key);
+
+create index if not exists idx_entity_tracking_state_tracking_status
+  on entity_tracking_state (tracking_status);
+
+create index if not exists idx_review_tasks_status_review_type
+  on review_tasks (status, review_type);
+
+create index if not exists idx_release_service_links_status
+  on release_service_links (status);


### PR DESCRIPTION
## Summary
- add a dedicated `backend/` area with a plain SQL baseline migration for the canonical write tables
- add thin Node helpers to apply the SQL migration and verify required tables/constraints against Neon
- document the migration location and run steps in `backend/sql/README.md` and the root README

## Verification
- `cd backend && npm install`
- `cd backend && source ~/.config/idol-song-app/neon.env && npm run migrate:apply`
- `cd backend && source ~/.config/idol-song-app/neon.env && npm run schema:verify`
- repeated `npm run migrate:apply` returns `skip: 0001_canonical_schema.sql already applied`
- `git diff --cached --check`

Closes #155