### PR TITLE
feat: dual-write release pipeline to canonical db

### DIFF
--- a/.github/workflows/weekly-kpop-scan.yml
+++ b/.github/workflows/weekly-kpop-scan.yml
@@ -28,11 +28,18 @@ jobs:
           python-version: "3.12"
 
       - name: Install Python dependencies
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
         run: |
           python -m pip install --upgrade pip
           pip install requests
+          if [ -n "${DATABASE_URL:-}" ]; then
+            pip install -r backend/requirements-import.txt
+          fi
 
       - name: Rebuild watchlist and scan future candidates
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
         run: |
           python build_tracking_watchlist.py
           python scan_upcoming_candidates.py
@@ -41,6 +48,11 @@ jobs:
           cp upcoming_release_candidates.json web/src/data/upcomingCandidates.json
           python hydrate_release_windows.py
           python build_mv_manual_review_queue.py
+          if [ -n "${DATABASE_URL:-}" ]; then
+            python sync_release_pipeline_to_neon.py --summary-path /tmp/release-pipeline-db-sync-summary.json
+          else
+            echo "DATABASE_URL not configured; skipping release pipeline DB sync."
+          fi
           python build_release_change_log.py
 
       - name: Set up Node.js

--- a/README.md
+++ b/README.md
@@ -117,6 +117,17 @@ python build_release_change_log.py
 python -m unittest test_youtube_mv_candidate_scoring.py
 ```
 
+Neon canonical DB까지 같이 최신화하려면 아래를 이어서 실행한다.
+
+```bash
+set -a
+source ~/.config/idol-song-app/neon.env
+set +a
+
+python3 -m pip install -r backend/requirements-import.txt
+python3 sync_release_pipeline_to_neon.py
+```
+
 ### 백엔드 migration baseline
 
 - migration location: `backend/sql/migrations/`

--- a/backend/README.md
+++ b/backend/README.md
@@ -67,6 +67,32 @@ python3 import_json_to_neon.py
   - `manual_review_queue.json`
   - `mv_manual_review_queue.json`
 
+## Release Pipeline Dual-Write
+
+기존 JSON export를 유지한 채 release hydration / service-link / MV review 흐름만 canonical DB에 다시 쓰려면 아래 명령을 사용한다.
+
+```bash
+set -a
+source ~/.config/idol-song-app/neon.env
+set +a
+
+python3 -m pip install -r backend/requirements-import.txt
+python3 sync_release_pipeline_to_neon.py
+```
+
+기본 보고서 출력:
+
+- `backend/reports/release_pipeline_db_sync_summary.json`
+
+이 명령은 아래 JSON 산출물을 source-of-export로 유지한 채 canonical release-side table만 idempotent upsert 한다.
+
+- `web/src/data/releaseDetails.json`
+- `web/src/data/releaseHistory.json`
+- `web/src/data/releaseArtwork.json`
+- `web/src/data/youtubeChannelAllowlists.json`
+- `release_detail_overrides.json`
+- `mv_manual_review_queue.json`
+
 ## Backend vs JSON Parity Report
 
 import 이후 또는 projection refresh 이후 현재 backend state와 shipped JSON baseline을 비교하려면 아래 명령을 사용한다.

--- a/backend/reports/release_pipeline_db_sync_summary.json
+++ b/backend/reports/release_pipeline_db_sync_summary.json
@@ -1,0 +1,151 @@
+{
+  "generated_at": "2026-03-07T07:51:00.028059+00:00",
+  "source_counts": {
+    "artist_profiles": 116,
+    "youtube_allowlists": 108,
+    "release_details": 117,
+    "release_history_groups": 115,
+    "release_history_rows": 1767,
+    "release_artwork": 117,
+    "upcoming_candidates": 71,
+    "watchlist": 116,
+    "release_detail_overrides": 67,
+    "manual_review_queue": 67,
+    "mv_manual_review_queue": 34,
+    "releases_rollup": 80
+  },
+  "source_duplicates": {
+    "entity_aliases": 1,
+    "youtube_channels": 25
+  },
+  "dropped_records": {},
+  "dropped_missing_fk_samples": {},
+  "unresolved_release_mappings": [],
+  "unresolved_review_links": [],
+  "entity_type_counts": {
+    "group": 104,
+    "project": 1,
+    "unit": 4,
+    "solo": 7
+  },
+  "samples": {
+    "entities": [
+      "and-team",
+      "g-i-dle",
+      "82major",
+      "8turn",
+      "ab6ix"
+    ],
+    "releases": [
+      "&TEAM | 2022-11-21 | song | Under the skin",
+      "&TEAM | 2022-12-06 | album | First Howling : ME",
+      "&TEAM | 2023-05-07 | song | Blind Love",
+      "&TEAM | 2023-06-14 | album | First Howling : WE",
+      "&TEAM | 2023-11-15 | album | First Howling : NOW"
+    ],
+    "upcoming_signals": [
+      "&TEAM sets April comeback with Japanese mini album ‘We on Fire’ - allkpop",
+      "AB6IX announces March comeback with their first full album in 5 years - allkpop",
+      "AB6IX begins the countdown for their March comeback with the full album ‘SEVEN : CRIMSON HORIZON’ - allkpop",
+      "AB6IX Unveils 'So Sweet' Ahead of March Album - 조선일보",
+      "ALL(H)OURS Sets March Comeback With 5th Mini-Album ‘NO DOUBT’ - hellokpop"
+    ],
+    "review_tasks": [
+      "upcoming_signal",
+      "upcoming_signal",
+      "upcoming_signal",
+      "upcoming_signal",
+      "upcoming_signal"
+    ]
+  },
+  "scope": "release_pipeline",
+  "stale_pruned": {
+    "review_tasks": 0
+  },
+  "operation_counts": {
+    "entities": {
+      "updated": 116
+    },
+    "youtube_channels": {
+      "updated": 86
+    },
+    "entity_youtube_channels": {
+      "updated": 111
+    },
+    "releases": {
+      "updated": 1768
+    },
+    "release_artwork": {
+      "updated": 117
+    },
+    "tracks": {
+      "updated": 497
+    },
+    "release_service_links": {
+      "updated": 351
+    },
+    "track_service_links": {},
+    "entity_tracking_state": {
+      "updated": 116
+    },
+    "review_tasks": {
+      "updated": 34
+    },
+    "release_link_overrides": {
+      "updated": 75
+    }
+  },
+  "db_row_counts": {
+    "entities": 116,
+    "youtube_channels": 86,
+    "entity_youtube_channels": 111,
+    "releases": 1768,
+    "release_artwork": 117,
+    "tracks": 497,
+    "release_service_links": 351,
+    "track_service_links": 0,
+    "entity_tracking_state": 116,
+    "review_tasks": 101,
+    "release_link_overrides": 75
+  },
+  "critical_checks": {
+    "release_service_status_counts": {
+      "spotify": {
+        "canonical": 77,
+        "no_link": 40
+      },
+      "youtube_music": {
+        "canonical": 2,
+        "manual_override": 50,
+        "no_link": 65
+      },
+      "youtube_mv": {
+        "manual_override": 25,
+        "needs_review": 2,
+        "relation_match": 1,
+        "unresolved": 89
+      }
+    },
+    "title_track_rows": 61,
+    "entity_channel_role_counts": {
+      "both": 79,
+      "mv_allowlist": 32
+    },
+    "mv_review_task_rows": 34,
+    "tracking_state_rows_with_latest_release": 84
+  },
+  "summary_path": "backend/reports/release_pipeline_db_sync_summary.json",
+  "table_source_counts": {
+    "entities": 116,
+    "youtube_channels": 86,
+    "entity_youtube_channels": 111,
+    "releases": 1768,
+    "release_artwork": 117,
+    "tracks": 497,
+    "release_service_links": 351,
+    "track_service_links": 0,
+    "entity_tracking_state": 116,
+    "review_tasks": 34,
+    "release_link_overrides": 75
+  }
+}

--- a/backend/sql/README.md
+++ b/backend/sql/README.md
@@ -27,6 +27,7 @@ npm run schema:verify
 cd ..
 python3 -m pip install -r backend/requirements-import.txt
 python3 import_json_to_neon.py
+python3 sync_release_pipeline_to_neon.py
 python3 build_backend_json_parity_report.py
 ```
 
