### PR TITLE
Convert upcoming scan pipeline to canonical DB writes

### DIFF
--- a/.github/workflows/weekly-kpop-scan.yml
+++ b/.github/workflows/weekly-kpop-scan.yml
@@ -49,9 +49,10 @@ jobs:
           python hydrate_release_windows.py
           python build_mv_manual_review_queue.py
           if [ -n "${DATABASE_URL:-}" ]; then
+            python sync_upcoming_pipeline_to_neon.py --summary-path /tmp/upcoming-pipeline-db-sync-summary.json
             python sync_release_pipeline_to_neon.py --summary-path /tmp/release-pipeline-db-sync-summary.json
           else
-            echo "DATABASE_URL not configured; skipping release pipeline DB sync."
+            echo "DATABASE_URL not configured; skipping upcoming/release pipeline DB sync."
           fi
           python build_release_change_log.py
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ source ~/.config/idol-song-app/neon.env
 set +a
 
 python3 -m pip install -r backend/requirements-import.txt
+python3 sync_upcoming_pipeline_to_neon.py
 python3 sync_release_pipeline_to_neon.py
 ```
 
@@ -132,6 +133,7 @@ python3 sync_release_pipeline_to_neon.py
 
 - migration location: `backend/sql/migrations/`
 - run note: `backend/sql/README.md`
+- upcoming dual-write report: `backend/reports/upcoming_pipeline_db_sync_summary.json`
 - projection refresh report: `backend/reports/projection_refresh_summary.json`
 
 Hydration dry-run 예시:

--- a/backend/README.md
+++ b/backend/README.md
@@ -93,6 +93,31 @@ python3 sync_release_pipeline_to_neon.py
 - `release_detail_overrides.json`
 - `mv_manual_review_queue.json`
 
+## Upcoming Pipeline Dual-Write
+
+기존 upcoming scan JSON export를 유지한 채 canonical DB에 `upcoming_signals`, `upcoming_signal_sources`, manual-review task, tracking state를 같이 쓰려면 아래 명령을 사용한다.
+
+```bash
+set -a
+source ~/.config/idol-song-app/neon.env
+set +a
+
+python3 -m pip install -r backend/requirements-import.txt
+python3 sync_upcoming_pipeline_to_neon.py
+```
+
+기본 보고서 출력:
+
+- `backend/reports/upcoming_pipeline_db_sync_summary.json`
+
+이 명령은 아래 산출물을 source-of-export로 유지한 채 upcoming-side canonical table을 idempotent upsert 하고, 누락된 기존 signal은 inactive로 내린다.
+
+- `tracking_watchlist.json`
+- `upcoming_release_candidates.json`
+- `manual_review_queue.json`
+- `web/src/data/watchlist.json`
+- `web/src/data/upcomingCandidates.json`
+
 ## Projection Refresh
 
 canonical table import 또는 dual-write 이후 product-facing read model projection을 다시 만들려면 아래 명령을 사용한다.

--- a/backend/reports/upcoming_pipeline_db_sync_summary.json
+++ b/backend/reports/upcoming_pipeline_db_sync_summary.json
@@ -1,0 +1,118 @@
+{
+  "generated_at": "2026-03-07T08:21:49.354868+00:00",
+  "source_counts": {
+    "artist_profiles": 116,
+    "youtube_allowlists": 108,
+    "release_details": 117,
+    "release_history_groups": 115,
+    "release_history_rows": 1767,
+    "release_artwork": 117,
+    "upcoming_candidates": 71,
+    "watchlist": 116,
+    "release_detail_overrides": 67,
+    "manual_review_queue": 67,
+    "mv_manual_review_queue": 34,
+    "releases_rollup": 80
+  },
+  "source_duplicates": {
+    "entity_aliases": 1,
+    "youtube_channels": 25,
+    "upcoming_signals": 12
+  },
+  "dropped_records": {},
+  "dropped_missing_fk_samples": {},
+  "unresolved_release_mappings": [],
+  "unresolved_review_links": [],
+  "entity_type_counts": {
+    "group": 104,
+    "project": 1,
+    "unit": 4,
+    "solo": 7
+  },
+  "samples": {
+    "entities": [
+      "and-team",
+      "g-i-dle",
+      "82major",
+      "8turn",
+      "ab6ix"
+    ],
+    "releases": [
+      "&TEAM | 2022-11-21 | song | Under the skin",
+      "&TEAM | 2022-12-06 | album | First Howling : ME",
+      "&TEAM | 2023-05-07 | song | Blind Love",
+      "&TEAM | 2023-06-14 | album | First Howling : WE",
+      "&TEAM | 2023-11-15 | album | First Howling : NOW"
+    ],
+    "upcoming_signals": [
+      "BABYMONSTER’s B-Side Track From Two Years Ago Makes a Reverse Chart Run… Reappears on ‘M Countdown’ → Live Clip Released",
+      "BLACKPINK’s New Title Track Is ‘GO’.. YG “Created with Great Care”",
+      "BIGBANG Returns for 20th Anniversary… Global Tour with YG confirmed",
+      "BIGBANG Returns for 20th Anniversary… Global Tour with YG confirmed",
+      "YG to Launch First New Boy Group in 6 Years Since TREASURE… Rookie Girl Group Project Also in Full Swing"
+    ],
+    "review_tasks": [
+      "upcoming_signal",
+      "upcoming_signal",
+      "upcoming_signal",
+      "upcoming_signal",
+      "upcoming_signal"
+    ]
+  },
+  "scope": "upcoming_pipeline",
+  "stale_pruned": {
+    "review_tasks": 0,
+    "upcoming_signals_deactivated": 71,
+    "upcoming_signal_sources_deleted": 71
+  },
+  "operation_counts": {
+    "entities": {
+      "updated": 116
+    },
+    "entity_aliases": {
+      "updated": 166
+    },
+    "entity_official_links": {
+      "updated": 425
+    },
+    "upcoming_signals": {
+      "inserted": 59
+    },
+    "upcoming_signal_sources": {
+      "inserted": 71
+    },
+    "entity_tracking_state": {
+      "updated": 116
+    },
+    "review_tasks": {
+      "updated": 67
+    }
+  },
+  "db_row_counts": {
+    "upcoming_signals": 130,
+    "upcoming_signal_sources": 71,
+    "entity_tracking_state": 116,
+    "review_tasks": 101
+  },
+  "critical_checks": {
+    "active_upcoming_by_precision": {
+      "exact": 6,
+      "month_only": 14,
+      "unknown": 39
+    },
+    "manual_review_task_types": {
+      "entity_onboarding": 3,
+      "upcoming_signal": 64
+    }
+  },
+  "summary_path": "backend/reports/upcoming_pipeline_db_sync_summary.json",
+  "table_source_counts": {
+    "entities": 116,
+    "entity_aliases": 166,
+    "entity_official_links": 425,
+    "upcoming_signals": 59,
+    "upcoming_signal_sources": 71,
+    "entity_tracking_state": 116,
+    "review_tasks": 67
+  }
+}

--- a/backend/sql/README.md
+++ b/backend/sql/README.md
@@ -29,6 +29,7 @@ npm run projection:refresh
 cd ..
 python3 -m pip install -r backend/requirements-import.txt
 python3 import_json_to_neon.py
+python3 sync_upcoming_pipeline_to_neon.py
 python3 sync_release_pipeline_to_neon.py
 cd backend
 npm run projection:refresh
@@ -43,6 +44,7 @@ python3 build_backend_json_parity_report.py
 - direct connection string인 `DATABASE_URL`을 우선 사용한다.
 - pooler URL은 migration보다 read traffic 용도에 가깝다.
 - first JSON baseline import summary는 `backend/reports/json_to_neon_import_summary.json`에 남긴다.
+- upcoming pipeline dual-write summary는 `backend/reports/upcoming_pipeline_db_sync_summary.json`에 남긴다.
 - release pipeline dual-write summary는 `backend/reports/release_pipeline_db_sync_summary.json`에 남긴다.
 - projection refresh summary는 `backend/reports/projection_refresh_summary.json`에 남긴다.
 - backend-vs-JSON parity report는 `backend/reports/backend_json_parity_report.json`에 남긴다.

--- a/build_backend_json_parity_report.py
+++ b/build_backend_json_parity_report.py
@@ -25,12 +25,13 @@ from import_json_to_neon import (
     UPCOMING_CANDIDATES_PATH,
     WATCHLIST_PATH,
     YOUTUBE_ALLOWLISTS_PATH,
+    build_upcoming_rows,
     load_json,
-    make_signal_dedupe_key,
     normalize_text,
     normalize_url,
     optional_text,
     parse_exact_date,
+    stable_uuid,
 )
 
 
@@ -155,15 +156,25 @@ def build_source_latest_release_maps(group_to_slug: Dict[str, str]) -> Tuple[Dic
 
 def build_source_upcoming_summary(group_to_slug: Dict[str, str]) -> Dict[str, Any]:
     rows = load_json(UPCOMING_CANDIDATES_PATH)
+    entity_ids = {group: stable_uuid("entity", slug) for group, slug in group_to_slug.items()}
+    entity_id_to_slug = {entity_id: slug for group, slug in group_to_slug.items() for entity_id in [entity_ids[group]]}
+    import_summary = {
+        "source_duplicates": Counter(),
+        "dropped_records": Counter(),
+        "dropped_missing_fk_samples": {},
+        "unresolved_release_mappings": [],
+        "unresolved_review_links": [],
+    }
+    signal_rows, _, _ = build_upcoming_rows(rows, entity_ids, import_summary)
     precision_counts = Counter()
     future_exact = []
     month_buckets = {"exact": Counter(), "month_only": Counter()}
 
-    for row in rows:
+    for row in signal_rows:
         precision = row["date_precision"]
         precision_counts[precision] += 1
-        scheduled_date = optional_text(row.get("scheduled_date"))
-        scheduled_month = optional_text(row.get("scheduled_month"))
+        scheduled_date = row.get("scheduled_date").isoformat() if row.get("scheduled_date") is not None else None
+        scheduled_month = row.get("scheduled_month").isoformat()[:7] if row.get("scheduled_month") is not None else None
 
         if precision == "exact" and scheduled_date:
             month_buckets["exact"][scheduled_date[:7]] += 1
@@ -171,20 +182,21 @@ def build_source_upcoming_summary(group_to_slug: Dict[str, str]) -> Dict[str, An
             if parsed and parsed >= TODAY:
                 future_exact.append(
                     {
-                        "slug": group_to_slug[row["group"]],
+                        "slug": entity_id_to_slug.get(row["entity_id"]),
                         "scheduled_date": scheduled_date,
                         "headline": row["headline"],
-                        "confidence": row.get("confidence") or 0,
+                        "confidence": row.get("confidence_score") or 0,
                     }
                 )
         elif precision == "month_only" and scheduled_month:
-            month_buckets["month_only"][scheduled_month[:7]] += 1
+            month_buckets["month_only"][scheduled_month] += 1
 
+    future_exact = [item for item in future_exact if item["slug"] is not None]
     future_exact.sort(key=lambda item: (item["scheduled_date"], -item["confidence"], item["slug"]))
     nearest = future_exact[0] if future_exact else None
 
     return {
-        "total": len(rows),
+        "total": len(signal_rows),
         "precision_counts": dict(precision_counts),
         "future_exact_count": len(future_exact),
         "nearest_exact": nearest,
@@ -378,6 +390,7 @@ def fetch_db_snapshot() -> Dict[str, Any]:
                 select e.slug, us.headline, us.scheduled_date::text, us.scheduled_month::text, us.date_precision, us.confidence_score
                 from upcoming_signals us
                 join entities e on e.id = us.entity_id
+                where us.is_active = true
                 order by e.slug, us.headline
                 """
             )

--- a/import_json_to_neon.py
+++ b/import_json_to_neon.py
@@ -66,6 +66,16 @@ RELEASE_PIPELINE_TABLES = [
     "release_link_overrides",
 ]
 RELEASE_PIPELINE_REVIEW_SOURCE_DATASETS = {"mv_manual_review_queue"}
+UPCOMING_PIPELINE_TABLES = [
+    "entities",
+    "entity_aliases",
+    "entity_official_links",
+    "upcoming_signals",
+    "upcoming_signal_sources",
+    "entity_tracking_state",
+    "review_tasks",
+]
+UPCOMING_PIPELINE_REVIEW_SOURCE_DATASETS = {"manual_review_queue"}
 
 NAMESPACE = uuid.uuid5(uuid.NAMESPACE_URL, "https://github.com/iAmSomething/idol-song-app/import-json-to-neon/v1")
 SOLO_SLUGS = {
@@ -81,6 +91,29 @@ UNIT_GROUPS = {"ARTMS", "NCT DREAM", "NCT WISH", "VIVIZ"}
 PROJECT_SLUGS = {"allday-project"}
 MUSICBRAINZ_ARTIST_PATTERN = re.compile(r"/artist/([0-9a-f-]{36})/?$", re.IGNORECASE)
 MUSICBRAINZ_RELEASE_GROUP_PATTERN = re.compile(r"/release-group/([0-9a-f-]{36})/?$", re.IGNORECASE)
+UPCOMING_QUOTED_LABEL_PATTERNS = (
+    re.compile(
+        r"(?:mini album|album|single|ep|title track|showcase(?:\s+for)?|trailer(?:\s+for)?|teaser(?:\s+for)?)\s*[“\"'‘]?([^“”\"'’]{2,80})[”\"'’]",
+        re.IGNORECASE,
+    ),
+    re.compile(r"[“\"'‘]([^“”\"'’]{2,80})[”\"'’]"),
+)
+UPCOMING_STOP_WORD_PATTERN = re.compile(
+    r"\b(?:comeback|comebacks|announce|announces|announced|announcing|return|returns|returning|release|releases|released|releasing|drop|drops|dropped|dropping|set|scheduled|schedule|showcase|notice|official|teaser|teasers|trailer|trailers|report|reports|ahead|after|with|their|first|new|album|mini|single|ep|tracklist|title|track|tour|global|hosts|hosted|concert|celebrate|chapter)\b",
+    re.IGNORECASE,
+)
+UPCOMING_ARTICLE_PATTERN = re.compile(r"\b(?:a|an|the|and|for|of|to|in|on|at|this|that)\b", re.IGNORECASE)
+UPCOMING_SOURCE_TIERS = {
+    "agency_notice": 4,
+    "weverse_notice": 3,
+    "official_social": 2,
+    "news_rss": 1,
+}
+UPCOMING_STATUS_RANK = {
+    "confirmed": 0,
+    "scheduled": 1,
+    "rumor": 2,
+}
 
 
 def load_json(path: Path) -> List[Dict[str, Any]]:
@@ -234,6 +267,213 @@ def make_signal_dedupe_key(row: Dict[str, Any]) -> str:
             normalize_url(row.get("source_url")) or "",
         ]
     )
+
+
+def _upcoming_context_tags(row: Dict[str, Any]) -> List[str]:
+    tags = row.get("context_tags") or []
+    if isinstance(tags, list):
+        return [str(tag) for tag in tags]
+    return []
+
+
+def get_upcoming_source_tier(source_type: Optional[str]) -> int:
+    return UPCOMING_SOURCE_TIERS.get(optional_text(source_type) or "", 0)
+
+
+def strip_upcoming_source_suffix(value: str) -> str:
+    return re.sub(r"\s+-\s+[^-]+$", " ", value)
+
+
+def normalize_upcoming_grouping_text(value: str, group: str) -> str:
+    normalized = (
+        strip_upcoming_source_suffix(value)
+        .lower()
+        .replace("’", "'")
+        .replace("‘", "'")
+        .replace("“", '"')
+        .replace("”", '"')
+        .replace("&", " and ")
+    )
+    normalized = re.sub(r"\[[^\]]*\]", " ", normalized)
+    normalized = re.sub(r"\([^)]*\)", " ", normalized)
+
+    for token in re.split(r"[^a-z0-9]+", group.lower()):
+        if len(token) < 2:
+            continue
+        normalized = re.sub(rf"\b{re.escape(token)}\b", " ", normalized)
+
+    normalized = UPCOMING_STOP_WORD_PATTERN.sub(" ", normalized)
+    normalized = re.sub(r"[^a-z0-9]+", " ", normalized)
+    normalized = UPCOMING_ARTICLE_PATTERN.sub(" ", normalized)
+    normalized = re.sub(r"\s+", " ", normalized).strip()
+    return normalized
+
+
+def extract_upcoming_release_label(row: Dict[str, Any]) -> str:
+    text = f"{optional_text(row.get('headline')) or ''} {optional_text(row.get('evidence_summary')) or ''}"
+    for pattern in UPCOMING_QUOTED_LABEL_PATTERNS:
+        for match in pattern.finditer(text):
+            candidate = normalize_upcoming_grouping_text(match.group(1) or "", row["group"])
+            if candidate:
+                return candidate
+    return ""
+
+
+def get_upcoming_date_precision_value(row: Dict[str, Any]) -> str:
+    precision = optional_text(row.get("date_precision")) or ""
+    if precision in {"exact", "month_only", "unknown"}:
+        return precision
+    if optional_text(row.get("scheduled_date")):
+        return "exact"
+    if optional_text(row.get("scheduled_month")):
+        return "month_only"
+    return "unknown"
+
+
+def has_exact_upcoming_date(row: Dict[str, Any]) -> bool:
+    return get_upcoming_date_precision_value(row) == "exact" and optional_text(row.get("scheduled_date")) is not None
+
+
+def get_upcoming_month_key(row: Dict[str, Any]) -> str:
+    if has_exact_upcoming_date(row):
+        return str(row["scheduled_date"])[:7]
+    if get_upcoming_date_precision_value(row) == "month_only":
+        return optional_text(row.get("scheduled_month")) or ""
+    return ""
+
+
+def get_upcoming_event_descriptor(row: Dict[str, Any]) -> str:
+    release_label = extract_upcoming_release_label(row)
+    if release_label:
+        return release_label
+
+    headline_key = normalize_upcoming_grouping_text(optional_text(row.get("headline")) or "", row["group"])
+    if headline_key:
+        return headline_key
+
+    summary_key = normalize_upcoming_grouping_text(optional_text(row.get("evidence_summary")) or "", row["group"])
+    return summary_key or "signal"
+
+
+def get_upcoming_structured_metadata_score(row: Dict[str, Any]) -> int:
+    score = 0
+    if optional_text(row.get("release_format")):
+        score += 2
+    score += len(_upcoming_context_tags(row))
+    if extract_upcoming_release_label(row):
+        score += 2
+    if optional_text(row.get("evidence_summary")):
+        score += 1
+    return score
+
+
+def get_upcoming_published_sort_value(row: Dict[str, Any]) -> float:
+    published_at = parse_timestamp(row.get("published_at"))
+    return published_at.timestamp() if published_at is not None else 0.0
+
+
+def upcoming_representative_sort_key(row: Dict[str, Any]) -> Tuple[Any, ...]:
+    precision_rank = {
+        "exact": 0,
+        "month_only": 1,
+        "unknown": 2,
+    }
+    precision = get_upcoming_date_precision_value(row)
+    return (
+        -get_upcoming_source_tier(optional_text(row.get("source_type"))),
+        precision_rank.get(precision, 2),
+        get_upcoming_month_key(row) or "9999-12",
+        UPCOMING_STATUS_RANK.get(optional_text(row.get("date_status")) or "", 9),
+        -(float(row.get("confidence", 0) or 0)),
+        -get_upcoming_structured_metadata_score(row),
+        -get_upcoming_published_sort_value(row),
+        (optional_text(row.get("headline")) or "").casefold(),
+    )
+
+
+def pick_upcoming_representative(rows: Sequence[Dict[str, Any]]) -> Dict[str, Any]:
+    return min(rows, key=upcoming_representative_sort_key)
+
+
+def select_best_upcoming_group(groups: Optional[Sequence[Dict[str, Any]]]) -> Optional[Dict[str, Any]]:
+    if not groups:
+        return None
+    return min(groups, key=lambda group: upcoming_representative_sort_key(pick_upcoming_representative(group["rows"])))
+
+
+def build_canonical_upcoming_signal_groups(upcoming_rows: Sequence[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    exact_groups: Dict[Tuple[str, str, str], List[Dict[str, Any]]] = {}
+    pending_groups: Dict[Tuple[str, str, str], List[Dict[str, Any]]] = {}
+
+    for row in upcoming_rows:
+        descriptor = get_upcoming_event_descriptor(row)
+        group_key = row["group"].lower()
+        if has_exact_upcoming_date(row):
+            key = (group_key, optional_text(row.get("scheduled_date")) or "", descriptor)
+            exact_groups.setdefault(key, []).append(row)
+        else:
+            pending_month_key = get_upcoming_month_key(row) or "undated"
+            key = (group_key, pending_month_key, descriptor)
+            pending_groups.setdefault(key, []).append(row)
+
+    exact_groups_by_date: Dict[Tuple[str, str], List[Tuple[Tuple[str, str, str], List[Dict[str, Any]]]]] = {}
+    for key, rows in exact_groups.items():
+        date_key = (key[0], key[1])
+        exact_groups_by_date.setdefault(date_key, []).append((key, rows))
+
+    normalized_exact_groups: List[Dict[str, Any]] = []
+    for (group_key, scheduled_date), date_groups in exact_groups_by_date.items():
+        bucket_rows = [row for _, rows in date_groups for row in rows]
+        has_official_source = any(get_upcoming_source_tier(optional_text(row.get("source_type"))) > get_upcoming_source_tier("news_rss") for row in bucket_rows)
+        if has_official_source:
+            normalized_exact_groups.append(
+                {
+                    "signal_key": "|".join([group_key, "exact", scheduled_date, "official"]),
+                    "rows": bucket_rows,
+                }
+            )
+            continue
+
+        for (original_group_key, original_date, descriptor), rows in date_groups:
+            normalized_exact_groups.append(
+                {
+                    "signal_key": "|".join([original_group_key, "exact", original_date, descriptor]),
+                    "rows": rows,
+                }
+            )
+
+    exact_groups_by_topic: Dict[Tuple[str, str], List[Dict[str, Any]]] = {}
+    exact_groups_by_month: Dict[Tuple[str, str], List[Dict[str, Any]]] = {}
+    for group in normalized_exact_groups:
+        representative = pick_upcoming_representative(group["rows"])
+        topic_key = (representative["group"].lower(), get_upcoming_event_descriptor(representative))
+        exact_groups_by_topic.setdefault(topic_key, []).append(group)
+
+        month_key = get_upcoming_month_key(representative)
+        if month_key:
+            exact_groups_by_month.setdefault((representative["group"].lower(), month_key), []).append(group)
+
+    merged_groups = list(normalized_exact_groups)
+    for (group_key, pending_month_key, descriptor), rows in pending_groups.items():
+        representative = pick_upcoming_representative(rows)
+        topic_match = select_best_upcoming_group(exact_groups_by_topic.get((group_key, get_upcoming_event_descriptor(representative))))
+        month_match = None
+        if topic_match is None and pending_month_key != "undated":
+            month_match = select_best_upcoming_group(exact_groups_by_month.get((group_key, pending_month_key)))
+
+        target_group = topic_match or month_match
+        if target_group is not None:
+            target_group["rows"].extend(rows)
+            continue
+
+        merged_groups.append(
+            {
+                "signal_key": "|".join([group_key, get_upcoming_date_precision_value(representative), pending_month_key, descriptor]),
+                "rows": rows,
+            }
+        )
+
+    return merged_groups
 
 
 def ensure_directory(path: Path) -> None:
@@ -800,9 +1040,8 @@ def build_upcoming_rows(
     signal_rows: List[Dict[str, Any]] = []
     source_rows: List[Dict[str, Any]] = []
     signal_ids_by_dedupe: Dict[str, uuid.UUID] = {}
-    seen_dedupe_keys = set()
 
-    for row in sorted(
+    candidate_rows = sorted(
         upcoming_rows,
         key=lambda item: (
             item["group"].casefold(),
@@ -810,70 +1049,87 @@ def build_upcoming_rows(
             item["headline"].casefold(),
             normalize_url(item.get("source_url")) or "",
         ),
+    )
+    canonical_groups = build_canonical_upcoming_signal_groups(candidate_rows)
+
+    for group in sorted(
+        canonical_groups,
+        key=lambda item: upcoming_representative_sort_key(pick_upcoming_representative(item["rows"])),
     ):
-        entity_id = entity_ids.get(row["group"])
+        representative = pick_upcoming_representative(group["rows"])
+        entity_id = entity_ids.get(representative["group"])
         if entity_id is None:
-            summary["dropped_records"]["upcoming_signals"] += 1
+            summary["dropped_records"]["upcoming_signals"] += len(group["rows"])
             record_drop(
                 summary["dropped_missing_fk_samples"],
                 "upcoming_signals",
-                {"reason": "entity_not_found", "group": row["group"], "headline": row["headline"]},
+                {
+                    "reason": "entity_not_found",
+                    "group": representative["group"],
+                    "headline": representative["headline"],
+                },
             )
             continue
 
-        dedupe_key = make_signal_dedupe_key(row)
-        if dedupe_key in seen_dedupe_keys:
-            summary["source_duplicates"]["upcoming_signals"] += 1
-            continue
-        seen_dedupe_keys.add(dedupe_key)
+        signal_id = stable_uuid("upcoming-signal", group["signal_key"])
+        for row in group["rows"]:
+            signal_ids_by_dedupe[make_signal_dedupe_key(row)] = signal_id
 
-        signal_id = stable_uuid("upcoming-signal", dedupe_key)
-        signal_ids_by_dedupe[dedupe_key] = signal_id
-        date_precision = row["date_precision"]
-        scheduled_date = parse_exact_date(row.get("scheduled_date")) if date_precision == "exact" else None
-        scheduled_month = parse_month_start(row.get("scheduled_month")) if date_precision == "month_only" else None
-        published_at = parse_timestamp(row.get("published_at"))
+        precision = get_upcoming_date_precision_value(representative)
+        published_values = [parse_timestamp(row.get("published_at")) for row in group["rows"]]
+        published_values = [value for value in published_values if value is not None]
         signal_rows.append(
             {
                 "id": signal_id,
                 "entity_id": entity_id,
-                "headline": row["headline"],
-                "normalized_headline": normalize_text(row["headline"]),
-                "scheduled_date": scheduled_date,
-                "scheduled_month": scheduled_month,
-                "date_precision": date_precision,
-                "date_status": row["date_status"],
-                "release_format": optional_text(row.get("release_format")),
-                "confidence_score": round(float(row["confidence"]), 2) if row.get("confidence") is not None else None,
-                "tracking_status": optional_text(row.get("tracking_status")),
-                "first_seen_at": published_at,
-                "latest_seen_at": published_at,
+                "headline": representative["headline"],
+                "normalized_headline": normalize_text(representative["headline"]),
+                "scheduled_date": parse_exact_date(representative.get("scheduled_date")) if precision == "exact" else None,
+                "scheduled_month": parse_month_start(representative.get("scheduled_month")) if precision == "month_only" else None,
+                "date_precision": precision,
+                "date_status": representative["date_status"],
+                "release_format": optional_text(representative.get("release_format")),
+                "confidence_score": round(float(representative["confidence"]), 2) if representative.get("confidence") is not None else None,
+                "tracking_status": optional_text(representative.get("tracking_status")),
+                "first_seen_at": min(published_values) if published_values else None,
+                "latest_seen_at": max(published_values) if published_values else None,
                 "is_active": True,
-                "dedupe_key": dedupe_key,
+                "dedupe_key": group["signal_key"],
             }
         )
-        source_url = normalize_url(row.get("source_url"))
-        if source_url is None:
-            summary["dropped_records"]["upcoming_signal_sources"] += 1
-            record_drop(
-                summary["dropped_missing_fk_samples"],
-                "upcoming_signal_sources",
-                {"reason": "missing_source_url", "headline": row["headline"]},
-            )
-            continue
 
-        source_rows.append(
-            {
-                "id": stable_uuid("upcoming-signal-source", signal_id, source_url),
-                "upcoming_signal_id": signal_id,
-                "source_type": row["source_type"],
-                "source_url": source_url,
-                "source_domain": optional_text(row.get("source_domain")),
-                "published_at": published_at,
-                "search_term": optional_text(row.get("search_term")),
-                "evidence_summary": optional_text(row.get("evidence_summary")),
-            }
-        )
+        grouped_source_rows: Dict[str, List[Dict[str, Any]]] = {}
+        for row in group["rows"]:
+            source_url = normalize_url(row.get("source_url"))
+            if source_url is None:
+                summary["dropped_records"]["upcoming_signal_sources"] += 1
+                record_drop(
+                    summary["dropped_missing_fk_samples"],
+                    "upcoming_signal_sources",
+                    {"reason": "missing_source_url", "headline": row["headline"]},
+                )
+                continue
+            grouped_source_rows.setdefault(source_url, []).append(row)
+
+        hidden_source_count = max(0, len(group["rows"]) - 1)
+        if hidden_source_count:
+            summary["source_duplicates"]["upcoming_signals"] += hidden_source_count
+
+        for source_url, rows_for_source in sorted(grouped_source_rows.items(), key=lambda item: item[0]):
+            source_representative = pick_upcoming_representative(rows_for_source)
+            published_at = parse_timestamp(source_representative.get("published_at"))
+            source_rows.append(
+                {
+                    "id": stable_uuid("upcoming-signal-source", signal_id, source_url),
+                    "upcoming_signal_id": signal_id,
+                    "source_type": source_representative["source_type"],
+                    "source_url": source_url,
+                    "source_domain": optional_text(source_representative.get("source_domain")),
+                    "published_at": published_at,
+                    "search_term": optional_text(source_representative.get("search_term")),
+                    "evidence_summary": optional_text(source_representative.get("evidence_summary")),
+                }
+            )
 
     return signal_rows, source_rows, signal_ids_by_dedupe
 
@@ -1211,6 +1467,23 @@ def build_release_pipeline_payload() -> Dict[str, Any]:
     ]
     payload["summary"]["scope"] = "release_pipeline"
     payload["tables"] = release_scope_tables
+    return payload
+
+
+def build_upcoming_pipeline_payload() -> Dict[str, Any]:
+    payload = build_import_payload()
+    upcoming_scope_tables = {
+        table: payload["tables"][table]
+        for table in UPCOMING_PIPELINE_TABLES
+    }
+    upcoming_scope_tables["review_tasks"] = [
+        row
+        for row in upcoming_scope_tables["review_tasks"]
+        if isinstance(row.get("payload"), dict)
+        and row["payload"].get("source_dataset") in UPCOMING_PIPELINE_REVIEW_SOURCE_DATASETS
+    ]
+    payload["summary"]["scope"] = "upcoming_pipeline"
+    payload["tables"] = upcoming_scope_tables
     return payload
 
 

--- a/sync_upcoming_pipeline_to_neon.py
+++ b/sync_upcoming_pipeline_to_neon.py
@@ -1,0 +1,455 @@
+import argparse
+import json
+import os
+from collections import Counter
+from pathlib import Path
+from typing import Any, Dict, Sequence
+
+try:
+    import psycopg
+    from psycopg.types.json import Jsonb
+except ImportError as error:  # pragma: no cover - runtime dependency guard
+    raise SystemExit(
+        "psycopg is required. Run `python3 -m pip install -r backend/requirements-import.txt` first."
+    ) from error
+
+import import_json_to_neon as canonical_import
+
+
+DEFAULT_SUMMARY_PATH = canonical_import.BACKEND_REPORTS_DIR / "upcoming_pipeline_db_sync_summary.json"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Sync upcoming scan / manual-review pipeline outputs into Neon canonical tables."
+    )
+    parser.add_argument(
+        "--summary-path",
+        default=str(DEFAULT_SUMMARY_PATH),
+        help="Path to write the machine-readable upcoming pipeline sync summary JSON.",
+    )
+    parser.add_argument(
+        "--database-url-env",
+        default="DATABASE_URL",
+        help="Environment variable name that contains the direct Neon connection string.",
+    )
+    return parser.parse_args()
+
+
+def prune_stale_manual_review_tasks(connection: "psycopg.Connection[Any]", review_task_rows: Sequence[Dict[str, Any]]) -> int:
+    desired_ids = [row["id"] for row in review_task_rows]
+    with connection.cursor() as cursor:
+        if desired_ids:
+            placeholders = ", ".join(["%s"] * len(desired_ids))
+            cursor.execute(
+                f"""
+                delete from review_tasks
+                where payload->>'source_dataset' = 'manual_review_queue'
+                  and id not in ({placeholders})
+                """,
+                desired_ids,
+            )
+        else:
+            cursor.execute(
+                """
+                delete from review_tasks
+                where payload->>'source_dataset' = 'manual_review_queue'
+                """
+            )
+        deleted = cursor.rowcount
+    connection.commit()
+    return deleted
+
+
+def deactivate_stale_upcoming_signals(connection: "psycopg.Connection[Any]", signal_rows: Sequence[Dict[str, Any]]) -> int:
+    desired_ids = [row["id"] for row in signal_rows]
+    with connection.cursor() as cursor:
+        if desired_ids:
+            placeholders = ", ".join(["%s"] * len(desired_ids))
+            cursor.execute(
+                f"""
+                update upcoming_signals
+                set is_active = false,
+                    updated_at = now()
+                where is_active = true
+                  and id not in ({placeholders})
+                """,
+                desired_ids,
+            )
+        else:
+            cursor.execute(
+                """
+                update upcoming_signals
+                set is_active = false,
+                    updated_at = now()
+                where is_active = true
+                """
+            )
+        updated = cursor.rowcount
+    connection.commit()
+    return updated
+
+
+def prune_stale_upcoming_signal_sources(connection: "psycopg.Connection[Any]", source_rows: Sequence[Dict[str, Any]]) -> int:
+    desired_ids = [row["id"] for row in source_rows]
+    with connection.cursor() as cursor:
+        if desired_ids:
+            placeholders = ", ".join(["%s"] * len(desired_ids))
+            cursor.execute(
+                f"""
+                delete from upcoming_signal_sources
+                where id not in ({placeholders})
+                """,
+                desired_ids,
+            )
+        else:
+            cursor.execute("delete from upcoming_signal_sources")
+        deleted = cursor.rowcount
+    connection.commit()
+    return deleted
+
+
+def upsert_upcoming_pipeline_rows(
+    connection: "psycopg.Connection[Any]",
+    payload: Dict[str, Any],
+    summary: Dict[str, Any],
+) -> None:
+    existing = canonical_import.fetch_existing_state(connection)
+    operations = {table: Counter() for table in canonical_import.UPCOMING_PIPELINE_TABLES}
+    summary["stale_pruned"] = {
+        "review_tasks": prune_stale_manual_review_tasks(connection, payload["tables"]["review_tasks"]),
+        "upcoming_signals_deactivated": deactivate_stale_upcoming_signals(connection, payload["tables"]["upcoming_signals"]),
+        "upcoming_signal_sources_deleted": prune_stale_upcoming_signal_sources(connection, payload["tables"]["upcoming_signal_sources"]),
+    }
+
+    def count_operations(table: str, rows: Sequence[Dict[str, Any]], key_builder) -> None:
+        current_keys = existing[table]
+        for row in rows:
+            key = key_builder(row)
+            operations[table]["updated" if key in current_keys else "inserted"] += 1
+
+    with connection.pipeline(), connection.cursor() as cursor:
+        entity_rows = payload["tables"]["entities"]
+        if entity_rows:
+            count_operations("entities", entity_rows, lambda row: str(row["id"]))
+            cursor.executemany(
+                """
+                insert into entities (
+                  id, slug, canonical_name, display_name, entity_type, agency_name, debut_year,
+                  representative_image_url, representative_image_source
+                )
+                values (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                on conflict (id) do update set
+                  slug = excluded.slug,
+                  canonical_name = excluded.canonical_name,
+                  display_name = excluded.display_name,
+                  entity_type = excluded.entity_type,
+                  agency_name = excluded.agency_name,
+                  debut_year = excluded.debut_year,
+                  representative_image_url = excluded.representative_image_url,
+                  representative_image_source = excluded.representative_image_source,
+                  updated_at = now()
+                """,
+                [
+                    (
+                        row["id"],
+                        row["slug"],
+                        row["canonical_name"],
+                        row["display_name"],
+                        row["entity_type"],
+                        row["agency_name"],
+                        row["debut_year"],
+                        row["representative_image_url"],
+                        row["representative_image_source"],
+                    )
+                    for row in entity_rows
+                ],
+            )
+
+        alias_rows = payload["tables"]["entity_aliases"]
+        if alias_rows:
+            count_operations("entity_aliases", alias_rows, lambda row: str(row["id"]))
+            cursor.executemany(
+                """
+                insert into entity_aliases (
+                  id, entity_id, alias, alias_type, normalized_alias, is_primary
+                )
+                values (%s, %s, %s, %s, %s, %s)
+                on conflict (id) do update set
+                  entity_id = excluded.entity_id,
+                  alias = excluded.alias,
+                  alias_type = excluded.alias_type,
+                  normalized_alias = excluded.normalized_alias,
+                  is_primary = excluded.is_primary
+                """,
+                [
+                    (
+                        row["id"],
+                        row["entity_id"],
+                        row["alias"],
+                        row["alias_type"],
+                        row["normalized_alias"],
+                        row["is_primary"],
+                    )
+                    for row in alias_rows
+                ],
+            )
+
+        official_link_rows = payload["tables"]["entity_official_links"]
+        if official_link_rows:
+            count_operations("entity_official_links", official_link_rows, lambda row: str(row["id"]))
+            cursor.executemany(
+                """
+                insert into entity_official_links (
+                  id, entity_id, link_type, url, is_primary, provenance
+                )
+                values (%s, %s, %s, %s, %s, %s)
+                on conflict (id) do update set
+                  entity_id = excluded.entity_id,
+                  link_type = excluded.link_type,
+                  url = excluded.url,
+                  is_primary = excluded.is_primary,
+                  provenance = excluded.provenance
+                """,
+                [
+                    (
+                        row["id"],
+                        row["entity_id"],
+                        row["link_type"],
+                        row["url"],
+                        row["is_primary"],
+                        row["provenance"],
+                    )
+                    for row in official_link_rows
+                ],
+            )
+
+        upcoming_signal_rows = payload["tables"]["upcoming_signals"]
+        if upcoming_signal_rows:
+            count_operations("upcoming_signals", upcoming_signal_rows, lambda row: str(row["id"]))
+            cursor.executemany(
+                """
+                insert into upcoming_signals (
+                  id, entity_id, headline, normalized_headline, scheduled_date, scheduled_month, date_precision,
+                  date_status, release_format, confidence_score, tracking_status,
+                  first_seen_at, latest_seen_at, is_active, dedupe_key
+                )
+                values (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                on conflict (id) do update set
+                  entity_id = excluded.entity_id,
+                  headline = excluded.headline,
+                  normalized_headline = excluded.normalized_headline,
+                  scheduled_date = excluded.scheduled_date,
+                  scheduled_month = excluded.scheduled_month,
+                  date_precision = excluded.date_precision,
+                  date_status = excluded.date_status,
+                  release_format = excluded.release_format,
+                  confidence_score = excluded.confidence_score,
+                  tracking_status = excluded.tracking_status,
+                  first_seen_at = excluded.first_seen_at,
+                  latest_seen_at = excluded.latest_seen_at,
+                  is_active = excluded.is_active,
+                  dedupe_key = excluded.dedupe_key,
+                  updated_at = now()
+                """,
+                [
+                    (
+                        row["id"],
+                        row["entity_id"],
+                        row["headline"],
+                        row["normalized_headline"],
+                        row["scheduled_date"],
+                        row["scheduled_month"],
+                        row["date_precision"],
+                        row["date_status"],
+                        row["release_format"],
+                        row["confidence_score"],
+                        row["tracking_status"],
+                        row["first_seen_at"],
+                        row["latest_seen_at"],
+                        row["is_active"],
+                        row["dedupe_key"],
+                    )
+                    for row in upcoming_signal_rows
+                ],
+            )
+
+        upcoming_source_rows = payload["tables"]["upcoming_signal_sources"]
+        if upcoming_source_rows:
+            count_operations("upcoming_signal_sources", upcoming_source_rows, lambda row: str(row["id"]))
+            cursor.executemany(
+                """
+                insert into upcoming_signal_sources (
+                  id, upcoming_signal_id, source_type, source_url, source_domain, published_at, search_term, evidence_summary
+                )
+                values (%s, %s, %s, %s, %s, %s, %s, %s)
+                on conflict (id) do update set
+                  upcoming_signal_id = excluded.upcoming_signal_id,
+                  source_type = excluded.source_type,
+                  source_url = excluded.source_url,
+                  source_domain = excluded.source_domain,
+                  published_at = excluded.published_at,
+                  search_term = excluded.search_term,
+                  evidence_summary = excluded.evidence_summary
+                """,
+                [
+                    (
+                        row["id"],
+                        row["upcoming_signal_id"],
+                        row["source_type"],
+                        row["source_url"],
+                        row["source_domain"],
+                        row["published_at"],
+                        row["search_term"],
+                        row["evidence_summary"],
+                    )
+                    for row in upcoming_source_rows
+                ],
+            )
+
+        tracking_state_rows = payload["tables"]["entity_tracking_state"]
+        if tracking_state_rows:
+            count_operations("entity_tracking_state", tracking_state_rows, lambda row: str(row["entity_id"]))
+            cursor.executemany(
+                """
+                insert into entity_tracking_state (
+                  entity_id, tier, watch_reason, tracking_status, latest_verified_release_id
+                )
+                values (%s, %s, %s, %s, %s)
+                on conflict (entity_id) do update set
+                  tier = excluded.tier,
+                  watch_reason = excluded.watch_reason,
+                  tracking_status = excluded.tracking_status,
+                  latest_verified_release_id = excluded.latest_verified_release_id,
+                  updated_at = now()
+                """,
+                [
+                    (
+                        row["entity_id"],
+                        row["tier"],
+                        row["watch_reason"],
+                        row["tracking_status"],
+                        row["latest_verified_release_id"],
+                    )
+                    for row in tracking_state_rows
+                ],
+            )
+
+        review_task_rows = payload["tables"]["review_tasks"]
+        if review_task_rows:
+            count_operations("review_tasks", review_task_rows, lambda row: str(row["id"]))
+            cursor.executemany(
+                """
+                insert into review_tasks (
+                  id, review_type, status, entity_id, release_id, upcoming_signal_id,
+                  review_reason, recommended_action, payload
+                )
+                values (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                on conflict (id) do update set
+                  review_type = excluded.review_type,
+                  status = excluded.status,
+                  entity_id = excluded.entity_id,
+                  release_id = excluded.release_id,
+                  upcoming_signal_id = excluded.upcoming_signal_id,
+                  review_reason = excluded.review_reason,
+                  recommended_action = excluded.recommended_action,
+                  payload = excluded.payload
+                """,
+                [
+                    (
+                        row["id"],
+                        row["review_type"],
+                        row["status"],
+                        row["entity_id"],
+                        row["release_id"],
+                        row["upcoming_signal_id"],
+                        row["review_reason"],
+                        row["recommended_action"],
+                        Jsonb(row["payload"]),
+                    )
+                    for row in review_task_rows
+                ],
+            )
+
+    connection.commit()
+    summary["operation_counts"] = {table: dict(counter) for table, counter in operations.items()}
+
+
+def fetch_upcoming_db_counts(connection: "psycopg.Connection[Any]") -> Dict[str, int]:
+    counts: Dict[str, int] = {}
+    with connection.cursor() as cursor:
+        for table in ("upcoming_signals", "upcoming_signal_sources", "entity_tracking_state", "review_tasks"):
+            cursor.execute(f"select count(*) from {table}")
+            counts[table] = cursor.fetchone()[0]
+    return counts
+
+
+def fetch_upcoming_critical_checks(connection: "psycopg.Connection[Any]") -> Dict[str, Any]:
+    critical: Dict[str, Any] = {}
+    with connection.cursor() as cursor:
+        cursor.execute(
+            """
+            select date_precision, count(*)
+            from upcoming_signals
+            where is_active = true
+            group by date_precision
+            order by date_precision
+            """
+        )
+        critical["active_upcoming_by_precision"] = {row[0]: row[1] for row in cursor.fetchall()}
+
+        cursor.execute(
+            """
+            select review_type, count(*)
+            from review_tasks
+            where payload->>'source_dataset' = 'manual_review_queue'
+            group by review_type
+            order by review_type
+            """
+        )
+        critical["manual_review_task_types"] = {row[0]: row[1] for row in cursor.fetchall()}
+    return critical
+
+
+def sanitize_summary(summary: Dict[str, Any]) -> Dict[str, Any]:
+    sanitized = dict(summary)
+    sanitized["source_duplicates"] = dict(summary["source_duplicates"])
+    sanitized["dropped_records"] = dict(summary["dropped_records"])
+    sanitized["unresolved_release_mappings"] = summary["unresolved_release_mappings"][:25]
+    sanitized["unresolved_review_links"] = summary["unresolved_review_links"][:25]
+    return sanitized
+
+
+def main() -> None:
+    args = parse_args()
+    database_url = os.environ.get(args.database_url_env)
+    if not database_url:
+        raise SystemExit(f"{args.database_url_env} is required. Source ~/.config/idol-song-app/neon.env first.")
+
+    payload = canonical_import.build_upcoming_pipeline_payload()
+    summary = payload["summary"]
+
+    with psycopg.connect(database_url) as connection:
+        upsert_upcoming_pipeline_rows(connection, payload, summary)
+        summary["db_row_counts"] = fetch_upcoming_db_counts(connection)
+        summary["critical_checks"] = fetch_upcoming_critical_checks(connection)
+
+    summary["summary_path"] = canonical_import.display_path(Path(args.summary_path))
+    summary["table_source_counts"] = {table: len(rows) for table, rows in payload["tables"].items()}
+    canonical_import.write_summary(Path(args.summary_path), sanitize_summary(summary))
+
+    print(
+        json.dumps(
+            {
+                "summary_path": summary["summary_path"],
+                "upcoming_signal_rows": summary["db_row_counts"]["upcoming_signals"],
+                "upcoming_signal_source_rows": summary["db_row_counts"]["upcoming_signal_sources"],
+                "manual_review_task_rows": summary["critical_checks"]["manual_review_task_types"],
+            },
+            ensure_ascii=False,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add upcoming-pipeline dual-write sync into Neon while preserving current JSON exports
- canonicalize upcoming signal dedupe into one signal with multiple evidence sources
- update parity/docs/workflow for the new upcoming DB sync path

## Verification
- python3 -m py_compile import_json_to_neon.py sync_upcoming_pipeline_to_neon.py build_backend_json_parity_report.py
- source .venv/bin/activate && source ~/.config/idol-song-app/neon.env && python sync_upcoming_pipeline_to_neon.py
- source .venv/bin/activate && source ~/.config/idol-song-app/neon.env && python sync_upcoming_pipeline_to_neon.py --summary-path /tmp/upcoming-pipeline-db-sync-rerun.json
- source .venv/bin/activate && source ~/.config/idol-song-app/neon.env && python build_backend_json_parity_report.py --report-path /tmp/backend-json-parity-after-169-rerun.json
- git diff --check

Closes #169