### PR TITLE
Implement projection-backed /v1/radar endpoint

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,8 +1,7 @@
 import Fastify, { type FastifyInstance } from 'fastify';
-import type pg from 'pg';
 
 import { loadConfig, type AppConfig } from './config.js';
-import { createDbPool } from './lib/db.js';
+import { createDbPool, type DbPool } from './lib/db.js';
 import { registerCalendarRoutes } from './routes/calendar.js';
 import { registerEntityRoutes } from './routes/entities.js';
 import { registerHealthRoute } from './routes/health.js';
@@ -13,7 +12,7 @@ import { registerSearchRoutes } from './routes/search.js';
 
 export type BuildAppOptions = {
   config?: AppConfig;
-  db?: pg.Pool;
+  db?: DbPool;
 };
 
 export function buildApp(options: BuildAppOptions = {}): FastifyInstance {
@@ -33,7 +32,7 @@ export function buildApp(options: BuildAppOptions = {}): FastifyInstance {
   registerSearchRoutes(app, config);
   registerEntityRoutes(app, config);
   registerReleaseRoutes(app, config);
-  registerRadarRoutes(app, config);
+  registerRadarRoutes(app, { config, db });
 
   return app;
 }

--- a/backend/src/lib/db.ts
+++ b/backend/src/lib/db.ts
@@ -4,7 +4,10 @@ import type { AppConfig } from '../config.js';
 
 const { Pool } = pg;
 
-export function createDbPool(config: AppConfig): pg.Pool {
+export type DbPool = pg.Pool;
+export type DbQueryable = Pick<pg.Pool, 'query'>;
+
+export function createDbPool(config: AppConfig): DbPool {
   return new Pool({
     connectionString: config.databaseUrl,
     application_name: 'idol-song-app-fastify',
@@ -13,6 +16,6 @@ export function createDbPool(config: AppConfig): pg.Pool {
   });
 }
 
-export async function pingDatabase(pool: pg.Pool): Promise<void> {
+export async function pingDatabase(pool: DbQueryable): Promise<void> {
   await pool.query('select 1');
 }

--- a/backend/src/routes/radar.ts
+++ b/backend/src/routes/radar.ts
@@ -1,10 +1,92 @@
 import type { FastifyInstance } from 'fastify';
 
 import type { AppConfig } from '../config.js';
-import { buildNotImplementedEnvelope } from '../lib/not-implemented.js';
+import type { DbQueryable } from '../lib/db.js';
 
-export function registerRadarRoutes(app: FastifyInstance, config: AppConfig): void {
-  app.get('/v1/radar', async (_request, reply) => {
-    return reply.code(501).send(buildNotImplementedEnvelope('/v1/radar', config.appTimezone));
+type RadarRouteContext = {
+  config: AppConfig;
+  db: DbQueryable;
+};
+
+type RadarProjectionRow = {
+  payload: unknown;
+  generated_at: Date | string;
+};
+
+type RadarResponseData = {
+  featured_upcoming: Record<string, unknown> | null;
+  weekly_upcoming: Record<string, unknown>[];
+  change_feed: Record<string, unknown>[];
+  long_gap: Record<string, unknown>[];
+  rookie: Record<string, unknown>[];
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function normalizeRecordArray(value: unknown): Record<string, unknown>[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter(isRecord);
+}
+
+function normalizeRadarPayload(payload: unknown): RadarResponseData {
+  if (!isRecord(payload)) {
+    return {
+      featured_upcoming: null,
+      weekly_upcoming: [],
+      change_feed: [],
+      long_gap: [],
+      rookie: [],
+    };
+  }
+
+  return {
+    featured_upcoming: isRecord(payload.featured_upcoming) ? payload.featured_upcoming : null,
+    weekly_upcoming: normalizeRecordArray(payload.weekly_upcoming),
+    change_feed: normalizeRecordArray(payload.change_feed),
+    long_gap: normalizeRecordArray(payload.long_gap),
+    rookie: normalizeRecordArray(payload.rookie),
+  };
+}
+
+function toIsoString(value: Date | string | undefined): string {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (typeof value === 'string' && value.length > 0) {
+    const parsed = new Date(value);
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed.toISOString();
+    }
+  }
+
+  return new Date().toISOString();
+}
+
+export function registerRadarRoutes(app: FastifyInstance, context: RadarRouteContext): void {
+  app.get('/v1/radar', async () => {
+    const result = await context.db.query<RadarProjectionRow>(
+      `
+        select payload, generated_at
+        from radar_projection
+        where projection_key = $1
+        limit 1
+      `,
+      ['default']
+    );
+
+    const row = result.rows[0];
+
+    return {
+      meta: {
+        generated_at: toIsoString(row?.generated_at),
+        timezone: context.config.appTimezone,
+      },
+      data: normalizeRadarPayload(row?.payload),
+    };
   });
 }

--- a/backend/src/routes/ready.ts
+++ b/backend/src/routes/ready.ts
@@ -1,12 +1,11 @@
 import type { FastifyInstance } from 'fastify';
-import type pg from 'pg';
 
 import type { AppConfig } from '../config.js';
-import { pingDatabase } from '../lib/db.js';
+import { pingDatabase, type DbQueryable } from '../lib/db.js';
 
 type ReadyContext = {
   config: AppConfig;
-  db: pg.Pool;
+  db: DbQueryable;
 };
 
 export function registerReadyRoute(app: FastifyInstance, context: ReadyContext): void {


### PR DESCRIPTION
## Summary
- implement backend-backed /v1/radar using radar_projection
- return stable meta/data envelope with explicit empty arrays and null featured fallback
- thread DB access through app route registration for projection-backed reads

## Verification
- cd backend && npm run build
- source ~/.config/idol-song-app/neon.env && PORT=3212 APP_TIMEZONE=Asia/Seoul npm run start
- curl -s http://127.0.0.1:3212/v1/radar
- cd backend && node --input-type=module <<'JS'
import { buildApp } from './dist/app.js';
const fakeDb = { async query() { return { rows: [] }; }, async end() {} };
const app = buildApp({ config: { port: 3000, appTimezone: 'Asia/Seoul', databaseUrl: 'postgres://unused', databaseMode: 'direct' }, db: fakeDb });
const response = await app.inject({ method: 'GET', url: '/v1/radar' });
console.log(response.statusCode, response.json());
await app.close();
JS
- git diff --check

Closes #170