@@ -37,4 +38,5 @@ python3 build_backend_json_parity_report.py
 - direct connection string인 `DATABASE_URL`을 우선 사용한다.
 - pooler URL은 migration보다 read traffic 용도에 가깝다.
 - first JSON baseline import summary는 `backend/reports/json_to_neon_import_summary.json`에 남긴다.
+- release pipeline dual-write summary는 `backend/reports/release_pipeline_db_sync_summary.json`에 남긴다.
 - backend-vs-JSON parity report는 `backend/reports/backend_json_parity_report.json`에 남긴다.

--- a/import_json_to_neon.py
+++ b/import_json_to_neon.py
@@ -52,6 +52,20 @@ TARGET_TABLES = [
     "review_tasks",
     "release_link_overrides",
 ]
+RELEASE_PIPELINE_TABLES = [
+    "entities",
+    "youtube_channels",
+    "entity_youtube_channels",
+    "releases",
+    "release_artwork",
+    "tracks",
+    "release_service_links",
+    "track_service_links",
+    "entity_tracking_state",
+    "review_tasks",
+    "release_link_overrides",
+]
+RELEASE_PIPELINE_REVIEW_SOURCE_DATASETS = {"mv_manual_review_queue"}
 
 NAMESPACE = uuid.uuid5(uuid.NAMESPACE_URL, "https://github.com/iAmSomething/idol-song-app/import-json-to-neon/v1")
 SOLO_SLUGS = {
@@ -1181,6 +1195,23 @@ def build_import_payload() -> Dict[str, Any]:
             "release_link_overrides": release_link_override_rows,
         },
     }
