### PR TITLE
Implement projection-backed release detail endpoints

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -31,7 +31,7 @@ export function buildApp(options: BuildAppOptions = {}): FastifyInstance {
   registerCalendarRoutes(app, config);
   registerSearchRoutes(app, config);
   registerEntityRoutes(app, config);
-  registerReleaseRoutes(app, config);
+  registerReleaseRoutes(app, { config, db });
   registerRadarRoutes(app, { config, db });
 
   return app;

--- a/backend/src/routes/releases.ts
+++ b/backend/src/routes/releases.ts
@@ -1,14 +1,435 @@
 import type { FastifyInstance } from 'fastify';
 
 import type { AppConfig } from '../config.js';
-import { buildNotImplementedEnvelope } from '../lib/not-implemented.js';
+import type { DbQueryable } from '../lib/db.js';
 
-export function registerReleaseRoutes(app: FastifyInstance, config: AppConfig): void {
-  app.get('/v1/releases/lookup', async (_request, reply) => {
-    return reply.code(501).send(buildNotImplementedEnvelope('/v1/releases/lookup', config.appTimezone));
+type ReleaseRouteContext = {
+  config: AppConfig;
+  db: DbQueryable;
+};
+
+type ReleaseDetailProjectionRow = {
+  release_id: string;
+  entity_slug: string;
+  normalized_release_title: string;
+  release_date: string;
+  stream: string;
+  payload: unknown;
+  generated_at: Date | string;
+};
+
+type ReleaseLookupQuery = {
+  entity_slug?: string;
+  title?: string;
+  date?: string;
+  stream?: string;
+};
+
+type ReleaseParams = {
+  id: string;
+};
+
+type ReleaseCore = {
+  release_id: string;
+  entity_slug: string;
+  display_name: string;
+  release_title: string;
+  release_date: string;
+  stream: string;
+  release_kind: string | null;
+};
+
+type ServiceLink = {
+  url?: string | null;
+  status?: string | null;
+  provenance?: string | null;
+};
+
+type TrackServiceLink = {
+  url?: string | null;
+  status?: string | null;
+  provenance?: string | null;
+};
+
+type ReleaseTrack = {
+  track_id: string;
+  order: number;
+  title: string;
+  is_title_track: boolean;
+  spotify: TrackServiceLink | null;
+  youtube_music: TrackServiceLink | null;
+};
+
+type ReleaseDetailData = {
+  release: ReleaseCore;
+  artwork: Record<string, unknown> | null;
+  service_links: {
+    spotify: ServiceLink | null;
+    youtube_music: ServiceLink | null;
+  };
+  tracks: ReleaseTrack[];
+  mv: {
+    url: string | null;
+    video_id: string | null;
+    status: string | null;
+    provenance: string | null;
+  };
+  credits: Record<string, unknown>[];
+  charts: Record<string, unknown>[];
+  notes: unknown;
+};
+
+type ReleaseLookupData = {
+  release_id: string;
+  canonical_path: string;
+  release: ReleaseCore;
+};
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const VALID_STREAMS = new Set(['album', 'song']);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function asNullableString(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function asNullableNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function toIsoString(value: Date | string | undefined): string {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (typeof value === 'string' && value.length > 0) {
+    const parsed = new Date(value);
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed.toISOString();
+    }
+  }
+
+  return new Date().toISOString();
+}
+
+function normalizeServiceLink(value: unknown): ServiceLink | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  return {
+    url: asNullableString(value.url),
+    status: asNullableString(value.status),
+    provenance: asNullableString(value.provenance),
+  };
+}
+
+function normalizeTrack(value: unknown): ReleaseTrack | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const trackId = asNullableString(value.track_id);
+  const order = asNullableNumber(value.order);
+  const title = asNullableString(value.title);
+
+  if (trackId === null || order === null || title === null) {
+    return null;
+  }
+
+  return {
+    track_id: trackId,
+    order,
+    title,
+    is_title_track: value.is_title_track === true,
+    spotify: normalizeServiceLink(value.spotify),
+    youtube_music: normalizeServiceLink(value.youtube_music),
+  };
+}
+
+function normalizeRecordArray(value: unknown): Record<string, unknown>[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter(isRecord);
+}
+
+function normalizeTracks(value: unknown): ReleaseTrack[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.map(normalizeTrack).filter((track): track is ReleaseTrack => track !== null);
+}
+
+function normalizeReleaseCore(value: unknown): ReleaseCore | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const releaseId = asNullableString(value.release_id);
+  const entitySlug = asNullableString(value.entity_slug);
+  const displayName = asNullableString(value.display_name);
+  const releaseTitle = asNullableString(value.release_title);
+  const releaseDate = asNullableString(value.release_date);
+  const stream = asNullableString(value.stream);
+
+  if (
+    releaseId === null ||
+    entitySlug === null ||
+    displayName === null ||
+    releaseTitle === null ||
+    releaseDate === null ||
+    stream === null
+  ) {
+    return null;
+  }
+
+  return {
+    release_id: releaseId,
+    entity_slug: entitySlug,
+    display_name: displayName,
+    release_title: releaseTitle,
+    release_date: releaseDate,
+    stream,
+    release_kind: asNullableString(value.release_kind),
+  };
+}
+
+function normalizeReleaseDetailPayload(payload: unknown, releaseId: string): ReleaseDetailData | null {
+  if (!isRecord(payload)) {
+    return null;
+  }
+
+  const release = normalizeReleaseCore(payload.release);
+  if (release === null || release.release_id !== releaseId) {
+    return null;
+  }
+
+  return {
+    release,
+    artwork: isRecord(payload.artwork) ? payload.artwork : null,
+    service_links: {
+      spotify: normalizeServiceLink(isRecord(payload.service_links) ? payload.service_links.spotify : null),
+      youtube_music: normalizeServiceLink(isRecord(payload.service_links) ? payload.service_links.youtube_music : null),
+    },
+    tracks: normalizeTracks(payload.tracks),
+    mv: {
+      url: asNullableString(isRecord(payload.mv) ? payload.mv.url : null),
+      video_id: asNullableString(isRecord(payload.mv) ? payload.mv.video_id : null),
+      status: asNullableString(isRecord(payload.mv) ? payload.mv.status : null),
+      provenance: asNullableString(isRecord(payload.mv) ? payload.mv.provenance : null),
+    },
+    credits: normalizeRecordArray(payload.credits),
+    charts: normalizeRecordArray(payload.charts),
+    notes: payload.notes ?? null,
+  };
+}
+
+function buildLookupData(row: ReleaseDetailProjectionRow): ReleaseLookupData | null {
+  const payload = normalizeReleaseDetailPayload(row.payload, row.release_id);
+  if (payload === null) {
+    return null;
+  }
+
+  return {
+    release_id: row.release_id,
+    canonical_path: `/v1/releases/${row.release_id}`,
+    release: payload.release,
+  };
+}
+
+function normalizeLegacyReleaseTitle(value: string): string {
+  return value.trim();
+}
+
+export function registerReleaseRoutes(app: FastifyInstance, context: ReleaseRouteContext): void {
+  app.get('/v1/releases/lookup', async (request, reply) => {
+    const { entity_slug, title, date, stream } = request.query as ReleaseLookupQuery;
+
+    if (!entity_slug || !title || !date || !stream) {
+      return reply.code(400).send({
+        meta: {
+          route: '/v1/releases/lookup',
+          generated_at: new Date().toISOString(),
+          timezone: context.config.appTimezone,
+        },
+        error: {
+          code: 'invalid_request',
+          message: 'entity_slug, title, date, and stream query parameters are required.',
+        },
+      });
+    }
+
+    const normalizedTitle = normalizeLegacyReleaseTitle(title);
+    if (!ISO_DATE_PATTERN.test(date) || !VALID_STREAMS.has(stream) || normalizedTitle.length === 0) {
+      return reply.code(400).send({
+        meta: {
+          route: '/v1/releases/lookup',
+          generated_at: new Date().toISOString(),
+          timezone: context.config.appTimezone,
+          lookup: {
+            entity_slug,
+            title,
+            date,
+            stream,
+          },
+        },
+        error: {
+          code: 'invalid_request',
+          message: 'lookup requires a non-empty title, YYYY-MM-DD date, and stream of album or song.',
+        },
+      });
+    }
+
+    const result = await context.db.query<ReleaseDetailProjectionRow>(
+      `
+        select
+          release_id::text as release_id,
+          entity_slug,
+          normalized_release_title,
+          release_date::text as release_date,
+          stream,
+          payload,
+          generated_at
+        from release_detail_projection
+        where entity_slug = $1
+          and normalized_release_title = projection_normalize_text($2)
+          and release_date = $3::date
+          and stream = $4
+        limit 1
+      `,
+      [entity_slug, normalizedTitle, date, stream]
+    );
+
+    const row = result.rows[0];
+    if (!row) {
+      return reply.code(404).send({
+        meta: {
+          route: '/v1/releases/lookup',
+          generated_at: new Date().toISOString(),
+          timezone: context.config.appTimezone,
+          lookup: {
+            entity_slug,
+            title,
+            date,
+            stream,
+          },
+        },
+        error: {
+          code: 'release_not_found',
+          message: 'No release matched the supplied legacy lookup key.',
+        },
+      });
+    }
+
+    const data = buildLookupData(row);
+    if (data === null) {
+      return reply.code(500).send({
+        meta: {
+          route: '/v1/releases/lookup',
+          generated_at: new Date().toISOString(),
+          timezone: context.config.appTimezone,
+        },
+        error: {
+          code: 'invalid_projection_payload',
+          message: 'release_detail_projection returned an unexpected payload shape.',
+        },
+      });
+    }
+
+    return {
+      meta: {
+        generated_at: toIsoString(row.generated_at),
+        timezone: context.config.appTimezone,
+        lookup: {
+          entity_slug,
+          title,
+          date,
+          stream,
+        },
+      },
+      data,
+    };
   });
 
-  app.get('/v1/releases/:id', async (_request, reply) => {
-    return reply.code(501).send(buildNotImplementedEnvelope('/v1/releases/:id', config.appTimezone));
+  app.get('/v1/releases/:id', async (request, reply) => {
+    const { id } = request.params as ReleaseParams;
+
+    if (!UUID_PATTERN.test(id)) {
+      return reply.code(400).send({
+        meta: {
+          route: '/v1/releases/:id',
+          generated_at: new Date().toISOString(),
+          timezone: context.config.appTimezone,
+          release_id: id,
+        },
+        error: {
+          code: 'invalid_request',
+          message: 'release_id must be a UUID.',
+        },
+      });
+    }
+
+    const result = await context.db.query<ReleaseDetailProjectionRow>(
+      `
+        select
+          release_id::text as release_id,
+          entity_slug,
+          normalized_release_title,
+          release_date::text as release_date,
+          stream,
+          payload,
+          generated_at
+        from release_detail_projection
+        where release_id = $1::uuid
+        limit 1
+      `,
+      [id]
+    );
+
+    const row = result.rows[0];
+    if (!row) {
+      return reply.code(404).send({
+        meta: {
+          route: '/v1/releases/:id',
+          generated_at: new Date().toISOString(),
+          timezone: context.config.appTimezone,
+          release_id: id,
+        },
+        error: {
+          code: 'release_not_found',
+          message: 'No release detail matched the supplied release_id.',
+        },
+      });
+    }
+
+    const data = normalizeReleaseDetailPayload(row.payload, row.release_id);
+    if (data === null) {
+      return reply.code(500).send({
+        meta: {
+          route: '/v1/releases/:id',
+          generated_at: new Date().toISOString(),
+          timezone: context.config.appTimezone,
+          release_id: row.release_id,
+        },
+        error: {
+          code: 'invalid_projection_payload',
+          message: 'release_detail_projection returned an unexpected payload shape.',
+        },
+      });
+    }
+
+    return {
+      meta: {
+        generated_at: toIsoString(row.generated_at),
+        timezone: context.config.appTimezone,
+        release_id: row.release_id,
+      },
+      data,
+    };
   });
 }

--- a/docs/specs/backend/shared-read-api-contracts.md
+++ b/docs/specs/backend/shared-read-api-contracts.md
@@ -310,6 +310,36 @@ lookup helper:
 
 - legacy JSON exact key에서 API `release_id`로 넘어가는 migration helper
 
+lookup helper response:
+
+```json
+{
+  "meta": {
+    "generated_at": "2026-03-07T09:00:00Z",
+    "timezone": "Asia/Seoul",
+    "lookup": {
+      "entity_slug": "blackpink",
+      "title": "DEADLINE",
+      "date": "2026-02-27",
+      "stream": "album"
+    }
+  },
+  "data": {
+    "release_id": "rel_blackpink_deadline_2026_02_27_album",
+    "canonical_path": "/v1/releases/rel_blackpink_deadline_2026_02_27_album",
+    "release": {
+      "release_id": "rel_blackpink_deadline_2026_02_27_album",
+      "entity_slug": "blackpink",
+      "display_name": "BLACKPINK",
+      "release_title": "DEADLINE",
+      "release_date": "2026-02-27",
+      "stream": "album",
+      "release_kind": "mini"
+    }
+  }
+}
+```
+
 ### 8.4 Response Responsibility
 
 - release meta


### PR DESCRIPTION
## Summary
- implement backend-backed /v1/releases/:id using release_detail_projection
- add legacy lookup helper to resolve exact-key access into stable release_id
- document the lookup helper response contract for migration clients

## Verification
- cd backend && npm run build
- source ~/.config/idol-song-app/neon.env && PORT=3213 APP_TIMEZONE=Asia/Seoul npm run start
- representative requests checked:
  - /v1/releases/lookup?entity_slug=blackpink&title=DEADLINE&date=2026-02-26&stream=album
  - /v1/releases/lookup?entity_slug=ive&title=REVIVE%2B&date=2026-02-23&stream=album
  - /v1/releases/lookup?entity_slug=qwer&title=%ED%9D%B0%EC%88%98%EC%97%BC%EA%B3%A0%EB%9E%98&date=2025-10-06&stream=song
  - /v1/releases/:id for the resolved BLACKPINK / IVE / QWER rows
  - /v1/releases/not-a-uuid
  - /v1/releases/00000000-0000-4000-8000-000000000000
  - invalid/missing lookup queries
- git diff --check

Closes #171