+
+
+def build_release_pipeline_payload() -> Dict[str, Any]:
+    payload = build_import_payload()
+    release_scope_tables = {
+        table: payload["tables"][table]
+        for table in RELEASE_PIPELINE_TABLES
+    }
+    release_scope_tables["review_tasks"] = [
+        row
+        for row in release_scope_tables["review_tasks"]
+        if isinstance(row.get("payload"), dict)
+        and row["payload"].get("source_dataset") in RELEASE_PIPELINE_REVIEW_SOURCE_DATASETS
+    ]
+    payload["summary"]["scope"] = "release_pipeline"
+    payload["tables"] = release_scope_tables
+    return payload
 
 
 def fetch_existing_state(connection: "psycopg.Connection[Any]") -> Dict[str, Any]:

--- a/sync_release_pipeline_to_neon.py
+++ b/sync_release_pipeline_to_neon.py
@@ -1,0 +1,524 @@
+import argparse
+import json
+import os
+from collections import Counter
+from pathlib import Path
+from typing import Any, Dict, Sequence
+
+try:
+    import psycopg
+    from psycopg.types.json import Jsonb
+except ImportError as error:  # pragma: no cover - runtime dependency guard
+    raise SystemExit(
+        "psycopg is required. Run `python3 -m pip install -r backend/requirements-import.txt` first."
+    ) from error
+
+import import_json_to_neon as canonical_import
+
+
+DEFAULT_SUMMARY_PATH = canonical_import.BACKEND_REPORTS_DIR / "release_pipeline_db_sync_summary.json"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Sync release hydration / service-link / MV review pipeline outputs into Neon canonical tables."
+    )
+    parser.add_argument(
+        "--summary-path",
+        default=str(DEFAULT_SUMMARY_PATH),
+        help="Path to write the machine-readable release pipeline sync summary JSON.",
+    )
+    parser.add_argument(
+        "--database-url-env",
+        default="DATABASE_URL",
+        help="Environment variable name that contains the direct Neon connection string.",
+    )
+    return parser.parse_args()
+
+
+def prune_stale_mv_review_tasks(connection: "psycopg.Connection[Any]", review_task_rows: Sequence[Dict[str, Any]]) -> int:
+    desired_ids = [row["id"] for row in review_task_rows]
+    with connection.cursor() as cursor:
+        if desired_ids:
+            placeholders = ", ".join(["%s"] * len(desired_ids))
+            cursor.execute(
+                f"""
+                delete from review_tasks
+                where payload->>'source_dataset' = 'mv_manual_review_queue'
+                  and id not in ({placeholders})
+                """,
+                desired_ids,
+            )
+        else:
+            cursor.execute(
+                """
+                delete from review_tasks
+                where payload->>'source_dataset' = 'mv_manual_review_queue'
+                """
+            )
+        deleted = cursor.rowcount
+    connection.commit()
+    return deleted
+
+
+def upsert_release_pipeline_rows(
+    connection: "psycopg.Connection[Any]",
+    payload: Dict[str, Any],
+    summary: Dict[str, Any],
+) -> None:
+    existing = canonical_import.fetch_existing_state(connection)
+    operations = {table: Counter() for table in canonical_import.RELEASE_PIPELINE_TABLES}
+    summary["stale_pruned"] = {
+        "review_tasks": prune_stale_mv_review_tasks(connection, payload["tables"]["review_tasks"])
+    }
+
+    def count_operations(table: str, rows: Sequence[Dict[str, Any]], key_builder) -> None:
+        current_keys = existing[table]
+        for row in rows:
+            key = key_builder(row)
+            operations[table]["updated" if key in current_keys else "inserted"] += 1
+
+    with connection.pipeline(), connection.cursor() as cursor:
+        entity_rows = payload["tables"]["entities"]
+        if entity_rows:
+            count_operations("entities", entity_rows, lambda row: str(row["id"]))
+            cursor.executemany(
+                """
+                insert into entities (
+                  id, slug, canonical_name, display_name, entity_type, agency_name, debut_year,
+                  representative_image_url, representative_image_source
+                )
+                values (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                on conflict (id) do update set
+                  slug = excluded.slug,
+                  canonical_name = excluded.canonical_name,
+                  display_name = excluded.display_name,
+                  entity_type = excluded.entity_type,
+                  agency_name = excluded.agency_name,
+                  debut_year = excluded.debut_year,
+                  representative_image_url = excluded.representative_image_url,
+                  representative_image_source = excluded.representative_image_source,
+                  updated_at = now()
+                """,
+                [
+                    (
+                        row["id"],
+                        row["slug"],
+                        row["canonical_name"],
+                        row["display_name"],
+                        row["entity_type"],
+                        row["agency_name"],
+                        row["debut_year"],
+                        row["representative_image_url"],
+                        row["representative_image_source"],
+                    )
+                    for row in entity_rows
+                ],
+            )
+
+        youtube_channel_rows = payload["tables"]["youtube_channels"]
+        if youtube_channel_rows:
+            count_operations("youtube_channels", youtube_channel_rows, lambda row: str(row["id"]))
+            cursor.executemany(
+                """
+                insert into youtube_channels (
+                  id, canonical_channel_url, channel_label, owner_type,
+                  display_in_team_links, allow_mv_uploads, provenance
+                )
+                values (%s, %s, %s, %s, %s, %s, %s)
+                on conflict (id) do update set
+                  canonical_channel_url = excluded.canonical_channel_url,
+                  channel_label = excluded.channel_label,
+                  owner_type = excluded.owner_type,
+                  display_in_team_links = excluded.display_in_team_links,
+                  allow_mv_uploads = excluded.allow_mv_uploads,
+                  provenance = excluded.provenance,
+                  updated_at = now()
+                """,
+                [
+                    (
+                        row["id"],
+                        row["canonical_channel_url"],
+                        row["channel_label"],
+                        row["owner_type"],
+                        row["display_in_team_links"],
+                        row["allow_mv_uploads"],
+                        row["provenance"],
+                    )
+                    for row in youtube_channel_rows
+                ],
+            )
+
+        entity_channel_rows = payload["tables"]["entity_youtube_channels"]
+        if entity_channel_rows:
+            count_operations(
+                "entity_youtube_channels",
+                entity_channel_rows,
+                lambda row: (str(row["entity_id"]), str(row["youtube_channel_id"])),
+            )
+            cursor.executemany(
+                """
+                insert into entity_youtube_channels (
+                  entity_id, youtube_channel_id, channel_role
+                )
+                values (%s, %s, %s)
+                on conflict (entity_id, youtube_channel_id) do update set
+                  channel_role = excluded.channel_role
+                """,
+                [(row["entity_id"], row["youtube_channel_id"], row["channel_role"]) for row in entity_channel_rows],
+            )
+
+        release_rows = payload["tables"]["releases"]
+        if release_rows:
+            count_operations("releases", release_rows, lambda row: str(row["id"]))
+            cursor.executemany(
+                """
+                insert into releases (
+                  id, entity_id, release_title, normalized_release_title, release_date, stream, release_kind,
+                  release_format, source_url, artist_source_url, musicbrainz_artist_id,
+                  musicbrainz_release_group_id, notes
+                )
+                values (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                on conflict (id) do update set
+                  entity_id = excluded.entity_id,
+                  release_title = excluded.release_title,
+                  normalized_release_title = excluded.normalized_release_title,
+                  release_date = excluded.release_date,
+                  stream = excluded.stream,
+                  release_kind = excluded.release_kind,
+                  release_format = excluded.release_format,
+                  source_url = excluded.source_url,
+                  artist_source_url = excluded.artist_source_url,
+                  musicbrainz_artist_id = excluded.musicbrainz_artist_id,
+                  musicbrainz_release_group_id = excluded.musicbrainz_release_group_id,
+                  notes = excluded.notes,
+                  updated_at = now()
+                """,
+                [
+                    (
+                        row["id"],
+                        row["entity_id"],
+                        row["release_title"],
+                        row["normalized_release_title"],
+                        row["release_date"],
+                        row["stream"],
+                        row["release_kind"],
+                        row["release_format"],
+                        row["source_url"],
+                        row["artist_source_url"],
+                        row["musicbrainz_artist_id"],
+                        row["musicbrainz_release_group_id"],
+                        row["notes"],
+                    )
+                    for row in release_rows
+                ],
+            )
+
+        release_artwork_rows = payload["tables"]["release_artwork"]
+        if release_artwork_rows:
+            count_operations("release_artwork", release_artwork_rows, lambda row: str(row["release_id"]))
+            cursor.executemany(
+                """
+                insert into release_artwork (
+                  release_id, cover_image_url, thumbnail_image_url, artwork_source_type, artwork_source_url
+                )
+                values (%s, %s, %s, %s, %s)
+                on conflict (release_id) do update set
+                  cover_image_url = excluded.cover_image_url,
+                  thumbnail_image_url = excluded.thumbnail_image_url,
+                  artwork_source_type = excluded.artwork_source_type,
+                  artwork_source_url = excluded.artwork_source_url,
+                  updated_at = now()
+                """,
+                [
+                    (
+                        row["release_id"],
+                        row["cover_image_url"],
+                        row["thumbnail_image_url"],
+                        row["artwork_source_type"],
+                        row["artwork_source_url"],
+                    )
+                    for row in release_artwork_rows
+                ],
+            )
+
+        track_rows = payload["tables"]["tracks"]
+        if track_rows:
+            count_operations("tracks", track_rows, lambda row: str(row["id"]))
+            cursor.executemany(
+                """
+                insert into tracks (
+                  id, release_id, track_order, track_title, normalized_track_title, is_title_track
+                )
+                values (%s, %s, %s, %s, %s, %s)
+                on conflict (id) do update set
+                  release_id = excluded.release_id,
+                  track_order = excluded.track_order,
+                  track_title = excluded.track_title,
+                  normalized_track_title = excluded.normalized_track_title,
+                  is_title_track = excluded.is_title_track,
+                  updated_at = now()
+                """,
+                [
+                    (
+                        row["id"],
+                        row["release_id"],
+                        row["track_order"],
+                        row["track_title"],
+                        row["normalized_track_title"],
+                        row["is_title_track"],
+                    )
+                    for row in track_rows
+                ],
+            )
+
+        release_service_rows = payload["tables"]["release_service_links"]
+        if release_service_rows:
+            count_operations("release_service_links", release_service_rows, lambda row: str(row["id"]))
+            cursor.executemany(
+                """
+                insert into release_service_links (
+                  id, release_id, service_type, url, status, provenance
+                )
+                values (%s, %s, %s, %s, %s, %s)
+                on conflict (id) do update set
+                  release_id = excluded.release_id,
+                  service_type = excluded.service_type,
+                  url = excluded.url,
+                  status = excluded.status,
+                  provenance = excluded.provenance,
+                  updated_at = now()
+                """,
+                [
+                    (
+                        row["id"],
+                        row["release_id"],
+                        row["service_type"],
+                        row["url"],
+                        row["status"],
+                        row["provenance"],
+                    )
+                    for row in release_service_rows
+                ],
+            )
+
+        track_service_rows = payload["tables"]["track_service_links"]
+        if track_service_rows:
+            count_operations(
+                "track_service_links",
+                track_service_rows,
+                lambda row: (str(row["track_id"]), row["service_type"]),
+            )
+            cursor.executemany(
+                """
+                insert into track_service_links (
+                  id, track_id, service_type, url, status, provenance
+                )
+                values (%s, %s, %s, %s, %s, %s)
+                on conflict (id) do update set
+                  track_id = excluded.track_id,
+                  service_type = excluded.service_type,
+                  url = excluded.url,
+                  status = excluded.status,
+                  provenance = excluded.provenance,
+                  updated_at = now()
+                """,
+                [
+                    (
+                        row["id"],
+                        row["track_id"],
+                        row["service_type"],
+                        row["url"],
+                        row["status"],
+                        row["provenance"],
+                    )
+                    for row in track_service_rows
+                ],
+            )
+
+        tracking_state_rows = payload["tables"]["entity_tracking_state"]
+        if tracking_state_rows:
+            count_operations("entity_tracking_state", tracking_state_rows, lambda row: str(row["entity_id"]))
+            cursor.executemany(
+                """
+                insert into entity_tracking_state (
+                  entity_id, tier, watch_reason, tracking_status, latest_verified_release_id
+                )
+                values (%s, %s, %s, %s, %s)
+                on conflict (entity_id) do update set
+                  tier = excluded.tier,
+                  watch_reason = excluded.watch_reason,
+                  tracking_status = excluded.tracking_status,
+                  latest_verified_release_id = excluded.latest_verified_release_id,
+                  updated_at = now()
+                """,
+                [
+                    (
+                        row["entity_id"],
+                        row["tier"],
+                        row["watch_reason"],
+                        row["tracking_status"],
+                        row["latest_verified_release_id"],
+                    )
+                    for row in tracking_state_rows
+                ],
+            )
+
+        review_task_rows = payload["tables"]["review_tasks"]
+        if review_task_rows:
+            count_operations("review_tasks", review_task_rows, lambda row: str(row["id"]))
+            cursor.executemany(
+                """
+                insert into review_tasks (
+                  id, review_type, status, entity_id, release_id, upcoming_signal_id,
+                  review_reason, recommended_action, payload
+                )
+                values (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                on conflict (id) do update set
+                  review_type = excluded.review_type,
+                  status = excluded.status,
+                  entity_id = excluded.entity_id,
+                  release_id = excluded.release_id,
+                  upcoming_signal_id = excluded.upcoming_signal_id,
+                  review_reason = excluded.review_reason,
+                  recommended_action = excluded.recommended_action,
+                  payload = excluded.payload
+                """,
+                [
+                    (
+                        row["id"],
+                        row["review_type"],
+                        row["status"],
+                        row["entity_id"],
+                        row["release_id"],
+                        row["upcoming_signal_id"],
+                        row["review_reason"],
+                        row["recommended_action"],
+                        Jsonb(row["payload"]),
+                    )
+                    for row in review_task_rows
+                ],
+            )
+
+        release_override_rows = payload["tables"]["release_link_overrides"]
+        if release_override_rows:
+            count_operations("release_link_overrides", release_override_rows, lambda row: str(row["id"]))
+            cursor.executemany(
+                """
+                insert into release_link_overrides (
+                  id, release_id, service_type, override_url, override_video_id, provenance
+                )
+                values (%s, %s, %s, %s, %s, %s)
+                on conflict (id) do update set
+                  release_id = excluded.release_id,
+                  service_type = excluded.service_type,
+                  override_url = excluded.override_url,
+                  override_video_id = excluded.override_video_id,
+                  provenance = excluded.provenance,
+                  updated_at = now()
+                """,
+                [
+                    (
+                        row["id"],
+                        row["release_id"],
+                        row["service_type"],
+                        row["override_url"],
+                        row["override_video_id"],
+                        row["provenance"],
+                    )
+                    for row in release_override_rows
+                ],
+            )
+
+    connection.commit()
+    summary["operation_counts"] = {table: dict(counter) for table, counter in operations.items()}
+
+
+def fetch_release_pipeline_counts(connection: "psycopg.Connection[Any]") -> Dict[str, int]:
+    counts: Dict[str, int] = {}
+    with connection.cursor() as cursor:
+        for table in canonical_import.RELEASE_PIPELINE_TABLES:
+            cursor.execute(f"select count(*) from {table}")
+            counts[table] = cursor.fetchone()[0]
+    return counts
+
+
+def fetch_release_pipeline_checks(connection: "psycopg.Connection[Any]") -> Dict[str, Any]:
+    checks: Dict[str, Any] = {}
+    with connection.cursor() as cursor:
+        cursor.execute(
+            """
+            select service_type, status, count(*)
+            from release_service_links
+            where service_type in ('spotify', 'youtube_music', 'youtube_mv')
+            group by service_type, status
+            order by service_type, status
+            """
+        )
+        service_status_counts: Dict[str, Dict[str, int]] = {}
+        for service_type, status, count in cursor.fetchall():
+            service_status_counts.setdefault(service_type, {})[status] = count
+        checks["release_service_status_counts"] = service_status_counts
+
+        cursor.execute("select count(*) from tracks where is_title_track is true")
+        checks["title_track_rows"] = cursor.fetchone()[0]
+
+        cursor.execute(
+            """
+            select channel_role, count(*)
+            from entity_youtube_channels
+            group by channel_role
+            order by channel_role
+            """
+        )
+        checks["entity_channel_role_counts"] = {row[0]: row[1] for row in cursor.fetchall()}
+
+        cursor.execute(
+            """
+            select count(*)
+            from review_tasks
+            where review_type = 'mv_candidate'
+              and payload->>'source_dataset' = 'mv_manual_review_queue'
+            """
+        )
+        checks["mv_review_task_rows"] = cursor.fetchone()[0]
+
+        cursor.execute("select count(*) from entity_tracking_state where latest_verified_release_id is not null")
+        checks["tracking_state_rows_with_latest_release"] = cursor.fetchone()[0]
+
+    return checks
+
+
+def main() -> None:
+    args = parse_args()
+    database_url = os.environ.get(args.database_url_env)
+    if not database_url:
+        raise SystemExit(f"{args.database_url_env} is required. Source ~/.config/idol-song-app/neon.env first.")
+
+    payload = canonical_import.build_release_pipeline_payload()
+    summary = payload["summary"]
+
+    with psycopg.connect(database_url) as connection:
+        upsert_release_pipeline_rows(connection, payload, summary)
+        summary["db_row_counts"] = fetch_release_pipeline_counts(connection)
+        summary["critical_checks"] = fetch_release_pipeline_checks(connection)
+
+    summary["summary_path"] = canonical_import.display_path(Path(args.summary_path))
+    summary["table_source_counts"] = {table: len(rows) for table, rows in payload["tables"].items()}
+    canonical_import.write_summary(Path(args.summary_path), canonical_import.sanitize_summary(summary))
+
+    print(
+        json.dumps(
+            {
+                "summary_path": summary["summary_path"],
+                "release_rows": summary["db_row_counts"]["releases"],
+                "track_rows": summary["db_row_counts"]["tracks"],
+                "mv_review_task_rows": summary["critical_checks"]["mv_review_task_rows"],
+            },
+            ensure_ascii=False,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a release-pipeline-specific Neon sync command that dual-writes canonical release tables from the current JSON export set
- update the weekly scan workflow to run the release pipeline DB sync when DATABASE_URL is configured
- document the release pipeline dual-write runbook and commit the first sync summary artifact

## Verification
- `python3 -m py_compile import_json_to_neon.py sync_release_pipeline_to_neon.py`
- `source ~/.config/idol-song-app/neon.env && source .venv/bin/activate && python sync_release_pipeline_to_neon.py`
- `source ~/.config/idol-song-app/neon.env && source .venv/bin/activate && python sync_release_pipeline_to_neon.py --summary-path /tmp/release-pipeline-db-sync-rerun.json`
- `source ~/.config/idol-song-app/neon.env && source .venv/bin/activate && python build_backend_json_parity_report.py --report-path /tmp/backend-json-parity-after-167.json`
- `git diff --check`

Closes #167
