### PR TITLE
Add backend shadow-read verification harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ python3 sync_release_pipeline_to_neon.py
 - run note: `backend/sql/README.md`
 - upcoming dual-write report: `backend/reports/upcoming_pipeline_db_sync_summary.json`
 - projection refresh report: `backend/reports/projection_refresh_summary.json`
+- endpoint shadow-read report: `backend/reports/backend_shadow_read_report.json`
 
 Hydration dry-run 예시:
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -171,3 +171,38 @@ python3 build_backend_json_parity_report.py
 - title-track / double-title 표현
 - YouTube Music / YouTube MV service-link state
 - review-required counts
+
+## Endpoint Shadow Read Report
+
+projection-backed read route를 current shipped web semantics와 직접 비교하려면 아래 명령을 사용한다.
+
+```bash
+set -a
+source ~/.config/idol-song-app/neon.env
+set +a
+
+cd backend
+npm run shadow:verify
+```
+
+기본 보고서 출력:
+
+- `backend/reports/backend_shadow_read_report.json`
+
+현재 shadow-read scope:
+
+- `/v1/search`
+- `/v1/entities/:slug`
+- `/v1/releases/lookup` + `/v1/releases/:id`
+- `/v1/calendar/month`
+- `/v1/radar`
+
+리포트는 clean 여부와 함께 다음 drift category를 surface 한다.
+
+- missing rows or segments
+- alias-match differences
+- exact-vs-month-only drift
+- latest-release or next-upcoming drift
+- title-track / MV-state drift
+- radar eligibility drift
+- field-shape mismatches

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,7 +8,8 @@
     "start": "node ./dist/server.js",
     "migrate:apply": "node ./scripts/apply-migration.mjs ./sql/migrations",
     "schema:verify": "node ./scripts/verify-canonical-schema.mjs",
-    "projection:refresh": "node ./scripts/refresh-projections.mjs"
+    "projection:refresh": "node ./scripts/refresh-projections.mjs",
+    "shadow:verify": "npm run build && node ./scripts/build-shadow-read-report.mjs"
   },
   "dependencies": {
     "fastify": "^5.2.1",

--- a/backend/reports/backend_shadow_read_report.json
+++ b/backend/reports/backend_shadow_read_report.json
@@ -1,0 +1,6219 @@
+{
+  "generated_at": "2026-03-07T09:25:27.296Z",
+  "clean": false,
+  "linked_parity_report": {
+    "exists": true,
+    "path": "backend/reports/backend_json_parity_report.json",
+    "clean": false,
+    "generated_at": "2026-03-07T07:38:47.525631+00:00",
+    "summary_lines": [
+      "entity alias/search coverage: clean (mismatched entities=0)",
+      "official links: clean (mismatched entities=0)",
+      "YouTube allowlists: clean (role mismatches=0, metadata mismatches=0)",
+      "latest verified release selection: drift (tracking mismatches=0, stream mismatches=3)",
+      "upcoming counts / nearest: clean (month bucket mismatches=0)",
+      "title-track / double-title: clean (mismatched releases=0)",
+      "YouTube Music / MV service-link state: clean (mismatched releases=0)",
+      "review-required counts: clean (review_type_counts_match=True, youtube_mv_status_counts_match=True)"
+    ]
+  },
+  "self_check": {
+    "passed": true
+  },
+  "coverage": {
+    "search": [
+      "트리플에스",
+      "투바투",
+      "최예나",
+      "REVIVE+",
+      "흰수염고래"
+    ],
+    "entity_detail": [
+      "yena",
+      "blackpink",
+      "and-team",
+      "allday-project"
+    ],
+    "release_detail": [
+      {
+        "entitySlug": "blackpink",
+        "title": "DEADLINE",
+        "date": "2026-02-26",
+        "stream": "album"
+      },
+      {
+        "entitySlug": "ive",
+        "title": "REVIVE+",
+        "date": "2026-02-23",
+        "stream": "album"
+      },
+      {
+        "entitySlug": "qwer",
+        "title": "흰수염고래",
+        "date": "2025-10-06",
+        "stream": "song"
+      }
+    ],
+    "calendar_month": [
+      "2026-03",
+      "2026-04",
+      "2025-10"
+    ],
+    "radar": [
+      "default"
+    ]
+  },
+  "summary_lines": [
+    "search: clean 1/5, drift 4/5",
+    "entity_detail: clean 0/4, drift 4/4",
+    "release_detail: clean 0/3, drift 3/3",
+    "calendar_month: clean 0/3, drift 3/3",
+    "radar: clean 0/1, drift 1/1",
+    "missing rows or segments: 14 case(s)",
+    "field-shape mismatches: 12 case(s)",
+    "latest-release or next-upcoming drift: 7 case(s)",
+    "exact-vs-month-only drift: 4 case(s)",
+    "alias-match differences: 3 case(s)",
+    "radar eligibility drift: 1 case(s)"
+  ],
+  "cases": [
+    {
+      "surface": "search",
+      "input": {
+        "q": "트리플에스"
+      },
+      "clean": true,
+      "mismatch_categories": [],
+      "mismatches": [],
+      "expected_snapshot": {
+        "entities": [
+          {
+            "entity_slug": "triples",
+            "display_name": "tripleS",
+            "canonical_name": "tripleS",
+            "agency_name": "MODHAUS",
+            "match_reason": "alias_exact",
+            "matched_alias": "트리플에스",
+            "latest_release": {
+              "release_title": "トキメティック",
+              "release_date": "2026-02-05",
+              "stream": "song",
+              "release_kind": "single"
+            },
+            "next_upcoming": null
+          }
+        ],
+        "releases": [
+          {
+            "entity_slug": "triples",
+            "display_name": "tripleS",
+            "release_title": "トキメティック",
+            "release_date": "2026-02-05",
+            "stream": "song",
+            "release_kind": "single",
+            "release_format": "single",
+            "match_reason": "entity_exact_latest_release",
+            "matched_alias": "트리플에스"
+          }
+        ],
+        "upcoming": []
+      },
+      "actual_snapshot": {
+        "entities": [
+          {
+            "entity_slug": "triples",
+            "display_name": "tripleS",
+            "canonical_name": "tripleS",
+            "entity_type": "group",
+            "agency_name": "MODHAUS",
+            "match_reason": "alias_exact",
+            "matched_alias": "트리플에스",
+            "latest_release": {
+              "release_id": "0f9b4a68-5b21-554f-bc5e-11c41291becf",
+              "release_title": "トキメティック",
+              "release_date": "2026-02-05",
+              "stream": "song",
+              "release_kind": "single"
+            },
+            "next_upcoming": null
+          }
+        ],
+        "releases": [
+          {
+            "release_id": "0f9b4a68-5b21-554f-bc5e-11c41291becf",
+            "canonical_path": "/v1/releases/0f9b4a68-5b21-554f-bc5e-11c41291becf",
+            "entity_slug": "triples",
+            "display_name": "tripleS",
+            "release_title": "トキメティック",
+            "release_date": "2026-02-05",
+            "stream": "song",
+            "release_kind": "single",
+            "release_format": "single",
+            "match_reason": "entity_exact_latest_release",
+            "matched_alias": "트리플에스"
+          }
+        ],
+        "upcoming": []
+      },
+      "actual_status_code": 200
+    },
+    {
+      "surface": "search",
+      "input": {
+        "q": "투바투"
+      },
+      "clean": false,
+      "mismatch_categories": [
+        "field-shape mismatches",
+        "latest-release or next-upcoming drift",
+        "missing rows or segments"
+      ],
+      "mismatches": [
+        {
+          "category": "field-shape mismatches",
+          "path": "data",
+          "shape_mismatches": [
+            {
+              "path": "data.entities[0].next_upcoming.scheduled_month",
+              "expected_type": "string",
+              "actual_type": "missing",
+              "message": "Missing key"
+            },
+            {
+              "path": "data.entities[0].next_upcoming.release_format",
+              "expected_type": "string",
+              "actual_type": "missing",
+              "message": "Missing key"
+            },
+            {
+              "path": "data.upcoming[0].scheduled_month",
+              "expected_type": "string",
+              "actual_type": "null",
+              "message": "Type mismatch"
+            },
+            {
+              "path": "data.upcoming[0].release_format",
+              "expected_type": "string",
+              "actual_type": "null",
+              "message": "Type mismatch"
+            }
+          ]
+        },
+        {
+          "category": "latest-release or next-upcoming drift",
+          "path": "data.entities[0].next_upcoming",
+          "expected": {
+            "headline": "[NOTICE] Comeback Showcase to Celebrate the Release of TOMORROW X TOGETHER “7TH YEAR: A Moment of Stillness in the Thorns”",
+            "scheduled_date": "2026-04-13",
+            "scheduled_month": "2026-04",
+            "date_precision": "exact",
+            "date_status": "confirmed"
+          },
+          "actual": {
+            "headline": "[NOTICE] Comeback Showcase to Celebrate the Release of TOMORROW X TOGETHER “7TH YEAR: A Moment of Stillness in the Thorns”",
+            "scheduled_date": "2026-04-13",
+            "scheduled_month": null,
+            "date_precision": "exact",
+            "date_status": "confirmed"
+          }
+        },
+        {
+          "category": "missing rows or segments",
+          "path": "data.upcoming[0]",
+          "expected": {
+            "entity_slug": "tomorrow-x-together",
+            "display_name": "TOMORROW X TOGETHER",
+            "headline": "[NOTICE] Comeback Showcase to Celebrate the Release of TOMORROW X TOGETHER “7TH YEAR: A Moment of Stillness in the Thorns”",
+            "scheduled_date": "2026-04-13",
+            "scheduled_month": "2026-04",
+            "date_precision": "exact",
+            "date_status": "confirmed",
+            "match_reason": "entity_exact",
+            "matched_alias": "투바투"
+          },
+          "actual": {
+            "entity_slug": "tomorrow-x-together",
+            "display_name": "TOMORROW X TOGETHER",
+            "headline": "[NOTICE] Comeback Showcase to Celebrate the Release of TOMORROW X TOGETHER “7TH YEAR: A Moment of Stillness in the Thorns”",
+            "scheduled_date": "2026-04-13",
+            "scheduled_month": null,
+            "date_precision": "exact",
+            "date_status": "confirmed",
+            "match_reason": "entity_exact",
+            "matched_alias": "투바투"
+          }
+        }
+      ],
+      "expected_snapshot": {
+        "entities": [
+          {
+            "entity_slug": "tomorrow-x-together",
+            "display_name": "TOMORROW X TOGETHER",
+            "canonical_name": "TOMORROW X TOGETHER",
+            "agency_name": "HYBE Labels",
+            "match_reason": "alias_exact",
+            "matched_alias": "투바투",
+            "latest_release": {
+              "release_title": "Starkissed",
+              "release_date": "2025-10-19",
+              "stream": "album",
+              "release_kind": "album"
+            },
+            "next_upcoming": {
+              "headline": "[NOTICE] Comeback Showcase to Celebrate the Release of TOMORROW X TOGETHER “7TH YEAR: A Moment of Stillness in the Thorns”",
+              "scheduled_date": "2026-04-13",
+              "scheduled_month": "2026-04",
+              "date_precision": "exact",
+              "date_status": "confirmed",
+              "confidence_score": 0.84,
+              "release_format": ""
+            }
+          }
+        ],
+        "releases": [
+          {
+            "entity_slug": "tomorrow-x-together",
+            "display_name": "TOMORROW X TOGETHER",
+            "release_title": "Starkissed",
+            "release_date": "2025-10-19",
+            "stream": "album",
+            "release_kind": "album",
+            "release_format": "album",
+            "match_reason": "entity_exact_latest_release",
+            "matched_alias": "투바투"
+          }
+        ],
+        "upcoming": [
+          {
+            "entity_slug": "tomorrow-x-together",
+            "display_name": "TOMORROW X TOGETHER",
+            "headline": "[NOTICE] Comeback Showcase to Celebrate the Release of TOMORROW X TOGETHER “7TH YEAR: A Moment of Stillness in the Thorns”",
+            "scheduled_date": "2026-04-13",
+            "scheduled_month": "2026-04",
+            "date_precision": "exact",
+            "date_status": "confirmed",
+            "release_format": "",
+            "confidence_score": 0.84,
+            "source_type": "weverse_notice",
+            "source_url": "https://weverse.io/txt/notice/34002",
+            "evidence_summary": "Future date reference: 2026-04-13. Hello. This is BIGHIT MUSIC. We are excited to announce an online and in-person comeback showcase scheduled for Monday, April 13, 2026 to celebrate the release...",
+            "match_reason": "entity_exact",
+            "matched_alias": "투바투"
+          }
+        ]
+      },
+      "actual_snapshot": {
+        "entities": [
+          {
+            "entity_slug": "tomorrow-x-together",
+            "display_name": "TOMORROW X TOGETHER",
+            "canonical_name": "TOMORROW X TOGETHER",
+            "entity_type": "group",
+            "agency_name": "HYBE Labels",
+            "match_reason": "alias_exact",
+            "matched_alias": "투바투",
+            "latest_release": {
+              "release_id": "d22706bb-fcc0-50d9-b853-34cd6d85c24f",
+              "release_title": "Starkissed",
+              "release_date": "2025-10-19",
+              "stream": "album",
+              "release_kind": "album"
+            },
+            "next_upcoming": {
+              "headline": "[NOTICE] Comeback Showcase to Celebrate the Release of TOMORROW X TOGETHER “7TH YEAR: A Moment of Stillness in the Thorns”",
+              "scheduled_date": "2026-04-13",
+              "date_precision": "exact",
+              "date_status": "confirmed",
+              "confidence_score": 0.84
+            }
+          }
+        ],
+        "releases": [
+          {
+            "release_id": "d22706bb-fcc0-50d9-b853-34cd6d85c24f",
+            "canonical_path": "/v1/releases/d22706bb-fcc0-50d9-b853-34cd6d85c24f",
+            "entity_slug": "tomorrow-x-together",
+            "display_name": "TOMORROW X TOGETHER",
+            "release_title": "Starkissed",
+            "release_date": "2025-10-19",
+            "stream": "album",
+            "release_kind": "album",
+            "release_format": "album",
+            "match_reason": "entity_exact_latest_release",
+            "matched_alias": "투바투"
+          }
+        ],
+        "upcoming": [
+          {
+            "upcoming_signal_id": "085d1cb7-4a4c-5232-abb0-a982534217b2",
+            "entity_slug": "tomorrow-x-together",
+            "display_name": "TOMORROW X TOGETHER",
+            "headline": "[NOTICE] Comeback Showcase to Celebrate the Release of TOMORROW X TOGETHER “7TH YEAR: A Moment of Stillness in the Thorns”",
+            "scheduled_date": "2026-04-13",
+            "scheduled_month": null,
+            "date_precision": "exact",
+            "date_status": "confirmed",
+            "release_format": null,
+            "confidence_score": 0.84,
+            "source_type": "news_rss",
+            "source_url": "https://news.google.com/rss/articles/CBMieEFVX3lxTE11U0FzM2s2dXpCcHhqME5ZMVdCSlB2MjJKT21JS0p0dmhocmxhcXI4UlVDdGRBRXJQTmZiS1NLV2VCdlNYVFBhQzdoa0RvRVRYcnV1RWtEa2JZTVR4VERGdVRZSWRQaFlJSHZWUG10NHBDSW9oMXMtQg?oc=5",
+            "evidence_summary": "Future month reference: 2026-04. TOMORROW X TOGETHER made their first comeback after renewing their contract..8th mini album released on April 13th starnewskorea.com",
+            "match_reason": "entity_exact",
+            "matched_alias": "투바투"
+          }
+        ]
+      },
+      "actual_status_code": 200
+    },
+    {
+      "surface": "search",
+      "input": {
+        "q": "최예나"
+      },
+      "clean": false,
+      "mismatch_categories": [
+        "field-shape mismatches",
+        "missing rows or segments",
+        "latest-release or next-upcoming drift",
+        "alias-match differences"
+      ],
+      "mismatches": [
+        {
+          "category": "field-shape mismatches",
+          "path": "data",
+          "shape_mismatches": [
+            {
+              "path": "data.entities[0].next_upcoming.scheduled_month",
+              "expected_type": "string",
+              "actual_type": "missing",
+              "message": "Missing key"
+            },
+            {
+              "path": "data.entities[0].next_upcoming.release_format",
+              "expected_type": "string",
+              "actual_type": "missing",
+              "message": "Missing key"
+            },
+            {
+              "path": "data.upcoming[0].scheduled_month",
+              "expected_type": "string",
+              "actual_type": "null",
+              "message": "Type mismatch"
+            }
+          ]
+        },
+        {
+          "category": "missing rows or segments",
+          "path": "data.releases",
+          "expected_count": 0,
+          "actual_count": 1
+        },
+        {
+          "category": "latest-release or next-upcoming drift",
+          "path": "data.entities[0].latest_release",
+          "expected": null,
+          "actual": {
+            "release_title": "STAR!",
+            "release_date": "2025-11-26",
+            "stream": "song"
+          }
+        },
+        {
+          "category": "latest-release or next-upcoming drift",
+          "path": "data.entities[0].next_upcoming",
+          "expected": {
+            "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
+            "scheduled_date": "2026-03-11",
+            "scheduled_month": "2026-03",
+            "date_precision": "exact",
+            "date_status": "confirmed"
+          },
+          "actual": {
+            "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
+            "scheduled_date": "2026-03-11",
+            "scheduled_month": null,
+            "date_precision": "exact",
+            "date_status": "confirmed"
+          }
+        },
+        {
+          "category": "alias-match differences",
+          "path": "data.releases[0]",
+          "expected": null,
+          "actual": {
+            "entity_slug": "yena",
+            "display_name": "YENA",
+            "release_title": "STAR!",
+            "release_date": "2025-11-26",
+            "stream": "song",
+            "match_reason": "entity_exact_latest_release",
+            "matched_alias": "최예나"
+          },
+          "query": "최예나"
+        },
+        {
+          "category": "missing rows or segments",
+          "path": "data.upcoming[0]",
+          "expected": {
+            "entity_slug": "yena",
+            "display_name": "YENA",
+            "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
+            "scheduled_date": "2026-03-11",
+            "scheduled_month": "2026-03",
+            "date_precision": "exact",
+            "date_status": "confirmed",
+            "match_reason": "entity_exact",
+            "matched_alias": "최예나"
+          },
+          "actual": {
+            "entity_slug": "yena",
+            "display_name": "YENA",
+            "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
+            "scheduled_date": "2026-03-11",
+            "scheduled_month": null,
+            "date_precision": "exact",
+            "date_status": "confirmed",
+            "match_reason": "entity_exact",
+            "matched_alias": "최예나"
+          }
+        }
+      ],
+      "expected_snapshot": {
+        "entities": [
+          {
+            "entity_slug": "yena",
+            "display_name": "YENA",
+            "canonical_name": "YENA",
+            "agency_name": null,
+            "match_reason": "alias_exact",
+            "matched_alias": "최예나",
+            "latest_release": null,
+            "next_upcoming": {
+              "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
+              "scheduled_date": "2026-03-11",
+              "scheduled_month": "2026-03",
+              "date_precision": "exact",
+              "date_status": "confirmed",
+              "confidence_score": 0.84,
+              "release_format": "ep"
+            }
+          }
+        ],
+        "releases": [],
+        "upcoming": [
+          {
+            "entity_slug": "yena",
+            "display_name": "YENA",
+            "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
+            "scheduled_date": "2026-03-11",
+            "scheduled_month": "2026-03",
+            "date_precision": "exact",
+            "date_status": "confirmed",
+            "release_format": "ep",
+            "confidence_score": 0.84,
+            "source_type": "news_rss",
+            "source_url": "https://www.starnewskorea.com/music/2026/02/23/2026022315005262396",
+            "evidence_summary": "Future date reference: 2026-03-11. YENA confirmed her comeback with the 5th mini album LOVE CATCHER, scheduled for March 11 at 6 p.m. KST.",
+            "match_reason": "entity_exact",
+            "matched_alias": "최예나"
+          }
+        ]
+      },
+      "actual_snapshot": {
+        "entities": [
+          {
+            "entity_slug": "yena",
+            "display_name": "YENA",
+            "canonical_name": "YENA",
+            "entity_type": "solo",
+            "agency_name": null,
+            "match_reason": "alias_exact",
+            "matched_alias": "최예나",
+            "latest_release": {
+              "release_id": "0363f526-e841-560d-940d-541a4e536e4e",
+              "release_title": "STAR!",
+              "release_date": "2025-11-26",
+              "stream": "song",
+              "release_kind": "single"
+            },
+            "next_upcoming": {
+              "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
+              "scheduled_date": "2026-03-11",
+              "date_precision": "exact",
+              "date_status": "confirmed",
+              "confidence_score": 0.84
+            }
+          }
+        ],
+        "releases": [
+          {
+            "release_id": "0363f526-e841-560d-940d-541a4e536e4e",
+            "canonical_path": "/v1/releases/0363f526-e841-560d-940d-541a4e536e4e",
+            "entity_slug": "yena",
+            "display_name": "YENA",
+            "release_title": "STAR!",
+            "release_date": "2025-11-26",
+            "stream": "song",
+            "release_kind": "single",
+            "release_format": "single",
+            "match_reason": "entity_exact_latest_release",
+            "matched_alias": "최예나"
+          }
+        ],
+        "upcoming": [
+          {
+            "upcoming_signal_id": "135cb637-d988-5028-b221-0ec2f59f124f",
+            "entity_slug": "yena",
+            "display_name": "YENA",
+            "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
+            "scheduled_date": "2026-03-11",
+            "scheduled_month": null,
+            "date_precision": "exact",
+            "date_status": "confirmed",
+            "release_format": "ep",
+            "confidence_score": 0.84,
+            "source_type": "news_rss",
+            "source_url": "https://www.starnewskorea.com/music/2026/02/23/2026022315005262396",
+            "evidence_summary": "Future date reference: 2026-03-11. YENA confirmed her comeback with the 5th mini album LOVE CATCHER, scheduled for March 11 at 6 p.m. KST.",
+            "match_reason": "entity_exact",
+            "matched_alias": "최예나"
+          }
+        ]
+      },
+      "actual_status_code": 200
+    },
+    {
+      "surface": "search",
+      "input": {
+        "q": "REVIVE+"
+      },
+      "clean": false,
+      "mismatch_categories": [
+        "missing rows or segments",
+        "alias-match differences",
+        "latest-release or next-upcoming drift"
+      ],
+      "mismatches": [
+        {
+          "category": "missing rows or segments",
+          "path": "data.entities",
+          "expected_count": 1,
+          "actual_count": 0
+        },
+        {
+          "category": "alias-match differences",
+          "path": "data.entities[0]",
+          "expected": {
+            "entity_slug": "ive",
+            "display_name": "IVE",
+            "match_reason": "partial",
+            "matched_alias": null,
+            "latest_release": {
+              "release_title": "REVIVE+",
+              "release_date": "2026-02-23",
+              "stream": "album"
+            },
+            "next_upcoming": null
+          },
+          "actual": null,
+          "query": "REVIVE+"
+        },
+        {
+          "category": "latest-release or next-upcoming drift",
+          "path": "data.entities[0].latest_release",
+          "expected": {
+            "release_title": "REVIVE+",
+            "release_date": "2026-02-23",
+            "stream": "album"
+          },
+          "actual": null
+        }
+      ],
+      "expected_snapshot": {
+        "entities": [
+          {
+            "entity_slug": "ive",
+            "display_name": "IVE",
+            "canonical_name": "IVE",
+            "agency_name": "Starship Entertainment",
+            "match_reason": "partial",
+            "matched_alias": null,
+            "latest_release": {
+              "release_title": "REVIVE+",
+              "release_date": "2026-02-23",
+              "stream": "album",
+              "release_kind": "album"
+            },
+            "next_upcoming": null
+          }
+        ],
+        "releases": [
+          {
+            "entity_slug": "ive",
+            "display_name": "IVE",
+            "release_title": "REVIVE+",
+            "release_date": "2026-02-23",
+            "stream": "album",
+            "release_kind": "album",
+            "release_format": "album",
+            "match_reason": "release_title_exact",
+            "matched_alias": "REVIVE+"
+          }
+        ],
+        "upcoming": []
+      },
+      "actual_snapshot": {
+        "entities": [],
+        "releases": [
+          {
+            "release_id": "c339f501-52fe-599d-8d2d-bf5694ae4de4",
+            "canonical_path": "/v1/releases/c339f501-52fe-599d-8d2d-bf5694ae4de4",
+            "entity_slug": "ive",
+            "display_name": "IVE",
+            "release_title": "REVIVE+",
+            "release_date": "2026-02-23",
+            "stream": "album",
+            "release_kind": "album",
+            "release_format": "album",
+            "match_reason": "release_title_exact",
+            "matched_alias": "REVIVE+"
+          }
+        ],
+        "upcoming": []
+      },
+      "actual_status_code": 200
+    },
+    {
+      "surface": "search",
+      "input": {
+        "q": "흰수염고래"
+      },
+      "clean": false,
+      "mismatch_categories": [
+        "missing rows or segments",
+        "alias-match differences",
+        "latest-release or next-upcoming drift"
+      ],
+      "mismatches": [
+        {
+          "category": "missing rows or segments",
+          "path": "data.entities",
+          "expected_count": 1,
+          "actual_count": 0
+        },
+        {
+          "category": "alias-match differences",
+          "path": "data.entities[0]",
+          "expected": {
+            "entity_slug": "qwer",
+            "display_name": "QWER",
+            "match_reason": "partial",
+            "matched_alias": null,
+            "latest_release": {
+              "release_title": "흰수염고래",
+              "release_date": "2025-10-06",
+              "stream": "song"
+            },
+            "next_upcoming": null
+          },
+          "actual": null,
+          "query": "흰수염고래"
+        },
+        {
+          "category": "latest-release or next-upcoming drift",
+          "path": "data.entities[0].latest_release",
+          "expected": {
+            "release_title": "흰수염고래",
+            "release_date": "2025-10-06",
+            "stream": "song"
+          },
+          "actual": null
+        }
+      ],
+      "expected_snapshot": {
+        "entities": [
+          {
+            "entity_slug": "qwer",
+            "display_name": "QWER",
+            "canonical_name": "QWER",
+            "agency_name": null,
+            "match_reason": "partial",
+            "matched_alias": null,
+            "latest_release": {
+              "release_title": "흰수염고래",
+              "release_date": "2025-10-06",
+              "stream": "song",
+              "release_kind": "single"
+            },
+            "next_upcoming": null
+          }
+        ],
+        "releases": [
+          {
+            "entity_slug": "qwer",
+            "display_name": "QWER",
+            "release_title": "흰수염고래",
+            "release_date": "2025-10-06",
+            "stream": "song",
+            "release_kind": "single",
+            "release_format": "single",
+            "match_reason": "release_title_exact",
+            "matched_alias": "흰수염고래"
+          }
+        ],
+        "upcoming": []
+      },
+      "actual_snapshot": {
+        "entities": [],
+        "releases": [
+          {
+            "release_id": "d9a85b3d-ed19-51bb-a6c4-e5e538401b50",
+            "canonical_path": "/v1/releases/d9a85b3d-ed19-51bb-a6c4-e5e538401b50",
+            "entity_slug": "qwer",
+            "display_name": "QWER",
+            "release_title": "흰수염고래",
+            "release_date": "2025-10-06",
+            "stream": "song",
+            "release_kind": "single",
+            "release_format": "single",
+            "match_reason": "release_title_exact",
+            "matched_alias": "흰수염고래"
+          }
+        ],
+        "upcoming": []
+      },
+      "actual_status_code": 200
+    },
+    {
+      "surface": "entity_detail",
+      "input": {
+        "slug": "yena"
+      },
+      "clean": false,
+      "mismatch_categories": [
+        "field-shape mismatches",
+        "missing rows or segments",
+        "latest-release or next-upcoming drift"
+      ],
+      "mismatches": [
+        {
+          "category": "field-shape mismatches",
+          "path": "data",
+          "shape_mismatches": [
+            {
+              "path": "data.next_upcoming.scheduled_month",
+              "expected_type": "string",
+              "actual_type": "null",
+              "message": "Type mismatch"
+            },
+            {
+              "path": "data.source_timeline[0].event_type",
+              "expected_type": "string",
+              "actual_type": "missing",
+              "message": "Missing key"
+            },
+            {
+              "path": "data.source_timeline[0].occurred_at",
+              "expected_type": "string",
+              "actual_type": "missing",
+              "message": "Missing key"
+            },
+            {
+              "path": "data.source_timeline[0].summary",
+              "expected_type": "string",
+              "actual_type": "missing",
+              "message": "Missing key"
+            }
+          ]
+        },
+        {
+          "category": "missing rows or segments",
+          "path": "data.official_links.instagram",
+          "expected": "https://www.instagram.com/yena.jigumina/",
+          "actual": "https://www.instagram.com/yena.jigumina"
+        },
+        {
+          "category": "missing rows or segments",
+          "path": "data.artist_source_url",
+          "expected": null,
+          "actual": "https://musicbrainz.org/artist/745c5b92-325f-451d-bd52-e6b95229c776"
+        },
+        {
+          "category": "latest-release or next-upcoming drift",
+          "path": "data.latest_release",
+          "expected": null,
+          "actual": {
+            "release_title": "STAR!",
+            "release_date": "2025-11-26",
+            "stream": "song",
+            "release_kind": "single"
+          }
+        },
+        {
+          "category": "latest-release or next-upcoming drift",
+          "path": "data.next_upcoming",
+          "expected": {
+            "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
+            "scheduled_date": "2026-03-11",
+            "scheduled_month": "2026-03",
+            "date_precision": "exact",
+            "date_status": "confirmed",
+            "release_format": "ep"
+          },
+          "actual": {
+            "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
+            "scheduled_date": "2026-03-11",
+            "scheduled_month": null,
+            "date_precision": "exact",
+            "date_status": "confirmed",
+            "release_format": "ep"
+          }
+        },
+        {
+          "category": "missing rows or segments",
+          "path": "data.source_timeline",
+          "expected": [
+            "first_signal|최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스|news_rss|https://www.starnewskorea.com/music/2026/02/23/2026022315005262396"
+          ],
+          "actual": [
+            "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스|news_rss|https://www.starnewskorea.com/music/2026/02/23/2026022315005262396"
+          ]
+        }
+      ],
+      "expected_snapshot": {
+        "identity": {
+          "entity_slug": "yena",
+          "display_name": "YENA",
+          "canonical_name": "YENA",
+          "agency_name": null,
+          "badge_image_url": null,
+          "representative_image_url": null,
+          "debut_year": null
+        },
+        "official_links": {
+          "youtube": "https://www.youtube.com/@yena_official",
+          "x": "https://x.com/YENA_OFFICIAL",
+          "instagram": "https://www.instagram.com/yena.jigumina/"
+        },
+        "youtube_channels": {
+          "primary_team_channel_url": null,
+          "mv_allowlist_urls": []
+        },
+        "tracking_state": {
+          "tier": "longtail",
+          "watch_reason": "manual_watch",
+          "tracking_status": "watch_only"
+        },
+        "next_upcoming": {
+          "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
+          "scheduled_date": "2026-03-11",
+          "scheduled_month": "2026-03",
+          "date_precision": "exact",
+          "date_status": "confirmed",
+          "confidence_score": 0.84,
+          "release_format": "ep"
+        },
+        "latest_release": null,
+        "recent_albums": [
+          {
+            "release_title": "Blooming Wings",
+            "release_date": "2025-07-29",
+            "stream": "album",
+            "release_kind": "ep"
+          },
+          {
+            "release_title": "GOOD MORNING",
+            "release_date": "2024-01-15",
+            "stream": "album",
+            "release_kind": "ep"
+          },
+          {
+            "release_title": "SMARTPHONE",
+            "release_date": "2022-08-03",
+            "stream": "album",
+            "release_kind": "ep"
+          },
+          {
+            "release_title": "ˣ‿ˣ (SMiLEY)",
+            "release_date": "2022-01-17",
+            "stream": "album",
+            "release_kind": "ep"
+          }
+        ],
+        "source_timeline": [
+          {
+            "event_type": "first_signal",
+            "source_type": "news_rss",
+            "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
+            "source_url": "https://www.starnewskorea.com/music/2026/02/23/2026022315005262396",
+            "source_domain": "starnewskorea.com",
+            "occurred_at": "2026-02-23T05:58:00.000Z",
+            "summary": "Future date reference: 2026-03-11. YENA confirmed her comeback with the 5th mini album LOVE CATCHER, scheduled for March 11 at 6 p.m. KST."
+          }
+        ],
+        "artist_source_url": null
+      },
+      "actual_snapshot": {
+        "identity": {
+          "entity_slug": "yena",
+          "display_name": "YENA",
+          "canonical_name": "YENA",
+          "entity_type": "solo",
+          "agency_name": null,
+          "debut_year": null,
+          "badge_image_url": null,
+          "representative_image_url": null
+        },
+        "official_links": {
+          "youtube": "https://www.youtube.com/@yena_official",
+          "x": "https://x.com/YENA_OFFICIAL",
+          "instagram": "https://www.instagram.com/yena.jigumina"
+        },
+        "youtube_channels": {
+          "primary_team_channel_url": null,
+          "mv_allowlist_urls": []
+        },
+        "tracking_state": {
+          "tier": "longtail",
+          "watch_reason": "manual_watch",
+          "tracking_status": "watch_only"
+        },
+        "next_upcoming": {
+          "upcoming_signal_id": "cd35b091-7589-514c-8277-154da992b434",
+          "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
+          "scheduled_date": "2026-03-11",
+          "scheduled_month": null,
+          "date_precision": "exact",
+          "date_status": "confirmed",
+          "release_format": "ep",
+          "confidence_score": 0.84,
+          "latest_seen_at": "2026-02-23T05:58:00+00:00"
+        },
+        "latest_release": {
+          "release_id": "0363f526-e841-560d-940d-541a4e536e4e",
+          "release_title": "STAR!",
+          "release_date": "2025-11-26",
+          "stream": "song",
+          "release_kind": "single"
+        },
+        "recent_albums": [
+          {
+            "release_id": "801052f3-72e8-5b48-b401-1b0aec55a955",
+            "release_title": "Blooming Wings",
+            "release_date": "2025-07-29",
+            "stream": "album",
+            "release_kind": "ep"
+          },
+          {
+            "release_id": "b18e824c-d318-5848-9b08-7341982cca31",
+            "release_title": "GOOD MORNING",
+            "release_date": "2024-01-15",
+            "stream": "album",
+            "release_kind": "ep"
+          },
+          {
+            "release_id": "6f634529-e1db-506a-b4fc-f5565b54beb3",
+            "release_title": "SMARTPHONE",
+            "release_date": "2022-08-03",
+            "stream": "album",
+            "release_kind": "ep"
+          },
+          {
+            "release_id": "cc26984b-ed23-5e96-9bbd-8364ce7c037b",
+            "release_title": "ˣ‿ˣ (SMiLEY)",
+            "release_date": "2022-01-17",
+            "stream": "album",
+            "release_kind": "ep"
+          }
+        ],
+        "source_timeline": [
+          {
+            "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
+            "source_url": "https://www.starnewskorea.com/music/2026/02/23/2026022315005262396",
+            "source_type": "news_rss",
+            "source_domain": "starnewskorea.com",
+            "published_at": "2026-02-23T05:58:00+00:00",
+            "scheduled_date": "2026-03-11",
+            "scheduled_month": null,
+            "date_precision": "exact",
+            "date_status": "confirmed",
+            "release_format": "ep",
+            "confidence_score": 0.84
+          }
+        ],
+        "artist_source_url": "https://musicbrainz.org/artist/745c5b92-325f-451d-bd52-e6b95229c776"
+      },
+      "actual_status_code": 200
+    },
+    {
+      "surface": "entity_detail",
+      "input": {
+        "slug": "blackpink"
+      },
+      "clean": false,
+      "mismatch_categories": [
+        "field-shape mismatches",
+        "missing rows or segments",
+        "latest-release or next-upcoming drift",
+        "exact-vs-month-only drift"
+      ],
+      "mismatches": [
+        {
+          "category": "field-shape mismatches",
+          "path": "data",
+          "shape_mismatches": [
+            {
+              "path": "data.identity.badge_image_url",
+              "expected_type": "string",
+              "actual_type": "null",
+              "message": "Type mismatch"
+            },
+            {
+              "path": "data.next_upcoming",
+              "expected_type": "object",
+              "actual_type": "null",
+              "message": "Type mismatch"
+            },
+            {
+              "path": "data.source_timeline[0].event_type",
+              "expected_type": "string",
+              "actual_type": "missing",
+              "message": "Missing key"
+            },
+            {
+              "path": "data.source_timeline[0].occurred_at",
+              "expected_type": "string",
+              "actual_type": "missing",
+              "message": "Missing key"
+            },
+            {
+              "path": "data.source_timeline[0].summary",
+              "expected_type": "string",
+              "actual_type": "missing",
+              "message": "Missing key"
+            }
+          ]
+        },
+        {
+          "category": "missing rows or segments",
+          "path": "data.official_links.instagram",
+          "expected": "https://www.instagram.com/blackpinkofficial/",
+          "actual": "https://www.instagram.com/blackpinkofficial"
+        },
+        {
+          "category": "latest-release or next-upcoming drift",
+          "path": "data.latest_release",
+          "expected": {
+            "release_title": "DEADLINE",
+            "release_date": "2026-02-26",
+            "stream": "album",
+            "release_kind": "ep"
+          },
+          "actual": {
+            "release_title": "DEADLINE",
+            "release_date": "2026-02-27",
+            "stream": "album",
+            "release_kind": "ep"
+          }
+        },
+        {
+          "category": "exact-vs-month-only drift",
+          "path": "data.next_upcoming",
+          "expected": {
+            "headline": "BLACKPINK Finally Reveals 'DEADLINE' Mini Album Release Date - TMZ",
+            "scheduled_date": "",
+            "scheduled_month": "",
+            "date_precision": "unknown",
+            "date_status": "rumor",
+            "release_format": "ep"
+          },
+          "actual": null
+        },
+        {
+          "category": "missing rows or segments",
+          "path": "data.source_timeline",
+          "expected": [
+            "first_signal|BLACKPINK Finally Reveals 'DEADLINE' Mini Album Release Date - TMZ|news_rss|https://news.google.com/rss/articles/CBMicEFVX3lxTE4waE5xc2U4eWNJaFhldTl2aGZEdGRxYl9DTVRRYnQ2Sk5rRGMtX2JHVVhiWFV3VTZJdUc1b1VoWWdmM25vcXhDb0dKSlBlanpHSlh2NDlHQ1hEMEtCalpvdkFudzNKZDJ0Y1VnVlpwOTA?oc=5",
+            "official_announcement|BLACKPINK’s New Title Track Is ‘GO’.. YG “Created with Great Care”|agency_notice|https://www.ygfamily.com/en/news/report/7378",
+            "release_verified|DEADLINE|release_catalog|https://musicbrainz.org/release-group/38204997-b295-4d09-a946-f7e119725031"
+          ],
+          "actual": [
+            "Blackpink’s Jisoo Shares Love for Album ‘Deadline,’ Talks New Netflix K-Drama: “Blinks Will Love It” - The Hollywood Reporter|news_rss|https://news.google.com/rss/articles/CBMiqwFBVV95cUxOcldhb1d6S2hhMDQxTDZndUlEa0VqLXROcEJucWkxLTZxdFNha25nckc0LWxVZ2I3MHhnVk0zX0xfM3NnRlpnaW9MemF5U3VnaTRyZWlYRVI0YmxtN1Y0T0U0WmxuZmNqVWRxeDNsaVFOeXpzNGJrSVVsSjEtMHlnMGRBT3hpNDl2RW1IelNpVzdYWTBrNXlZUFNZZHN0VHFkVG1RZERvT3k3SlE?oc=5",
+            "Blackpink's DEADLINE sells 1.46 million copies on day of release, sets new K-pop girl group record - The Korea Economic Daily Global Edition|news_rss|https://news.google.com/rss/articles/CBMiZ0FVX3lxTE94bmhvU2RuMVBXTGNpS1VMaExLUXN6c0lCekxVbm1KTy1McTNvTkUycE1KNUl1c0U3b2c5ajh3cE9WSEs0TGJwNlgyZU9LX3JHam55VVhGX3h2SDBoaUdtcGYwWmdGdHc?oc=5",
+            "Blackpink Sets New Record As ‘Deadline’ Tops First-Day Sales Among K-Pop Girl Groups - Outlook Luxe|news_rss|https://news.google.com/rss/articles/CBMiuwFBVV95cUxQREV5ZV9pTDZyVFVyS0JqTDJEbWJGMzh0UDhwcnFKLVFFbDhmVW5rcmVrdGt5cTFkR1BHSzQ4Z0dBZG9RNFBXQVN5UlRKcGF0V1Bycm1KT2ZObWRpS0FBZll0N2RrWjlYWTZlQ3M4Nk8zc2o4dzFMcnlmTzFVMk4zcGZKUms3eFNMQzlLSzN2UERxVmZOOGVyWm90Tzh2b0tHVlJUMHdVZjU5Z0QzWWFibGhEYWtRbzRuNHBZ0gHIAUFVX3lxTFA5LVQ4Uk41RERaWnk5UXh0eC1MTEppZWVTd05yVGlNeEs0UHVKRnExQ3hBcFVsX2wyUmp3Z1U3Z0Q2R3hWcFdBU09hVHV1blJ6VHIyTEgxTnNUc0V5VmxWOUt1S2hwcm11QmRZdUY5c3dfTGZPWE5MT1IzQndIdkUzVHF6NDhCaE9ZeWc5T1JBVlg3MURjV2hrVVVuRDV5ek1LdlRTS1lSTFNCemJxa0t6VlN2bURxM3Uxb0tMRXl0dkJSU3FQbm9l?oc=5",
+            "K-Pop girl group Blackpink drops their third mini album Deadline - Indulgexpress|news_rss|https://news.google.com/rss/articles/CBMivAFBVV95cUxQVG9PNFdjS19QUkVoYU95M21Rb2l5em5EQUVZSzZrcU9qa1hYMWRQSGRnc3dJZDFUYWtBcWstQVREcEw5c3BKc2M5WHJETHB0LUlFTGI3dmFKbXdBbWRtOEZRVTVzZ29UWTRaLVJ5RnhDc25IS2ZsRVNTTXVTWnEtZENIdTVDeUVmM0ZGTXlBSnNBek1aSEs0TFJ4UndGTjVYMDdZWVhmV2tPc092MDN5WnZWYlBiNkJ5M09nbNIBygFBVV95cUxOWlFldno4Y0RLNjhoRFkxN29BT2J3WHdBaFN6THNuYk1HbEZUdzAwSzA5T0U5V3QwVWg1WDZCQUs1S0ZVdDVnSXo3TGpCeTNsZm5tS1VsRDZoVlhyR3doOFNEcVVTVEJubVJTLXNIVG5RX21xN3BEc3preXJVREU0MUVlU2JMalh1Q0QxamJhZ0xIcHFKcTNDV3V4RHFKeV9qZ0dnS2IySkJNaXBVU3lvRDA0eXhYbS1BZFdEbVZBclJQcU9UeFRhUlBB?oc=5",
+            "BLACKPINK’s New Title Track Is ‘GO’.. YG “Created with Great Care”|agency_notice|https://www.ygfamily.com/en/news/report/7378",
+            "BLACKPINK Finally Reveals 'DEADLINE' Mini Album Release Date - TMZ|news_rss|https://news.google.com/rss/articles/CBMicEFVX3lxTE4waE5xc2U4eWNJaFhldTl2aGZEdGRxYl9DTVRRYnQ2Sk5rRGMtX2JHVVhiWFV3VTZJdUc1b1VoWWdmM25vcXhDb0dKSlBlanpHSlh2NDlHQ1hEMEtCalpvdkFudzNKZDJ0Y1VnVlpwOTA?oc=5",
+            "Blackpink Sets Release Date for Comeback Album - Pitchfork|news_rss|https://news.google.com/rss/articles/CBMiekFVX3lxTE9Ucm80bHB0cUYwcHNhZkJxaWM1MnA5SnJUVzk0ZkdyQmg3b0Q2SXFudk41aXVRN1RjLURta0tvemNPdl8yaE10cVdHbkc2d3dnM3VxSDhtNWhlSGZtM3RYNzJFVThxRzhqWlFjSzR4ekNGM04tLWdWWW9n?oc=5",
+            "K-pop group Blackpink announces new mini album Deadline, out Feb 27 - CNA Lifestyle|news_rss|https://news.google.com/rss/articles/CBMirgFBVV95cUxOUFhWaFpuYnA5UDVRQmR0bHhuS2NIS2pfa255aDEzNGlFMHUzQ0p4MVRRLVVGUm13czJyclV5d3Rhd2xCakNqSmNaaDRtdkZhSWxqbk1VbWc0RzdMX3FjZ1RQTEY5RTV1czR6a3pXQmR4RS0wVVZNSHo3QllWLTBidzlESGpVNGwybzZ1Ti1Wc2VuLXE5WWk1U1Y2QlBtY1JWWXp6cjF3VGZwblhfclE?oc=5"
+          ]
+        }
+      ],
+      "expected_snapshot": {
+        "identity": {
+          "entity_slug": "blackpink",
+          "display_name": "BLACKPINK",
+          "canonical_name": "BLACKPINK",
+          "agency_name": "YG Entertainment",
+          "badge_image_url": "https://yt3.googleusercontent.com/U3VrCkKjzTpQ3VYv4SCPjNfDHeJV-swGNnhLYhr0nV4lZz_GVUNzK4EB-HFRfKv9S5VNh14uAg=s900-c-k-c0x00ffffff-no-rj",
+          "representative_image_url": null,
+          "debut_year": null
+        },
+        "official_links": {
+          "youtube": "https://www.youtube.com/channel/UCOmHUn--16B90oW2L6FRR3A",
+          "x": "https://x.com/blackpink",
+          "instagram": "https://www.instagram.com/blackpinkofficial/"
+        },
+        "youtube_channels": {
+          "primary_team_channel_url": "https://www.youtube.com/channel/UCOmHUn--16B90oW2L6FRR3A",
+          "mv_allowlist_urls": [
+            "https://www.youtube.com/channel/UCOmHUn--16B90oW2L6FRR3A",
+            "https://www.youtube.com/@YGEntertainment"
+          ]
+        },
+        "tracking_state": {
+          "tier": "core",
+          "watch_reason": "recent_release",
+          "tracking_status": "recent_release"
+        },
+        "next_upcoming": {
+          "headline": "BLACKPINK Finally Reveals 'DEADLINE' Mini Album Release Date - TMZ",
+          "scheduled_date": "",
+          "scheduled_month": "",
+          "date_precision": "unknown",
+          "date_status": "rumor",
+          "confidence_score": 0.68,
+          "release_format": "ep"
+        },
+        "latest_release": {
+          "release_title": "DEADLINE",
+          "release_date": "2026-02-26",
+          "stream": "album",
+          "release_kind": "ep"
+        },
+        "recent_albums": [
+          {
+            "release_title": "DEADLINE",
+            "release_date": "2026-02-27",
+            "stream": "album",
+            "release_kind": "ep"
+          },
+          {
+            "release_title": "DEADLINE",
+            "release_date": "2026-02-26",
+            "stream": "album",
+            "release_kind": "ep"
+          },
+          {
+            "release_title": "BORN PINK",
+            "release_date": "2022-09-16",
+            "stream": "album",
+            "release_kind": "album"
+          },
+          {
+            "release_title": "THE ALBUM",
+            "release_date": "2020-10-02",
+            "stream": "album",
+            "release_kind": "album"
+          },
+          {
+            "release_title": "KILL THIS LOVE",
+            "release_date": "2019-04-05",
+            "stream": "album",
+            "release_kind": "ep"
+          },
+          {
+            "release_title": "SQUARE UP",
+            "release_date": "2018-06-15",
+            "stream": "album",
+            "release_kind": "ep"
+          },
+          {
+            "release_title": "BLACKPINK",
+            "release_date": "2017-08-29",
+            "stream": "album",
+            "release_kind": "ep"
+          }
+        ],
+        "source_timeline": [
+          {
+            "event_type": "first_signal",
+            "source_type": "news_rss",
+            "headline": "BLACKPINK Finally Reveals 'DEADLINE' Mini Album Release Date - TMZ",
+            "source_url": "https://news.google.com/rss/articles/CBMicEFVX3lxTE4waE5xc2U4eWNJaFhldTl2aGZEdGRxYl9DTVRRYnQ2Sk5rRGMtX2JHVVhiWFV3VTZJdUc1b1VoWWdmM25vcXhDb0dKSlBlanpHSlh2NDlHQ1hEMEtCalpvdkFudzNKZDJ0Y1VnVlpwOTA?oc=5",
+            "source_domain": "news.google.com",
+            "occurred_at": "2026-01-14T08:00:00.000Z",
+            "summary": "BLACKPINK Finally Reveals 'DEADLINE' Mini Album Release Date TMZ"
+          },
+          {
+            "event_type": "official_announcement",
+            "source_type": "agency_notice",
+            "headline": "BLACKPINK’s New Title Track Is ‘GO’.. YG “Created with Great Care”",
+            "source_url": "https://www.ygfamily.com/en/news/report/7378",
+            "source_domain": "www.ygfamily.com",
+            "occurred_at": "2026-02-06T00:00:00.000Z",
+            "summary": "BLACKPINK’s New Title Track Is ‘GO’.. YG “Created with Great Care” BLACKPINK has unveiled the tracklist for their new release. According to YG Entertainment on..."
+          },
+          {
+            "event_type": "release_verified",
+            "source_type": "release_catalog",
+            "headline": "DEADLINE",
+            "source_url": "https://musicbrainz.org/release-group/38204997-b295-4d09-a946-f7e119725031",
+            "source_domain": "musicbrainz.org",
+            "occurred_at": "2026-02-26",
+            "summary": "Latest verified album record in the dataset for BLACKPINK, captured from the release catalog."
+          }
+        ],
+        "artist_source_url": "https://musicbrainz.org/artist/48646387-1664-4c9a-9139-9bfd091b823c"
+      },
+      "actual_snapshot": {
+        "identity": {
+          "entity_slug": "blackpink",
+          "display_name": "BLACKPINK",
+          "canonical_name": "BLACKPINK",
+          "entity_type": "group",
+          "agency_name": "YG Entertainment",
+          "debut_year": null,
+          "badge_image_url": null,
+          "representative_image_url": null
+        },
+        "official_links": {
+          "youtube": "https://www.youtube.com/channel/UCOmHUn--16B90oW2L6FRR3A",
+          "x": "https://x.com/blackpink",
+          "instagram": "https://www.instagram.com/blackpinkofficial"
+        },
+        "youtube_channels": {
+          "primary_team_channel_url": "https://www.youtube.com/channel/UCOmHUn--16B90oW2L6FRR3A",
+          "mv_allowlist_urls": [
+            "https://www.youtube.com/@YGEntertainment",
+            "https://www.youtube.com/channel/UCOmHUn--16B90oW2L6FRR3A"
+          ]
+        },
+        "tracking_state": {
+          "tier": "core",
+          "watch_reason": "recent_release",
+          "tracking_status": "recent_release"
+        },
+        "next_upcoming": null,
+        "latest_release": {
+          "release_id": "75d59b7a-9f0e-526c-9920-3a156c1a9e36",
+          "release_title": "DEADLINE",
+          "release_date": "2026-02-27",
+          "stream": "album",
+          "release_kind": "ep"
+        },
+        "recent_albums": [
+          {
+            "release_id": "75d59b7a-9f0e-526c-9920-3a156c1a9e36",
+            "release_title": "DEADLINE",
+            "release_date": "2026-02-27",
+            "stream": "album",
+            "release_kind": "ep"
+          },
+          {
+            "release_id": "e3526174-e804-56f2-9d50-17f9f817a351",
+            "release_title": "DEADLINE",
+            "release_date": "2026-02-26",
+            "stream": "album",
+            "release_kind": "ep"
+          },
+          {
+            "release_id": "0571a361-1b4e-58ab-a628-ff715c81bada",
+            "release_title": "BORN PINK",
+            "release_date": "2022-09-16",
+            "stream": "album",
+            "release_kind": "album"
+          },
+          {
+            "release_id": "e0a1b8e5-7e83-515e-8cad-bf1916aeb8dd",
+            "release_title": "THE ALBUM",
+            "release_date": "2020-10-02",
+            "stream": "album",
+            "release_kind": "album"
+          },
+          {
+            "release_id": "6476d409-4ef3-5050-b581-a72e973ed65f",
+            "release_title": "KILL THIS LOVE",
+            "release_date": "2019-04-05",
+            "stream": "album",
+            "release_kind": "ep"
+          },
+          {
+            "release_id": "fbca20e6-f7a3-5b69-9abd-d27a36dd11d9",
+            "release_title": "SQUARE UP",
+            "release_date": "2018-06-15",
+            "stream": "album",
+            "release_kind": "ep"
+          },
+          {
+            "release_id": "756b10bf-d09a-525f-ba50-0879d91f228e",
+            "release_title": "BLACKPINK",
+            "release_date": "2017-08-29",
+            "stream": "album",
+            "release_kind": "ep"
+          }
+        ],
+        "source_timeline": [
+          {
+            "headline": "Blackpink’s Jisoo Shares Love for Album ‘Deadline,’ Talks New Netflix K-Drama: “Blinks Will Love It” - The Hollywood Reporter",
+            "source_url": "https://news.google.com/rss/articles/CBMiqwFBVV95cUxOcldhb1d6S2hhMDQxTDZndUlEa0VqLXROcEJucWkxLTZxdFNha25nckc0LWxVZ2I3MHhnVk0zX0xfM3NnRlpnaW9MemF5U3VnaTRyZWlYRVI0YmxtN1Y0T0U0WmxuZmNqVWRxeDNsaVFOeXpzNGJrSVVsSjEtMHlnMGRBT3hpNDl2RW1IelNpVzdYWTBrNXlZUFNZZHN0VHFkVG1RZERvT3k3SlE?oc=5",
+            "source_type": "news_rss",
+            "source_domain": "news.google.com",
+            "published_at": "2026-03-02T15:11:07+00:00",
+            "scheduled_date": null,
+            "scheduled_month": null,
+            "date_precision": "unknown",
+            "date_status": "rumor",
+            "release_format": "album",
+            "confidence_score": 0.68
+          },
+          {
+            "headline": "Blackpink's DEADLINE sells 1.46 million copies on day of release, sets new K-pop girl group record - The Korea Economic Daily Global Edition",
+            "source_url": "https://news.google.com/rss/articles/CBMiZ0FVX3lxTE94bmhvU2RuMVBXTGNpS1VMaExLUXN6c0lCekxVbm1KTy1McTNvTkUycE1KNUl1c0U3b2c5ajh3cE9WSEs0TGJwNlgyZU9LX3JHam55VVhGX3h2SDBoaUdtcGYwWmdGdHc?oc=5",
+            "source_type": "news_rss",
+            "source_domain": "news.google.com",
+            "published_at": "2026-03-01T17:47:48+00:00",
+            "scheduled_date": null,
+            "scheduled_month": null,
+            "date_precision": "unknown",
+            "date_status": "rumor",
+            "release_format": null,
+            "confidence_score": 0.68
+          },
+          {
+            "headline": "Blackpink Sets New Record As ‘Deadline’ Tops First-Day Sales Among K-Pop Girl Groups - Outlook Luxe",
+            "source_url": "https://news.google.com/rss/articles/CBMiuwFBVV95cUxQREV5ZV9pTDZyVFVyS0JqTDJEbWJGMzh0UDhwcnFKLVFFbDhmVW5rcmVrdGt5cTFkR1BHSzQ4Z0dBZG9RNFBXQVN5UlRKcGF0V1Bycm1KT2ZObWRpS0FBZll0N2RrWjlYWTZlQ3M4Nk8zc2o4dzFMcnlmTzFVMk4zcGZKUms3eFNMQzlLSzN2UERxVmZOOGVyWm90Tzh2b0tHVlJUMHdVZjU5Z0QzWWFibGhEYWtRbzRuNHBZ0gHIAUFVX3lxTFA5LVQ4Uk41RERaWnk5UXh0eC1MTEppZWVTd05yVGlNeEs0UHVKRnExQ3hBcFVsX2wyUmp3Z1U3Z0Q2R3hWcFdBU09hVHV1blJ6VHIyTEgxTnNUc0V5VmxWOUt1S2hwcm11QmRZdUY5c3dfTGZPWE5MT1IzQndIdkUzVHF6NDhCaE9ZeWc5T1JBVlg3MURjV2hrVVVuRDV5ek1LdlRTS1lSTFNCemJxa0t6VlN2bURxM3Uxb0tMRXl0dkJSU3FQbm9l?oc=5",
+            "source_type": "news_rss",
+            "source_domain": "news.google.com",
+            "published_at": "2026-02-28T10:50:00+00:00",
+            "scheduled_date": null,
+            "scheduled_month": null,
+            "date_precision": "unknown",
+            "date_status": "rumor",
+            "release_format": null,
+            "confidence_score": 0.56
+          },
+          {
+            "headline": "K-Pop girl group Blackpink drops their third mini album Deadline - Indulgexpress",
+            "source_url": "https://news.google.com/rss/articles/CBMivAFBVV95cUxQVG9PNFdjS19QUkVoYU95M21Rb2l5em5EQUVZSzZrcU9qa1hYMWRQSGRnc3dJZDFUYWtBcWstQVREcEw5c3BKc2M5WHJETHB0LUlFTGI3dmFKbXdBbWRtOEZRVTVzZ29UWTRaLVJ5RnhDc25IS2ZsRVNTTXVTWnEtZENIdTVDeUVmM0ZGTXlBSnNBek1aSEs0TFJ4UndGTjVYMDdZWVhmV2tPc092MDN5WnZWYlBiNkJ5M09nbNIBygFBVV95cUxOWlFldno4Y0RLNjhoRFkxN29BT2J3WHdBaFN6THNuYk1HbEZUdzAwSzA5T0U5V3QwVWg1WDZCQUs1S0ZVdDVnSXo3TGpCeTNsZm5tS1VsRDZoVlhyR3doOFNEcVVTVEJubVJTLXNIVG5RX21xN3BEc3preXJVREU0MUVlU2JMalh1Q0QxamJhZ0xIcHFKcTNDV3V4RHFKeV9qZ0dnS2IySkJNaXBVU3lvRDA0eXhYbS1BZFdEbVZBclJQcU9UeFRhUlBB?oc=5",
+            "source_type": "news_rss",
+            "source_domain": "news.google.com",
+            "published_at": "2026-02-28T06:59:53+00:00",
+            "scheduled_date": null,
+            "scheduled_month": null,
+            "date_precision": "unknown",
+            "date_status": "rumor",
+            "release_format": "ep",
+            "confidence_score": 0.68
+          },
+          {
+            "headline": "BLACKPINK’s New Title Track Is ‘GO’.. YG “Created with Great Care”",
+            "source_url": "https://www.ygfamily.com/en/news/report/7378",
+            "source_type": "agency_notice",
+            "source_domain": "www.ygfamily.com",
+            "published_at": "2026-02-06T00:00:00+00:00",
+            "scheduled_date": null,
+            "scheduled_month": null,
+            "date_precision": "unknown",
+            "date_status": "rumor",
+            "release_format": "single",
+            "confidence_score": 0.64
+          },
+          {
+            "headline": "BLACKPINK Finally Reveals 'DEADLINE' Mini Album Release Date - TMZ",
+            "source_url": "https://news.google.com/rss/articles/CBMicEFVX3lxTE4waE5xc2U4eWNJaFhldTl2aGZEdGRxYl9DTVRRYnQ2Sk5rRGMtX2JHVVhiWFV3VTZJdUc1b1VoWWdmM25vcXhDb0dKSlBlanpHSlh2NDlHQ1hEMEtCalpvdkFudzNKZDJ0Y1VnVlpwOTA?oc=5",
+            "source_type": "news_rss",
+            "source_domain": "news.google.com",
+            "published_at": "2026-01-14T08:00:00+00:00",
+            "scheduled_date": null,
+            "scheduled_month": null,
+            "date_precision": "unknown",
+            "date_status": "rumor",
+            "release_format": "ep",
+            "confidence_score": 0.68
+          },
+          {
+            "headline": "Blackpink Sets Release Date for Comeback Album - Pitchfork",
+            "source_url": "https://news.google.com/rss/articles/CBMiekFVX3lxTE9Ucm80bHB0cUYwcHNhZkJxaWM1MnA5SnJUVzk0ZkdyQmg3b0Q2SXFudk41aXVRN1RjLURta0tvemNPdl8yaE10cVdHbkc2d3dnM3VxSDhtNWhlSGZtM3RYNzJFVThxRzhqWlFjSzR4ekNGM04tLWdWWW9n?oc=5",
+            "source_type": "news_rss",
+            "source_domain": "news.google.com",
+            "published_at": "2026-01-14T08:00:00+00:00",
+            "scheduled_date": null,
+            "scheduled_month": null,
+            "date_precision": "unknown",
+            "date_status": "rumor",
+            "release_format": "album",
+            "confidence_score": 0.68
+          },
+          {
+            "headline": "K-pop group Blackpink announces new mini album Deadline, out Feb 27 - CNA Lifestyle",
+            "source_url": "https://news.google.com/rss/articles/CBMirgFBVV95cUxOUFhWaFpuYnA5UDVRQmR0bHhuS2NIS2pfa255aDEzNGlFMHUzQ0p4MVRRLVVGUm13czJyclV5d3Rhd2xCakNqSmNaaDRtdkZhSWxqbk1VbWc0RzdMX3FjZ1RQTEY5RTV1czR6a3pXQmR4RS0wVVZNSHo3QllWLTBidzlESGpVNGwybzZ1Ti1Wc2VuLXE5WWk1U1Y2QlBtY1JWWXp6cjF3VGZwblhfclE?oc=5",
+            "source_type": "news_rss",
+            "source_domain": "news.google.com",
+            "published_at": "2026-01-14T08:00:00+00:00",
+            "scheduled_date": null,
+            "scheduled_month": null,
+            "date_precision": "unknown",
+            "date_status": "rumor",
+            "release_format": "ep",
+            "confidence_score": 0.68
+          }
+        ],
+        "artist_source_url": "https://musicbrainz.org/artist/48646387-1664-4c9a-9139-9bfd091b823c"
+      },
+      "actual_status_code": 200
+    },
+    {
+      "surface": "entity_detail",
+      "input": {
+        "slug": "and-team"
+      },
+      "clean": false,
+      "mismatch_categories": [
+        "field-shape mismatches",
+        "missing rows or segments",
+        "exact-vs-month-only drift"
+      ],
+      "mismatches": [
+        {
+          "category": "field-shape mismatches",
+          "path": "data",
+          "shape_mismatches": [
+            {
+              "path": "data.identity.badge_image_url",
+              "expected_type": "string",
+              "actual_type": "null",
+              "message": "Type mismatch"
+            },
+            {
+              "path": "data.next_upcoming",
+              "expected_type": "object",
+              "actual_type": "null",
+              "message": "Type mismatch"
+            },
+            {
+              "path": "data.source_timeline[0].event_type",
+              "expected_type": "string",
+              "actual_type": "missing",
+              "message": "Missing key"
+            },
+            {
+              "path": "data.source_timeline[0].occurred_at",
+              "expected_type": "string",
+              "actual_type": "missing",
+              "message": "Missing key"
+            },
+            {
+              "path": "data.source_timeline[0].summary",
+              "expected_type": "string",
+              "actual_type": "missing",
+              "message": "Missing key"
+            }
+          ]
+        },
+        {
+          "category": "missing rows or segments",
+          "path": "data.official_links.instagram",
+          "expected": "https://www.instagram.com/andteam_official/",
+          "actual": "https://www.instagram.com/andteam_official"
+        },
+        {
+          "category": "exact-vs-month-only drift",
+          "path": "data.next_upcoming",
+          "expected": {
+            "headline": "&TEAM sets April comeback with Japanese mini album ‘We on Fire’ - allkpop",
+            "scheduled_date": "",
+            "scheduled_month": "2026-04",
+            "date_precision": "month_only",
+            "date_status": "scheduled",
+            "release_format": "ep"
+          },
+          "actual": null
+        },
+        {
+          "category": "missing rows or segments",
+          "path": "data.source_timeline",
+          "expected": [
+            "release_verified|Back to Life|release_catalog|https://musicbrainz.org/release-group/159eca09-5a9a-4ee2-a1ea-56a08269229f",
+            "first_signal|&TEAM sets April comeback with Japanese mini album ‘We on Fire’ - allkpop|news_rss|https://news.google.com/rss/articles/CBMiogFBVV95cUxNdzN5MmFQbjJLQVdlcktGS1V1MkZnLUxhVDBjQnNlbmtXSkxOZTJCMjVkNXptekllbE5mY2VSanJqZXV5SGJ1T3BPM1huZWlhbWhYeGFsOW55UlFSMDlCY29BYjNDZWxWUGV1RjdNb09MRFFHbWdRdkRKanBTS3lNVS05Xy0yZzVVOGRLZF9Dc1RhT2hVRUFfMFlTX0RELUYtcHc?oc=5"
+          ],
+          "actual": [
+            "&TEAM sets April comeback with Japanese mini album ‘We on Fire’ - allkpop|news_rss|https://news.google.com/rss/articles/CBMiogFBVV95cUxNdzN5MmFQbjJLQVdlcktGS1V1MkZnLUxhVDBjQnNlbmtXSkxOZTJCMjVkNXptekllbE5mY2VSanJqZXV5SGJ1T3BPM1huZWlhbWhYeGFsOW55UlFSMDlCY29BYjNDZWxWUGV1RjdNb09MRFFHbWdRdkRKanBTS3lNVS05Xy0yZzVVOGRLZF9Dc1RhT2hVRUFfMFlTX0RELUYtcHc?oc=5"
+          ]
+        }
+      ],
+      "expected_snapshot": {
+        "identity": {
+          "entity_slug": "and-team",
+          "display_name": "&TEAM",
+          "canonical_name": "&TEAM",
+          "agency_name": "HYBE Labels",
+          "badge_image_url": "https://yt3.googleusercontent.com/xqtV6QEH8rfsXXZ1sZZRjn2X7ZCxKB0_eoWN6z5gnqtN8TnC-XQN8-OlMzDVvxrKKnwDDvRxQA=s900-c-k-c0x00ffffff-no-rj",
+          "representative_image_url": null,
+          "debut_year": null
+        },
+        "official_links": {
+          "youtube": "https://www.youtube.com/channel/UCHD1jo5RhijLfx5-0Ehe_cg",
+          "x": "https://x.com/andTEAMofficial",
+          "instagram": "https://www.instagram.com/andteam_official/"
+        },
+        "youtube_channels": {
+          "primary_team_channel_url": "https://www.youtube.com/channel/UCHD1jo5RhijLfx5-0Ehe_cg",
+          "mv_allowlist_urls": [
+            "https://www.youtube.com/channel/UCHD1jo5RhijLfx5-0Ehe_cg",
+            "https://www.youtube.com/@HYBELABELS"
+          ]
+        },
+        "tracking_state": {
+          "tier": "core",
+          "watch_reason": "recent_release",
+          "tracking_status": "recent_release"
+        },
+        "next_upcoming": {
+          "headline": "&TEAM sets April comeback with Japanese mini album ‘We on Fire’ - allkpop",
+          "scheduled_date": "",
+          "scheduled_month": "2026-04",
+          "date_precision": "month_only",
+          "date_status": "scheduled",
+          "confidence_score": 0.76,
+          "release_format": "ep"
+        },
+        "latest_release": {
+          "release_title": "Back to Life",
+          "release_date": "2025-10-28",
+          "stream": "album",
+          "release_kind": "ep"
+        },
+        "recent_albums": [
+          {
+            "release_title": "Back to Life",
+            "release_date": "2025-10-28",
+            "stream": "album",
+            "release_kind": "ep"
+          },
+          {
+            "release_title": "Go in Blind (月狼)",
+            "release_date": "2025-04-20",
+            "stream": "album",
+            "release_kind": "ep"
+          },
+          {
+            "release_title": "雪明かり (Yukiakari)",
+            "release_date": "2024-12-17",
+            "stream": "album",
+            "release_kind": "album"
+          },
+          {
+            "release_title": "First Howling : NOW",
+            "release_date": "2023-11-15",
+            "stream": "album",
+            "release_kind": "album"
+          },
+          {
+            "release_title": "First Howling : WE",
+            "release_date": "2023-06-14",
+            "stream": "album",
+            "release_kind": "ep"
+          },
+          {
+            "release_title": "First Howling : ME",
+            "release_date": "2022-12-06",
+            "stream": "album",
+            "release_kind": "ep"
+          }
+        ],
+        "source_timeline": [
+          {
+            "event_type": "release_verified",
+            "source_type": "release_catalog",
+            "headline": "Back to Life",
+            "source_url": "https://musicbrainz.org/release-group/159eca09-5a9a-4ee2-a1ea-56a08269229f",
+            "source_domain": "musicbrainz.org",
+            "occurred_at": "2025-10-28",
+            "summary": "Latest verified album record in the dataset for &TEAM, captured from the release catalog."
+          },
+          {
+            "event_type": "first_signal",
+            "source_type": "news_rss",
+            "headline": "&TEAM sets April comeback with Japanese mini album ‘We on Fire’ - allkpop",
+            "source_url": "https://news.google.com/rss/articles/CBMiogFBVV95cUxNdzN5MmFQbjJLQVdlcktGS1V1MkZnLUxhVDBjQnNlbmtXSkxOZTJCMjVkNXptekllbE5mY2VSanJqZXV5SGJ1T3BPM1huZWlhbWhYeGFsOW55UlFSMDlCY29BYjNDZWxWUGV1RjdNb09MRFFHbWdRdkRKanBTS3lNVS05Xy0yZzVVOGRLZF9Dc1RhT2hVRUFfMFlTX0RELUYtcHc?oc=5",
+            "source_domain": "news.google.com",
+            "occurred_at": "2026-02-12T09:38:51.000Z",
+            "summary": "Future month reference: 2026-04. &TEAM sets April comeback with Japanese mini album ‘We on Fire’ allkpop"
+          }
+        ],
+        "artist_source_url": "https://musicbrainz.org/artist/bba737dc-7ec8-482d-b79f-68d949ef2c7f"
+      },
+      "actual_snapshot": {
+        "identity": {
+          "entity_slug": "and-team",
+          "display_name": "&TEAM",
+          "canonical_name": "&TEAM",
+          "entity_type": "group",
+          "agency_name": "HYBE Labels",
+          "debut_year": null,
+          "badge_image_url": null,
+          "representative_image_url": null
+        },
+        "official_links": {
+          "youtube": "https://www.youtube.com/channel/UCHD1jo5RhijLfx5-0Ehe_cg",
+          "x": "https://x.com/andTEAMofficial",
+          "instagram": "https://www.instagram.com/andteam_official"
+        },
+        "youtube_channels": {
+          "primary_team_channel_url": "https://www.youtube.com/channel/UCHD1jo5RhijLfx5-0Ehe_cg",
+          "mv_allowlist_urls": [
+            "https://www.youtube.com/@HYBELABELS",
+            "https://www.youtube.com/channel/UCHD1jo5RhijLfx5-0Ehe_cg"
+          ]
+        },
+        "tracking_state": {
+          "tier": "core",
+          "watch_reason": "recent_release",
+          "tracking_status": "recent_release"
+        },
+        "next_upcoming": null,
+        "latest_release": {
+          "release_id": "085eff5b-a7ab-5798-b23c-2d1db3d22420",
+          "release_title": "Back to Life",
+          "release_date": "2025-10-28",
+          "stream": "album",
+          "release_kind": "ep"
+        },
+        "recent_albums": [
+          {
+            "release_id": "085eff5b-a7ab-5798-b23c-2d1db3d22420",
+            "release_title": "Back to Life",
+            "release_date": "2025-10-28",
+            "stream": "album",
+            "release_kind": "ep"
+          },
+          {
+            "release_id": "1752455a-9838-5209-8c3e-14e7ddba6595",
+            "release_title": "Go in Blind (月狼)",
+            "release_date": "2025-04-20",
+            "stream": "album",
+            "release_kind": "ep"
+          },
+          {
+            "release_id": "4953a8e4-60a7-5eb2-95ad-9108f883211c",
+            "release_title": "雪明かり (Yukiakari)",
+            "release_date": "2024-12-17",
+            "stream": "album",
+            "release_kind": "album"
+          },
+          {
+            "release_id": "60649bc4-3862-5435-b11e-74efc4cd6c41",
+            "release_title": "First Howling : NOW",
+            "release_date": "2023-11-15",
+            "stream": "album",
+            "release_kind": "album"
+          },
+          {
+            "release_id": "1e32ea5c-2ccc-5a27-807c-d1e1b24cc39f",
+            "release_title": "First Howling : WE",
+            "release_date": "2023-06-14",
+            "stream": "album",
+            "release_kind": "ep"
+          },
+          {
+            "release_id": "e0f26669-7cae-59e0-aed7-ce93b60a1df3",
+            "release_title": "First Howling : ME",
+            "release_date": "2022-12-06",
+            "stream": "album",
+            "release_kind": "ep"
+          }
+        ],
+        "source_timeline": [
+          {
+            "headline": "&TEAM sets April comeback with Japanese mini album ‘We on Fire’ - allkpop",
+            "source_url": "https://news.google.com/rss/articles/CBMiogFBVV95cUxNdzN5MmFQbjJLQVdlcktGS1V1MkZnLUxhVDBjQnNlbmtXSkxOZTJCMjVkNXptekllbE5mY2VSanJqZXV5SGJ1T3BPM1huZWlhbWhYeGFsOW55UlFSMDlCY29BYjNDZWxWUGV1RjdNb09MRFFHbWdRdkRKanBTS3lNVS05Xy0yZzVVOGRLZF9Dc1RhT2hVRUFfMFlTX0RELUYtcHc?oc=5",
+            "source_type": "news_rss",
+            "source_domain": "news.google.com",
+            "published_at": "2026-02-12T09:38:51+00:00",
+            "scheduled_date": null,
+            "scheduled_month": "2026-04-01",
+            "date_precision": "month_only",
+            "date_status": "scheduled",
+            "release_format": "ep",
+            "confidence_score": 0.76
+          }
+        ],
+        "artist_source_url": "https://musicbrainz.org/artist/bba737dc-7ec8-482d-b79f-68d949ef2c7f"
+      },
+      "actual_status_code": 200
+    },
+    {
+      "surface": "entity_detail",
+      "input": {
+        "slug": "allday-project"
+      },
+      "clean": false,
+      "mismatch_categories": [
+        "missing rows or segments",
+        "latest-release or next-upcoming drift"
+      ],
+      "mismatches": [
+        {
+          "category": "missing rows or segments",
+          "path": "data.artist_source_url",
+          "expected": null,
+          "actual": "https://musicbrainz.org/artist/ce5c564c-0fbe-429c-b93b-5d7e3109cf40"
+        },
+        {
+          "category": "latest-release or next-upcoming drift",
+          "path": "data.latest_release",
+          "expected": {
+            "release_title": "ALLDAY PROJECT",
+            "release_date": "2025-12-08",
+            "stream": "watchlist",
+            "release_kind": "ep"
+          },
+          "actual": {
+            "release_title": "ALLDAY PROJECT",
+            "release_date": "2025-12-08",
+            "stream": "album",
+            "release_kind": "ep"
+          }
+        }
+      ],
+      "expected_snapshot": {
+        "identity": {
+          "entity_slug": "allday-project",
+          "display_name": "ALLDAY PROJECT",
+          "canonical_name": "ALLDAY PROJECT",
+          "agency_name": null,
+          "badge_image_url": null,
+          "representative_image_url": null,
+          "debut_year": 2025
+        },
+        "official_links": {
+          "youtube": null,
+          "x": null,
+          "instagram": null
+        },
+        "youtube_channels": {
+          "primary_team_channel_url": null,
+          "mv_allowlist_urls": []
+        },
+        "tracking_state": {
+          "tier": "manual",
+          "watch_reason": "manual_watch",
+          "tracking_status": "watch_only"
+        },
+        "next_upcoming": null,
+        "latest_release": {
+          "release_title": "ALLDAY PROJECT",
+          "release_date": "2025-12-08",
+          "stream": "watchlist",
+          "release_kind": "ep"
+        },
+        "recent_albums": [
+          {
+            "release_title": "ALLDAY PROJECT",
+            "release_date": "2025-12-08",
+            "stream": "album",
+            "release_kind": "ep"
+          }
+        ],
+        "source_timeline": [],
+        "artist_source_url": null
+      },
+      "actual_snapshot": {
+        "identity": {
+          "entity_slug": "allday-project",
+          "display_name": "ALLDAY PROJECT",
+          "canonical_name": "ALLDAY PROJECT",
+          "entity_type": "project",
+          "agency_name": null,
+          "debut_year": 2025,
+          "badge_image_url": null,
+          "representative_image_url": null
+        },
+        "official_links": {
+          "youtube": null,
+          "x": null,
+          "instagram": null
+        },
+        "youtube_channels": {
+          "primary_team_channel_url": null,
+          "mv_allowlist_urls": []
+        },
+        "tracking_state": {
+          "tier": "manual",
+          "watch_reason": "manual_watch",
+          "tracking_status": "watch_only"
+        },
+        "next_upcoming": null,
+        "latest_release": {
+          "release_id": "c00920b0-930d-5662-9874-82603c0ad5f7",
+          "release_title": "ALLDAY PROJECT",
+          "release_date": "2025-12-08",
+          "stream": "album",
+          "release_kind": "ep"
+        },
+        "recent_albums": [
+          {
+            "release_id": "c00920b0-930d-5662-9874-82603c0ad5f7",
+            "release_title": "ALLDAY PROJECT",
+            "release_date": "2025-12-08",
+            "stream": "album",
+            "release_kind": "ep"
+          }
+        ],
+        "source_timeline": [],
+        "artist_source_url": "https://musicbrainz.org/artist/ce5c564c-0fbe-429c-b93b-5d7e3109cf40"
+      },
+      "actual_status_code": 200
+    },
+    {
+      "surface": "release_detail",
+      "input": {
+        "entitySlug": "blackpink",
+        "title": "DEADLINE",
+        "date": "2026-02-26",
+        "stream": "album"
+      },
+      "clean": false,
+      "mismatch_categories": [
+        "field-shape mismatches",
+        "missing rows or segments"
+      ],
+      "mismatches": [
+        {
+          "category": "field-shape mismatches",
+          "path": "data",
+          "shape_mismatches": [
+            {
+              "path": "data.entity_slug",
+              "expected_type": "string",
+              "actual_type": "missing",
+              "message": "Missing key"
+            },
+            {
+              "path": "data.release_title",
+              "expected_type": "string",
+              "actual_type": "missing",
+              "message": "Missing key"
+            },
+            {
+              "path": "data.release_date",
+              "expected_type": "string",
+              "actual_type": "missing",
+              "message": "Missing key"
+            },
+            {
+              "path": "data.stream",
+              "expected_type": "string",
+              "actual_type": "missing",
+              "message": "Missing key"
+            },
+            {
+              "path": "data.release_kind",
+              "expected_type": "string",
+              "actual_type": "missing",
+              "message": "Missing key"
+            },
+            {
+              "path": "data.display_name",
+              "expected_type": "string",
+              "actual_type": "missing",
+              "message": "Missing key"
+            }
+          ]
+        },
+        {
+          "category": "missing rows or segments",
+          "path": "data.detail.artwork",
+          "expected": {
+            "cover_image_url": "https://coverartarchive.org/release-group/38204997-b295-4d09-a946-f7e119725031/front",
+            "thumbnail_image_url": "https://coverartarchive.org/release-group/38204997-b295-4d09-a946-f7e119725031/front-250",
+            "artwork_source_type": "cover_art_archive",
+            "artwork_source_url": "https://coverartarchive.org/release-group/38204997-b295-4d09-a946-f7e119725031"
+          },
+          "actual": {
+            "cover_image_url": "https://coverartarchive.org/release-group/38204997-b295-4d09-a946-f7e119725031/front",
+            "artwork_source_url": "https://coverartarchive.org/release-group/38204997-b295-4d09-a946-f7e119725031",
+            "artwork_source_type": "cover_art_archive",
+            "thumbnail_image_url": "https://coverartarchive.org/release-group/38204997-b295-4d09-a946-f7e119725031/front-250"
+          }
+        },
+        {
+          "category": "missing rows or segments",
+          "path": "data.detail.service_links.spotify",
+          "expected": {
+            "url": "https://open.spotify.com/album/0al74j1n8XIEkZMMFRfsbx",
+            "status": "canonical"
+          },
+          "actual": {
+            "url": "https://open.spotify.com/album/0al74j1n8XIEkZMMFRfsbx",
+            "status": "canonical",
+            "provenance": "releaseDetails.spotify_url"
+          }
+        },
+        {
+          "category": "missing rows or segments",
+          "path": "data.detail.service_links.youtube_music",
+          "expected": {
+            "url": "https://music.youtube.com/playlist?list=OLAK5uy_l3QGS6y9ZWficqzcu429HoCvcKlpMmmmY",
+            "status": "canonical"
+          },
+          "actual": {
+            "url": "https://music.youtube.com/playlist?list=OLAK5uy_l3QGS6y9ZWficqzcu429HoCvcKlpMmmmY",
+            "status": "manual_override",
+            "provenance": "ytmusicapi exact album search match"
+          }
+        },
+        {
+          "category": "missing rows or segments",
+          "path": "data.detail.credits",
+          "expected": [
+            {
+              "role": "lyrics",
+              "names": [
+                "Deadline Writers Camp"
+              ]
+            },
+            {
+              "role": "composition",
+              "names": [
+                "Atlas Signal Team",
+                "Midnight Loop"
+              ]
+            },
+            {
+              "role": "arrangement",
+              "names": [
+                "Neon Bureau",
+                "City Echo"
+              ]
+            }
+          ],
+          "actual": []
+        },
+        {
+          "category": "missing rows or segments",
+          "path": "data.detail.charts",
+          "expected": [
+            {
+              "source": "Seed weekly board",
+              "label": "Album momentum",
+              "peak": "#1",
+              "dated_at": "2026-03-02"
+            },
+            {
+              "source": "Seed global board",
+              "label": "Cross-market pickup",
+              "peak": "#2",
+              "dated_at": "2026-03-04"
+            }
+          ],
+          "actual": []
+        }
+      ],
+      "expected_snapshot": {
+        "lookup": {
+          "entity_slug": "blackpink",
+          "release_title": "DEADLINE",
+          "release_date": "2026-02-26",
+          "stream": "album",
+          "release_kind": "ep",
+          "display_name": "BLACKPINK"
+        },
+        "detail": {
+          "release": {
+            "entity_slug": "blackpink",
+            "display_name": "BLACKPINK",
+            "release_title": "DEADLINE",
+            "release_date": "2026-02-26",
+            "stream": "album",
+            "release_kind": "ep"
+          },
+          "artwork": {
+            "cover_image_url": "https://coverartarchive.org/release-group/38204997-b295-4d09-a946-f7e119725031/front",
+            "thumbnail_image_url": "https://coverartarchive.org/release-group/38204997-b295-4d09-a946-f7e119725031/front-250",
+            "artwork_source_type": "cover_art_archive",
+            "artwork_source_url": "https://coverartarchive.org/release-group/38204997-b295-4d09-a946-f7e119725031"
+          },
+          "service_links": {
+            "spotify": {
+              "url": "https://open.spotify.com/album/0al74j1n8XIEkZMMFRfsbx",
+              "status": "canonical"
+            },
+            "youtube_music": {
+              "url": "https://music.youtube.com/playlist?list=OLAK5uy_l3QGS6y9ZWficqzcu429HoCvcKlpMmmmY",
+              "status": "canonical"
+            }
+          },
+          "tracks": [
+            {
+              "order": 1,
+              "title": "JUMP",
+              "is_title_track": false
+            },
+            {
+              "order": 2,
+              "title": "GO",
+              "is_title_track": true
+            },
+            {
+              "order": 3,
+              "title": "Me and my",
+              "is_title_track": false
+            },
+            {
+              "order": 4,
+              "title": "Champion",
+              "is_title_track": false
+            },
+            {
+              "order": 5,
+              "title": "Fxxxboy",
+              "is_title_track": false
+            }
+          ],
+          "mv": {
+            "url": "https://www.youtube.com/watch?v=2GJfWMYCWY0",
+            "video_id": "2GJfWMYCWY0",
+            "status": "manual_override",
+            "provenance": "official artist channel watch URL"
+          },
+          "credits": [
+            {
+              "role": "lyrics",
+              "names": [
+                "[truncated]"
+              ]
+            },
+            {
+              "role": "composition",
+              "names": [
+                "[truncated]",
+                "[truncated]"
+              ]
+            },
+            {
+              "role": "arrangement",
+              "names": [
+                "[truncated]",
+                "[truncated]"
+              ]
+            }
+          ],
+          "charts": [
+            {
+              "source": "Seed weekly board",
+              "label": "Album momentum",
+              "peak": "#1",
+              "dated_at": "2026-03-02"
+            },
+            {
+              "source": "Seed global board",
+              "label": "Cross-market pickup",
+              "peak": "#2",
+              "dated_at": "2026-03-04"
+            }
+          ],
+          "notes": "Representative MusicBrainz EP seed with 5 tracks. Canonical links: Spotify. Canonical YouTube Music URL preserved from release_detail_overrides.json (ytmusicapi exact album search match). Canonical YouTube MV preserved from release_detail_overrides.json (official artist channel watch URL)."
+        }
+      },
+      "actual_snapshot": {
+        "lookup": {
+          "release_id": "e3526174-e804-56f2-9d50-17f9f817a351",
+          "canonical_path": "/v1/releases/e3526174-e804-56f2-9d50-17f9f817a351",
+          "release": {
+            "release_id": "e3526174-e804-56f2-9d50-17f9f817a351",
+            "entity_slug": "blackpink",
+            "display_name": "BLACKPINK",
+            "release_title": "DEADLINE",
+            "release_date": "2026-02-26",
+            "stream": "album",
+            "release_kind": "ep"
+          }
+        },
+        "detail": {
+          "release": {
+            "release_id": "e3526174-e804-56f2-9d50-17f9f817a351",
+            "entity_slug": "blackpink",
+            "display_name": "BLACKPINK",
+            "release_title": "DEADLINE",
+            "release_date": "2026-02-26",
+            "stream": "album",
+            "release_kind": "ep"
+          },
+          "artwork": {
+            "cover_image_url": "https://coverartarchive.org/release-group/38204997-b295-4d09-a946-f7e119725031/front",
+            "artwork_source_url": "https://coverartarchive.org/release-group/38204997-b295-4d09-a946-f7e119725031",
+            "artwork_source_type": "cover_art_archive",
+            "thumbnail_image_url": "https://coverartarchive.org/release-group/38204997-b295-4d09-a946-f7e119725031/front-250"
+          },
+          "service_links": {
+            "spotify": {
+              "url": "https://open.spotify.com/album/0al74j1n8XIEkZMMFRfsbx",
+              "status": "canonical",
+              "provenance": "releaseDetails.spotify_url"
+            },
+            "youtube_music": {
+              "url": "https://music.youtube.com/playlist?list=OLAK5uy_l3QGS6y9ZWficqzcu429HoCvcKlpMmmmY",
+              "status": "manual_override",
+              "provenance": "ytmusicapi exact album search match"
+            }
+          },
+          "tracks": [
+            {
+              "track_id": "9ccf1a37-0d13-5707-a429-1cc23b0d8dc4",
+              "order": 1,
+              "title": "JUMP",
+              "is_title_track": false,
+              "spotify": null,
+              "youtube_music": null
+            },
+            {
+              "track_id": "8a2931df-280f-59df-84d4-bc84637dc9d8",
+              "order": 2,
+              "title": "GO",
+              "is_title_track": true,
+              "spotify": null,
+              "youtube_music": null
+            },
+            {
+              "track_id": "d4ed0ed9-6dde-52e7-bd98-f2778a132d99",
+              "order": 3,
+              "title": "Me and my",
+              "is_title_track": false,
+              "spotify": null,
+              "youtube_music": null
+            },
+            {
+              "track_id": "97402bab-4bcd-5f28-bf5c-2fdb4e83338b",
+              "order": 4,
+              "title": "Champion",
+              "is_title_track": false,
+              "spotify": null,
+              "youtube_music": null
+            },
+            {
+              "track_id": "7186b0a1-0ee0-5fa7-8bfa-e8d3f1ca99db",
+              "order": 5,
+              "title": "Fxxxboy",
+              "is_title_track": false,
+              "spotify": null,
+              "youtube_music": null
+            }
+          ],
+          "mv": {
+            "url": "https://www.youtube.com/watch?v=2GJfWMYCWY0",
+            "video_id": "2GJfWMYCWY0",
+            "status": "manual_override",
+            "provenance": "official artist channel watch URL"
+          },
+          "credits": [],
+          "charts": [],
+          "notes": "Representative MusicBrainz EP seed with 5 tracks. Canonical links: Spotify. Canonical YouTube Music URL preserved from release_detail_overrides.json (ytmusicapi exact album search match). Canonical YouTube MV preserved from release_detail_overrides.json (official artist channel watch URL)."
+        }
+      },
+      "lookup_status_code": 200,
+      "detail_status_code": 200
+    },
+    {
+      "surface": "release_detail",
+      "input": {
+        "entitySlug": "ive",
+        "title": "REVIVE+",
+        "date": "2026-02-23",
+        "stream": "album"
+      },
+      "clean": false,
+      "mismatch_categories": [
+        "field-shape mismatches",
+        "missing rows or segments"
+      ],
+      "mismatches": [
+        {
+          "category": "field-shape mismatches",
+          "path": "data",
+          "shape_mismatches": [
+            {
+              "path": "data.entity_slug",
+              "expected_type": "string",
+              "actual_type": "missing",
+              "message": "Missing key"
+            },
+            {
+              "path": "data.release_title",
+              "expected_type": "string",
+              "actual_type": "missing",
+              "message": "Missing key"
+            },
+            {
+              "path": "data.release_date",
+              "expected_type": "string",
+              "actual_type": "missing",
+              "message": "Missing key"
+            },
+            {
+              "path": "data.stream",
+              "expected_type": "string",
+              "actual_type": "missing",
+              "message": "Missing key"
+            },
+            {
+              "path": "data.release_kind",
+              "expected_type": "string",
+              "actual_type": "missing",
+              "message": "Missing key"
+            },
+            {
+              "path": "data.display_name",
+              "expected_type": "string",
+              "actual_type": "missing",
+              "message": "Missing key"
+            }
+          ]
+        },
+        {
+          "category": "missing rows or segments",
+          "path": "data.detail.artwork",
+          "expected": {
+            "cover_image_url": "https://coverartarchive.org/release-group/5a37b657-9f1d-4bce-b85f-9b1f5b72feca/front",
+            "thumbnail_image_url": "https://coverartarchive.org/release-group/5a37b657-9f1d-4bce-b85f-9b1f5b72feca/front-250",
+            "artwork_source_type": "cover_art_archive",
+            "artwork_source_url": "https://coverartarchive.org/release-group/5a37b657-9f1d-4bce-b85f-9b1f5b72feca"
+          },
+          "actual": {
+            "cover_image_url": "https://coverartarchive.org/release-group/5a37b657-9f1d-4bce-b85f-9b1f5b72feca/front",
+            "artwork_source_url": "https://coverartarchive.org/release-group/5a37b657-9f1d-4bce-b85f-9b1f5b72feca",
+            "artwork_source_type": "cover_art_archive",
+            "thumbnail_image_url": "https://coverartarchive.org/release-group/5a37b657-9f1d-4bce-b85f-9b1f5b72feca/front-250"
+          }
+        },
+        {
+          "category": "missing rows or segments",
+          "path": "data.detail.service_links.spotify",
+          "expected": {
+            "url": null,
+            "status": "no_link"
+          },
+          "actual": {
+            "url": null,
+            "status": "no_link",
+            "provenance": null
+          }
+        },
+        {
+          "category": "missing rows or segments",
+          "path": "data.detail.service_links.youtube_music",
+          "expected": {
+            "url": "https://music.youtube.com/playlist?list=OLAK5uy_nO8Pcb0tAIwvqIb6on8b1QXJ1VhnHHgdE",
+            "status": "canonical"
+          },
+          "actual": {
+            "url": "https://music.youtube.com/playlist?list=OLAK5uy_nO8Pcb0tAIwvqIb6on8b1QXJ1VhnHHgdE",
+            "status": "manual_override",
+            "provenance": "ytmusicapi exact album search match"
+          }
+        },
+        {
+          "category": "missing rows or segments",
+          "path": "data.detail.credits",
+          "expected": [
+            {
+              "role": "lyrics",
+              "names": [
+                "Velvet Draft Unit",
+                "Studio Seed"
+              ]
+            },
+            {
+              "role": "composition",
+              "names": [
+                "Aurora Pattern Lab",
+                "Mono Harbor"
+              ]
+            },
+            {
+              "role": "arrangement",
+              "names": [
+                "Frame Signal"
+              ]
+            }
+          ],
+          "actual": []
+        },
+        {
+          "category": "missing rows or segments",
+          "path": "data.detail.charts",
+          "expected": [
+            {
+              "source": "Seed weekly board",
+              "label": "Album momentum",
+              "peak": "#2",
+              "dated_at": "2026-03-01"
+            }
+          ],
+          "actual": []
+        }
+      ],
+      "expected_snapshot": {
+        "lookup": {
+          "entity_slug": "ive",
+          "release_title": "REVIVE+",
+          "release_date": "2026-02-23",
+          "stream": "album",
+          "release_kind": "album",
+          "display_name": "IVE"
+        },
+        "detail": {
+          "release": {
+            "entity_slug": "ive",
+            "display_name": "IVE",
+            "release_title": "REVIVE+",
+            "release_date": "2026-02-23",
+            "stream": "album",
+            "release_kind": "album"
+          },
+          "artwork": {
+            "cover_image_url": "https://coverartarchive.org/release-group/5a37b657-9f1d-4bce-b85f-9b1f5b72feca/front",
+            "thumbnail_image_url": "https://coverartarchive.org/release-group/5a37b657-9f1d-4bce-b85f-9b1f5b72feca/front-250",
+            "artwork_source_type": "cover_art_archive",
+            "artwork_source_url": "https://coverartarchive.org/release-group/5a37b657-9f1d-4bce-b85f-9b1f5b72feca"
+          },
+          "service_links": {
+            "spotify": {
+              "url": null,
+              "status": "no_link"
+            },
+            "youtube_music": {
+              "url": "https://music.youtube.com/playlist?list=OLAK5uy_nO8Pcb0tAIwvqIb6on8b1QXJ1VhnHHgdE",
+              "status": "canonical"
+            }
+          },
+          "tracks": [
+            {
+              "order": 1,
+              "title": "BLACKHOLE",
+              "is_title_track": true
+            },
+            {
+              "order": 2,
+              "title": "BANG BANG",
+              "is_title_track": true
+            },
+            {
+              "order": 3,
+              "title": "숨바꼭질 (Hush)",
+              "is_title_track": false
+            },
+            {
+              "order": 4,
+              "title": "악성코드 (Stuck in Your Head)",
+              "is_title_track": false
+            },
+            {
+              "order": 5,
+              "title": "Fireworks",
+              "is_title_track": false
+            },
+            {
+              "order": 6,
+              "title": "HOT COFFEE",
+              "is_title_track": false
+            },
+            {
+              "order": 7,
+              "title": "8",
+              "is_title_track": false
+            },
+            {
+              "order": 8,
+              "title": "Odd",
+              "is_title_track": false
+            },
+            {
+              "order": 9,
+              "title": "Super ICY",
+              "is_title_track": false
+            },
+            {
+              "order": 10,
+              "title": "Unreal",
+              "is_title_track": false
+            },
+            {
+              "order": 11,
+              "title": "In Your Heart",
+              "is_title_track": false
+            },
+            {
+              "order": 12,
+              "title": "Force",
+              "is_title_track": false
+            }
+          ],
+          "mv": {
+            "url": null,
+            "video_id": null,
+            "status": "unresolved",
+            "provenance": null
+          },
+          "credits": [
+            {
+              "role": "lyrics",
+              "names": [
+                "[truncated]",
+                "[truncated]"
+              ]
+            },
+            {
+              "role": "composition",
+              "names": [
+                "[truncated]",
+                "[truncated]"
+              ]
+            },
+            {
+              "role": "arrangement",
+              "names": [
+                "[truncated]"
+              ]
+            }
+          ],
+          "charts": [
+            {
+              "source": "Seed weekly board",
+              "label": "Album momentum",
+              "peak": "#2",
+              "dated_at": "2026-03-01"
+            }
+          ],
+          "notes": "Representative MusicBrainz ALBUM seed with 12 tracks. Canonical YouTube Music URL preserved from release_detail_overrides.json (ytmusicapi exact album search match)."
+        }
+      },
+      "actual_snapshot": {
+        "lookup": {
+          "release_id": "c339f501-52fe-599d-8d2d-bf5694ae4de4",
+          "canonical_path": "/v1/releases/c339f501-52fe-599d-8d2d-bf5694ae4de4",
+          "release": {
+            "release_id": "c339f501-52fe-599d-8d2d-bf5694ae4de4",
+            "entity_slug": "ive",
+            "display_name": "IVE",
+            "release_title": "REVIVE+",
+            "release_date": "2026-02-23",
+            "stream": "album",
+            "release_kind": "album"
+          }
+        },
+        "detail": {
+          "release": {
+            "release_id": "c339f501-52fe-599d-8d2d-bf5694ae4de4",
+            "entity_slug": "ive",
+            "display_name": "IVE",
+            "release_title": "REVIVE+",
+            "release_date": "2026-02-23",
+            "stream": "album",
+            "release_kind": "album"
+          },
+          "artwork": {
+            "cover_image_url": "https://coverartarchive.org/release-group/5a37b657-9f1d-4bce-b85f-9b1f5b72feca/front",
+            "artwork_source_url": "https://coverartarchive.org/release-group/5a37b657-9f1d-4bce-b85f-9b1f5b72feca",
+            "artwork_source_type": "cover_art_archive",
+            "thumbnail_image_url": "https://coverartarchive.org/release-group/5a37b657-9f1d-4bce-b85f-9b1f5b72feca/front-250"
+          },
+          "service_links": {
+            "spotify": {
+              "url": null,
+              "status": "no_link",
+              "provenance": null
+            },
+            "youtube_music": {
+              "url": "https://music.youtube.com/playlist?list=OLAK5uy_nO8Pcb0tAIwvqIb6on8b1QXJ1VhnHHgdE",
+              "status": "manual_override",
+              "provenance": "ytmusicapi exact album search match"
+            }
+          },
+          "tracks": [
+            {
+              "track_id": "43ef3406-00f3-51bf-a60e-fdb1d869270e",
+              "order": 1,
+              "title": "BLACKHOLE",
+              "is_title_track": true,
+              "spotify": null,
+              "youtube_music": null
+            },
+            {
+              "track_id": "d94ebc8a-ac55-551d-8723-debbaaff6e4e",
+              "order": 2,
+              "title": "BANG BANG",
+              "is_title_track": true,
+              "spotify": null,
+              "youtube_music": null
+            },
+            {
+              "track_id": "9d839d27-5532-5b65-825b-b000cc0051be",
+              "order": 3,
+              "title": "숨바꼭질 (Hush)",
+              "is_title_track": false,
+              "spotify": null,
+              "youtube_music": null
+            },
+            {
+              "track_id": "337ca635-7cab-5351-9b6a-9dd9f32a833b",
+              "order": 4,
+              "title": "악성코드 (Stuck in Your Head)",
+              "is_title_track": false,
+              "spotify": null,
+              "youtube_music": null
+            },
+            {
+              "track_id": "13e6b565-f48b-5baa-86c1-eb143230ea55",
+              "order": 5,
+              "title": "Fireworks",
+              "is_title_track": false,
+              "spotify": null,
+              "youtube_music": null
+            },
+            {
+              "track_id": "6fdf7055-67a3-5915-9bca-518a4f11dc1c",
+              "order": 6,
+              "title": "HOT COFFEE",
+              "is_title_track": false,
+              "spotify": null,
+              "youtube_music": null
+            },
+            {
+              "track_id": "79db0db8-0054-5990-afb9-234715b1b7da",
+              "order": 7,
+              "title": "8",
+              "is_title_track": false,
+              "spotify": null,
+              "youtube_music": null
+            },
+            {
+              "track_id": "c2e390ca-ad10-52f1-83b3-1255a5edc811",
+              "order": 8,
+              "title": "Odd",
+              "is_title_track": false,
+              "spotify": null,
+              "youtube_music": null
+            },
+            {
+              "track_id": "f361782c-55a3-5dea-a8ed-030faa75d8e0",
+              "order": 9,
+              "title": "Super ICY",
+              "is_title_track": false,
+              "spotify": null,
+              "youtube_music": null
+            },
+            {
+              "track_id": "e61c7105-6ce5-5d00-99b7-f9dad1e26598",
+              "order": 10,
+              "title": "Unreal",
+              "is_title_track": false,
+              "spotify": null,
+              "youtube_music": null
+            },
+            {
+              "track_id": "f292c4bf-92df-5418-9aba-135fbbe9de2f",
+              "order": 11,
+              "title": "In Your Heart",
+              "is_title_track": false,
+              "spotify": null,
+              "youtube_music": null
+            },
+            {
+              "track_id": "9f9457ff-b8e4-5e97-b095-b4cc41650077",
+              "order": 12,
+              "title": "Force",
+              "is_title_track": false,
+              "spotify": null,
+              "youtube_music": null
+            }
+          ],
+          "mv": {
+            "url": null,
+            "video_id": null,
+            "status": "unresolved",
+            "provenance": null
+          },
+          "credits": [],
+          "charts": [],
+          "notes": "Representative MusicBrainz ALBUM seed with 12 tracks. Canonical YouTube Music URL preserved from release_detail_overrides.json (ytmusicapi exact album search match)."
+        }
+      },
+      "lookup_status_code": 200,
+      "detail_status_code": 200
+    },
+    {
+      "surface": "release_detail",
+      "input": {
+        "entitySlug": "qwer",
+        "title": "흰수염고래",
+        "date": "2025-10-06",
+        "stream": "song"
+      },
+      "clean": false,
+      "mismatch_categories": [
+        "field-shape mismatches",
+        "missing rows or segments"
+      ],
+      "mismatches": [
+        {
+          "category": "field-shape mismatches",
+          "path": "data",
+          "shape_mismatches": [
+            {
+              "path": "data.entity_slug",
+              "expected_type": "string",
+              "actual_type": "missing",
+              "message": "Missing key"
+            },
+            {
+              "path": "data.release_title",
+              "expected_type": "string",
+              "actual_type": "missing",
+              "message": "Missing key"
+            },
+            {
+              "path": "data.release_date",
+              "expected_type": "string",
+              "actual_type": "missing",
+              "message": "Missing key"
+            },
+            {
+              "path": "data.stream",
+              "expected_type": "string",
+              "actual_type": "missing",
+              "message": "Missing key"
+            },
+            {
+              "path": "data.release_kind",
+              "expected_type": "string",
+              "actual_type": "missing",
+              "message": "Missing key"
+            },
+            {
+              "path": "data.display_name",
+              "expected_type": "string",
+              "actual_type": "missing",
+              "message": "Missing key"
+            }
+          ]
+        },
+        {
+          "category": "missing rows or segments",
+          "path": "data.detail.artwork",
+          "expected": {
+            "cover_image_url": "https://coverartarchive.org/release-group/f6027192-7e1d-4e68-a82b-b43cab18efea/front",
+            "thumbnail_image_url": "https://coverartarchive.org/release-group/f6027192-7e1d-4e68-a82b-b43cab18efea/front-250",
+            "artwork_source_type": "cover_art_archive",
+            "artwork_source_url": "https://coverartarchive.org/release-group/f6027192-7e1d-4e68-a82b-b43cab18efea"
+          },
+          "actual": {
+            "cover_image_url": "https://coverartarchive.org/release-group/f6027192-7e1d-4e68-a82b-b43cab18efea/front",
+            "artwork_source_url": "https://coverartarchive.org/release-group/f6027192-7e1d-4e68-a82b-b43cab18efea",
+            "artwork_source_type": "cover_art_archive",
+            "thumbnail_image_url": "https://coverartarchive.org/release-group/f6027192-7e1d-4e68-a82b-b43cab18efea/front-250"
+          }
+        },
+        {
+          "category": "missing rows or segments",
+          "path": "data.detail.service_links.spotify",
+          "expected": {
+            "url": null,
+            "status": "no_link"
+          },
+          "actual": {
+            "url": null,
+            "status": "no_link",
+            "provenance": null
+          }
+        },
+        {
+          "category": "missing rows or segments",
+          "path": "data.detail.service_links.youtube_music",
+          "expected": {
+            "url": null,
+            "status": "no_link"
+          },
+          "actual": {
+            "url": null,
+            "status": "no_link",
+            "provenance": null
+          }
+        }
+      ],
+      "expected_snapshot": {
+        "lookup": {
+          "entity_slug": "qwer",
+          "release_title": "흰수염고래",
+          "release_date": "2025-10-06",
+          "stream": "song",
+          "release_kind": "single",
+          "display_name": "QWER"
+        },
+        "detail": {
+          "release": {
+            "entity_slug": "qwer",
+            "display_name": "QWER",
+            "release_title": "흰수염고래",
+            "release_date": "2025-10-06",
+            "stream": "song",
+            "release_kind": "single"
+          },
+          "artwork": {
+            "cover_image_url": "https://coverartarchive.org/release-group/f6027192-7e1d-4e68-a82b-b43cab18efea/front",
+            "thumbnail_image_url": "https://coverartarchive.org/release-group/f6027192-7e1d-4e68-a82b-b43cab18efea/front-250",
+            "artwork_source_type": "cover_art_archive",
+            "artwork_source_url": "https://coverartarchive.org/release-group/f6027192-7e1d-4e68-a82b-b43cab18efea"
+          },
+          "service_links": {
+            "spotify": {
+              "url": null,
+              "status": "no_link"
+            },
+            "youtube_music": {
+              "url": null,
+              "status": "no_link"
+            }
+          },
+          "tracks": [
+            {
+              "order": 1,
+              "title": "흰수염고래",
+              "is_title_track": true
+            }
+          ],
+          "mv": {
+            "url": null,
+            "video_id": null,
+            "status": "needs_review",
+            "provenance": "Official YouTube search currently surfaces a special clip instead of a clearly canonical MV object."
+          },
+          "credits": [],
+          "charts": [],
+          "notes": "Representative MusicBrainz SINGLE seed with 1 track."
+        }
+      },
+      "actual_snapshot": {
+        "lookup": {
+          "release_id": "d9a85b3d-ed19-51bb-a6c4-e5e538401b50",
+          "canonical_path": "/v1/releases/d9a85b3d-ed19-51bb-a6c4-e5e538401b50",
+          "release": {
+            "release_id": "d9a85b3d-ed19-51bb-a6c4-e5e538401b50",
+            "entity_slug": "qwer",
+            "display_name": "QWER",
+            "release_title": "흰수염고래",
+            "release_date": "2025-10-06",
+            "stream": "song",
+            "release_kind": "single"
+          }
+        },
+        "detail": {
+          "release": {
+            "release_id": "d9a85b3d-ed19-51bb-a6c4-e5e538401b50",
+            "entity_slug": "qwer",
+            "display_name": "QWER",
+            "release_title": "흰수염고래",
+            "release_date": "2025-10-06",
+            "stream": "song",
+            "release_kind": "single"
+          },
+          "artwork": {
+            "cover_image_url": "https://coverartarchive.org/release-group/f6027192-7e1d-4e68-a82b-b43cab18efea/front",
+            "artwork_source_url": "https://coverartarchive.org/release-group/f6027192-7e1d-4e68-a82b-b43cab18efea",
+            "artwork_source_type": "cover_art_archive",
+            "thumbnail_image_url": "https://coverartarchive.org/release-group/f6027192-7e1d-4e68-a82b-b43cab18efea/front-250"
+          },
+          "service_links": {
+            "spotify": {
+              "url": null,
+              "status": "no_link",
+              "provenance": null
+            },
+            "youtube_music": {
+              "url": null,
+              "status": "no_link",
+              "provenance": null
+            }
+          },
+          "tracks": [
+            {
+              "track_id": "cba6c241-1e36-576c-8560-9da8f97f4fcd",
+              "order": 1,
+              "title": "흰수염고래",
+              "is_title_track": true,
+              "spotify": null,
+              "youtube_music": null
+            }
+          ],
+          "mv": {
+            "url": null,
+            "video_id": null,
+            "status": "needs_review",
+            "provenance": "Official YouTube search currently surfaces a special clip instead of a clearly canonical MV object."
+          },
+          "credits": [],
+          "charts": [],
+          "notes": "Representative MusicBrainz SINGLE seed with 1 track."
+        }
+      },
+      "lookup_status_code": 200,
+      "detail_status_code": 200
+    },
+    {
+      "surface": "calendar_month",
+      "input": {
+        "month": "2026-03"
+      },
+      "clean": false,
+      "mismatch_categories": [
+        "field-shape mismatches",
+        "missing rows or segments",
+        "exact-vs-month-only drift"
+      ],
+      "mismatches": [
+        {
+          "category": "field-shape mismatches",
+          "path": "data",
+          "shape_mismatches": [
+            {
+              "path": "data.days[0].verified_releases[0].release_date",
+              "expected_type": "string",
+              "actual_type": "missing",
+              "message": "Missing key"
+            },
+            {
+              "path": "data.scheduled_list[0].scheduled_month",
+              "expected_type": "string",
+              "actual_type": "null",
+              "message": "Type mismatch"
+            }
+          ]
+        },
+        {
+          "category": "missing rows or segments",
+          "path": "data.summary",
+          "expected": {
+            "verified_count": 1,
+            "exact_upcoming_count": 4,
+            "month_only_upcoming_count": 4
+          },
+          "actual": {
+            "verified_count": 2,
+            "exact_upcoming_count": 4,
+            "month_only_upcoming_count": 10
+          }
+        },
+        {
+          "category": "missing rows or segments",
+          "path": "data.days",
+          "expected": [
+            {
+              "date": "2026-03-03",
+              "verified_releases": [
+                "tunexx|SET BY US ONLY|2026-03-03|album"
+              ],
+              "exact_upcoming": []
+            },
+            {
+              "date": "2026-03-11",
+              "verified_releases": [],
+              "exact_upcoming": [
+                "yena|최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스|2026-03-11||exact|confirmed"
+              ]
+            },
+            {
+              "date": "2026-03-12",
+              "verified_releases": [],
+              "exact_upcoming": [
+                "p1harmony|P1Harmony's Hero's Return: 9th Mini-Album Drops March 12 - 조선일보|2026-03-12||exact|confirmed"
+              ]
+            },
+            {
+              "date": "2026-03-20",
+              "verified_releases": [],
+              "exact_upcoming": [
+                "bts|Arirang BTS drops highly anticipated comeback album March 20 after 3-year hiatus - artthreat.net|2026-03-20||exact|confirmed"
+              ]
+            },
+            {
+              "date": "2026-03-21",
+              "verified_releases": [],
+              "exact_upcoming": [
+                "bts|Gwanghwamun Square hosts BTS comeback concert March 21, expecting 260k fans - artthreat.net|2026-03-21||exact|scheduled"
+              ]
+            }
+          ],
+          "actual": [
+            {
+              "date": "2026-03-03",
+              "verified_releases": [
+                "tunexx|SET BY US ONLY||album"
+              ],
+              "exact_upcoming": []
+            },
+            {
+              "date": "2026-03-05",
+              "verified_releases": [
+                "h1-key|LOVECHAPTER||album"
+              ],
+              "exact_upcoming": []
+            },
+            {
+              "date": "2026-03-11",
+              "verified_releases": [],
+              "exact_upcoming": [
+                "yena|최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스|2026-03-11||exact|confirmed"
+              ]
+            },
+            {
+              "date": "2026-03-12",
+              "verified_releases": [],
+              "exact_upcoming": [
+                "p1harmony|P1Harmony's Hero's Return: 9th Mini-Album Drops March 12 - 조선일보|2026-03-12||exact|confirmed"
+              ]
+            },
+            {
+              "date": "2026-03-20",
+              "verified_releases": [],
+              "exact_upcoming": [
+                "bts|Arirang BTS drops highly anticipated comeback album March 20 after 3-year hiatus - artthreat.net|2026-03-20||exact|confirmed"
+              ]
+            },
+            {
+              "date": "2026-03-21",
+              "verified_releases": [],
+              "exact_upcoming": [
+                "bts|Gwanghwamun Square hosts BTS comeback concert March 21, expecting 260k fans - artthreat.net|2026-03-21||exact|scheduled"
+              ]
+            }
+          ]
+        },
+        {
+          "category": "exact-vs-month-only drift",
+          "path": "data.month_only_upcoming",
+          "expected": [
+            "ab6ix|AB6IX announces March comeback with their first full album in 5 years - allkpop||2026-03|month_only|scheduled",
+            "all-h-ours|ALL(H)OURS Sets March Comeback With 5th Mini-Album ‘NO DOUBT’ - hellokpop||2026-03|month_only|scheduled",
+            "ab6ix|AB6IX begins the countdown for their March comeback with the full album ‘SEVEN : CRIMSON HORIZON’ - allkpop||2026-03|month_only|scheduled",
+            "ab6ix|AB6IX Unveils 'So Sweet' Ahead of March Album - 조선일보||2026-03|month_only|scheduled"
+          ],
+          "actual": [
+            "ab6ix|AB6IX announces March comeback with their first full album in 5 years - allkpop||2026-03-01|month_only|scheduled",
+            "all-h-ours|ALL(H)OURS Sets March Comeback With 5th Mini-Album ‘NO DOUBT’ - hellokpop||2026-03-01|month_only|scheduled",
+            "bts|BTS announces March comeback date, putting an end to a nearly 4-year hiatus - ABC7 Los Angeles||2026-03-01|month_only|scheduled",
+            "p1harmony|P1Harmony announces March comeback with new trailer release - Music Mundial||2026-03-01|month_only|scheduled",
+            "ab6ix|AB6IX begins the countdown for their March comeback with the full album ‘SEVEN : CRIMSON HORIZON’ - allkpop||2026-03-01|month_only|scheduled",
+            "bts|BTS Confirm 2026 Comeback with New Album and World Tour Set for March - L'Officiel Singapore||2026-03-01|month_only|scheduled",
+            "p1harmony|P1Harmony teases March comeback - The Korea Herald||2026-03-01|month_only|scheduled",
+            "p1harmony|P1Harmony to return in March: report - The Korea Herald||2026-03-01|month_only|scheduled",
+            "ab6ix|AB6IX Unveils 'So Sweet' Ahead of March Album - 조선일보||2026-03-01|month_only|scheduled",
+            "bts|BTS Is Dropping New Music in March — and Heading Out on Tour - Rolling Stone||2026-03-01|month_only|scheduled"
+          ]
+        },
+        {
+          "category": "missing rows or segments",
+          "path": "data.verified_list",
+          "expected": [
+            "tunexx|SET BY US ONLY|2026-03-03|album"
+          ],
+          "actual": [
+            "tunexx|SET BY US ONLY|2026-03-03|album",
+            "h1-key|LOVECHAPTER|2026-03-05|album"
+          ]
+        },
+        {
+          "category": "exact-vs-month-only drift",
+          "path": "data.scheduled_list",
+          "expected": [
+            "yena|최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스|2026-03-11|2026-03|exact|confirmed",
+            "p1harmony|P1Harmony's Hero's Return: 9th Mini-Album Drops March 12 - 조선일보|2026-03-12|2026-03|exact|confirmed",
+            "bts|Arirang BTS drops highly anticipated comeback album March 20 after 3-year hiatus - artthreat.net|2026-03-20|2026-03|exact|confirmed",
+            "bts|Gwanghwamun Square hosts BTS comeback concert March 21, expecting 260k fans - artthreat.net|2026-03-21|2026-03|exact|scheduled"
+          ],
+          "actual": [
+            "yena|최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스|2026-03-11||exact|confirmed",
+            "p1harmony|P1Harmony's Hero's Return: 9th Mini-Album Drops March 12 - 조선일보|2026-03-12||exact|confirmed",
+            "bts|Arirang BTS drops highly anticipated comeback album March 20 after 3-year hiatus - artthreat.net|2026-03-20||exact|confirmed",
+            "bts|Gwanghwamun Square hosts BTS comeback concert March 21, expecting 260k fans - artthreat.net|2026-03-21||exact|scheduled",
+            "ab6ix|AB6IX announces March comeback with their first full album in 5 years - allkpop||2026-03-01|month_only|scheduled",
+            "all-h-ours|ALL(H)OURS Sets March Comeback With 5th Mini-Album ‘NO DOUBT’ - hellokpop||2026-03-01|month_only|scheduled",
+            "bts|BTS announces March comeback date, putting an end to a nearly 4-year hiatus - ABC7 Los Angeles||2026-03-01|month_only|scheduled",
+            "p1harmony|P1Harmony announces March comeback with new trailer release - Music Mundial||2026-03-01|month_only|scheduled",
+            "ab6ix|AB6IX begins the countdown for their March comeback with the full album ‘SEVEN : CRIMSON HORIZON’ - allkpop||2026-03-01|month_only|scheduled",
+            "bts|BTS Confirm 2026 Comeback with New Album and World Tour Set for March - L'Officiel Singapore||2026-03-01|month_only|scheduled",
+            "p1harmony|P1Harmony teases March comeback - The Korea Herald||2026-03-01|month_only|scheduled",
+            "p1harmony|P1Harmony to return in March: report - The Korea Herald||2026-03-01|month_only|scheduled",
+            "ab6ix|AB6IX Unveils 'So Sweet' Ahead of March Album - 조선일보||2026-03-01|month_only|scheduled",
+            "bts|BTS Is Dropping New Music in March — and Heading Out on Tour - Rolling Stone||2026-03-01|month_only|scheduled"
+          ]
+        }
+      ],
+      "expected_snapshot": {
+        "summary": {
+          "verified_count": 1,
+          "exact_upcoming_count": 4,
+          "month_only_upcoming_count": 4
+        },
+        "nearest_upcoming": {
+          "entity_slug": "yena",
+          "display_name": "YENA",
+          "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
+          "scheduled_date": "2026-03-11",
+          "date_precision": "exact",
+          "date_status": "confirmed",
+          "confidence_score": 0.84
+        },
+        "days": [
+          {
+            "date": "2026-03-03",
+            "verified_releases": [
+              {
+                "entity_slug": "[truncated]",
+                "display_name": "[truncated]",
+                "release_title": "[truncated]",
+                "stream": "[truncated]",
+                "release_kind": "[truncated]",
+                "release_date": "[truncated]"
+              }
+            ],
+            "exact_upcoming": []
+          },
+          {
+            "date": "2026-03-11",
+            "verified_releases": [],
+            "exact_upcoming": [
+              {
+                "entity_slug": "[truncated]",
+                "display_name": "[truncated]",
+                "headline": "[truncated]",
+                "scheduled_date": "[truncated]",
+                "date_precision": "[truncated]",
+                "date_status": "[truncated]",
+                "confidence_score": "[truncated]",
+                "release_format": "[truncated]"
+              }
+            ]
+          },
+          {
+            "date": "2026-03-12",
+            "verified_releases": [],
+            "exact_upcoming": [
+              {
+                "entity_slug": "[truncated]",
+                "display_name": "[truncated]",
+                "headline": "[truncated]",
+                "scheduled_date": "[truncated]",
+                "date_precision": "[truncated]",
+                "date_status": "[truncated]",
+                "confidence_score": "[truncated]",
+                "release_format": "[truncated]"
+              }
+            ]
+          },
+          {
+            "date": "2026-03-20",
+            "verified_releases": [],
+            "exact_upcoming": [
+              {
+                "entity_slug": "[truncated]",
+                "display_name": "[truncated]",
+                "headline": "[truncated]",
+                "scheduled_date": "[truncated]",
+                "date_precision": "[truncated]",
+                "date_status": "[truncated]",
+                "confidence_score": "[truncated]",
+                "release_format": "[truncated]"
+              }
+            ]
+          },
+          {
+            "date": "2026-03-21",
+            "verified_releases": [],
+            "exact_upcoming": [
+              {
+                "entity_slug": "[truncated]",
+                "display_name": "[truncated]",
+                "headline": "[truncated]",
+                "scheduled_date": "[truncated]",
+                "date_precision": "[truncated]",
+                "date_status": "[truncated]",
+                "confidence_score": "[truncated]",
+                "release_format": "[truncated]"
+              }
+            ]
+          }
+        ],
+        "month_only_upcoming": [
+          {
+            "entity_slug": "ab6ix",
+            "display_name": "AB6IX",
+            "headline": "AB6IX announces March comeback with their first full album in 5 years - allkpop",
+            "scheduled_month": "2026-03",
+            "date_precision": "month_only",
+            "date_status": "scheduled",
+            "confidence_score": 0.76,
+            "release_format": "album"
+          },
+          {
+            "entity_slug": "all-h-ours",
+            "display_name": "ALL(H)OURS",
+            "headline": "ALL(H)OURS Sets March Comeback With 5th Mini-Album ‘NO DOUBT’ - hellokpop",
+            "scheduled_month": "2026-03",
+            "date_precision": "month_only",
+            "date_status": "scheduled",
+            "confidence_score": 0.76,
+            "release_format": "ep"
+          },
+          {
+            "entity_slug": "ab6ix",
+            "display_name": "AB6IX",
+            "headline": "AB6IX begins the countdown for their March comeback with the full album ‘SEVEN : CRIMSON HORIZON’ - allkpop",
+            "scheduled_month": "2026-03",
+            "date_precision": "month_only",
+            "date_status": "scheduled",
+            "confidence_score": 0.58,
+            "release_format": "album"
+          },
+          {
+            "entity_slug": "ab6ix",
+            "display_name": "AB6IX",
+            "headline": "AB6IX Unveils 'So Sweet' Ahead of March Album - 조선일보",
+            "scheduled_month": "2026-03",
+            "date_precision": "month_only",
+            "date_status": "scheduled",
+            "confidence_score": 0.46,
+            "release_format": "album"
+          }
+        ],
+        "verified_list": [
+          {
+            "entity_slug": "tunexx",
+            "display_name": "TUNEXX",
+            "release_title": "SET BY US ONLY",
+            "release_date": "2026-03-03",
+            "stream": "album",
+            "release_kind": "ep"
+          }
+        ],
+        "scheduled_list": [
+          {
+            "entity_slug": "yena",
+            "display_name": "YENA",
+            "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
+            "scheduled_date": "2026-03-11",
+            "scheduled_month": "2026-03",
+            "date_precision": "exact",
+            "date_status": "confirmed",
+            "confidence_score": 0.84,
+            "release_format": "ep"
+          },
+          {
+            "entity_slug": "p1harmony",
+            "display_name": "P1Harmony",
+            "headline": "P1Harmony's Hero's Return: 9th Mini-Album Drops March 12 - 조선일보",
+            "scheduled_date": "2026-03-12",
+            "scheduled_month": "2026-03",
+            "date_precision": "exact",
+            "date_status": "confirmed",
+            "confidence_score": 0.82,
+            "release_format": "ep"
+          },
+          {
+            "entity_slug": "bts",
+            "display_name": "BTS",
+            "headline": "Arirang BTS drops highly anticipated comeback album March 20 after 3-year hiatus - artthreat.net",
+            "scheduled_date": "2026-03-20",
+            "scheduled_month": "2026-03",
+            "date_precision": "exact",
+            "date_status": "confirmed",
+            "confidence_score": 0.82,
+            "release_format": "album"
+          },
+          {
+            "entity_slug": "bts",
+            "display_name": "BTS",
+            "headline": "Gwanghwamun Square hosts BTS comeback concert March 21, expecting 260k fans - artthreat.net",
+            "scheduled_date": "2026-03-21",
+            "scheduled_month": "2026-03",
+            "date_precision": "exact",
+            "date_status": "scheduled",
+            "confidence_score": 0.64,
+            "release_format": ""
+          }
+        ]
+      },
+      "actual_snapshot": {
+        "summary": {
+          "verified_count": 2,
+          "exact_upcoming_count": 4,
+          "month_only_upcoming_count": 10
+        },
+        "nearest_upcoming": {
+          "upcoming_signal_id": "cd35b091-7589-514c-8277-154da992b434",
+          "entity_slug": "yena",
+          "display_name": "YENA",
+          "scheduled_date": "2026-03-11",
+          "date_precision": "exact",
+          "date_status": "confirmed",
+          "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
+          "confidence_score": 0.84
+        },
+        "days": [
+          {
+            "date": "2026-03-03",
+            "verified_releases": [
+              {
+                "release_id": "[truncated]",
+                "entity_slug": "[truncated]",
+                "display_name": "[truncated]",
+                "release_title": "[truncated]",
+                "stream": "[truncated]",
+                "release_kind": "[truncated]"
+              }
+            ],
+            "exact_upcoming": []
+          },
+          {
+            "date": "2026-03-05",
+            "verified_releases": [
+              {
+                "release_id": "[truncated]",
+                "entity_slug": "[truncated]",
+                "display_name": "[truncated]",
+                "release_title": "[truncated]",
+                "stream": "[truncated]",
+                "release_kind": "[truncated]"
+              }
+            ],
+            "exact_upcoming": []
+          },
+          {
+            "date": "2026-03-11",
+            "verified_releases": [],
+            "exact_upcoming": [
+              {
+                "upcoming_signal_id": "[truncated]",
+                "entity_slug": "[truncated]",
+                "display_name": "[truncated]",
+                "headline": "[truncated]",
+                "scheduled_date": "[truncated]",
+                "scheduled_month": "[truncated]",
+                "date_precision": "[truncated]",
+                "date_status": "[truncated]",
+                "confidence_score": "[truncated]",
+                "release_format": "[truncated]"
+              }
+            ]
+          },
+          {
+            "date": "2026-03-12",
+            "verified_releases": [],
+            "exact_upcoming": [
+              {
+                "upcoming_signal_id": "[truncated]",
+                "entity_slug": "[truncated]",
+                "display_name": "[truncated]",
+                "headline": "[truncated]",
+                "scheduled_date": "[truncated]",
+                "scheduled_month": "[truncated]",
+                "date_precision": "[truncated]",
+                "date_status": "[truncated]",
+                "confidence_score": "[truncated]",
+                "release_format": "[truncated]"
+              }
+            ]
+          },
+          {
+            "date": "2026-03-20",
+            "verified_releases": [],
+            "exact_upcoming": [
+              {
+                "upcoming_signal_id": "[truncated]",
+                "entity_slug": "[truncated]",
+                "display_name": "[truncated]",
+                "headline": "[truncated]",
+                "scheduled_date": "[truncated]",
+                "scheduled_month": "[truncated]",
+                "date_precision": "[truncated]",
+                "date_status": "[truncated]",
+                "confidence_score": "[truncated]",
+                "release_format": "[truncated]"
+              }
+            ]
+          },
+          {
+            "date": "2026-03-21",
+            "verified_releases": [],
+            "exact_upcoming": [
+              {
+                "upcoming_signal_id": "[truncated]",
+                "entity_slug": "[truncated]",
+                "display_name": "[truncated]",
+                "headline": "[truncated]",
+                "scheduled_date": "[truncated]",
+                "scheduled_month": "[truncated]",
+                "date_precision": "[truncated]",
+                "date_status": "[truncated]",
+                "confidence_score": "[truncated]",
+                "release_format": "[truncated]"
+              }
+            ]
+          }
+        ],
+        "month_only_upcoming": [
+          {
+            "upcoming_signal_id": "4c35431e-9bd9-5eb6-aa3b-8b1ec8de4291",
+            "entity_slug": "ab6ix",
+            "display_name": "AB6IX",
+            "headline": "AB6IX announces March comeback with their first full album in 5 years - allkpop",
+            "scheduled_date": null,
+            "scheduled_month": "2026-03-01",
+            "date_precision": "month_only",
+            "date_status": "scheduled",
+            "confidence_score": 0.76,
+            "release_format": "album"
+          },
+          {
+            "upcoming_signal_id": "9ead3b72-3595-5cbd-a04e-412458eeb8c5",
+            "entity_slug": "all-h-ours",
+            "display_name": "ALL(H)OURS",
+            "headline": "ALL(H)OURS Sets March Comeback With 5th Mini-Album ‘NO DOUBT’ - hellokpop",
+            "scheduled_date": null,
+            "scheduled_month": "2026-03-01",
+            "date_precision": "month_only",
+            "date_status": "scheduled",
+            "confidence_score": 0.76,
+            "release_format": "ep"
+          },
+          {
+            "upcoming_signal_id": "c2749f79-ff25-50b2-8fa4-c0dd784e71d2",
+            "entity_slug": "bts",
+            "display_name": "BTS",
+            "headline": "BTS announces March comeback date, putting an end to a nearly 4-year hiatus - ABC7 Los Angeles",
+            "scheduled_date": null,
+            "scheduled_month": "2026-03-01",
+            "date_precision": "month_only",
+            "date_status": "scheduled",
+            "confidence_score": 0.76,
+            "release_format": null
+          },
+          {
+            "upcoming_signal_id": "1842569e-5f24-54ac-a9a8-61806d565da0",
+            "entity_slug": "p1harmony",
+            "display_name": "P1Harmony",
+            "headline": "P1Harmony announces March comeback with new trailer release - Music Mundial",
+            "scheduled_date": null,
+            "scheduled_month": "2026-03-01",
+            "date_precision": "month_only",
+            "date_status": "scheduled",
+            "confidence_score": 0.76,
+            "release_format": null
+          },
+          {
+            "upcoming_signal_id": "800fe9b2-9acd-5bd6-982c-d5182aabedda",
+            "entity_slug": "ab6ix",
+            "display_name": "AB6IX",
+            "headline": "AB6IX begins the countdown for their March comeback with the full album ‘SEVEN : CRIMSON HORIZON’ - allkpop",
+            "scheduled_date": null,
+            "scheduled_month": "2026-03-01",
+            "date_precision": "month_only",
+            "date_status": "scheduled",
+            "confidence_score": 0.58,
+            "release_format": "album"
+          },
+          {
+            "upcoming_signal_id": "23a31cb6-336c-5108-bd54-f904fce89758",
+            "entity_slug": "bts",
+            "display_name": "BTS",
+            "headline": "BTS Confirm 2026 Comeback with New Album and World Tour Set for March - L'Officiel Singapore",
+            "scheduled_date": null,
+            "scheduled_month": "2026-03-01",
+            "date_precision": "month_only",
+            "date_status": "scheduled",
+            "confidence_score": 0.58,
+            "release_format": "album"
+          },
+          {
+            "upcoming_signal_id": "0c229747-5459-5279-899f-db88db4d9a11",
+            "entity_slug": "p1harmony",
+            "display_name": "P1Harmony",
+            "headline": "P1Harmony teases March comeback - The Korea Herald",
+            "scheduled_date": null,
+            "scheduled_month": "2026-03-01",
+            "date_precision": "month_only",
+            "date_status": "scheduled",
+            "confidence_score": 0.58,
+            "release_format": null
+          },
+          {
+            "upcoming_signal_id": "5017fc94-4bc0-5bd3-aed9-ca45040b9542",
+            "entity_slug": "p1harmony",
+            "display_name": "P1Harmony",
+            "headline": "P1Harmony to return in March: report - The Korea Herald",
+            "scheduled_date": null,
+            "scheduled_month": "2026-03-01",
+            "date_precision": "month_only",
+            "date_status": "scheduled",
+            "confidence_score": 0.58,
+            "release_format": null
+          },
+          {
+            "upcoming_signal_id": "4029aa3d-c7f9-5183-95cf-3989a337c05d",
+            "entity_slug": "ab6ix",
+            "display_name": "AB6IX",
+            "headline": "AB6IX Unveils 'So Sweet' Ahead of March Album - 조선일보",
+            "scheduled_date": null,
+            "scheduled_month": "2026-03-01",
+            "date_precision": "month_only",
+            "date_status": "scheduled",
+            "confidence_score": 0.46,
+            "release_format": "album"
+          },
+          {
+            "upcoming_signal_id": "266b8df2-f19c-50f2-a271-4145920969b2",
+            "entity_slug": "bts",
+            "display_name": "BTS",
+            "headline": "BTS Is Dropping New Music in March — and Heading Out on Tour - Rolling Stone",
+            "scheduled_date": null,
+            "scheduled_month": "2026-03-01",
+            "date_precision": "month_only",
+            "date_status": "scheduled",
+            "confidence_score": 0.46,
+            "release_format": null
+          }
+        ],
+        "verified_list": [
+          {
+            "release_id": "bd9eebee-c5fe-509e-8b08-8b76ef26499e",
+            "entity_slug": "tunexx",
+            "display_name": "TUNEXX",
+            "release_title": "SET BY US ONLY",
+            "stream": "album",
+            "release_kind": "ep",
+            "release_date": "2026-03-03"
+          },
+          {
+            "release_id": "6a1db562-83b4-5e9d-a00f-6ea0ebfb6680",
+            "entity_slug": "h1-key",
+            "display_name": "H1-KEY",
+            "release_title": "LOVECHAPTER",
+            "stream": "album",
+            "release_kind": "ep",
+            "release_date": "2026-03-05"
+          }
+        ],
+        "scheduled_list": [
+          {
+            "upcoming_signal_id": "cd35b091-7589-514c-8277-154da992b434",
+            "entity_slug": "yena",
+            "display_name": "YENA",
+            "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
+            "scheduled_date": "2026-03-11",
+            "scheduled_month": null,
+            "date_precision": "exact",
+            "date_status": "confirmed",
+            "confidence_score": 0.84,
+            "release_format": "ep"
+          },
+          {
+            "upcoming_signal_id": "7150643f-66ad-5e29-b2b4-fadcfcd96eac",
+            "entity_slug": "p1harmony",
+            "display_name": "P1Harmony",
+            "headline": "P1Harmony's Hero's Return: 9th Mini-Album Drops March 12 - 조선일보",
+            "scheduled_date": "2026-03-12",
+            "scheduled_month": null,
+            "date_precision": "exact",
+            "date_status": "confirmed",
+            "confidence_score": 0.82,
+            "release_format": "ep"
+          },
+          {
+            "upcoming_signal_id": "270ed092-e246-5415-9233-99694320e11c",
+            "entity_slug": "bts",
+            "display_name": "BTS",
+            "headline": "Arirang BTS drops highly anticipated comeback album March 20 after 3-year hiatus - artthreat.net",
+            "scheduled_date": "2026-03-20",
+            "scheduled_month": null,
+            "date_precision": "exact",
+            "date_status": "confirmed",
+            "confidence_score": 0.82,
+            "release_format": "album"
+          },
+          {
+            "upcoming_signal_id": "69b11442-62aa-5a4c-9110-2f674acffc3b",
+            "entity_slug": "bts",
+            "display_name": "BTS",
+            "headline": "Gwanghwamun Square hosts BTS comeback concert March 21, expecting 260k fans - artthreat.net",
+            "scheduled_date": "2026-03-21",
+            "scheduled_month": null,
+            "date_precision": "exact",
+            "date_status": "scheduled",
+            "confidence_score": 0.64,
+            "release_format": null
+          },
+          {
+            "upcoming_signal_id": "4c35431e-9bd9-5eb6-aa3b-8b1ec8de4291",
+            "entity_slug": "ab6ix",
+            "display_name": "AB6IX",
+            "headline": "AB6IX announces March comeback with their first full album in 5 years - allkpop",
+            "scheduled_date": null,
+            "scheduled_month": "2026-03-01",
+            "date_precision": "month_only",
+            "date_status": "scheduled",
+            "confidence_score": 0.76,
+            "release_format": "album"
+          },
+          {
+            "upcoming_signal_id": "9ead3b72-3595-5cbd-a04e-412458eeb8c5",
+            "entity_slug": "all-h-ours",
+            "display_name": "ALL(H)OURS",
+            "headline": "ALL(H)OURS Sets March Comeback With 5th Mini-Album ‘NO DOUBT’ - hellokpop",
+            "scheduled_date": null,
+            "scheduled_month": "2026-03-01",
+            "date_precision": "month_only",
+            "date_status": "scheduled",
+            "confidence_score": 0.76,
+            "release_format": "ep"
+          },
+          {
+            "upcoming_signal_id": "c2749f79-ff25-50b2-8fa4-c0dd784e71d2",
+            "entity_slug": "bts",
+            "display_name": "BTS",
+            "headline": "BTS announces March comeback date, putting an end to a nearly 4-year hiatus - ABC7 Los Angeles",
+            "scheduled_date": null,
+            "scheduled_month": "2026-03-01",
+            "date_precision": "month_only",
+            "date_status": "scheduled",
+            "confidence_score": 0.76,
+            "release_format": null
+          },
+          {
+            "upcoming_signal_id": "1842569e-5f24-54ac-a9a8-61806d565da0",
+            "entity_slug": "p1harmony",
+            "display_name": "P1Harmony",
+            "headline": "P1Harmony announces March comeback with new trailer release - Music Mundial",
+            "scheduled_date": null,
+            "scheduled_month": "2026-03-01",
+            "date_precision": "month_only",
+            "date_status": "scheduled",
+            "confidence_score": 0.76,
+            "release_format": null
+          },
+          {
+            "upcoming_signal_id": "800fe9b2-9acd-5bd6-982c-d5182aabedda",
+            "entity_slug": "ab6ix",
+            "display_name": "AB6IX",
+            "headline": "AB6IX begins the countdown for their March comeback with the full album ‘SEVEN : CRIMSON HORIZON’ - allkpop",
+            "scheduled_date": null,
+            "scheduled_month": "2026-03-01",
+            "date_precision": "month_only",
+            "date_status": "scheduled",
+            "confidence_score": 0.58,
+            "release_format": "album"
+          },
+          {
+            "upcoming_signal_id": "23a31cb6-336c-5108-bd54-f904fce89758",
+            "entity_slug": "bts",
+            "display_name": "BTS",
+            "headline": "BTS Confirm 2026 Comeback with New Album and World Tour Set for March - L'Officiel Singapore",
+            "scheduled_date": null,
+            "scheduled_month": "2026-03-01",
+            "date_precision": "month_only",
+            "date_status": "scheduled",
+            "confidence_score": 0.58,
+            "release_format": "album"
+          },
+          {
+            "upcoming_signal_id": "0c229747-5459-5279-899f-db88db4d9a11",
+            "entity_slug": "p1harmony",
+            "display_name": "P1Harmony",
+            "headline": "P1Harmony teases March comeback - The Korea Herald",
+            "scheduled_date": null,
+            "scheduled_month": "2026-03-01",
+            "date_precision": "month_only",
+            "date_status": "scheduled",
+            "confidence_score": 0.58,
+            "release_format": null
+          },
+          {
+            "upcoming_signal_id": "5017fc94-4bc0-5bd3-aed9-ca45040b9542",
+            "entity_slug": "p1harmony",
+            "display_name": "P1Harmony",
+            "headline": "P1Harmony to return in March: report - The Korea Herald",
+            "scheduled_date": null,
+            "scheduled_month": "2026-03-01",
+            "date_precision": "month_only",
+            "date_status": "scheduled",
+            "confidence_score": 0.58,
+            "release_format": null
+          }
+        ]
+      },
+      "actual_status_code": 200
+    },
+    {
+      "surface": "calendar_month",
+      "input": {
+        "month": "2026-04"
+      },
+      "clean": false,
+      "mismatch_categories": [
+        "field-shape mismatches",
+        "missing rows or segments",
+        "exact-vs-month-only drift"
+      ],
+      "mismatches": [
+        {
+          "category": "field-shape mismatches",
+          "path": "data",
+          "shape_mismatches": [
+            {
+              "path": "data.days[0].exact_upcoming[0].release_format",
+              "expected_type": "string",
+              "actual_type": "null",
+              "message": "Type mismatch"
+            },
+            {
+              "path": "data.scheduled_list[0].scheduled_month",
+              "expected_type": "string",
+              "actual_type": "null",
+              "message": "Type mismatch"
+            },
+            {
+              "path": "data.scheduled_list[0].release_format",
+              "expected_type": "string",
+              "actual_type": "null",
+              "message": "Type mismatch"
+            }
+          ]
+        },
+        {
+          "category": "missing rows or segments",
+          "path": "data.summary",
+          "expected": {
+            "verified_count": 0,
+            "exact_upcoming_count": 2,
+            "month_only_upcoming_count": 10
+          },
+          "actual": {
+            "verified_count": 0,
+            "exact_upcoming_count": 3,
+            "month_only_upcoming_count": 11
+          }
+        },
+        {
+          "category": "missing rows or segments",
+          "path": "data.days",
+          "expected": [
+            {
+              "date": "2026-04-07",
+              "verified_releases": [],
+              "exact_upcoming": [
+                "plave|PLAVE Sets April 7 Comeback After Million-Seller Run | Outlook Respawn - Outlook Respawn|2026-04-07||exact|confirmed"
+              ]
+            },
+            {
+              "date": "2026-04-13",
+              "verified_releases": [],
+              "exact_upcoming": [
+                "tomorrow-x-together|[NOTICE] Comeback Showcase to Celebrate the Release of TOMORROW X TOGETHER “7TH YEAR: A Moment of Stillness in the Thorns”|2026-04-13||exact|confirmed"
+              ]
+            }
+          ],
+          "actual": [
+            {
+              "date": "2026-04-07",
+              "verified_releases": [],
+              "exact_upcoming": [
+                "plave|PLAVE Sets April 7 Comeback After Million-Seller Run | Outlook Respawn - Outlook Respawn|2026-04-07||exact|confirmed"
+              ]
+            },
+            {
+              "date": "2026-04-13",
+              "verified_releases": [],
+              "exact_upcoming": [
+                "tomorrow-x-together|[NOTICE] Comeback Showcase to Celebrate the Release of TOMORROW X TOGETHER “7TH YEAR: A Moment of Stillness in the Thorns”|2026-04-13||exact|confirmed",
+                "tomorrow-x-together|TOMORROW X TOGETHER mark comeback after contract renewal with April 13 showcase in Korea - CHOSUNBIZ - Chosunbiz|2026-04-13||exact|scheduled"
+              ]
+            }
+          ]
+        },
+        {
+          "category": "exact-vs-month-only drift",
+          "path": "data.month_only_upcoming",
+          "expected": [
+            "and-team|&TEAM sets April comeback with Japanese mini album ‘We on Fire’ - allkpop||2026-04|month_only|scheduled",
+            "kickflip|KickFlip announces April comeback - Music Mundial||2026-04|month_only|scheduled",
+            "kickflip|KickFlip announces April comeback with their 4th mini-album - allkpop||2026-04|month_only|scheduled",
+            "kickflip|KickFlip wraps first nationwide fan-con tour and announces April comeback - allkpop||2026-04|month_only|scheduled",
+            "young-posse|YOUNG POSSE announces April comeback with new digital single - allkpop||2026-04|month_only|scheduled",
+            "kiss-of-life|KISS OF LIFE Teases April Comeback with 'COMING SOON' Video - 조선일보||2026-04|month_only|scheduled",
+            "tws|LE SSERAFIM and TWS join April comeback lineup - allkpop||2026-04|month_only|scheduled",
+            "le-sserafim|LE SSERAFIM and TWS Set for April Comebacks as K-Pop Return Rush Intensifies - DIPE.CO.KR||2026-04|month_only|scheduled",
+            "tws|LE SSERAFIM and TWS Set for April Comebacks as K-Pop Return Rush Intensifies - DIPE.CO.KR||2026-04|month_only|scheduled",
+            "tws|TWS Set for a High-Energy Spring Comeback Confirmed for April - OtakuKart||2026-04|month_only|scheduled"
+          ],
+          "actual": [
+            "and-team|&TEAM sets April comeback with Japanese mini album ‘We on Fire’ - allkpop||2026-04-01|month_only|scheduled",
+            "kickflip|KickFlip announces April comeback - Music Mundial||2026-04-01|month_only|scheduled",
+            "kickflip|KickFlip announces April comeback with their 4th mini-album - allkpop||2026-04-01|month_only|scheduled",
+            "kickflip|KickFlip wraps first nationwide fan-con tour and announces April comeback - allkpop||2026-04-01|month_only|scheduled",
+            "young-posse|YOUNG POSSE announces April comeback with new digital single - allkpop||2026-04-01|month_only|scheduled",
+            "kiss-of-life|KISS OF LIFE Teases April Comeback with 'COMING SOON' Video - 조선일보||2026-04-01|month_only|scheduled",
+            "le-sserafim|LE SSERAFIM and TWS Set for April Comebacks as K-Pop Return Rush Intensifies - DIPE.CO.KR||2026-04-01|month_only|scheduled",
+            "tomorrow-x-together|TOMORROW X TOGETHER made their first comeback after renewing their contract..8th mini album released on April 13th - starnewskorea.com||2026-04-01|month_only|scheduled",
+            "tws|LE SSERAFIM and TWS Set for April Comebacks as K-Pop Return Rush Intensifies - DIPE.CO.KR||2026-04-01|month_only|scheduled",
+            "tws|LE SSERAFIM and TWS join April comeback lineup - allkpop||2026-04-01|month_only|scheduled",
+            "tws|TWS Set for a High-Energy Spring Comeback Confirmed for April - OtakuKart||2026-04-01|month_only|scheduled"
+          ]
+        },
+        {
+          "category": "exact-vs-month-only drift",
+          "path": "data.scheduled_list",
+          "expected": [
+            "plave|PLAVE Sets April 7 Comeback After Million-Seller Run | Outlook Respawn - Outlook Respawn|2026-04-07|2026-04|exact|confirmed",
+            "tomorrow-x-together|[NOTICE] Comeback Showcase to Celebrate the Release of TOMORROW X TOGETHER “7TH YEAR: A Moment of Stillness in the Thorns”|2026-04-13|2026-04|exact|confirmed"
+          ],
+          "actual": [
+            "plave|PLAVE Sets April 7 Comeback After Million-Seller Run | Outlook Respawn - Outlook Respawn|2026-04-07||exact|confirmed",
+            "tomorrow-x-together|[NOTICE] Comeback Showcase to Celebrate the Release of TOMORROW X TOGETHER “7TH YEAR: A Moment of Stillness in the Thorns”|2026-04-13||exact|confirmed",
+            "tomorrow-x-together|TOMORROW X TOGETHER mark comeback after contract renewal with April 13 showcase in Korea - CHOSUNBIZ - Chosunbiz|2026-04-13||exact|scheduled",
+            "and-team|&TEAM sets April comeback with Japanese mini album ‘We on Fire’ - allkpop||2026-04-01|month_only|scheduled",
+            "kickflip|KickFlip announces April comeback - Music Mundial||2026-04-01|month_only|scheduled",
+            "kickflip|KickFlip announces April comeback with their 4th mini-album - allkpop||2026-04-01|month_only|scheduled",
+            "kickflip|KickFlip wraps first nationwide fan-con tour and announces April comeback - allkpop||2026-04-01|month_only|scheduled",
+            "young-posse|YOUNG POSSE announces April comeback with new digital single - allkpop||2026-04-01|month_only|scheduled",
+            "kiss-of-life|KISS OF LIFE Teases April Comeback with 'COMING SOON' Video - 조선일보||2026-04-01|month_only|scheduled",
+            "le-sserafim|LE SSERAFIM and TWS Set for April Comebacks as K-Pop Return Rush Intensifies - DIPE.CO.KR||2026-04-01|month_only|scheduled",
+            "tomorrow-x-together|TOMORROW X TOGETHER made their first comeback after renewing their contract..8th mini album released on April 13th - starnewskorea.com||2026-04-01|month_only|scheduled",
+            "tws|LE SSERAFIM and TWS Set for April Comebacks as K-Pop Return Rush Intensifies - DIPE.CO.KR||2026-04-01|month_only|scheduled",
+            "tws|LE SSERAFIM and TWS join April comeback lineup - allkpop||2026-04-01|month_only|scheduled",
+            "tws|TWS Set for a High-Energy Spring Comeback Confirmed for April - OtakuKart||2026-04-01|month_only|scheduled"
+          ]
+        }
+      ],
+      "expected_snapshot": {
+        "summary": {
+          "verified_count": 0,
+          "exact_upcoming_count": 2,
+          "month_only_upcoming_count": 10
+        },
+        "nearest_upcoming": {
+          "entity_slug": "yena",
+          "display_name": "YENA",
+          "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
+          "scheduled_date": "2026-03-11",
+          "date_precision": "exact",
+          "date_status": "confirmed",
+          "confidence_score": 0.84
+        },
+        "days": [
+          {
+            "date": "2026-04-07",
+            "verified_releases": [],
+            "exact_upcoming": [
+              {
+                "entity_slug": "[truncated]",
+                "display_name": "[truncated]",
+                "headline": "[truncated]",
+                "scheduled_date": "[truncated]",
+                "date_precision": "[truncated]",
+                "date_status": "[truncated]",
+                "confidence_score": "[truncated]",
+                "release_format": "[truncated]"
+              }
+            ]
+          },
+          {
+            "date": "2026-04-13",
+            "verified_releases": [],
+            "exact_upcoming": [
+              {
+                "entity_slug": "[truncated]",
+                "display_name": "[truncated]",
+                "headline": "[truncated]",
+                "scheduled_date": "[truncated]",
+                "date_precision": "[truncated]",
+                "date_status": "[truncated]",
+                "confidence_score": "[truncated]",
+                "release_format": "[truncated]"
+              }
+            ]
+          }
+        ],
+        "month_only_upcoming": [
+          {
+            "entity_slug": "and-team",
+            "display_name": "&TEAM",
+            "headline": "&TEAM sets April comeback with Japanese mini album ‘We on Fire’ - allkpop",
+            "scheduled_month": "2026-04",
+            "date_precision": "month_only",
+            "date_status": "scheduled",
+            "confidence_score": 0.76,
+            "release_format": "ep"
+          },
+          {
+            "entity_slug": "kickflip",
+            "display_name": "KickFlip",
+            "headline": "KickFlip announces April comeback - Music Mundial",
+            "scheduled_month": "2026-04",
+            "date_precision": "month_only",
+            "date_status": "scheduled",
+            "confidence_score": 0.76,
+            "release_format": ""
+          },
+          {
+            "entity_slug": "kickflip",
+            "display_name": "KickFlip",
+            "headline": "KickFlip announces April comeback with their 4th mini-album - allkpop",
+            "scheduled_month": "2026-04",
+            "date_precision": "month_only",
+            "date_status": "scheduled",
+            "confidence_score": 0.76,
+            "release_format": "ep"
+          },
+          {
+            "entity_slug": "kickflip",
+            "display_name": "KickFlip",
+            "headline": "KickFlip wraps first nationwide fan-con tour and announces April comeback - allkpop",
+            "scheduled_month": "2026-04",
+            "date_precision": "month_only",
+            "date_status": "scheduled",
+            "confidence_score": 0.76,
+            "release_format": ""
+          },
+          {
+            "entity_slug": "young-posse",
+            "display_name": "YOUNG POSSE",
+            "headline": "YOUNG POSSE announces April comeback with new digital single - allkpop",
+            "scheduled_month": "2026-04",
+            "date_precision": "month_only",
+            "date_status": "scheduled",
+            "confidence_score": 0.76,
+            "release_format": "single"
+          },
+          {
+            "entity_slug": "kiss-of-life",
+            "display_name": "KISS OF LIFE",
+            "headline": "KISS OF LIFE Teases April Comeback with 'COMING SOON' Video - 조선일보",
+            "scheduled_month": "2026-04",
+            "date_precision": "month_only",
+            "date_status": "scheduled",
+            "confidence_score": 0.58,
+            "release_format": ""
+          },
+          {
+            "entity_slug": "tws",
+            "display_name": "TWS",
+            "headline": "LE SSERAFIM and TWS join April comeback lineup - allkpop",
+            "scheduled_month": "2026-04",
+            "date_precision": "month_only",
+            "date_status": "scheduled",
+            "confidence_score": 0.58,
+            "release_format": ""
+          },
+          {
+            "entity_slug": "le-sserafim",
+            "display_name": "LE SSERAFIM",
+            "headline": "LE SSERAFIM and TWS Set for April Comebacks as K-Pop Return Rush Intensifies - DIPE.CO.KR",
+            "scheduled_month": "2026-04",
+            "date_precision": "month_only",
+            "date_status": "scheduled",
+            "confidence_score": 0.58,
+            "release_format": ""
+          },
+          {
+            "entity_slug": "tws",
+            "display_name": "TWS",
+            "headline": "LE SSERAFIM and TWS Set for April Comebacks as K-Pop Return Rush Intensifies - DIPE.CO.KR",
+            "scheduled_month": "2026-04",
+            "date_precision": "month_only",
+            "date_status": "scheduled",
+            "confidence_score": 0.58,
+            "release_format": ""
+          },
+          {
+            "entity_slug": "tws",
+            "display_name": "TWS",
+            "headline": "TWS Set for a High-Energy Spring Comeback Confirmed for April - OtakuKart",
+            "scheduled_month": "2026-04",
+            "date_precision": "month_only",
+            "date_status": "scheduled",
+            "confidence_score": 0.58,
+            "release_format": ""
+          }
+        ],
+        "verified_list": [],
+        "scheduled_list": [
+          {
+            "entity_slug": "plave",
+            "display_name": "PLAVE",
+            "headline": "PLAVE Sets April 7 Comeback After Million-Seller Run | Outlook Respawn - Outlook Respawn",
+            "scheduled_date": "2026-04-07",
+            "scheduled_month": "2026-04",
+            "date_precision": "exact",
+            "date_status": "confirmed",
+            "confidence_score": 0.82,
+            "release_format": ""
+          },
+          {
+            "entity_slug": "tomorrow-x-together",
+            "display_name": "TOMORROW X TOGETHER",
+            "headline": "[NOTICE] Comeback Showcase to Celebrate the Release of TOMORROW X TOGETHER “7TH YEAR: A Moment of Stillness in the Thorns”",
+            "scheduled_date": "2026-04-13",
+            "scheduled_month": "2026-04",
+            "date_precision": "exact",
+            "date_status": "confirmed",
+            "confidence_score": 0.84,
+            "release_format": ""
+          }
+        ]
+      },
+      "actual_snapshot": {
+        "summary": {
+          "verified_count": 0,
+          "exact_upcoming_count": 3,
+          "month_only_upcoming_count": 11
+        },
+        "nearest_upcoming": {
+          "upcoming_signal_id": "cd35b091-7589-514c-8277-154da992b434",
+          "entity_slug": "yena",
+          "display_name": "YENA",
+          "scheduled_date": "2026-03-11",
+          "date_precision": "exact",
+          "date_status": "confirmed",
+          "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
+          "confidence_score": 0.84
+        },
+        "days": [
+          {
+            "date": "2026-04-07",
+            "verified_releases": [],
+            "exact_upcoming": [
+              {
+                "upcoming_signal_id": "[truncated]",
+                "entity_slug": "[truncated]",
+                "display_name": "[truncated]",
+                "headline": "[truncated]",
+                "scheduled_date": "[truncated]",
+                "scheduled_month": "[truncated]",
+                "date_precision": "[truncated]",
+                "date_status": "[truncated]",
+                "confidence_score": "[truncated]",
+                "release_format": "[truncated]"
+              }
+            ]
+          },
+          {
+            "date": "2026-04-13",
+            "verified_releases": [],
+            "exact_upcoming": [
+              {
+                "upcoming_signal_id": "[truncated]",
+                "entity_slug": "[truncated]",
+                "display_name": "[truncated]",
+                "headline": "[truncated]",
+                "scheduled_date": "[truncated]",
+                "scheduled_month": "[truncated]",
+                "date_precision": "[truncated]",
+                "date_status": "[truncated]",
+                "confidence_score": "[truncated]",
+                "release_format": "[truncated]"
+              },
+              {
+                "upcoming_signal_id": "[truncated]",
+                "entity_slug": "[truncated]",
+                "display_name": "[truncated]",
+                "headline": "[truncated]",
+                "scheduled_date": "[truncated]",
+                "scheduled_month": "[truncated]",
+                "date_precision": "[truncated]",
+                "date_status": "[truncated]",
+                "confidence_score": "[truncated]",
+                "release_format": "[truncated]"
+              }
+            ]
+          }
+        ],
+        "month_only_upcoming": [
+          {
+            "upcoming_signal_id": "dc34b46b-b234-56de-8c78-2e11af56c992",
+            "entity_slug": "and-team",
+            "display_name": "&TEAM",
+            "headline": "&TEAM sets April comeback with Japanese mini album ‘We on Fire’ - allkpop",
+            "scheduled_date": null,
+            "scheduled_month": "2026-04-01",
+            "date_precision": "month_only",
+            "date_status": "scheduled",
+            "confidence_score": 0.76,
+            "release_format": "ep"
+          },
+          {
+            "upcoming_signal_id": "a2225095-7ab3-554d-84c1-0ea9614d71e9",
+            "entity_slug": "kickflip",
+            "display_name": "KickFlip",
+            "headline": "KickFlip announces April comeback - Music Mundial",
+            "scheduled_date": null,
+            "scheduled_month": "2026-04-01",
+            "date_precision": "month_only",
+            "date_status": "scheduled",
+            "confidence_score": 0.76,
+            "release_format": null
+          },
+          {
+            "upcoming_signal_id": "2cb3cce3-a756-5c1b-aad6-6df398c63111",
+            "entity_slug": "kickflip",
+            "display_name": "KickFlip",
+            "headline": "KickFlip announces April comeback with their 4th mini-album - allkpop",
+            "scheduled_date": null,
+            "scheduled_month": "2026-04-01",
+            "date_precision": "month_only",
+            "date_status": "scheduled",
+            "confidence_score": 0.76,
+            "release_format": "ep"
+          },
+          {
+            "upcoming_signal_id": "6c740ff3-389f-5023-bf15-c5b671f16402",
+            "entity_slug": "kickflip",
+            "display_name": "KickFlip",
+            "headline": "KickFlip wraps first nationwide fan-con tour and announces April comeback - allkpop",
+            "scheduled_date": null,
+            "scheduled_month": "2026-04-01",
+            "date_precision": "month_only",
+            "date_status": "scheduled",
+            "confidence_score": 0.76,
+            "release_format": null
+          },
+          {
+            "upcoming_signal_id": "dd6851f2-eb97-55d8-bf44-0cdf53aceb6d",
+            "entity_slug": "young-posse",
+            "display_name": "YOUNG POSSE",
+            "headline": "YOUNG POSSE announces April comeback with new digital single - allkpop",
+            "scheduled_date": null,
+            "scheduled_month": "2026-04-01",
+            "date_precision": "month_only",
+            "date_status": "scheduled",
+            "confidence_score": 0.76,
+            "release_format": "single"
+          },
+          {
+            "upcoming_signal_id": "3c2245e3-3f6f-5bf1-95f9-18c18ba31382",
+            "entity_slug": "kiss-of-life",
+            "display_name": "KISS OF LIFE",
+            "headline": "KISS OF LIFE Teases April Comeback with 'COMING SOON' Video - 조선일보",
+            "scheduled_date": null,
+            "scheduled_month": "2026-04-01",
+            "date_precision": "month_only",
+            "date_status": "scheduled",
+            "confidence_score": 0.58,
+            "release_format": null
+          },
+          {
+            "upcoming_signal_id": "6af4aaee-ebbc-565b-a88a-c178bdd6e75f",
+            "entity_slug": "le-sserafim",
+            "display_name": "LE SSERAFIM",
+            "headline": "LE SSERAFIM and TWS Set for April Comebacks as K-Pop Return Rush Intensifies - DIPE.CO.KR",
+            "scheduled_date": null,
+            "scheduled_month": "2026-04-01",
+            "date_precision": "month_only",
+            "date_status": "scheduled",
+            "confidence_score": 0.58,
+            "release_format": null
+          },
+          {
+            "upcoming_signal_id": "149767f1-b5e8-5eb9-a549-878da539607d",
+            "entity_slug": "tomorrow-x-together",
+            "display_name": "TOMORROW X TOGETHER",
+            "headline": "TOMORROW X TOGETHER made their first comeback after renewing their contract..8th mini album released on April 13th - starnewskorea.com",
+            "scheduled_date": null,
+            "scheduled_month": "2026-04-01",
+            "date_precision": "month_only",
+            "date_status": "scheduled",
+            "confidence_score": 0.58,
+            "release_format": "ep"
+          },
+          {
+            "upcoming_signal_id": "65bc2cfa-bdf4-5237-9fa9-855d1569fb31",
+            "entity_slug": "tws",
+            "display_name": "TWS",
+            "headline": "LE SSERAFIM and TWS Set for April Comebacks as K-Pop Return Rush Intensifies - DIPE.CO.KR",
+            "scheduled_date": null,
+            "scheduled_month": "2026-04-01",
+            "date_precision": "month_only",
+            "date_status": "scheduled",
+            "confidence_score": 0.58,
+            "release_format": null
+          },
+          {
+            "upcoming_signal_id": "03ccbf77-3a65-517d-960b-7b0b44d70594",
+            "entity_slug": "tws",
+            "display_name": "TWS",
+            "headline": "LE SSERAFIM and TWS join April comeback lineup - allkpop",
+            "scheduled_date": null,
+            "scheduled_month": "2026-04-01",
+            "date_precision": "month_only",
+            "date_status": "scheduled",
+            "confidence_score": 0.58,
+            "release_format": null
+          },
+          {
+            "upcoming_signal_id": "cfac3159-28cc-5ef3-b615-0fdff89fb626",
+            "entity_slug": "tws",
+            "display_name": "TWS",
+            "headline": "TWS Set for a High-Energy Spring Comeback Confirmed for April - OtakuKart",
+            "scheduled_date": null,
+            "scheduled_month": "2026-04-01",
+            "date_precision": "month_only",
+            "date_status": "scheduled",
+            "confidence_score": 0.58,
+            "release_format": null
+          }
+        ],
+        "verified_list": [],
+        "scheduled_list": [
+          {
+            "upcoming_signal_id": "8ed515cd-7571-5dd1-ac84-2286986b2149",
+            "entity_slug": "plave",
+            "display_name": "PLAVE",
+            "headline": "PLAVE Sets April 7 Comeback After Million-Seller Run | Outlook Respawn - Outlook Respawn",
+            "scheduled_date": "2026-04-07",
+            "scheduled_month": null,
+            "date_precision": "exact",
+            "date_status": "confirmed",
+            "confidence_score": 0.82,
+            "release_format": null
+          },
+          {
+            "upcoming_signal_id": "5299f667-d0b0-52f8-a437-02e0ccc557da",
+            "entity_slug": "tomorrow-x-together",
+            "display_name": "TOMORROW X TOGETHER",
+            "headline": "[NOTICE] Comeback Showcase to Celebrate the Release of TOMORROW X TOGETHER “7TH YEAR: A Moment of Stillness in the Thorns”",
+            "scheduled_date": "2026-04-13",
+            "scheduled_month": null,
+            "date_precision": "exact",
+            "date_status": "confirmed",
+            "confidence_score": 0.84,
+            "release_format": null
+          },
+          {
+            "upcoming_signal_id": "409f62f3-6726-5b73-bf2a-e0abba1b1e45",
+            "entity_slug": "tomorrow-x-together",
+            "display_name": "TOMORROW X TOGETHER",
+            "headline": "TOMORROW X TOGETHER mark comeback after contract renewal with April 13 showcase in Korea - CHOSUNBIZ - Chosunbiz",
+            "scheduled_date": "2026-04-13",
+            "scheduled_month": null,
+            "date_precision": "exact",
+            "date_status": "scheduled",
+            "confidence_score": 0.64,
+            "release_format": null
+          },
+          {
+            "upcoming_signal_id": "dc34b46b-b234-56de-8c78-2e11af56c992",
+            "entity_slug": "and-team",
+            "display_name": "&TEAM",
+            "headline": "&TEAM sets April comeback with Japanese mini album ‘We on Fire’ - allkpop",
+            "scheduled_date": null,
+            "scheduled_month": "2026-04-01",
+            "date_precision": "month_only",
+            "date_status": "scheduled",
+            "confidence_score": 0.76,
+            "release_format": "ep"
+          },
+          {
+            "upcoming_signal_id": "a2225095-7ab3-554d-84c1-0ea9614d71e9",
+            "entity_slug": "kickflip",
+            "display_name": "KickFlip",
+            "headline": "KickFlip announces April comeback - Music Mundial",
+            "scheduled_date": null,
+            "scheduled_month": "2026-04-01",
+            "date_precision": "month_only",
+            "date_status": "scheduled",
+            "confidence_score": 0.76,
+            "release_format": null
+          },
+          {
+            "upcoming_signal_id": "2cb3cce3-a756-5c1b-aad6-6df398c63111",
+            "entity_slug": "kickflip",
+            "display_name": "KickFlip",
+            "headline": "KickFlip announces April comeback with their 4th mini-album - allkpop",
+            "scheduled_date": null,
+            "scheduled_month": "2026-04-01",
+            "date_precision": "month_only",
+            "date_status": "scheduled",
+            "confidence_score": 0.76,
+            "release_format": "ep"
+          },
+          {
+            "upcoming_signal_id": "6c740ff3-389f-5023-bf15-c5b671f16402",
+            "entity_slug": "kickflip",
+            "display_name": "KickFlip",
+            "headline": "KickFlip wraps first nationwide fan-con tour and announces April comeback - allkpop",
+            "scheduled_date": null,
+            "scheduled_month": "2026-04-01",
+            "date_precision": "month_only",
+            "date_status": "scheduled",
+            "confidence_score": 0.76,
+            "release_format": null
+          },
+          {
+            "upcoming_signal_id": "dd6851f2-eb97-55d8-bf44-0cdf53aceb6d",
+            "entity_slug": "young-posse",
+            "display_name": "YOUNG POSSE",
+            "headline": "YOUNG POSSE announces April comeback with new digital single - allkpop",
+            "scheduled_date": null,
+            "scheduled_month": "2026-04-01",
+            "date_precision": "month_only",
+            "date_status": "scheduled",
+            "confidence_score": 0.76,
+            "release_format": "single"
+          },
+          {
+            "upcoming_signal_id": "3c2245e3-3f6f-5bf1-95f9-18c18ba31382",
+            "entity_slug": "kiss-of-life",
+            "display_name": "KISS OF LIFE",
+            "headline": "KISS OF LIFE Teases April Comeback with 'COMING SOON' Video - 조선일보",
+            "scheduled_date": null,
+            "scheduled_month": "2026-04-01",
+            "date_precision": "month_only",
+            "date_status": "scheduled",
+            "confidence_score": 0.58,
+            "release_format": null
+          },
+          {
+            "upcoming_signal_id": "6af4aaee-ebbc-565b-a88a-c178bdd6e75f",
+            "entity_slug": "le-sserafim",
+            "display_name": "LE SSERAFIM",
+            "headline": "LE SSERAFIM and TWS Set for April Comebacks as K-Pop Return Rush Intensifies - DIPE.CO.KR",
+            "scheduled_date": null,
+            "scheduled_month": "2026-04-01",
+            "date_precision": "month_only",
+            "date_status": "scheduled",
+            "confidence_score": 0.58,
+            "release_format": null
+          },
+          {
+            "upcoming_signal_id": "149767f1-b5e8-5eb9-a549-878da539607d",
+            "entity_slug": "tomorrow-x-together",
+            "display_name": "TOMORROW X TOGETHER",
+            "headline": "TOMORROW X TOGETHER made their first comeback after renewing their contract..8th mini album released on April 13th - starnewskorea.com",
+            "scheduled_date": null,
+            "scheduled_month": "2026-04-01",
+            "date_precision": "month_only",
+            "date_status": "scheduled",
+            "confidence_score": 0.58,
+            "release_format": "ep"
+          },
+          {
+            "upcoming_signal_id": "65bc2cfa-bdf4-5237-9fa9-855d1569fb31",
+            "entity_slug": "tws",
+            "display_name": "TWS",
+            "headline": "LE SSERAFIM and TWS Set for April Comebacks as K-Pop Return Rush Intensifies - DIPE.CO.KR",
+            "scheduled_date": null,
+            "scheduled_month": "2026-04-01",
+            "date_precision": "month_only",
+            "date_status": "scheduled",
+            "confidence_score": 0.58,
+            "release_format": null
+          }
+        ]
+      },
+      "actual_status_code": 200
+    },
+    {
+      "surface": "calendar_month",
+      "input": {
+        "month": "2025-10"
+      },
+      "clean": false,
+      "mismatch_categories": [
+        "field-shape mismatches",
+        "missing rows or segments"
+      ],
+      "mismatches": [
+        {
+          "category": "field-shape mismatches",
+          "path": "data",
+          "shape_mismatches": [
+            {
+              "path": "data.days[0].verified_releases[0].release_date",
+              "expected_type": "string",
+              "actual_type": "missing",
+              "message": "Missing key"
+            }
+          ]
+        },
+        {
+          "category": "missing rows or segments",
+          "path": "data.summary",
+          "expected": {
+            "verified_count": 22,
+            "exact_upcoming_count": 0,
+            "month_only_upcoming_count": 0
+          },
+          "actual": {
+            "verified_count": 29,
+            "exact_upcoming_count": 0,
+            "month_only_upcoming_count": 0
+          }
+        },
+        {
+          "category": "missing rows or segments",
+          "path": "data.days",
+          "expected": [
+            {
+              "date": "2025-10-03",
+              "verified_releases": [
+                "g-i-dle|i‐dle|2025-10-03|album",
+                "bae173|What’s wrong?|2025-10-03|song"
+              ],
+              "exact_upcoming": []
+            },
+            {
+              "date": "2025-10-06",
+              "verified_releases": [
+                "qwer|흰수염고래|2025-10-06|song"
+              ],
+              "exact_upcoming": []
+            },
+            {
+              "date": "2025-10-07",
+              "verified_releases": [
+                "onewe|MAZE : AD ASTRA|2025-10-07|album"
+              ],
+              "exact_upcoming": []
+            },
+            {
+              "date": "2025-10-10",
+              "verified_releases": [
+                "babymonster|WE GO UP|2025-10-10|album",
+                "twice|TEN: The Story Goes On|2025-10-10|album"
+              ],
+              "exact_upcoming": []
+            },
+            {
+              "date": "2025-10-13",
+              "verified_releases": [
+                "nmixx|Blue Valentine|2025-10-13|album",
+                "tws|play hard|2025-10-13|album"
+              ],
+              "exact_upcoming": []
+            },
+            {
+              "date": "2025-10-14",
+              "verified_releases": [
+                "bae173|NEW CHAPTER : DESEAR|2025-10-14|album",
+                "meovv|BURNING UP|2025-10-14|song"
+              ],
+              "exact_upcoming": []
+            },
+            {
+              "date": "2025-10-19",
+              "verified_releases": [
+                "tomorrow-x-together|Starkissed|2025-10-19|album"
+              ],
+              "exact_upcoming": []
+            },
+            {
+              "date": "2025-10-20",
+              "verified_releases": [
+                "boynextdoor|The Action|2025-10-20|album",
+                "hearts2hearts|FOCUS|2025-10-20|album"
+              ],
+              "exact_upcoming": []
+            },
+            {
+              "date": "2025-10-23",
+              "verified_releases": [
+                "dkb|Emotion|2025-10-23|album"
+              ],
+              "exact_upcoming": []
+            },
+            {
+              "date": "2025-10-24",
+              "verified_releases": [
+                "le-sserafim|SPAGHETTI|2025-10-24|song",
+                "xdinary-heroes|LXVE to DEATH|2025-10-24|album"
+              ],
+              "exact_upcoming": []
+            },
+            {
+              "date": "2025-10-27",
+              "verified_releases": [
+                "nexz|Beat‐Boxer|2025-10-27|album",
+                "tempest|As I am|2025-10-27|album"
+              ],
+              "exact_upcoming": []
+            },
+            {
+              "date": "2025-10-28",
+              "verified_releases": [
+                "and-team|Back to Life|2025-10-28|album"
+              ],
+              "exact_upcoming": []
+            },
+            {
+              "date": "2025-10-29",
+              "verified_releases": [
+                "wei|Wonderland|2025-10-29|album"
+              ],
+              "exact_upcoming": []
+            },
+            {
+              "date": "2025-10-30",
+              "verified_releases": [
+                "82major|Trophy|2025-10-30|album"
+              ],
+              "exact_upcoming": []
+            },
+            {
+              "date": "2025-10-31",
+              "verified_releases": [
+                "xikers|HOUSE OF TRICKY : WRECKING THE HOUSE|2025-10-31|album"
+              ],
+              "exact_upcoming": []
+            }
+          ],
+          "actual": [
+            {
+              "date": "2025-10-01",
+              "verified_releases": [
+                "triples|tripleS ∞! < SecretHimitsuBimil >||album"
+              ],
+              "exact_upcoming": []
+            },
+            {
+              "date": "2025-10-02",
+              "verified_releases": [
+                "bae173|One day||song"
+              ],
+              "exact_upcoming": []
+            },
+            {
+              "date": "2025-10-03",
+              "verified_releases": [
+                "g-i-dle|i‐dle||album",
+                "bae173|What’s wrong?||song"
+              ],
+              "exact_upcoming": []
+            },
+            {
+              "date": "2025-10-06",
+              "verified_releases": [
+                "qwer|흰수염고래||song"
+              ],
+              "exact_upcoming": []
+            },
+            {
+              "date": "2025-10-07",
+              "verified_releases": [
+                "onewe|MAZE : AD ASTRA||album"
+              ],
+              "exact_upcoming": []
+            },
+            {
+              "date": "2025-10-08",
+              "verified_releases": [
+                "itzy|Collector||album"
+              ],
+              "exact_upcoming": []
+            },
+            {
+              "date": "2025-10-10",
+              "verified_releases": [
+                "babymonster|WE GO UP||album",
+                "twice|TEN: The Story Goes On||album"
+              ],
+              "exact_upcoming": []
+            },
+            {
+              "date": "2025-10-13",
+              "verified_releases": [
+                "nmixx|Blue Valentine||album",
+                "tws|play hard||album"
+              ],
+              "exact_upcoming": []
+            },
+            {
+              "date": "2025-10-14",
+              "verified_releases": [
+                "bae173|NEW CHAPTER : DESEAR||album",
+                "meovv|BURNING UP||song"
+              ],
+              "exact_upcoming": []
+            },
+            {
+              "date": "2025-10-19",
+              "verified_releases": [
+                "tomorrow-x-together|Starkissed||album"
+              ],
+              "exact_upcoming": []
+            },
+            {
+              "date": "2025-10-20",
+              "verified_releases": [
+                "boynextdoor|The Action||album",
+                "hearts2hearts|FOCUS||album"
+              ],
+              "exact_upcoming": []
+            },
+            {
+              "date": "2025-10-23",
+              "verified_releases": [
+                "dkb|Emotion||album",
+                "yuju|내향남녀 X 유주||song"
+              ],
+              "exact_upcoming": []
+            },
+            {
+              "date": "2025-10-24",
+              "verified_releases": [
+                "ateez|From (2018)||song",
+                "le-sserafim|Pearlies (My oyster is the world)||song",
+                "le-sserafim|SPAGHETTI||song",
+                "xdinary-heroes|LXVE to DEATH||album"
+              ],
+              "exact_upcoming": []
+            },
+            {
+              "date": "2025-10-27",
+              "verified_releases": [
+                "nexz|Beat‐Boxer||album",
+                "tempest|As I am||album"
+              ],
+              "exact_upcoming": []
+            },
+            {
+              "date": "2025-10-28",
+              "verified_releases": [
+                "and-team|Back to Life||album"
+              ],
+              "exact_upcoming": []
+            },
+            {
+              "date": "2025-10-29",
+              "verified_releases": [
+                "trendz|Crime||song",
+                "wei|Wonderland||album"
+              ],
+              "exact_upcoming": []
+            },
+            {
+              "date": "2025-10-30",
+              "verified_releases": [
+                "82major|Trophy||album"
+              ],
+              "exact_upcoming": []
+            },
+            {
+              "date": "2025-10-31",
+              "verified_releases": [
+                "xikers|HOUSE OF TRICKY : WRECKING THE HOUSE||album"
+              ],
+              "exact_upcoming": []
+            }
+          ]
+        },
+        {
+          "category": "missing rows or segments",
+          "path": "data.verified_list",
+          "expected": [
+            "g-i-dle|i‐dle|2025-10-03|album",
+            "bae173|What’s wrong?|2025-10-03|song",
+            "qwer|흰수염고래|2025-10-06|song",
+            "onewe|MAZE : AD ASTRA|2025-10-07|album",
+            "babymonster|WE GO UP|2025-10-10|album",
+            "twice|TEN: The Story Goes On|2025-10-10|album",
+            "nmixx|Blue Valentine|2025-10-13|album",
+            "tws|play hard|2025-10-13|album",
+            "bae173|NEW CHAPTER : DESEAR|2025-10-14|album",
+            "meovv|BURNING UP|2025-10-14|song",
+            "tomorrow-x-together|Starkissed|2025-10-19|album",
+            "boynextdoor|The Action|2025-10-20|album",
+            "hearts2hearts|FOCUS|2025-10-20|album",
+            "dkb|Emotion|2025-10-23|album",
+            "le-sserafim|SPAGHETTI|2025-10-24|song",
+            "xdinary-heroes|LXVE to DEATH|2025-10-24|album",
+            "nexz|Beat‐Boxer|2025-10-27|album",
+            "tempest|As I am|2025-10-27|album",
+            "and-team|Back to Life|2025-10-28|album",
+            "wei|Wonderland|2025-10-29|album",
+            "82major|Trophy|2025-10-30|album",
+            "xikers|HOUSE OF TRICKY : WRECKING THE HOUSE|2025-10-31|album"
+          ],
+          "actual": [
+            "triples|tripleS ∞! < SecretHimitsuBimil >|2025-10-01|album",
+            "bae173|One day|2025-10-02|song",
+            "g-i-dle|i‐dle|2025-10-03|album",
+            "bae173|What’s wrong?|2025-10-03|song",
+            "qwer|흰수염고래|2025-10-06|song",
+            "onewe|MAZE : AD ASTRA|2025-10-07|album",
+            "itzy|Collector|2025-10-08|album",
+            "babymonster|WE GO UP|2025-10-10|album",
+            "twice|TEN: The Story Goes On|2025-10-10|album",
+            "nmixx|Blue Valentine|2025-10-13|album",
+            "tws|play hard|2025-10-13|album",
+            "bae173|NEW CHAPTER : DESEAR|2025-10-14|album",
+            "meovv|BURNING UP|2025-10-14|song",
+            "tomorrow-x-together|Starkissed|2025-10-19|album",
+            "boynextdoor|The Action|2025-10-20|album",
+            "hearts2hearts|FOCUS|2025-10-20|album",
+            "dkb|Emotion|2025-10-23|album",
+            "yuju|내향남녀 X 유주|2025-10-23|song",
+            "ateez|From (2018)|2025-10-24|song",
+            "le-sserafim|Pearlies (My oyster is the world)|2025-10-24|song",
+            "le-sserafim|SPAGHETTI|2025-10-24|song",
+            "xdinary-heroes|LXVE to DEATH|2025-10-24|album",
+            "nexz|Beat‐Boxer|2025-10-27|album",
+            "tempest|As I am|2025-10-27|album",
+            "and-team|Back to Life|2025-10-28|album",
+            "trendz|Crime|2025-10-29|song",
+            "wei|Wonderland|2025-10-29|album",
+            "82major|Trophy|2025-10-30|album",
+            "xikers|HOUSE OF TRICKY : WRECKING THE HOUSE|2025-10-31|album"
+          ]
+        }
+      ],
+      "expected_snapshot": {
+        "summary": {
+          "verified_count": 22,
+          "exact_upcoming_count": 0,
+          "month_only_upcoming_count": 0
+        },
+        "nearest_upcoming": {
+          "entity_slug": "yena",
+          "display_name": "YENA",
+          "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
+          "scheduled_date": "2026-03-11",
+          "date_precision": "exact",
+          "date_status": "confirmed",
+          "confidence_score": 0.84
+        },
+        "days": [
+          {
+            "date": "2025-10-03",
+            "verified_releases": [
+              {
+                "entity_slug": "[truncated]",
+                "display_name": "[truncated]",
+                "release_title": "[truncated]",
+                "stream": "[truncated]",
+                "release_kind": "[truncated]",
+                "release_date": "[truncated]"
+              },
+              {
+                "entity_slug": "[truncated]",
+                "display_name": "[truncated]",
+                "release_title": "[truncated]",
+                "stream": "[truncated]",
+                "release_kind": "[truncated]",
+                "release_date": "[truncated]"
+              }
+            ],
+            "exact_upcoming": []
+          },
+          {
+            "date": "2025-10-06",
+            "verified_releases": [
+              {
+                "entity_slug": "[truncated]",
+                "display_name": "[truncated]",
+                "release_title": "[truncated]",
+                "stream": "[truncated]",
+                "release_kind": "[truncated]",
+                "release_date": "[truncated]"
+              }
+            ],
+            "exact_upcoming": []
+          },
+          {
+            "date": "2025-10-07",
+            "verified_releases": [
+              {
+                "entity_slug": "[truncated]",
+                "display_name": "[truncated]",
+                "release_title": "[truncated]",
+                "stream": "[truncated]",
+                "release_kind": "[truncated]",
+                "release_date": "[truncated]"
+              }
+            ],
+            "exact_upcoming": []
+          },
+          {
+            "date": "2025-10-10",
+            "verified_releases": [
+              {
+                "entity_slug": "[truncated]",
+                "display_name": "[truncated]",
+                "release_title": "[truncated]",
+                "stream": "[truncated]",
+                "release_kind": "[truncated]",
+                "release_date": "[truncated]"
+              },
+              {
+                "entity_slug": "[truncated]",
+                "display_name": "[truncated]",
+                "release_title": "[truncated]",
+                "stream": "[truncated]",
+                "release_kind": "[truncated]",
+                "release_date": "[truncated]"
+              }
+            ],
+            "exact_upcoming": []
+          },
+          {
+            "date": "2025-10-13",
+            "verified_releases": [
+              {
+                "entity_slug": "[truncated]",
+                "display_name": "[truncated]",
+                "release_title": "[truncated]",
+                "stream": "[truncated]",
+                "release_kind": "[truncated]",
+                "release_date": "[truncated]"
+              },
+              {
+                "entity_slug": "[truncated]",
+                "display_name": "[truncated]",
+                "release_title": "[truncated]",
+                "stream": "[truncated]",
+                "release_kind": "[truncated]",
+                "release_date": "[truncated]"
+              }
+            ],
+            "exact_upcoming": []
+          },
+          {
+            "date": "2025-10-14",
+            "verified_releases": [
+              {
+                "entity_slug": "[truncated]",
+                "display_name": "[truncated]",
+                "release_title": "[truncated]",
+                "stream": "[truncated]",
+                "release_kind": "[truncated]",
+                "release_date": "[truncated]"
+              },
+              {
+                "entity_slug": "[truncated]",
+                "display_name": "[truncated]",
+                "release_title": "[truncated]",
+                "stream": "[truncated]",
+                "release_kind": "[truncated]",
+                "release_date": "[truncated]"
+              }
+            ],
+            "exact_upcoming": []
+          },
+          {
+            "date": "2025-10-19",
+            "verified_releases": [
+              {
+                "entity_slug": "[truncated]",
+                "display_name": "[truncated]",
+                "release_title": "[truncated]",
+                "stream": "[truncated]",
+                "release_kind": "[truncated]",
+                "release_date": "[truncated]"
+              }
+            ],
+            "exact_upcoming": []
+          },
+          {
+            "date": "2025-10-20",
+            "verified_releases": [
+              {
+                "entity_slug": "[truncated]",
+                "display_name": "[truncated]",
+                "release_title": "[truncated]",
+                "stream": "[truncated]",
+                "release_kind": "[truncated]",
+                "release_date": "[truncated]"
+              },
+              {
+                "entity_slug": "[truncated]",
+                "display_name": "[truncated]",
+                "release_title": "[truncated]",
+                "stream": "[truncated]",
+                "release_kind": "[truncated]",
+                "release_date": "[truncated]"
+              }
+            ],
+            "exact_upcoming": []
+          },
+          {
+            "date": "2025-10-23",
+            "verified_releases": [
+              {
+                "entity_slug": "[truncated]",
+                "display_name": "[truncated]",
+                "release_title": "[truncated]",
+                "stream": "[truncated]",
+                "release_kind": "[truncated]",
+                "release_date": "[truncated]"
+              }
+            ],
+            "exact_upcoming": []
+          },
+          {
+            "date": "2025-10-24",
+            "verified_releases": [
+              {
+                "entity_slug": "[truncated]",
+                "display_name": "[truncated]",
+                "release_title": "[truncated]",
+                "stream": "[truncated]",
+                "release_kind": "[truncated]",
+                "release_date": "[truncated]"
+              },
+              {
+                "entity_slug": "[truncated]",
+                "display_name": "[truncated]",
+                "release_title": "[truncated]",
+                "stream": "[truncated]",
+                "release_kind": "[truncated]",
+                "release_date": "[truncated]"
+              }
+            ],
+            "exact_upcoming": []
+          },
+          {
+            "date": "2025-10-27",
+            "verified_releases": [
+              {
+                "entity_slug": "[truncated]",
+                "display_name": "[truncated]",
+                "release_title": "[truncated]",
+                "stream": "[truncated]",
+                "release_kind": "[truncated]",
+                "release_date": "[truncated]"
+              },
+              {
+                "entity_slug": "[truncated]",
+                "display_name": "[truncated]",
+                "release_title": "[truncated]",
+                "stream": "[truncated]",
+                "release_kind": "[truncated]",
+                "release_date": "[truncated]"
+              }
+            ],
+            "exact_upcoming": []
+          },
+          {
+            "date": "2025-10-28",
+            "verified_releases": [
+              {
+                "entity_slug": "[truncated]",
+                "display_name": "[truncated]",
+                "release_title": "[truncated]",
+                "stream": "[truncated]",
+                "release_kind": "[truncated]",
+                "release_date": "[truncated]"
+              }
+            ],
+            "exact_upcoming": []
+          }
+        ],
+        "month_only_upcoming": [],
+        "verified_list": [
+          {
+            "entity_slug": "g-i-dle",
+            "display_name": "(G)I-DLE",
+            "release_title": "i‐dle",
+            "release_date": "2025-10-03",
+            "stream": "album",
+            "release_kind": "ep"
+          },
+          {
+            "entity_slug": "bae173",
+            "display_name": "BAE173",
+            "release_title": "What’s wrong?",
+            "release_date": "2025-10-03",
+            "stream": "song",
+            "release_kind": "single"
+          },
+          {
+            "entity_slug": "qwer",
+            "display_name": "QWER",
+            "release_title": "흰수염고래",
+            "release_date": "2025-10-06",
+            "stream": "song",
+            "release_kind": "single"
+          },
+          {
+            "entity_slug": "onewe",
+            "display_name": "ONEWE",
+            "release_title": "MAZE : AD ASTRA",
+            "release_date": "2025-10-07",
+            "stream": "album",
+            "release_kind": "ep"
+          },
+          {
+            "entity_slug": "babymonster",
+            "display_name": "BABYMONSTER",
+            "release_title": "WE GO UP",
+            "release_date": "2025-10-10",
+            "stream": "album",
+            "release_kind": "ep"
+          },
+          {
+            "entity_slug": "twice",
+            "display_name": "TWICE",
+            "release_title": "TEN: The Story Goes On",
+            "release_date": "2025-10-10",
+            "stream": "album",
+            "release_kind": "album"
+          },
+          {
+            "entity_slug": "nmixx",
+            "display_name": "NMIXX",
+            "release_title": "Blue Valentine",
+            "release_date": "2025-10-13",
+            "stream": "album",
+            "release_kind": "album"
+          },
+          {
+            "entity_slug": "tws",
+            "display_name": "TWS",
+            "release_title": "play hard",
+            "release_date": "2025-10-13",
+            "stream": "album",
+            "release_kind": "ep"
+          },
+          {
+            "entity_slug": "bae173",
+            "display_name": "BAE173",
+            "release_title": "NEW CHAPTER : DESEAR",
+            "release_date": "2025-10-14",
+            "stream": "album",
+            "release_kind": "ep"
+          },
+          {
+            "entity_slug": "meovv",
+            "display_name": "MEOVV",
+            "release_title": "BURNING UP",
+            "release_date": "2025-10-14",
+            "stream": "song",
+            "release_kind": "single"
+          },
+          {
+            "entity_slug": "tomorrow-x-together",
+            "display_name": "TOMORROW X TOGETHER",
+            "release_title": "Starkissed",
+            "release_date": "2025-10-19",
+            "stream": "album",
+            "release_kind": "album"
+          },
+          {
+            "entity_slug": "boynextdoor",
+            "display_name": "BOYNEXTDOOR",
+            "release_title": "The Action",
+            "release_date": "2025-10-20",
+            "stream": "album",
+            "release_kind": "ep"
+          }
+        ],
+        "scheduled_list": []
+      },
+      "actual_snapshot": {
+        "summary": {
+          "verified_count": 29,
+          "exact_upcoming_count": 0,
+          "month_only_upcoming_count": 0
+        },
+        "nearest_upcoming": {
+          "upcoming_signal_id": "cd35b091-7589-514c-8277-154da992b434",
+          "entity_slug": "yena",
+          "display_name": "YENA",
+          "scheduled_date": "2026-03-11",
+          "date_precision": "exact",
+          "date_status": "confirmed",
+          "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
+          "confidence_score": 0.84
+        },
+        "days": [
+          {
+            "date": "2025-10-01",
+            "verified_releases": [
+              {
+                "release_id": "[truncated]",
+                "entity_slug": "[truncated]",
+                "display_name": "[truncated]",
+                "release_title": "[truncated]",
+                "stream": "[truncated]",
+                "release_kind": "[truncated]"
+              }
+            ],
+            "exact_upcoming": []
+          },
+          {
+            "date": "2025-10-02",
+            "verified_releases": [
+              {
+                "release_id": "[truncated]",
+                "entity_slug": "[truncated]",
+                "display_name": "[truncated]",
+                "release_title": "[truncated]",
+                "stream": "[truncated]",
+                "release_kind": "[truncated]"
+              }
+            ],
+            "exact_upcoming": []
+          },
+          {
+            "date": "2025-10-03",
+            "verified_releases": [
+              {
+                "release_id": "[truncated]",
+                "entity_slug": "[truncated]",
+                "display_name": "[truncated]",
+                "release_title": "[truncated]",
+                "stream": "[truncated]",
+                "release_kind": "[truncated]"
+              },
+              {
+                "release_id": "[truncated]",
+                "entity_slug": "[truncated]",
+                "display_name": "[truncated]",
+                "release_title": "[truncated]",
+                "stream": "[truncated]",
+                "release_kind": "[truncated]"
+              }
+            ],
+            "exact_upcoming": []
+          },
+          {
+            "date": "2025-10-06",
+            "verified_releases": [
+              {
+                "release_id": "[truncated]",
+                "entity_slug": "[truncated]",
+                "display_name": "[truncated]",
+                "release_title": "[truncated]",
+                "stream": "[truncated]",
+                "release_kind": "[truncated]"
+              }
+            ],
+            "exact_upcoming": []
+          },
+          {
+            "date": "2025-10-07",
+            "verified_releases": [
+              {
+                "release_id": "[truncated]",
+                "entity_slug": "[truncated]",
+                "display_name": "[truncated]",
+                "release_title": "[truncated]",
+                "stream": "[truncated]",
+                "release_kind": "[truncated]"
+              }
+            ],
+            "exact_upcoming": []
+          },
+          {
+            "date": "2025-10-08",
+            "verified_releases": [
+              {
+                "release_id": "[truncated]",
+                "entity_slug": "[truncated]",
+                "display_name": "[truncated]",
+                "release_title": "[truncated]",
+                "stream": "[truncated]",
+                "release_kind": "[truncated]"
+              }
+            ],
+            "exact_upcoming": []
+          },
+          {
+            "date": "2025-10-10",
+            "verified_releases": [
+              {
+                "release_id": "[truncated]",
+                "entity_slug": "[truncated]",
+                "display_name": "[truncated]",
+                "release_title": "[truncated]",
+                "stream": "[truncated]",
+                "release_kind": "[truncated]"
+              },
+              {
+                "release_id": "[truncated]",
+                "entity_slug": "[truncated]",
+                "display_name": "[truncated]",
+                "release_title": "[truncated]",
+                "stream": "[truncated]",
+                "release_kind": "[truncated]"
+              }
+            ],
+            "exact_upcoming": []
+          },
+          {
+            "date": "2025-10-13",
+            "verified_releases": [
+              {
+                "release_id": "[truncated]",
+                "entity_slug": "[truncated]",
+                "display_name": "[truncated]",
+                "release_title": "[truncated]",
+                "stream": "[truncated]",
+                "release_kind": "[truncated]"
+              },
+              {
+                "release_id": "[truncated]",
+                "entity_slug": "[truncated]",
+                "display_name": "[truncated]",
+                "release_title": "[truncated]",
+                "stream": "[truncated]",
+                "release_kind": "[truncated]"
+              }
+            ],
+            "exact_upcoming": []
+          },
+          {
+            "date": "2025-10-14",
+            "verified_releases": [
+              {
+                "release_id": "[truncated]",
+                "entity_slug": "[truncated]",
+                "display_name": "[truncated]",
+                "release_title": "[truncated]",
+                "stream": "[truncated]",
+                "release_kind": "[truncated]"
+              },
+              {
+                "release_id": "[truncated]",
+                "entity_slug": "[truncated]",
+                "display_name": "[truncated]",
+                "release_title": "[truncated]",
+                "stream": "[truncated]",
+                "release_kind": "[truncated]"
+              }
+            ],
+            "exact_upcoming": []
+          },
+          {
+            "date": "2025-10-19",
+            "verified_releases": [
+              {
+                "release_id": "[truncated]",
+                "entity_slug": "[truncated]",
+                "display_name": "[truncated]",
+                "release_title": "[truncated]",
+                "stream": "[truncated]",
+                "release_kind": "[truncated]"
+              }
+            ],
+            "exact_upcoming": []
+          },
+          {
+            "date": "2025-10-20",
+            "verified_releases": [
+              {
+                "release_id": "[truncated]",
+                "entity_slug": "[truncated]",
+                "display_name": "[truncated]",
+                "release_title": "[truncated]",
+                "stream": "[truncated]",
+                "release_kind": "[truncated]"
+              },
+              {
+                "release_id": "[truncated]",
+                "entity_slug": "[truncated]",
+                "display_name": "[truncated]",
+                "release_title": "[truncated]",
+                "stream": "[truncated]",
+                "release_kind": "[truncated]"
+              }
+            ],
+            "exact_upcoming": []
+          },
+          {
+            "date": "2025-10-23",
+            "verified_releases": [
+              {
+                "release_id": "[truncated]",
+                "entity_slug": "[truncated]",
+                "display_name": "[truncated]",
+                "release_title": "[truncated]",
+                "stream": "[truncated]",
+                "release_kind": "[truncated]"
+              },
+              {
+                "release_id": "[truncated]",
+                "entity_slug": "[truncated]",
+                "display_name": "[truncated]",
+                "release_title": "[truncated]",
+                "stream": "[truncated]",
+                "release_kind": "[truncated]"
+              }
+            ],
+            "exact_upcoming": []
+          }
+        ],
+        "month_only_upcoming": [],
+        "verified_list": [
+          {
+            "release_id": "f52f59c6-a551-5dd2-b5b6-2c9e465f3828",
+            "entity_slug": "triples",
+            "display_name": "tripleS",
+            "release_title": "tripleS ∞! < SecretHimitsuBimil >",
+            "stream": "album",
+            "release_kind": "album",
+            "release_date": "2025-10-01"
+          },
+          {
+            "release_id": "297299cc-138e-52c1-9430-c10c22f95415",
+            "entity_slug": "bae173",
+            "display_name": "BAE173",
+            "release_title": "One day",
+            "stream": "song",
+            "release_kind": "single",
+            "release_date": "2025-10-02"
+          },
+          {
+            "release_id": "f49d9a86-bd1b-53a8-8c31-7f8163cdbb29",
+            "entity_slug": "g-i-dle",
+            "display_name": "(G)I-DLE",
+            "release_title": "i‐dle",
+            "stream": "album",
+            "release_kind": "ep",
+            "release_date": "2025-10-03"
+          },
+          {
+            "release_id": "05a34ac3-1116-5cc7-a9b8-8d5127790193",
+            "entity_slug": "bae173",
+            "display_name": "BAE173",
+            "release_title": "What’s wrong?",
+            "stream": "song",
+            "release_kind": "single",
+            "release_date": "2025-10-03"
+          },
+          {
+            "release_id": "d9a85b3d-ed19-51bb-a6c4-e5e538401b50",
+            "entity_slug": "qwer",
+            "display_name": "QWER",
+            "release_title": "흰수염고래",
+            "stream": "song",
+            "release_kind": "single",
+            "release_date": "2025-10-06"
+          },
+          {
+            "release_id": "184a3749-a2e9-5309-b0be-2dc995e48e3f",
+            "entity_slug": "onewe",
+            "display_name": "ONEWE",
+            "release_title": "MAZE : AD ASTRA",
+            "stream": "album",
+            "release_kind": "ep",
+            "release_date": "2025-10-07"
+          },
+          {
+            "release_id": "da4197ce-7ce3-5a60-ad58-185d842c716d",
+            "entity_slug": "itzy",
+            "display_name": "ITZY",
+            "release_title": "Collector",
+            "stream": "album",
+            "release_kind": "album",
+            "release_date": "2025-10-08"
+          },
+          {
+            "release_id": "ee1e9da9-904f-5f37-aa38-11f9a05bce84",
+            "entity_slug": "babymonster",
+            "display_name": "BABYMONSTER",
+            "release_title": "WE GO UP",
+            "stream": "album",
+            "release_kind": "ep",
+            "release_date": "2025-10-10"
+          },
+          {
+            "release_id": "5a3a11fe-195d-50c4-a215-347eba0e018e",
+            "entity_slug": "twice",
+            "display_name": "TWICE",
+            "release_title": "TEN: The Story Goes On",
+            "stream": "album",
+            "release_kind": "album",
+            "release_date": "2025-10-10"
+          },
+          {
+            "release_id": "510353ab-c5c1-5461-80ce-eaeb26f94a12",
+            "entity_slug": "nmixx",
+            "display_name": "NMIXX",
+            "release_title": "Blue Valentine",
+            "stream": "album",
+            "release_kind": "album",
+            "release_date": "2025-10-13"
+          },
+          {
+            "release_id": "c0c2c69b-8f5c-53e9-a9b1-115b6e82e886",
+            "entity_slug": "tws",
+            "display_name": "TWS",
+            "release_title": "play hard",
+            "stream": "album",
+            "release_kind": "ep",
+            "release_date": "2025-10-13"
+          },
+          {
+            "release_id": "4fc193c7-cc0a-5d88-b656-d9615f60e359",
+            "entity_slug": "bae173",
+            "display_name": "BAE173",
+            "release_title": "NEW CHAPTER : DESEAR",
+            "stream": "album",
+            "release_kind": "ep",
+            "release_date": "2025-10-14"
+          }
+        ],
+        "scheduled_list": []
+      },
+      "actual_status_code": 200
+    },
+    {
+      "surface": "radar",
+      "input": {
+        "surface": "default"
+      },
+      "clean": false,
+      "mismatch_categories": [
+        "field-shape mismatches",
+        "radar eligibility drift"
+      ],
+      "mismatches": [
+        {
+          "category": "field-shape mismatches",
+          "path": "data",
+          "shape_mismatches": [
+            {
+              "path": "data.weekly_upcoming[0].release_title",
+              "expected_type": "string",
+              "actual_type": "missing",
+              "message": "Missing key"
+            },
+            {
+              "path": "data.weekly_upcoming[0].release_date",
+              "expected_type": "string",
+              "actual_type": "missing",
+              "message": "Missing key"
+            },
+            {
+              "path": "data.weekly_upcoming[0].stream",
+              "expected_type": "string",
+              "actual_type": "missing",
+              "message": "Missing key"
+            },
+            {
+              "path": "data.weekly_upcoming[0].release_kind",
+              "expected_type": "string",
+              "actual_type": "missing",
+              "message": "Missing key"
+            },
+            {
+              "path": "data.change_feed[0].release_title",
+              "expected_type": "string",
+              "actual_type": "missing",
+              "message": "Missing key"
+            },
+            {
+              "path": "data.change_feed[0].release_date",
+              "expected_type": "string",
+              "actual_type": "missing",
+              "message": "Missing key"
+            },
+            {
+              "path": "data.change_feed[0].stream",
+              "expected_type": "string",
+              "actual_type": "missing",
+              "message": "Missing key"
+            },
+            {
+              "path": "data.change_feed[0].release_kind",
+              "expected_type": "string",
+              "actual_type": "missing",
+              "message": "Missing key"
+            },
+            {
+              "path": "data.change_feed[0].release_format",
+              "expected_type": "string",
+              "actual_type": "missing",
+              "message": "Missing key"
+            },
+            {
+              "path": "data.rookie[0].latest_signal.scheduled_date",
+              "expected_type": "string",
+              "actual_type": "null",
+              "message": "Type mismatch"
+            },
+            {
+              "path": "data.rookie[0].latest_signal.scheduled_month",
+              "expected_type": "string",
+              "actual_type": "null",
+              "message": "Type mismatch"
+            },
+            {
+              "path": "data.rookie[0].latest_signal.release_format",
+              "expected_type": "string",
+              "actual_type": "null",
+              "message": "Type mismatch"
+            }
+          ]
+        },
+        {
+          "category": "radar eligibility drift",
+          "path": "data.weekly_upcoming",
+          "expected": [
+            "tunexx|SET BY US ONLY|2026-03-03|album",
+            "rescene|[RESCENE X ???]|2026-02-27|song",
+            "nct-wish|Same Sky|2026-02-27|song",
+            "blackpink|DEADLINE|2026-02-26|album",
+            "atheart|Shut Up|2026-02-26|song",
+            "nmixx|TIC TIC|2026-02-26|song",
+            "wjsn|Bloom hour|2026-02-25|song"
+          ],
+          "actual": [
+            "yena|최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스|2026-03-11||exact|confirmed",
+            "p1harmony|P1Harmony's Hero's Return: 9th Mini-Album Drops March 12 - 조선일보|2026-03-12||exact|confirmed"
+          ]
+        },
+        {
+          "category": "radar eligibility drift",
+          "path": "data.change_feed",
+          "expected": [
+            "tunexx|SET BY US ONLY|2026-03-03|album",
+            "nct-wish|Same Sky|2026-02-27|song",
+            "rescene|[RESCENE X ???]|2026-02-27|song",
+            "atheart|Shut Up|2026-02-26|song",
+            "blackpink|DEADLINE|2026-02-26|album",
+            "nmixx|TIC TIC|2026-02-26|song",
+            "wjsn|Bloom hour|2026-02-25|song",
+            "ive|REVIVE+|2026-02-23|album",
+            "hearts2hearts|RUDE!|2026-02-20|song",
+            "trendz|Kart Racer|2026-02-13|song"
+          ],
+          "actual": [
+            "upcoming_signal|tomorrow-x-together|[NOTICE] Comeback Showcase to Celebrate the Release of TOMORROW X TOGETHER “7TH YEAR: A Moment of Stillness in the Thorns”|",
+            "ateez|GOLDEN HOUR : Part.4|2026-02-06|album",
+            "atheart|Shut Up|2026-02-26|song",
+            "blackpink|DEADLINE|2026-02-27|album",
+            "blackpink|DEADLINE|2026-02-26|album",
+            "chung-ha|Save me|2026-02-09|song",
+            "h1-key|LOVECHAPTER|2026-03-05|album",
+            "hearts2hearts|RUDE!|2026-02-20|song",
+            "ive|REVIVE+|2026-02-23|album",
+            "ive|BANG BANG|2026-02-09|song",
+            "monsta-x|growing pains|2026-02-06|song",
+            "nct-wish|Same Sky|2026-02-27|song",
+            "nmixx|TIC TIC|2026-02-26|song",
+            "rescene|[RESCENE X ???]|2026-02-27|song",
+            "riize|All of You|2026-02-09|song",
+            "stayc|STAY ALIVE|2026-02-11|album",
+            "trendz|Kart Racer|2026-02-13|song",
+            "tunexx|SET BY US ONLY|2026-03-03|album",
+            "wjsn|Bloom hour|2026-02-25|song",
+            "triples|トキメティック|2026-02-05|song"
+          ]
+        },
+        {
+          "category": "radar eligibility drift",
+          "path": "data.long_gap",
+          "expected": [
+            "weeekly|long_gap|Bliss|2024-07-09|watchlist|606|false|null",
+            "woo-ah|long_gap|Shining on you|2024-07-16|watchlist|599|false|null"
+          ],
+          "actual": [
+            "weeekly|long_gap|Bliss|2024-07-09|album|606|false|null",
+            "woo-ah|long_gap|Shining on you|2024-07-16|song|599|false|null"
+          ]
+        },
+        {
+          "category": "radar eligibility drift",
+          "path": "data.rookie",
+          "expected": [
+            "atheart|2025|Shut Up|2026-02-26|song|true|undefined|Rookie group AtHeart drops bold new teaser photos for 'The New Black' - allkpop|||unknown|rumor",
+            "hearts2hearts|2025|RUDE!|2026-02-20|song|true|undefined|Hearts2Hearts Announce Comeback Single “RUDE!”: Here’s When It Drops - inmusicblog.com|||unknown|rumor",
+            "kiiikiii|2025|Delulu Pack|2026-01-25|album|true|undefined|Kakao Entertainment announces 2026 plans for its artists MONSTA X, IVE, KiiiKiii, & more - allkpop|||unknown|rumor",
+            "kickflip|2025|From KickFlip, To WeFlip|2026-01-20|song|true|undefined|KickFlip announces April comeback - Music Mundial||2026-04|month_only|scheduled",
+            "allday-project|2025|ALLDAY PROJECT|2025-12-08|watchlist|false|null",
+            "ifeye|2025|sweet tang|2025-07-16|album|false|null",
+            "close-your-eyes|2025|ETERNALT|2025-04-02|watchlist|false|null"
+          ],
+          "actual": [
+            "atheart|2025|Shut Up|2026-02-26|song|true|undefined|Rookie group AtHeart drops bold new teaser photos for 'The New Black' - allkpop|||unknown|rumor",
+            "hearts2hearts|2025|RUDE!|2026-02-20|song|true|undefined|Hearts2Hearts Announce Comeback Single “RUDE!”: Here’s When It Drops - inmusicblog.com|||unknown|rumor",
+            "kiiikiii|2025|Delulu Pack|2026-01-25|album|true|undefined|Kakao Entertainment announces 2026 plans for its artists MONSTA X, IVE, KiiiKiii, & more - allkpop|||unknown|rumor",
+            "kickflip|2025|From KickFlip, To WeFlip|2026-01-20|song|true|undefined|KickFlip announces April comeback - Music Mundial||2026-04-01|month_only|scheduled",
+            "allday-project|2025|ALLDAY PROJECT|2025-12-08|album|false|null",
+            "close-your-eyes|2025|blackout|2025-11-11|album|false|null",
+            "ifeye|2025|sweet tang|2025-07-16|album|false|null"
+          ]
+        }
+      ],
+      "expected_snapshot": {
+        "featured_upcoming": {
+          "entity_slug": "yena",
+          "display_name": "YENA",
+          "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
+          "scheduled_date": "2026-03-11",
+          "date_precision": "exact",
+          "date_status": "confirmed",
+          "confidence_score": 0.84,
+          "release_format": "ep"
+        },
+        "weekly_upcoming": [
+          {
+            "entity_slug": "tunexx",
+            "display_name": "TUNEXX",
+            "release_title": "SET BY US ONLY",
+            "release_date": "2026-03-03",
+            "stream": "album",
+            "release_kind": "ep",
+            "release_format": "ep"
+          },
+          {
+            "entity_slug": "rescene",
+            "display_name": "RESCENE",
+            "release_title": "[RESCENE X ???]",
+            "release_date": "2026-02-27",
+            "stream": "song",
+            "release_kind": "single",
+            "release_format": "single"
+          },
+          {
+            "entity_slug": "nct-wish",
+            "display_name": "NCT WISH",
+            "release_title": "Same Sky",
+            "release_date": "2026-02-27",
+            "stream": "song",
+            "release_kind": "single",
+            "release_format": "single"
+          },
+          {
+            "entity_slug": "blackpink",
+            "display_name": "BLACKPINK",
+            "release_title": "DEADLINE",
+            "release_date": "2026-02-26",
+            "stream": "album",
+            "release_kind": "ep",
+            "release_format": "ep"
+          },
+          {
+            "entity_slug": "atheart",
+            "display_name": "AtHeart",
+            "release_title": "Shut Up",
+            "release_date": "2026-02-26",
+            "stream": "song",
+            "release_kind": "single",
+            "release_format": "single"
+          },
+          {
+            "entity_slug": "nmixx",
+            "display_name": "NMIXX",
+            "release_title": "TIC TIC",
+            "release_date": "2026-02-26",
+            "stream": "song",
+            "release_kind": "single",
+            "release_format": "single"
+          },
+          {
+            "entity_slug": "wjsn",
+            "display_name": "WJSN",
+            "release_title": "Bloom hour",
+            "release_date": "2026-02-25",
+            "stream": "song",
+            "release_kind": "single",
+            "release_format": "single"
+          }
+        ],
+        "change_feed": [
+          {
+            "entity_slug": "tunexx",
+            "display_name": "TUNEXX",
+            "release_title": "SET BY US ONLY",
+            "release_date": "2026-03-03",
+            "stream": "album",
+            "release_kind": "ep",
+            "release_format": "ep"
+          },
+          {
+            "entity_slug": "nct-wish",
+            "display_name": "NCT WISH",
+            "release_title": "Same Sky",
+            "release_date": "2026-02-27",
+            "stream": "song",
+            "release_kind": "single",
+            "release_format": "single"
+          },
+          {
+            "entity_slug": "rescene",
+            "display_name": "RESCENE",
+            "release_title": "[RESCENE X ???]",
+            "release_date": "2026-02-27",
+            "stream": "song",
+            "release_kind": "single",
+            "release_format": "single"
+          },
+          {
+            "entity_slug": "atheart",
+            "display_name": "AtHeart",
+            "release_title": "Shut Up",
+            "release_date": "2026-02-26",
+            "stream": "song",
+            "release_kind": "single",
+            "release_format": "single"
+          },
+          {
+            "entity_slug": "blackpink",
+            "display_name": "BLACKPINK",
+            "release_title": "DEADLINE",
+            "release_date": "2026-02-26",
+            "stream": "album",
+            "release_kind": "ep",
+            "release_format": "ep"
+          },
+          {
+            "entity_slug": "nmixx",
+            "display_name": "NMIXX",
+            "release_title": "TIC TIC",
+            "release_date": "2026-02-26",
+            "stream": "song",
+            "release_kind": "single",
+            "release_format": "single"
+          },
+          {
+            "entity_slug": "wjsn",
+            "display_name": "WJSN",
+            "release_title": "Bloom hour",
+            "release_date": "2026-02-25",
+            "stream": "song",
+            "release_kind": "single",
+            "release_format": "single"
+          },
+          {
+            "entity_slug": "ive",
+            "display_name": "IVE",
+            "release_title": "REVIVE+",
+            "release_date": "2026-02-23",
+            "stream": "album",
+            "release_kind": "album",
+            "release_format": "album"
+          },
+          {
+            "entity_slug": "hearts2hearts",
+            "display_name": "Hearts2Hearts",
+            "release_title": "RUDE!",
+            "release_date": "2026-02-20",
+            "stream": "song",
+            "release_kind": "single",
+            "release_format": "single"
+          },
+          {
+            "entity_slug": "trendz",
+            "display_name": "TRENDZ",
+            "release_title": "Kart Racer",
+            "release_date": "2026-02-13",
+            "stream": "song",
+            "release_kind": "single",
+            "release_format": "single"
+          }
+        ],
+        "long_gap": [
+          {
+            "entity_slug": "weeekly",
+            "display_name": "Weeekly",
+            "watch_reason": "long_gap",
+            "latest_release": {
+              "release_title": "Bliss",
+              "release_date": "2024-07-09",
+              "stream": "watchlist",
+              "release_kind": "ep"
+            },
+            "gap_days": 606,
+            "has_upcoming_signal": false,
+            "latest_signal": null
+          },
+          {
+            "entity_slug": "woo-ah",
+            "display_name": "woo!ah!",
+            "watch_reason": "long_gap",
+            "latest_release": {
+              "release_title": "Shining on you",
+              "release_date": "2024-07-16",
+              "stream": "watchlist",
+              "release_kind": "single"
+            },
+            "gap_days": 599,
+            "has_upcoming_signal": false,
+            "latest_signal": null
+          }
+        ],
+        "rookie": [
+          {
+            "entity_slug": "atheart",
+            "display_name": "AtHeart",
+            "debut_year": 2025,
+            "latest_release": {
+              "release_title": "Shut Up",
+              "release_date": "2026-02-26",
+              "stream": "song",
+              "release_kind": "single"
+            },
+            "has_upcoming_signal": true,
+            "latest_signal": {
+              "headline": "Rookie group AtHeart drops bold new teaser photos for 'The New Black' - allkpop",
+              "scheduled_date": "",
+              "scheduled_month": "",
+              "date_precision": "unknown",
+              "date_status": "rumor",
+              "release_format": "",
+              "confidence_score": 0.68
+            }
+          },
+          {
+            "entity_slug": "hearts2hearts",
+            "display_name": "Hearts2Hearts",
+            "debut_year": 2025,
+            "latest_release": {
+              "release_title": "RUDE!",
+              "release_date": "2026-02-20",
+              "stream": "song",
+              "release_kind": "single"
+            },
+            "has_upcoming_signal": true,
+            "latest_signal": {
+              "headline": "Hearts2Hearts Announce Comeback Single “RUDE!”: Here’s When It Drops - inmusicblog.com",
+              "scheduled_date": "",
+              "scheduled_month": "",
+              "date_precision": "unknown",
+              "date_status": "rumor",
+              "release_format": "single",
+              "confidence_score": 0.68
+            }
+          },
+          {
+            "entity_slug": "kiiikiii",
+            "display_name": "KiiiKiii",
+            "debut_year": 2025,
+            "latest_release": {
+              "release_title": "Delulu Pack",
+              "release_date": "2026-01-25",
+              "stream": "album",
+              "release_kind": "ep"
+            },
+            "has_upcoming_signal": true,
+            "latest_signal": {
+              "headline": "Kakao Entertainment announces 2026 plans for its artists MONSTA X, IVE, KiiiKiii, & more - allkpop",
+              "scheduled_date": "",
+              "scheduled_month": "",
+              "date_precision": "unknown",
+              "date_status": "rumor",
+              "release_format": "",
+              "confidence_score": 0.56
+            }
+          },
+          {
+            "entity_slug": "kickflip",
+            "display_name": "KickFlip",
+            "debut_year": 2025,
+            "latest_release": {
+              "release_title": "From KickFlip, To WeFlip",
+              "release_date": "2026-01-20",
+              "stream": "song",
+              "release_kind": "single"
+            },
+            "has_upcoming_signal": true,
+            "latest_signal": {
+              "headline": "KickFlip announces April comeback - Music Mundial",
+              "scheduled_date": "",
+              "scheduled_month": "2026-04",
+              "date_precision": "month_only",
+              "date_status": "scheduled",
+              "release_format": "",
+              "confidence_score": 0.76
+            }
+          },
+          {
+            "entity_slug": "allday-project",
+            "display_name": "ALLDAY PROJECT",
+            "debut_year": 2025,
+            "latest_release": {
+              "release_title": "ALLDAY PROJECT",
+              "release_date": "2025-12-08",
+              "stream": "watchlist",
+              "release_kind": "ep"
+            },
+            "has_upcoming_signal": false,
+            "latest_signal": null
+          },
+          {
+            "entity_slug": "ifeye",
+            "display_name": "ifeye",
+            "debut_year": 2025,
+            "latest_release": {
+              "release_title": "sweet tang",
+              "release_date": "2025-07-16",
+              "stream": "album",
+              "release_kind": "ep"
+            },
+            "has_upcoming_signal": false,
+            "latest_signal": null
+          },
+          {
+            "entity_slug": "close-your-eyes",
+            "display_name": "CLOSE YOUR EYES",
+            "debut_year": 2025,
+            "latest_release": {
+              "release_title": "ETERNALT",
+              "release_date": "2025-04-02",
+              "stream": "watchlist",
+              "release_kind": "ep"
+            },
+            "has_upcoming_signal": false,
+            "latest_signal": null
+          }
+        ]
+      },
+      "actual_snapshot": {
+        "featured_upcoming": {
+          "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
+          "date_status": "confirmed",
+          "entity_slug": "yena",
+          "display_name": "YENA",
+          "date_precision": "exact",
+          "release_format": "ep",
+          "scheduled_date": "2026-03-11",
+          "confidence_score": 0.84,
+          "upcoming_signal_id": "cd35b091-7589-514c-8277-154da992b434"
+        },
+        "weekly_upcoming": [
+          {
+            "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
+            "date_status": "confirmed",
+            "entity_slug": "yena",
+            "display_name": "YENA",
+            "date_precision": "exact",
+            "release_format": "ep",
+            "scheduled_date": "2026-03-11",
+            "confidence_score": 0.84,
+            "upcoming_signal_id": "cd35b091-7589-514c-8277-154da992b434"
+          },
+          {
+            "headline": "P1Harmony's Hero's Return: 9th Mini-Album Drops March 12 - 조선일보",
+            "date_status": "confirmed",
+            "entity_slug": "p1harmony",
+            "display_name": "P1Harmony",
+            "date_precision": "exact",
+            "release_format": "ep",
+            "scheduled_date": "2026-03-12",
+            "confidence_score": 0.82,
+            "upcoming_signal_id": "7150643f-66ad-5e29-b2b4-fadcfcd96eac"
+          }
+        ],
+        "change_feed": [
+          {
+            "kind": "upcoming_signal",
+            "headline": "[NOTICE] Comeback Showcase to Celebrate the Release of TOMORROW X TOGETHER “7TH YEAR: A Moment of Stillness in the Thorns”",
+            "date_status": "confirmed",
+            "entity_slug": "tomorrow-x-together",
+            "occurred_at": null,
+            "display_name": "TOMORROW X TOGETHER",
+            "date_precision": "exact",
+            "scheduled_date": "2026-04-13",
+            "scheduled_month": null,
+            "confidence_score": 0.84,
+            "upcoming_signal_id": "5299f667-d0b0-52f8-a437-02e0ccc557da"
+          },
+          {
+            "kind": "verified_release",
+            "stream": "album",
+            "release_id": "6a97ac23-629a-5468-9fd1-996c434052b2",
+            "entity_slug": "ateez",
+            "occurred_at": "2026-03-07T07:51:07.368683+00:00",
+            "display_name": "ATEEZ",
+            "release_date": "2026-02-06",
+            "release_kind": "ep",
+            "release_title": "GOLDEN HOUR : Part.4"
+          },
+          {
+            "kind": "verified_release",
+            "stream": "song",
+            "release_id": "e5976e68-a795-52dd-b40e-a72493038dd3",
+            "entity_slug": "atheart",
+            "occurred_at": "2026-03-07T07:51:07.368683+00:00",
+            "display_name": "AtHeart",
+            "release_date": "2026-02-26",
+            "release_kind": "single",
+            "release_title": "Shut Up"
+          },
+          {
+            "kind": "verified_release",
+            "stream": "album",
+            "release_id": "75d59b7a-9f0e-526c-9920-3a156c1a9e36",
+            "entity_slug": "blackpink",
+            "occurred_at": "2026-03-07T07:51:07.368683+00:00",
+            "display_name": "BLACKPINK",
+            "release_date": "2026-02-27",
+            "release_kind": "ep",
+            "release_title": "DEADLINE"
+          },
+          {
+            "kind": "verified_release",
+            "stream": "album",
+            "release_id": "e3526174-e804-56f2-9d50-17f9f817a351",
+            "entity_slug": "blackpink",
+            "occurred_at": "2026-03-07T07:51:07.368683+00:00",
+            "display_name": "BLACKPINK",
+            "release_date": "2026-02-26",
+            "release_kind": "ep",
+            "release_title": "DEADLINE"
+          },
+          {
+            "kind": "verified_release",
+            "stream": "song",
+            "release_id": "6e323520-f064-5ba5-bf87-d56898edb48e",
+            "entity_slug": "chung-ha",
+            "occurred_at": "2026-03-07T07:51:07.368683+00:00",
+            "display_name": "CHUNG HA",
+            "release_date": "2026-02-09",
+            "release_kind": "single",
+            "release_title": "Save me"
+          },
+          {
+            "kind": "verified_release",
+            "stream": "album",
+            "release_id": "6a1db562-83b4-5e9d-a00f-6ea0ebfb6680",
+            "entity_slug": "h1-key",
+            "occurred_at": "2026-03-07T07:51:07.368683+00:00",
+            "display_name": "H1-KEY",
+            "release_date": "2026-03-05",
+            "release_kind": "ep",
+            "release_title": "LOVECHAPTER"
+          },
+          {
+            "kind": "verified_release",
+            "stream": "song",
+            "release_id": "06aa603b-b554-52a8-b9e4-47c6a6764e53",
+            "entity_slug": "hearts2hearts",
+            "occurred_at": "2026-03-07T07:51:07.368683+00:00",
+            "display_name": "Hearts2Hearts",
+            "release_date": "2026-02-20",
+            "release_kind": "single",
+            "release_title": "RUDE!"
+          },
+          {
+            "kind": "verified_release",
+            "stream": "album",
+            "release_id": "c339f501-52fe-599d-8d2d-bf5694ae4de4",
+            "entity_slug": "ive",
+            "occurred_at": "2026-03-07T07:51:07.368683+00:00",
+            "display_name": "IVE",
+            "release_date": "2026-02-23",
+            "release_kind": "album",
+            "release_title": "REVIVE+"
+          },
+          {
+            "kind": "verified_release",
+            "stream": "song",
+            "release_id": "78bb2629-2cd8-5f57-aaf1-a029b271ae8f",
+            "entity_slug": "ive",
+            "occurred_at": "2026-03-07T07:51:07.368683+00:00",
+            "display_name": "IVE",
+            "release_date": "2026-02-09",
+            "release_kind": "single",
+            "release_title": "BANG BANG"
+          },
+          {
+            "kind": "verified_release",
+            "stream": "song",
+            "release_id": "48080244-9689-5f33-9e44-f5e854a5f0e8",
+            "entity_slug": "monsta-x",
+            "occurred_at": "2026-03-07T07:51:07.368683+00:00",
+            "display_name": "MONSTA X",
+            "release_date": "2026-02-06",
+            "release_kind": "single",
+            "release_title": "growing pains"
+          },
+          {
+            "kind": "verified_release",
+            "stream": "song",
+            "release_id": "179b842f-9bd1-56ca-aaf6-b33e3f87159b",
+            "entity_slug": "nct-wish",
+            "occurred_at": "2026-03-07T07:51:07.368683+00:00",
+            "display_name": "NCT WISH",
+            "release_date": "2026-02-27",
+            "release_kind": "single",
+            "release_title": "Same Sky"
+          }
+        ],
+        "long_gap": [
+          {
+            "gap_days": 606,
+            "entity_slug": "weeekly",
+            "display_name": "Weeekly",
+            "watch_reason": "long_gap",
+            "latest_signal": null,
+            "latest_release": {
+              "stream": "album",
+              "release_id": "f4a2b5b1-c9e2-5a1a-9cd6-56afa855ef8f",
+              "release_date": "2024-07-09",
+              "release_kind": "ep",
+              "release_title": "Bliss"
+            },
+            "has_upcoming_signal": false
+          },
+          {
+            "gap_days": 599,
+            "entity_slug": "woo-ah",
+            "display_name": "woo!ah!",
+            "watch_reason": "long_gap",
+            "latest_signal": null,
+            "latest_release": {
+              "stream": "song",
+              "release_id": "2d4803a4-8bd7-57d2-86b3-ffac2999300b",
+              "release_date": "2024-07-16",
+              "release_kind": "single",
+              "release_title": "Shining on you"
+            },
+            "has_upcoming_signal": false
+          }
+        ],
+        "rookie": [
+          {
+            "debut_year": 2025,
+            "entity_slug": "atheart",
+            "display_name": "AtHeart",
+            "latest_signal": {
+              "headline": "Rookie group AtHeart drops bold new teaser photos for 'The New Black' - allkpop",
+              "date_status": "rumor",
+              "date_precision": "unknown",
+              "latest_seen_at": "2026-01-31T08:00:00+00:00",
+              "release_format": null,
+              "scheduled_date": null,
+              "scheduled_month": null,
+              "confidence_score": 0.68,
+              "upcoming_signal_id": "fdd6dcf8-8d58-5136-897c-b9fecec90e2f"
+            },
+            "latest_release": {
+              "stream": "song",
+              "release_id": "e5976e68-a795-52dd-b40e-a72493038dd3",
+              "release_date": "2026-02-26",
+              "release_kind": "single",
+              "release_title": "Shut Up"
+            },
+            "has_upcoming_signal": true
+          },
+          {
+            "debut_year": 2025,
+            "entity_slug": "hearts2hearts",
+            "display_name": "Hearts2Hearts",
+            "latest_signal": {
+              "headline": "Hearts2Hearts Announce Comeback Single “RUDE!”: Here’s When It Drops - inmusicblog.com",
+              "date_status": "rumor",
+              "date_precision": "unknown",
+              "latest_seen_at": "2026-02-12T15:30:11+00:00",
+              "release_format": "single",
+              "scheduled_date": null,
+              "scheduled_month": null,
+              "confidence_score": 0.68,
+              "upcoming_signal_id": "b2539788-c088-51e8-bf8f-4679db90c10d"
+            },
+            "latest_release": {
+              "stream": "song",
+              "release_id": "06aa603b-b554-52a8-b9e4-47c6a6764e53",
+              "release_date": "2026-02-20",
+              "release_kind": "single",
+              "release_title": "RUDE!"
+            },
+            "has_upcoming_signal": true
+          },
+          {
+            "debut_year": 2025,
+            "entity_slug": "kiiikiii",
+            "display_name": "KiiiKiii",
+            "latest_signal": {
+              "headline": "Kakao Entertainment announces 2026 plans for its artists MONSTA X, IVE, KiiiKiii, & more - allkpop",
+              "date_status": "rumor",
+              "date_precision": "unknown",
+              "latest_seen_at": "2026-01-27T08:00:00+00:00",
+              "release_format": null,
+              "scheduled_date": null,
+              "scheduled_month": null,
+              "confidence_score": 0.56,
+              "upcoming_signal_id": "078dbbc6-7ede-504a-a66f-e4384ec2a542"
+            },
+            "latest_release": {
+              "stream": "album",
+              "release_id": "da1a7f42-5755-5649-b235-e8568b2e4a58",
+              "release_date": "2026-01-25",
+              "release_kind": "ep",
+              "release_title": "Delulu Pack"
+            },
+            "has_upcoming_signal": true
+          },
+          {
+            "debut_year": 2025,
+            "entity_slug": "kickflip",
+            "display_name": "KickFlip",
+            "latest_signal": {
+              "headline": "KickFlip announces April comeback - Music Mundial",
+              "date_status": "scheduled",
+              "date_precision": "month_only",
+              "latest_seen_at": "2026-03-02T18:54:14+00:00",
+              "release_format": null,
+              "scheduled_date": null,
+              "scheduled_month": "2026-04-01",
+              "confidence_score": 0.76,
+              "upcoming_signal_id": "a2225095-7ab3-554d-84c1-0ea9614d71e9"
+            },
+            "latest_release": {
+              "stream": "song",
+              "release_id": "f8f95da5-91f9-53f5-bef1-fa14153369f3",
+              "release_date": "2026-01-20",
+              "release_kind": "single",
+              "release_title": "From KickFlip, To WeFlip"
+            },
+            "has_upcoming_signal": true
+          },
+          {
+            "debut_year": 2025,
+            "entity_slug": "allday-project",
+            "display_name": "ALLDAY PROJECT",
+            "latest_signal": null,
+            "latest_release": {
+              "stream": "album",
+              "release_id": "c00920b0-930d-5662-9874-82603c0ad5f7",
+              "release_date": "2025-12-08",
+              "release_kind": "ep",
+              "release_title": "ALLDAY PROJECT"
+            },
+            "has_upcoming_signal": false
+          },
+          {
+            "debut_year": 2025,
+            "entity_slug": "close-your-eyes",
+            "display_name": "CLOSE YOUR EYES",
+            "latest_signal": null,
+            "latest_release": {
+              "stream": "album",
+              "release_id": "f6355382-6712-52f4-87ff-593f96ca7869",
+              "release_date": "2025-11-11",
+              "release_kind": "ep",
+              "release_title": "blackout"
+            },
+            "has_upcoming_signal": false
+          },
+          {
+            "debut_year": 2025,
+            "entity_slug": "ifeye",
+            "display_name": "ifeye",
+            "latest_signal": null,
+            "latest_release": {
+              "stream": "album",
+              "release_id": "40006299-e74f-5b9e-9174-36fa3fe552b3",
+              "release_date": "2025-07-16",
+              "release_kind": "ep",
+              "release_title": "sweet tang"
+            },
+            "has_upcoming_signal": false
+          }
+        ]
+      },
+      "actual_status_code": 200
+    }
+  ]
+}

--- a/backend/scripts/build-shadow-read-report.mjs
+++ b/backend/scripts/build-shadow-read-report.mjs
@@ -1,0 +1,3285 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { buildApp } from '../dist/app.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const BACKEND_DIR = path.resolve(__dirname, '..');
+const REPO_ROOT = path.resolve(BACKEND_DIR, '..');
+const DEFAULT_REPORT_PATH = path.join(BACKEND_DIR, 'reports', 'backend_shadow_read_report.json');
+const PARITY_REPORT_PATH = path.join(BACKEND_DIR, 'reports', 'backend_json_parity_report.json');
+
+const ARTIST_PROFILES_PATH = path.join(REPO_ROOT, 'web', 'src', 'data', 'artistProfiles.json');
+const RELEASES_PATH = path.join(REPO_ROOT, 'web', 'src', 'data', 'releases.json');
+const RELEASE_HISTORY_PATH = path.join(REPO_ROOT, 'web', 'src', 'data', 'releaseHistory.json');
+const RELEASE_DETAILS_PATH = path.join(REPO_ROOT, 'web', 'src', 'data', 'releaseDetails.json');
+const RELEASE_ARTWORK_PATH = path.join(REPO_ROOT, 'web', 'src', 'data', 'releaseArtwork.json');
+const RELEASE_ENRICHMENT_PATH = path.join(REPO_ROOT, 'web', 'src', 'data', 'releaseEnrichment.json');
+const UPCOMING_CANDIDATES_PATH = path.join(REPO_ROOT, 'web', 'src', 'data', 'upcomingCandidates.json');
+const WATCHLIST_PATH = path.join(REPO_ROOT, 'web', 'src', 'data', 'watchlist.json');
+const YOUTUBE_ALLOWLISTS_PATH = path.join(REPO_ROOT, 'web', 'src', 'data', 'youtubeChannelAllowlists.json');
+const TEAM_BADGE_ASSETS_PATH = path.join(REPO_ROOT, 'web', 'src', 'data', 'teamBadgeAssets.json');
+
+const RELEASE_ARTWORK_PLACEHOLDER_URL = '/release-placeholder.svg';
+const LONG_GAP_THRESHOLD_DAYS = 365;
+const ROOKIE_RECENT_YEAR_WINDOW = 2;
+const WEEKLY_DIGEST_MAX_ITEMS = 8;
+const UNIT_GROUPS = new Set(['ARTMS', 'NCT DREAM', 'NCT WISH', 'VIVIZ']);
+
+const SEARCH_CASES = ['트리플에스', '투바투', '최예나', 'REVIVE+', '흰수염고래'];
+const ENTITY_CASES = ['yena', 'blackpink', 'and-team', 'allday-project'];
+const RELEASE_CASES = [
+  { entitySlug: 'blackpink', title: 'DEADLINE', date: '2026-02-26', stream: 'album' },
+  { entitySlug: 'ive', title: 'REVIVE+', date: '2026-02-23', stream: 'album' },
+  { entitySlug: 'qwer', title: '흰수염고래', date: '2025-10-06', stream: 'song' },
+];
+const CALENDAR_CASES = ['2026-03', '2026-04', '2025-10'];
+
+function parseArgs(argv) {
+  const args = {
+    reportPath: DEFAULT_REPORT_PATH,
+  };
+
+  for (let index = 2; index < argv.length; index += 1) {
+    const value = argv[index];
+    if (value === '--report-path') {
+      args.reportPath = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${value}`);
+  }
+
+  return args;
+}
+
+function loadJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function optionalText(value) {
+  return typeof value === 'string' && value.trim() ? value.trim() : '';
+}
+
+function isRecord(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function cloneJson(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function normalizeSearchText(value) {
+  return String(value ?? '')
+    .normalize('NFKC')
+    .replace(/[×✕]/g, 'x')
+    .replace(/&/g, ' and ')
+    .toLowerCase()
+    .replace(/['’`]/g, '')
+    .replace(/[^a-z0-9ㄱ-ㅎㅏ-ㅣ가-힣]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function collapseSearchText(value) {
+  return value.replace(/\s+/g, '');
+}
+
+function createSearchNeedle(value) {
+  const normalized = normalizeSearchText(value);
+  if (!normalized) {
+    return null;
+  }
+
+  return {
+    normalized,
+    compact: collapseSearchText(normalized),
+  };
+}
+
+function buildSearchIndex(values) {
+  const normalizedTerms = new Set();
+  const compactTerms = new Set();
+
+  for (const value of values) {
+    if (!value) {
+      continue;
+    }
+
+    const normalized = normalizeSearchText(value);
+    if (!normalized) {
+      continue;
+    }
+
+    normalizedTerms.add(normalized);
+    compactTerms.add(collapseSearchText(normalized));
+  }
+
+  return {
+    normalizedTerms: [...normalizedTerms],
+    compactTerms: [...compactTerms],
+  };
+}
+
+function matchesSearchIndex(index, needle) {
+  if (!needle) {
+    return true;
+  }
+
+  if (!index) {
+    return false;
+  }
+
+  return (
+    index.normalizedTerms.some((term) => term.includes(needle.normalized)) ||
+    index.compactTerms.some((term) => term.includes(needle.compact))
+  );
+}
+
+function findExactMatch(values, needle) {
+  for (const value of values) {
+    const normalized = normalizeSearchText(value);
+    if (!normalized) {
+      continue;
+    }
+
+    if (normalized === needle.normalized || collapseSearchText(normalized) === needle.compact) {
+      return value;
+    }
+  }
+
+  return null;
+}
+
+function findPartialMatch(values, needle) {
+  for (const value of values) {
+    const normalized = normalizeSearchText(value);
+    if (!normalized) {
+      continue;
+    }
+
+    if (normalized.includes(needle.normalized) || collapseSearchText(normalized).includes(needle.compact)) {
+      return value;
+    }
+  }
+
+  return null;
+}
+
+function getKstTodayIso(now = new Date()) {
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Asia/Seoul',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(now);
+}
+
+function isExactDate(value) {
+  return /^\d{4}-\d{2}-\d{2}$/.test(String(value ?? ''));
+}
+
+function isMonthKey(value) {
+  return /^\d{4}-\d{2}$/.test(String(value ?? ''));
+}
+
+function parseDateValue(value) {
+  if (!isExactDate(value)) {
+    return -1;
+  }
+  return new Date(`${value}T00:00:00`).getTime();
+}
+
+function monthKeyToDate(monthKey) {
+  const [year, month] = monthKey.split('-').map(Number);
+  return new Date(year, month - 1, 1);
+}
+
+function getMonthKey(date) {
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, '0');
+  return `${year}-${month}`;
+}
+
+function getDateDaysBefore(referenceDate, days) {
+  const nextDate = new Date(referenceDate);
+  nextDate.setDate(nextDate.getDate() - days);
+  return nextDate;
+}
+
+function getElapsedDaysSinceDate(value, todayIso) {
+  if (!isExactDate(value)) {
+    return 0;
+  }
+  const targetDate = new Date(`${value}T00:00:00`);
+  const today = new Date(`${todayIso}T00:00:00`);
+  return Math.max(0, Math.round((today.getTime() - targetDate.getTime()) / (24 * 60 * 60 * 1000)));
+}
+
+function normalizeAgencyName(agency) {
+  if (!agency) {
+    return '';
+  }
+
+  const normalized = String(agency).trim().replace(/\s+/g, ' ');
+  const canonicalMap = {
+    'brand new music': 'Brand New Music',
+    'c9 entertainment': 'C9 Entertainment',
+    'cube entertainment': 'Cube Entertainment',
+    'fnc entertainment': 'FNC Entertainment',
+    glg: 'GLG',
+    'hybe labels': 'HYBE Labels',
+    'ist entertainment': 'IST Entertainment',
+    'jellyfish entertainment': 'Jellyfish Entertainment',
+    'jyp entertainment': 'JYP Entertainment',
+    'kq entertainment': 'KQ Entertainment',
+    modhaus: 'MODHAUS',
+    rbw: 'RBW',
+    's2 entertainment': 'S2 Entertainment',
+    'sm entertainment': 'SM Entertainment',
+    'starship entertainment': 'Starship Entertainment',
+    vlast: 'VLAST',
+    wakeone: 'WAKEONE',
+    'wm entertainment': 'WM Entertainment',
+    'woollim entertainment': 'Woollim Entertainment',
+    'yg entertainment': 'YG Entertainment',
+    'yuehua entertainment': 'Yuehua Entertainment',
+  };
+
+  return canonicalMap[normalized.toLowerCase()] ?? normalized;
+}
+
+function slugifyGroup(group) {
+  return group
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/&/g, ' and ')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function slugifyPathSegment(value) {
+  return String(value ?? '')
+    .normalize('NFKC')
+    .replace(/[×✕]/g, 'x')
+    .replace(/&/g, ' and ')
+    .toLowerCase()
+    .replace(/['’`]/g, '')
+    .replace(/[^a-z0-9ㄱ-ㅎㅏ-ㅣ가-힣]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function normalizeReleaseStream(stream, releaseKind) {
+  if (stream === 'album') {
+    return 'album';
+  }
+  if (stream === 'song') {
+    return 'song';
+  }
+  return releaseKind === 'album' || releaseKind === 'ep' ? 'album' : 'song';
+}
+
+function getReleaseLookupKey(group, releaseTitle, releaseDate, stream) {
+  return [group, releaseTitle, releaseDate, stream].join('::');
+}
+
+function buildYouTubeMvCanonicalUrl(videoId) {
+  return `https://www.youtube.com/watch?v=${videoId}`;
+}
+
+function buildYouTubeNoCookieEmbedUrl(videoId) {
+  return `https://www.youtube-nocookie.com/embed/${videoId}?rel=0`;
+}
+
+function extractYouTubeVideoId(value) {
+  if (!value) {
+    return '';
+  }
+
+  if (/^[a-zA-Z0-9_-]{11}$/.test(value)) {
+    return value;
+  }
+
+  try {
+    const url = new URL(value);
+
+    if (url.hostname.includes('youtu.be')) {
+      return url.pathname.replace(/^\//, '');
+    }
+
+    const watchId = url.searchParams.get('v');
+    if (watchId) {
+      return watchId;
+    }
+
+    const segments = url.pathname.split('/').filter(Boolean);
+    const embedIndex = segments.findIndex((segment) => segment === 'embed' || segment === 'shorts');
+    if (embedIndex >= 0) {
+      return segments[embedIndex + 1] ?? '';
+    }
+  } catch {
+    return '';
+  }
+
+  return '';
+}
+
+function getReleaseDetailMvUrls(detail) {
+  const videoId = extractYouTubeVideoId(detail.youtube_video_id) || extractYouTubeVideoId(detail.youtube_video_url);
+  return {
+    canonicalUrl: videoId ? buildYouTubeMvCanonicalUrl(videoId) : '',
+    embedUrl: videoId ? buildYouTubeNoCookieEmbedUrl(videoId) : '',
+    videoId,
+  };
+}
+
+function getUpcomingDatePrecisionValue(item) {
+  if (item.date_precision === 'exact' || item.date_precision === 'month_only' || item.date_precision === 'unknown') {
+    return item.date_precision;
+  }
+
+  if (isExactDate(item.scheduled_date)) {
+    return 'exact';
+  }
+
+  if (isMonthKey(item.scheduled_month)) {
+    return 'month_only';
+  }
+
+  return 'unknown';
+}
+
+function hasExactUpcomingDate(item) {
+  return getUpcomingDatePrecisionValue(item) === 'exact' && isExactDate(item.scheduled_date);
+}
+
+function getUpcomingMonthKey(item) {
+  if (hasExactUpcomingDate(item)) {
+    return item.scheduled_date.slice(0, 7);
+  }
+  if (getUpcomingDatePrecisionValue(item) === 'month_only' && isMonthKey(item.scheduled_month)) {
+    return item.scheduled_month;
+  }
+  return '';
+}
+
+function getActType(group) {
+  return UNIT_GROUPS.has(group) ? 'unit' : 'group';
+}
+
+function expandReleaseRow(row) {
+  return ['latest_song', 'latest_album'].flatMap((key) => {
+    const release = row[key];
+    if (!release) {
+      return [];
+    }
+
+    return [
+      {
+        ...release,
+        group: row.group,
+        artist_name_mb: row.artist_name_mb,
+        artist_mbid: row.artist_mbid,
+        artist_source: row.artist_source,
+        actType: getActType(row.group),
+        stream: key === 'latest_song' ? 'song' : 'album',
+        dateValue: new Date(`${release.date}T00:00:00`),
+        isoDate: release.date,
+      },
+    ];
+  });
+}
+
+function buildSeededVerifiedReleaseHistory(rows) {
+  return rows
+    .flatMap((row) =>
+      row.releases.map((release) => ({
+        ...release,
+        group: row.group,
+        artist_name_mb: row.artist_name_mb,
+        artist_mbid: row.artist_mbid,
+        artist_source: row.artist_source,
+        actType: getActType(row.group),
+        dateValue: new Date(`${release.date}T00:00:00`),
+        isoDate: release.date,
+      })),
+    )
+    .sort((left, right) => {
+      if (left.dateValue.getTime() !== right.dateValue.getTime()) {
+        return right.dateValue.getTime() - left.dateValue.getTime();
+      }
+
+      if (left.stream !== right.stream) {
+        return left.stream.localeCompare(right.stream);
+      }
+
+      return left.title.localeCompare(right.title);
+    });
+}
+
+function buildVerifiedReleaseHistory(seedReleases, releaseDetailsCatalog, releaseCatalogByGroup, releaseCatalog, releaseCatalogByKey) {
+  const historyByKey = new Map();
+
+  for (const release of seedReleases) {
+    historyByKey.set(getReleaseLookupKey(release.group, release.title, release.date, release.stream), release);
+  }
+
+  for (const detail of releaseDetailsCatalog) {
+    const releaseRow = releaseCatalogByGroup.get(detail.group);
+    const matchedRelease =
+      releaseRow?.latest_song &&
+      releaseRow.latest_song.title === detail.release_title &&
+      releaseRow.latest_song.date === detail.release_date &&
+      normalizeReleaseStream('song', releaseRow.latest_song.release_kind) === detail.stream
+        ? releaseRow.latest_song
+        : releaseRow?.latest_album &&
+            releaseRow.latest_album.title === detail.release_title &&
+            releaseRow.latest_album.date === detail.release_date &&
+            normalizeReleaseStream('album', releaseRow.latest_album.release_kind) === detail.stream
+          ? releaseRow.latest_album
+          : null;
+
+    historyByKey.set(getReleaseLookupKey(detail.group, detail.release_title, detail.release_date, detail.stream), {
+      title: detail.release_title,
+      date: detail.release_date,
+      source: matchedRelease?.source ?? '',
+      release_kind: detail.release_kind,
+      release_format: matchedRelease?.release_format ?? detail.release_kind,
+      context_tags: matchedRelease?.context_tags ?? [],
+      music_handoffs: matchedRelease?.music_handoffs,
+      group: detail.group,
+      artist_name_mb: releaseRow?.artist_name_mb ?? detail.group,
+      artist_mbid: releaseRow?.artist_mbid ?? '',
+      artist_source: releaseRow?.artist_source ?? '',
+      actType: getActType(detail.group),
+      stream: detail.stream,
+      dateValue: new Date(`${detail.release_date}T00:00:00`),
+      isoDate: detail.release_date,
+    });
+  }
+
+  for (const release of releaseCatalog) {
+    const key = getReleaseLookupKey(release.group, release.title, release.date, release.stream);
+    if (!historyByKey.has(key)) {
+      historyByKey.set(key, release);
+    }
+  }
+
+  return [...historyByKey.values()].sort((left, right) => {
+    if (left.dateValue.getTime() !== right.dateValue.getTime()) {
+      return right.dateValue.getTime() - left.dateValue.getTime();
+    }
+
+    if (left.stream !== right.stream) {
+      return left.stream.localeCompare(right.stream);
+    }
+
+    return left.title.localeCompare(right.title);
+  });
+}
+
+function groupReleasesByGroup(rows) {
+  return rows.reduce((map, row) => {
+    const bucket = map.get(row.group) ?? [];
+    bucket.push(row);
+    map.set(row.group, bucket);
+    return map;
+  }, new Map());
+}
+
+function groupUpcomingCandidatesByGroup(rows) {
+  return rows.reduce((map, row) => {
+    const bucket = map.get(row.group) ?? [];
+    bucket.push(row);
+    map.set(row.group, bucket);
+    return map;
+  }, new Map());
+}
+
+function stripUpcomingSourceSuffix(value) {
+  return value.replace(/\s+-\s+[^-]+$/u, ' ');
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function normalizeUpcomingGroupingText(value, group) {
+  let normalized = stripUpcomingSourceSuffix(value)
+    .toLowerCase()
+    .replace(/[’‘]/g, "'")
+    .replace(/[“”]/g, '"')
+    .replace(/&/g, ' and ')
+    .replace(/\[[^\]]*]/g, ' ')
+    .replace(/\([^)]*\)/g, ' ');
+
+  for (const token of group.toLowerCase().split(/[^a-z0-9]+/).filter(Boolean)) {
+    if (token.length < 2) {
+      continue;
+    }
+    normalized = normalized.replace(new RegExp(`\\b${escapeRegExp(token)}\\b`, 'g'), ' ');
+  }
+
+  return normalized
+    .replace(
+      /\b(?:comeback|comebacks|announce|announces|announced|announcing|return|returns|returning|release|releases|released|releasing|drop|drops|dropped|dropping|set|scheduled|schedule|showcase|notice|official|teaser|teasers|trailer|trailers|report|reports|ahead|after|with|their|first|new|album|mini|single|ep|tracklist|title|track|tour|global|hosts|hosted|concert|celebrate|chapter)\b/g,
+      ' ',
+    )
+    .replace(/[^a-z0-9]+/g, ' ')
+    .replace(/\b(?:a|an|the|and|for|of|to|in|on|at|this|that)\b/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function extractUpcomingReleaseLabel(item) {
+  const text = `${item.headline} ${item.evidence_summary ?? ''}`;
+  const patterns = [
+    /(?:mini album|album|single|ep|title track|showcase(?:\s+for)?|trailer(?:\s+for)?|teaser(?:\s+for)?)\s*[“"'‘]?([^“”"'’]{2,80})[”"'’]/gi,
+    /[“"'‘]([^“”"'’]{2,80})[”"'’]/g,
+  ];
+
+  for (const pattern of patterns) {
+    for (const match of text.matchAll(pattern)) {
+      const normalized = normalizeUpcomingGroupingText(match[1] ?? '', item.group);
+      if (normalized) {
+        return normalized;
+      }
+    }
+  }
+
+  return '';
+}
+
+function getUpcomingEventDescriptor(item) {
+  const releaseLabel = extractUpcomingReleaseLabel(item);
+  if (releaseLabel) {
+    return releaseLabel;
+  }
+
+  const headlineKey = normalizeUpcomingGroupingText(item.headline, item.group);
+  if (headlineKey) {
+    return headlineKey;
+  }
+
+  const summaryKey = normalizeUpcomingGroupingText(item.evidence_summary ?? '', item.group);
+  return summaryKey || 'signal';
+}
+
+function getUpcomingStructuredMetadataScore(item) {
+  let score = 0;
+  if (item.release_format) {
+    score += 2;
+  }
+  score += (item.context_tags ?? []).length;
+  if (extractUpcomingReleaseLabel(item)) {
+    score += 2;
+  }
+  if (item.evidence_summary) {
+    score += 1;
+  }
+  return score;
+}
+
+function getUpcomingPublishedSortValue(item) {
+  const timestamp = Date.parse(item.published_at);
+  return Number.isNaN(timestamp) ? 0 : timestamp;
+}
+
+function getUpcomingSourceTier(sourceType) {
+  const tiers = {
+    agency_notice: 4,
+    weverse_notice: 3,
+    official_social: 2,
+    news_rss: 1,
+  };
+
+  return tiers[sourceType] ?? 0;
+}
+
+function compareUpcomingRepresentativeRows(left, right) {
+  const sourceCompare = getUpcomingSourceTier(right.source_type) - getUpcomingSourceTier(left.source_type);
+  if (sourceCompare !== 0) {
+    return sourceCompare;
+  }
+
+  const leftPrecision = getUpcomingDatePrecisionValue(left);
+  const rightPrecision = getUpcomingDatePrecisionValue(right);
+  const precisionRank = {
+    exact: 0,
+    month_only: 1,
+    unknown: 2,
+  };
+  if (precisionRank[leftPrecision] !== precisionRank[rightPrecision]) {
+    return precisionRank[leftPrecision] - precisionRank[rightPrecision];
+  }
+
+  const leftMonthKey = getUpcomingMonthKey(left);
+  const rightMonthKey = getUpcomingMonthKey(right);
+  if (leftMonthKey && rightMonthKey && leftMonthKey !== rightMonthKey) {
+    return leftMonthKey.localeCompare(rightMonthKey);
+  }
+
+  const statusRank = {
+    confirmed: 0,
+    scheduled: 1,
+    rumor: 2,
+  };
+  if (statusRank[left.date_status] !== statusRank[right.date_status]) {
+    return statusRank[left.date_status] - statusRank[right.date_status];
+  }
+
+  if ((left.confidence ?? 0) !== (right.confidence ?? 0)) {
+    return (right.confidence ?? 0) - (left.confidence ?? 0);
+  }
+
+  const metadataCompare = getUpcomingStructuredMetadataScore(right) - getUpcomingStructuredMetadataScore(left);
+  if (metadataCompare !== 0) {
+    return metadataCompare;
+  }
+
+  const publishedCompare = getUpcomingPublishedSortValue(right) - getUpcomingPublishedSortValue(left);
+  if (publishedCompare !== 0) {
+    return publishedCompare;
+  }
+
+  return left.headline.localeCompare(right.headline);
+}
+
+function pickUpcomingRepresentative(rows) {
+  return [...rows].sort(compareUpcomingRepresentativeRows)[0];
+}
+
+function pushUpcomingGroup(map, key, value) {
+  const bucket = map.get(key) ?? [];
+  bucket.push(value);
+  map.set(key, bucket);
+}
+
+function selectBestUpcomingGroup(groups) {
+  if (!groups?.length) {
+    return null;
+  }
+
+  return [...groups].sort((left, right) => {
+    const leftRepresentative = pickUpcomingRepresentative(left);
+    const rightRepresentative = pickUpcomingRepresentative(right);
+    return compareUpcomingRepresentativeRows(leftRepresentative, rightRepresentative);
+  })[0];
+}
+
+function compareUpcomingSignals(left, right) {
+  if (!left && !right) {
+    return 0;
+  }
+  if (!left) {
+    return 1;
+  }
+  if (!right) {
+    return -1;
+  }
+
+  const leftHasDate = hasExactUpcomingDate(left);
+  const rightHasDate = hasExactUpcomingDate(right);
+  const leftPrecision = getUpcomingDatePrecisionValue(left);
+  const rightPrecision = getUpcomingDatePrecisionValue(right);
+  const precisionRank = {
+    exact: 0,
+    month_only: 1,
+    unknown: 2,
+  };
+  if (precisionRank[leftPrecision] !== precisionRank[rightPrecision]) {
+    return precisionRank[leftPrecision] - precisionRank[rightPrecision];
+  }
+  if (leftHasDate && rightHasDate) {
+    const dateCompare = parseDateValue(left.scheduled_date) - parseDateValue(right.scheduled_date);
+    if (dateCompare !== 0) {
+      return dateCompare;
+    }
+  } else if (leftHasDate !== rightHasDate) {
+    return leftHasDate ? -1 : 1;
+  }
+
+  const leftMonthKey = getUpcomingMonthKey(left);
+  const rightMonthKey = getUpcomingMonthKey(right);
+  if (leftMonthKey && rightMonthKey && leftMonthKey !== rightMonthKey) {
+    return leftMonthKey.localeCompare(rightMonthKey);
+  }
+
+  const statusRank = {
+    confirmed: 0,
+    scheduled: 1,
+    rumor: 2,
+  };
+  if (statusRank[left.date_status] !== statusRank[right.date_status]) {
+    return statusRank[left.date_status] - statusRank[right.date_status];
+  }
+
+  if ((left.confidence ?? 0) !== (right.confidence ?? 0)) {
+    return (right.confidence ?? 0) - (left.confidence ?? 0);
+  }
+
+  return left.headline.localeCompare(right.headline);
+}
+
+function buildUpcomingDisplayRow(rows) {
+  const representative = pickUpcomingRepresentative(rows);
+  const monthKey = getUpcomingMonthKey(representative) || 'undated';
+  return {
+    ...representative,
+    event_key: [representative.group.toLowerCase(), representative.scheduled_date || monthKey, getUpcomingEventDescriptor(representative)].join(
+      '::',
+    ),
+    evidence_count: rows.length,
+    hidden_source_count: Math.max(rows.length - 1, 0),
+  };
+}
+
+function dedupeUpcomingCandidatesForDisplay(rows) {
+  const exactGroups = new Map();
+  const pendingGroups = new Map();
+
+  for (const row of rows) {
+    const descriptor = getUpcomingEventDescriptor(row);
+    if (hasExactUpcomingDate(row)) {
+      pushUpcomingGroup(exactGroups, [row.group.toLowerCase(), row.scheduled_date, descriptor].join('::'), row);
+      continue;
+    }
+
+    const pendingMonthKey = getUpcomingMonthKey(row) || 'undated';
+    pushUpcomingGroup(pendingGroups, [row.group.toLowerCase(), pendingMonthKey, descriptor].join('::'), row);
+  }
+
+  const exactGroupsByDate = new Map();
+  for (const exactGroup of exactGroups.values()) {
+    const bucketKey = [exactGroup[0].group.toLowerCase(), exactGroup[0].scheduled_date].join('::');
+    pushUpcomingGroup(exactGroupsByDate, bucketKey, exactGroup);
+  }
+
+  const normalizedExactGroups = [];
+  for (const dateBucket of exactGroupsByDate.values()) {
+    const bucketRows = dateBucket.flat();
+    const hasOfficialSource = bucketRows.some((item) => getUpcomingSourceTier(item.source_type) > getUpcomingSourceTier('news_rss'));
+    if (hasOfficialSource) {
+      normalizedExactGroups.push(bucketRows);
+      continue;
+    }
+    normalizedExactGroups.push(...dateBucket);
+  }
+
+  const exactGroupsByTopic = new Map();
+  const exactGroupsByMonth = new Map();
+  for (const exactGroup of normalizedExactGroups) {
+    const representative = pickUpcomingRepresentative(exactGroup);
+    pushUpcomingGroup(exactGroupsByTopic, [representative.group.toLowerCase(), getUpcomingEventDescriptor(representative)].join('::'), exactGroup);
+
+    const exactMonthKey = getUpcomingMonthKey(representative);
+    if (exactMonthKey) {
+      pushUpcomingGroup(exactGroupsByMonth, [representative.group.toLowerCase(), exactMonthKey].join('::'), exactGroup);
+    }
+  }
+
+  const mergedGroups = [...normalizedExactGroups];
+  for (const pendingGroup of pendingGroups.values()) {
+    const representative = pickUpcomingRepresentative(pendingGroup);
+    const topicMatch = selectBestUpcomingGroup(
+      exactGroupsByTopic.get([representative.group.toLowerCase(), getUpcomingEventDescriptor(representative)].join('::')),
+    );
+    const monthKey = getUpcomingMonthKey(representative);
+    const monthMatch =
+      topicMatch || !monthKey
+        ? null
+        : selectBestUpcomingGroup(exactGroupsByMonth.get([representative.group.toLowerCase(), monthKey].join('::')));
+
+    if (topicMatch ?? monthMatch) {
+      (topicMatch ?? monthMatch).push(...pendingGroup);
+      continue;
+    }
+
+    mergedGroups.push(pendingGroup);
+  }
+
+  return mergedGroups.map(buildUpcomingDisplayRow).sort(compareUpcomingSignals);
+}
+
+function expandUpcomingCandidate(row) {
+  if (!hasExactUpcomingDate(row)) {
+    return [];
+  }
+
+  return [
+    {
+      ...row,
+      dateValue: new Date(`${row.scheduled_date}T00:00:00`),
+      isoDate: row.scheduled_date,
+    },
+  ];
+}
+
+function getSourceDomain(sourceUrl) {
+  if (!sourceUrl) {
+    return '';
+  }
+
+  try {
+    return new URL(sourceUrl).hostname;
+  } catch {
+    return '';
+  }
+}
+
+function truncateTimelineSummary(value, maxLength = 180) {
+  if (!value) {
+    return '';
+  }
+
+  const normalized = value.replace(/\s+/g, ' ').trim();
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+
+  return `${normalized.slice(0, maxLength - 1).trimEnd()}…`;
+}
+
+function getSignalOccurredAt(item) {
+  if (item.published_at && !Number.isNaN(Date.parse(item.published_at))) {
+    return new Date(Date.parse(item.published_at)).toISOString();
+  }
+
+  return item.scheduled_date;
+}
+
+function getSourceTimelineSortValue(value) {
+  if (!value) {
+    return Number.MAX_SAFE_INTEGER;
+  }
+
+  const timestamp = Date.parse(value);
+  if (!Number.isNaN(timestamp)) {
+    return timestamp;
+  }
+
+  if (isExactDate(value)) {
+    return new Date(`${value}T00:00:00`).getTime();
+  }
+
+  return Number.MAX_SAFE_INTEGER;
+}
+
+function getSourceTimelineSignalKey(item) {
+  return [item.group, item.source_url, item.headline, item.published_at, item.scheduled_date, item.scheduled_month].join('::');
+}
+
+function getSourceTimelineItemKey(item) {
+  return [item.event_type, item.headline, item.occurred_at, item.source_url].join('::');
+}
+
+function isOfficialAnnouncementSignal(item) {
+  if (item.source_type === 'agency_notice' || item.source_type === 'weverse_notice') {
+    return true;
+  }
+
+  return String(item.search_term ?? '').startsWith('official_');
+}
+
+function isTracklistRevealSignal(item) {
+  const text = `${item.headline} ${item.evidence_summary ?? ''}`.toLowerCase();
+  return /track\s*list|tracklist|title track/.test(text);
+}
+
+function findDateUpdateSignal(rows, usedSignalKeys) {
+  const datedRows = rows.filter((item) => hasExactUpcomingDate(item));
+  if (!datedRows.length) {
+    return null;
+  }
+
+  for (let index = datedRows.length - 1; index >= 0; index -= 1) {
+    const row = datedRows[index];
+    if (usedSignalKeys.has(getSourceTimelineSignalKey(row))) {
+      continue;
+    }
+
+    const previousDate = datedRows[index - 1]?.scheduled_date ?? '';
+    if (!previousDate || previousDate !== row.scheduled_date || index === 0) {
+      return row;
+    }
+  }
+
+  return null;
+}
+
+function compareTimelineSignals(left, right) {
+  const leftValue = getSourceTimelineSortValue(getSignalOccurredAt(left));
+  const rightValue = getSourceTimelineSortValue(getSignalOccurredAt(right));
+  if (leftValue !== rightValue) {
+    return leftValue - rightValue;
+  }
+
+  if ((left.confidence ?? 0) !== (right.confidence ?? 0)) {
+    return (right.confidence ?? 0) - (left.confidence ?? 0);
+  }
+
+  return left.headline.localeCompare(right.headline);
+}
+
+function compareSourceTimelineItems(left, right) {
+  if (left.sortValue !== right.sortValue) {
+    return left.sortValue - right.sortValue;
+  }
+
+  return left.headline.localeCompare(right.headline);
+}
+
+function buildUpcomingTimelineSummary(item, eventType) {
+  if (eventType === 'date_update' && item.scheduled_date) {
+    return truncateTimelineSummary(
+      item.evidence_summary || `The strongest captured date signal currently points to ${item.scheduled_date}.`,
+    );
+  }
+
+  if (eventType === 'official_announcement') {
+    return truncateTimelineSummary(
+      item.evidence_summary || 'An official channel or agency notice confirmed the comeback context.',
+    );
+  }
+
+  if (eventType === 'tracklist_reveal') {
+    return truncateTimelineSummary(
+      item.evidence_summary || 'A tracklist or title-track clue was captured for this comeback cycle.',
+    );
+  }
+
+  if (eventType === 'first_signal') {
+    return truncateTimelineSummary(item.evidence_summary || 'This was the earliest captured comeback signal.');
+  }
+
+  return truncateTimelineSummary(item.evidence_summary ?? '');
+}
+
+function buildUpcomingTimelineItem(group, item, eventType) {
+  const occurredAt = getSignalOccurredAt(item);
+  return {
+    group,
+    occurred_at: occurredAt,
+    event_type: eventType,
+    source_type: item.source_type || 'pending',
+    headline: item.headline,
+    source_url: item.source_url,
+    summary: buildUpcomingTimelineSummary(item, eventType),
+    source_domain: item.source_domain || getSourceDomain(item.source_url),
+    sortValue: getSourceTimelineSortValue(occurredAt),
+  };
+}
+
+function buildReleaseTimelineItem(group, release) {
+  return {
+    group,
+    occurred_at: release.date,
+    event_type: 'release_verified',
+    source_type: 'release_catalog',
+    headline: `${release.title}`,
+    source_url: release.source,
+    summary: truncateTimelineSummary(
+      `Latest verified ${release.stream} record in the dataset for ${group}, captured from the release catalog.`,
+    ),
+    source_domain: getSourceDomain(release.source),
+    sortValue: getSourceTimelineSortValue(release.date),
+  };
+}
+
+function buildSourceTimeline(group, upcomingSignals, groupReleases) {
+  const timelineItems = [];
+  const usedSignalKeys = new Set();
+  const timelineSignals = [...upcomingSignals].sort(compareTimelineSignals);
+  const firstSignal = timelineSignals[0];
+
+  if (firstSignal) {
+    timelineItems.push(buildUpcomingTimelineItem(group, firstSignal, 'first_signal'));
+    usedSignalKeys.add(getSourceTimelineSignalKey(firstSignal));
+  }
+
+  const officialAnnouncement = timelineSignals.find(
+    (item) => !usedSignalKeys.has(getSourceTimelineSignalKey(item)) && isOfficialAnnouncementSignal(item),
+  );
+  if (officialAnnouncement) {
+    timelineItems.push(buildUpcomingTimelineItem(group, officialAnnouncement, 'official_announcement'));
+    usedSignalKeys.add(getSourceTimelineSignalKey(officialAnnouncement));
+  }
+
+  const tracklistReveal = timelineSignals.find(
+    (item) => !usedSignalKeys.has(getSourceTimelineSignalKey(item)) && isTracklistRevealSignal(item),
+  );
+  if (tracklistReveal) {
+    timelineItems.push(buildUpcomingTimelineItem(group, tracklistReveal, 'tracklist_reveal'));
+    usedSignalKeys.add(getSourceTimelineSignalKey(tracklistReveal));
+  }
+
+  const dateUpdate = findDateUpdateSignal(timelineSignals, usedSignalKeys);
+  if (dateUpdate) {
+    timelineItems.push(buildUpcomingTimelineItem(group, dateUpdate, 'date_update'));
+    usedSignalKeys.add(getSourceTimelineSignalKey(dateUpdate));
+  }
+
+  const latestVerifiedRelease = groupReleases[0];
+  if (latestVerifiedRelease?.source) {
+    timelineItems.push(buildReleaseTimelineItem(group, latestVerifiedRelease));
+  }
+
+  return timelineItems
+    .sort(compareSourceTimelineItems)
+    .filter((item, index, items) => {
+      const previous = items[index - 1];
+      return !previous || getSourceTimelineItemKey(previous) !== getSourceTimelineItemKey(item);
+    });
+}
+
+function getTeamBadgeImageUrl(group, teamBadgeAssetByGroup, artistProfileByGroup) {
+  return teamBadgeAssetByGroup.get(group)?.badge_image_url ?? artistProfileByGroup.get(group)?.representative_image_url ?? null;
+}
+
+function getPrimaryTeamYouTubeUrl(group, youtubeChannelAllowlistByGroup, artistProfileByGroup) {
+  return youtubeChannelAllowlistByGroup.get(group)?.primary_team_channel_url ?? artistProfileByGroup.get(group)?.official_youtube_url ?? null;
+}
+
+function deriveLatestRelease(groupReleases, watchRow, releaseRow) {
+  const latestVerified = groupReleases[0];
+  if (latestVerified) {
+    return {
+      title: latestVerified.title,
+      date: latestVerified.date,
+      releaseKind: latestVerified.release_kind,
+      releaseFormat: latestVerified.release_format,
+      contextTags: latestVerified.context_tags,
+      streamLabel: latestVerified.stream,
+      stream: latestVerified.stream,
+      source: latestVerified.source,
+      artistSource: latestVerified.artist_source,
+      musicHandoffs: latestVerified.music_handoffs,
+      verified: true,
+    };
+  }
+
+  if (!watchRow?.latest_release_title && !watchRow?.latest_release_date) {
+    return null;
+  }
+
+  return {
+    title: watchRow.latest_release_title || 'Tracked release pending',
+    date: watchRow.latest_release_date || '',
+    releaseKind: watchRow.latest_release_kind || 'unknown',
+    releaseFormat:
+      watchRow.latest_release_kind === 'single' ||
+      watchRow.latest_release_kind === 'album' ||
+      watchRow.latest_release_kind === 'ep'
+        ? watchRow.latest_release_kind
+        : '',
+    contextTags: [],
+    streamLabel: 'watchlist',
+    stream: 'watchlist',
+    source: '',
+    artistSource: releaseRow?.artist_source ?? '',
+    verified: false,
+  };
+}
+
+function compareTeamProfiles(left, right) {
+  const upcomingCompare = compareUpcomingSignals(left.nextUpcomingSignal, right.nextUpcomingSignal);
+  if (upcomingCompare !== 0) {
+    return upcomingCompare;
+  }
+
+  const leftDate = parseDateValue(left.latestRelease?.date);
+  const rightDate = parseDateValue(right.latestRelease?.date);
+  if (leftDate !== rightDate) {
+    return rightDate - leftDate;
+  }
+
+  return left.group.localeCompare(right.group);
+}
+
+function buildSearchIndexByGroup(artistProfiles, watchlist, releaseCatalog, upcomingCandidates, artistProfileByGroup, releaseCatalogByGroup, upcomingByGroup) {
+  const groups = new Set([
+    ...artistProfiles.map((row) => row.group),
+    ...watchlist.map((row) => row.group),
+    ...releaseCatalog.map((row) => row.group),
+    ...upcomingCandidates.map((row) => row.group),
+  ]);
+
+  return new Map(
+    [...groups].map((group) => {
+      const artistProfile = artistProfileByGroup.get(group);
+      const releaseRow = releaseCatalogByGroup.get(group);
+      const upcomingSignals = upcomingByGroup.get(group) ?? [];
+
+      return [
+        group,
+        buildSearchIndex([
+          group,
+          artistProfile?.slug,
+          artistProfile?.display_name,
+          ...(artistProfile?.aliases ?? []),
+          ...(artistProfile?.search_aliases ?? []),
+          releaseRow?.latest_song?.title,
+          releaseRow?.latest_album?.title,
+          ...upcomingSignals.map((item) => item.headline),
+        ]),
+      ];
+    }),
+  );
+}
+
+function getTeamRelatedRadarTags(group, artistProfileByGroup, watchlistByGroup) {
+  const tags = new Set();
+  const profile = artistProfileByGroup.get(group);
+  const watchRow = watchlistByGroup.get(group);
+
+  if (profile?.radar_tags?.includes('rookie')) {
+    tags.add('rookie');
+  }
+
+  if (watchRow?.watch_reason === 'long_gap') {
+    tags.add('long_gap');
+  }
+
+  if (watchRow?.watch_reason === 'manual_watch') {
+    tags.add('manual_watch');
+  }
+
+  return tags;
+}
+
+function pickLatestRadarSignal(rows) {
+  return [...rows].sort(compareLatestRadarSignals)[0] ?? null;
+}
+
+function compareLatestRadarSignals(left, right) {
+  const leftOccurredAt = getSourceTimelineSortValue(getSignalOccurredAt(left));
+  const rightOccurredAt = getSourceTimelineSortValue(getSignalOccurredAt(right));
+  if (leftOccurredAt !== rightOccurredAt) {
+    return rightOccurredAt - leftOccurredAt;
+  }
+
+  if ((left.confidence ?? 0) !== (right.confidence ?? 0)) {
+    return (right.confidence ?? 0) - (left.confidence ?? 0);
+  }
+
+  return compareUpcomingSignals(left, right);
+}
+
+function isRookieEligible(profile, todayYear) {
+  if (profile.radar_tags?.includes('rookie')) {
+    return true;
+  }
+
+  if (typeof profile.debut_year !== 'number') {
+    return false;
+  }
+
+  const minimumYear = todayYear - (ROOKIE_RECENT_YEAR_WINDOW - 1);
+  return profile.debut_year >= minimumYear && profile.debut_year <= todayYear;
+}
+
+function compareLongGapRadarEntries(left, right) {
+  if (left.hasUpcomingSignal !== right.hasUpcomingSignal) {
+    return left.hasUpcomingSignal ? -1 : 1;
+  }
+
+  const leftConfidence = left.latestSignal?.confidence ?? -1;
+  const rightConfidence = right.latestSignal?.confidence ?? -1;
+  if (leftConfidence !== rightConfidence) {
+    return rightConfidence - leftConfidence;
+  }
+
+  const leftOccurredAt = left.latestSignal ? getSourceTimelineSortValue(getSignalOccurredAt(left.latestSignal)) : -1;
+  const rightOccurredAt = right.latestSignal ? getSourceTimelineSortValue(getSignalOccurredAt(right.latestSignal)) : -1;
+  if (leftOccurredAt !== rightOccurredAt) {
+    return rightOccurredAt - leftOccurredAt;
+  }
+
+  if (left.gapDays !== right.gapDays) {
+    return right.gapDays - left.gapDays;
+  }
+
+  return left.group.localeCompare(right.group);
+}
+
+function compareRookieRadarEntries(left, right) {
+  if (left.hasUpcomingSignal !== right.hasUpcomingSignal) {
+    return left.hasUpcomingSignal ? -1 : 1;
+  }
+
+  const leftReleaseDate = parseDateValue(left.latestRelease?.date);
+  const rightReleaseDate = parseDateValue(right.latestRelease?.date);
+  if (leftReleaseDate !== rightReleaseDate) {
+    return rightReleaseDate - leftReleaseDate;
+  }
+
+  if ((left.debutYear ?? -1) !== (right.debutYear ?? -1)) {
+    return (right.debutYear ?? -1) - (left.debutYear ?? -1);
+  }
+
+  return left.group.localeCompare(right.group);
+}
+
+function buildLongGapRadarEntries(teamProfiles, watchlistByGroup, todayIso) {
+  return teamProfiles
+    .flatMap((team) => {
+      const watchRow = watchlistByGroup.get(team.group);
+      if (!watchRow || watchRow.watch_reason !== 'long_gap') {
+        return [];
+      }
+
+      if (!team.latestRelease?.date || !isExactDate(team.latestRelease.date)) {
+        return [];
+      }
+
+      const gapDays = getElapsedDaysSinceDate(team.latestRelease.date, todayIso);
+      if (gapDays < LONG_GAP_THRESHOLD_DAYS) {
+        return [];
+      }
+
+      return [
+        {
+          group: team.group,
+          watchReason: watchRow.watch_reason,
+          latestRelease: team.latestRelease,
+          gapDays,
+          hasUpcomingSignal: team.upcomingSignals.length > 0,
+          latestSignal: pickLatestRadarSignal(team.upcomingSignals),
+        },
+      ];
+    })
+    .sort(compareLongGapRadarEntries);
+}
+
+function buildRookieRadarEntries(teamProfiles, artistProfileByGroup, todayYear) {
+  return teamProfiles
+    .flatMap((team) => {
+      const artistProfile = artistProfileByGroup.get(team.group);
+      if (!artistProfile || !isRookieEligible(artistProfile, todayYear)) {
+        return [];
+      }
+
+      return [
+        {
+          group: team.group,
+          debutYear: artistProfile.debut_year ?? null,
+          latestRelease: team.latestRelease,
+          hasUpcomingSignal: team.upcomingSignals.length > 0,
+          latestSignal: pickLatestRadarSignal(team.upcomingSignals),
+        },
+      ];
+    })
+    .sort(compareRookieRadarEntries);
+}
+
+function getWeeklyDigestDiversityScore(candidate, selected) {
+  const seenFormats = new Set(selected.map((item) => item.release_format));
+  const seenContextTags = new Set(selected.flatMap((item) => item.context_tags));
+  let score = seenFormats.has(candidate.release_format) ? 0 : 4;
+
+  for (const contextTag of candidate.context_tags) {
+    if (!seenContextTags.has(contextTag)) {
+      score += 1;
+    }
+  }
+
+  return score;
+}
+
+function compareWeeklyDigestCandidates(left, right, selected) {
+  if (left.dateValue.getTime() !== right.dateValue.getTime()) {
+    return right.dateValue.getTime() - left.dateValue.getTime();
+  }
+
+  const diversityCompare = getWeeklyDigestDiversityScore(right, selected) - getWeeklyDigestDiversityScore(left, selected);
+  if (diversityCompare !== 0) {
+    return diversityCompare;
+  }
+
+  if (left.context_tags.length !== right.context_tags.length) {
+    return right.context_tags.length - left.context_tags.length;
+  }
+
+  if (left.release_format !== right.release_format) {
+    return left.release_format.localeCompare(right.release_format);
+  }
+
+  const groupCompare = left.group.localeCompare(right.group);
+  if (groupCompare !== 0) {
+    return groupCompare;
+  }
+
+  return left.title.localeCompare(right.title);
+}
+
+function buildWeeklyDigestRows(rows, maxItems) {
+  const groupedByDate = rows.reduce((map, row) => {
+    const bucket = map.get(row.isoDate) ?? [];
+    bucket.push(row);
+    map.set(row.isoDate, bucket);
+    return map;
+  }, new Map());
+
+  const selected = [];
+  const sortedDates = [...groupedByDate.keys()].sort((left, right) => parseDateValue(right) - parseDateValue(left));
+
+  for (const isoDate of sortedDates) {
+    const remaining = [...(groupedByDate.get(isoDate) ?? [])];
+    while (remaining.length && selected.length < maxItems) {
+      remaining.sort((left, right) => compareWeeklyDigestCandidates(left, right, selected));
+      selected.push(remaining.shift());
+    }
+
+    if (selected.length >= maxItems) {
+      break;
+    }
+  }
+
+  return selected;
+}
+
+function compareMonthlyDashboardVerified(left, right) {
+  if (left.dateValue.getTime() !== right.dateValue.getTime()) {
+    return left.dateValue.getTime() - right.dateValue.getTime();
+  }
+
+  return left.group.localeCompare(right.group);
+}
+
+function compareMonthlyDashboardUpcoming(left, right) {
+  if (left.dateValue.getTime() !== right.dateValue.getTime()) {
+    return left.dateValue.getTime() - right.dateValue.getTime();
+  }
+
+  if ((left.confidence ?? 0) !== (right.confidence ?? 0)) {
+    return (right.confidence ?? 0) - (left.confidence ?? 0);
+  }
+
+  return left.group.localeCompare(right.group);
+}
+
+function groupByDate(rows) {
+  return rows.reduce((map, row) => {
+    const bucket = map.get(row.isoDate) ?? [];
+    bucket.push(row);
+    map.set(row.isoDate, bucket);
+    return map;
+  }, new Map());
+}
+
+function groupUpcomingByDate(rows) {
+  return rows.reduce((map, row) => {
+    const bucket = map.get(row.isoDate) ?? [];
+    bucket.push(row);
+    map.set(row.isoDate, bucket);
+    return map;
+  }, new Map());
+}
+
+function buildCalendarDays(date, todayIso) {
+  const startOfMonth = new Date(date.getFullYear(), date.getMonth(), 1);
+  const endOfMonth = new Date(date.getFullYear(), date.getMonth() + 1, 0);
+  const leadingDays = startOfMonth.getDay();
+  const trailingDays = 6 - endOfMonth.getDay();
+  const gridStart = new Date(startOfMonth);
+  const gridEnd = new Date(endOfMonth);
+  gridStart.setDate(startOfMonth.getDate() - leadingDays);
+  gridEnd.setDate(endOfMonth.getDate() + trailingDays);
+
+  const days = [];
+  const cursor = new Date(gridStart);
+
+  while (cursor <= gridEnd) {
+    const iso = getKstTodayIso(cursor);
+    days.push({
+      date: new Date(cursor),
+      iso,
+      inMonth: cursor.getMonth() === date.getMonth(),
+    });
+    cursor.setDate(cursor.getDate() + 1);
+  }
+
+  return days;
+}
+
+function compareEntityMatches(left, right) {
+  if (left.score !== right.score) {
+    return right.score - left.score;
+  }
+
+  const leftUpcoming = left.next_upcoming?.scheduled_date ?? left.next_upcoming?.scheduled_month ?? '';
+  const rightUpcoming = right.next_upcoming?.scheduled_date ?? right.next_upcoming?.scheduled_month ?? '';
+  if (leftUpcoming !== rightUpcoming) {
+    if (!leftUpcoming) {
+      return 1;
+    }
+    if (!rightUpcoming) {
+      return -1;
+    }
+    return leftUpcoming.localeCompare(rightUpcoming);
+  }
+
+  const leftRelease = left.latest_release?.release_date ?? '';
+  const rightRelease = right.latest_release?.release_date ?? '';
+  if (leftRelease !== rightRelease) {
+    return rightRelease.localeCompare(leftRelease);
+  }
+
+  return left.display_name.localeCompare(right.display_name);
+}
+
+function compareReleaseMatches(left, right) {
+  if (left.score !== right.score) {
+    return right.score - left.score;
+  }
+
+  if (left.release_date !== right.release_date) {
+    return right.release_date.localeCompare(left.release_date);
+  }
+
+  return left.release_title.localeCompare(right.release_title);
+}
+
+function compareUpcomingMatches(left, right) {
+  if (left.score !== right.score) {
+    return right.score - left.score;
+  }
+
+  const leftDate = left.scheduled_date ?? left.scheduled_month ?? '';
+  const rightDate = right.scheduled_date ?? right.scheduled_month ?? '';
+  if (leftDate !== rightDate) {
+    if (!leftDate) {
+      return 1;
+    }
+    if (!rightDate) {
+      return -1;
+    }
+    return leftDate.localeCompare(rightDate);
+  }
+
+  return left.display_name.localeCompare(right.display_name);
+}
+
+function getReleaseArtwork(group, releaseTitle, releaseDate, stream, releaseKind, releaseArtworkByKey) {
+  const normalizedStream = normalizeReleaseStream(stream, releaseKind);
+  const artwork = releaseArtworkByKey.get(getReleaseLookupKey(group, releaseTitle, releaseDate, normalizedStream));
+  if (!artwork) {
+    return {
+      group,
+      release_title: releaseTitle,
+      release_date: releaseDate,
+      stream: normalizedStream,
+      cover_image_url: RELEASE_ARTWORK_PLACEHOLDER_URL,
+      thumbnail_image_url: RELEASE_ARTWORK_PLACEHOLDER_URL,
+      artwork_source_type: 'placeholder',
+      artwork_source_url: RELEASE_ARTWORK_PLACEHOLDER_URL,
+      isPlaceholder: true,
+    };
+  }
+
+  return {
+    ...artwork,
+    isPlaceholder: artwork.artwork_source_type === 'placeholder',
+  };
+}
+
+function getReleaseDetail(group, releaseTitle, releaseDate, stream, releaseKind, releaseDetailsByKey) {
+  const normalizedStream = normalizeReleaseStream(stream, releaseKind);
+  const detail = releaseDetailsByKey.get(getReleaseLookupKey(group, releaseTitle, releaseDate, normalizedStream));
+  if (!detail) {
+    return {
+      group,
+      release_title: releaseTitle,
+      release_date: releaseDate,
+      stream: normalizedStream,
+      release_kind: releaseKind === 'album' || releaseKind === 'ep' ? releaseKind : 'single',
+      tracks: [],
+      spotify_url: null,
+      youtube_music_url: null,
+      youtube_video_id: null,
+      youtube_video_url: null,
+      youtube_video_status: null,
+      youtube_video_provenance: null,
+      notes: '',
+      isFallback: true,
+    };
+  }
+
+  return {
+    ...detail,
+    isFallback: false,
+  };
+}
+
+function getReleaseEnrichment(group, releaseTitle, releaseDate, stream, releaseKind, releaseEnrichmentByKey) {
+  const normalizedStream = normalizeReleaseStream(stream, releaseKind);
+  const enrichment = releaseEnrichmentByKey.get(getReleaseLookupKey(group, releaseTitle, releaseDate, normalizedStream));
+  if (!enrichment) {
+    return {
+      group,
+      release_title: releaseTitle,
+      release_date: releaseDate,
+      stream: normalizedStream,
+      credits: {
+        lyrics: [],
+        composition: [],
+        arrangement: [],
+      },
+      charts: [],
+      notes: '',
+      isFallback: true,
+    };
+  }
+
+  return {
+    ...enrichment,
+    isFallback: false,
+  };
+}
+
+function createBaselineState(now = new Date()) {
+  const artistProfiles = loadJson(ARTIST_PROFILES_PATH);
+  const releaseCatalogRaw = loadJson(RELEASES_PATH);
+  const releaseHistoryRows = loadJson(RELEASE_HISTORY_PATH);
+  const releaseDetailsCatalog = loadJson(RELEASE_DETAILS_PATH);
+  const releaseArtworkCatalog = loadJson(RELEASE_ARTWORK_PATH);
+  const releaseEnrichmentCatalog = loadJson(RELEASE_ENRICHMENT_PATH);
+  const upcomingCandidates = loadJson(UPCOMING_CANDIDATES_PATH);
+  const watchlist = loadJson(WATCHLIST_PATH);
+  const youtubeChannelAllowlists = loadJson(YOUTUBE_ALLOWLISTS_PATH);
+  const teamBadgeAssets = loadJson(TEAM_BADGE_ASSETS_PATH);
+
+  const todayIso = getKstTodayIso(now);
+  const todayYear = Number.parseInt(todayIso.slice(0, 4), 10);
+  const releaseCatalog = releaseCatalogRaw.flatMap((row) => expandReleaseRow(row)).sort((left, right) => right.dateValue.getTime() - left.dateValue.getTime());
+
+  const artistProfileByGroup = new Map(artistProfiles.map((row) => [row.group, row]));
+  const artistProfileBySlug = new Map(artistProfiles.map((row) => [row.slug, row]));
+  const releaseCatalogByGroup = new Map(releaseCatalogRaw.map((row) => [row.group, row]));
+  const watchlistByGroup = new Map(watchlist.map((row) => [row.group, row]));
+  const youtubeChannelAllowlistByGroup = new Map(youtubeChannelAllowlists.map((row) => [row.group, row]));
+  const teamBadgeAssetByGroup = new Map(teamBadgeAssets.map((row) => [row.group, row]));
+  const releaseArtworkByKey = new Map(
+    releaseArtworkCatalog.map((row) => [getReleaseLookupKey(row.group, row.release_title, row.release_date, row.stream), row]),
+  );
+  const releaseDetailsByKey = new Map(
+    releaseDetailsCatalog.map((row) => [getReleaseLookupKey(row.group, row.release_title, row.release_date, row.stream), row]),
+  );
+  const releaseEnrichmentByKey = new Map(
+    releaseEnrichmentCatalog.map((row) => [getReleaseLookupKey(row.group, row.release_title, row.release_date, row.stream), row]),
+  );
+
+  const seededVerifiedReleaseHistory = buildSeededVerifiedReleaseHistory(releaseHistoryRows);
+  const verifiedReleaseHistory = buildVerifiedReleaseHistory(
+    seededVerifiedReleaseHistory,
+    releaseDetailsCatalog,
+    releaseCatalogByGroup,
+    releaseCatalog,
+  );
+  const verifiedReleaseHistoryByGroup = groupReleasesByGroup(verifiedReleaseHistory);
+
+  const dedupedUpcomingCandidates = dedupeUpcomingCandidatesForDisplay(upcomingCandidates);
+  const rawUpcomingByGroup = groupUpcomingCandidatesByGroup(upcomingCandidates);
+  const upcomingByGroup = groupUpcomingCandidatesByGroup(dedupedUpcomingCandidates);
+
+  const searchIndexByGroup = buildSearchIndexByGroup(
+    artistProfiles,
+    watchlist,
+    releaseCatalogRaw,
+    upcomingCandidates,
+    artistProfileByGroup,
+    releaseCatalogByGroup,
+    upcomingByGroup,
+  );
+
+  const releaseGroups = groupReleasesByGroup(releaseCatalog);
+
+  const teamProfiles = [...new Set([
+    ...watchlist.map((row) => row.group),
+    ...releaseCatalog.map((row) => row.group),
+    ...upcomingCandidates.map((row) => row.group),
+  ])]
+    .map((group) => {
+      const watchRow = watchlistByGroup.get(group);
+      const releaseRow = releaseCatalogByGroup.get(group);
+      const artistProfile = artistProfileByGroup.get(group);
+      const groupReleases = releaseGroups.get(group) ?? [];
+      const verifiedHistory = verifiedReleaseHistoryByGroup.get(group) ?? [];
+      const upcomingSignals = [...(upcomingByGroup.get(group) ?? [])].sort(compareUpcomingSignals);
+      const sourceTimeline = buildSourceTimeline(group, rawUpcomingByGroup.get(group) ?? [], groupReleases);
+      const latestRelease = deriveLatestRelease(groupReleases, watchRow, releaseRow);
+
+      return {
+        group,
+        slug: artistProfile?.slug ?? slugifyGroup(group),
+        displayName: artistProfile?.display_name ?? group,
+        tier: watchRow?.tier ?? 'tracked',
+        trackingStatus: watchRow?.tracking_status ?? 'watch_only',
+        watchReason: watchRow?.watch_reason ?? null,
+        artistSource: releaseRow?.artist_source ?? latestRelease?.artistSource ?? '',
+        xUrl: artistProfile?.official_x_url ?? watchRow?.x_url ?? '',
+        instagramUrl: artistProfile?.official_instagram_url ?? watchRow?.instagram_url ?? '',
+        youtubeUrl: getPrimaryTeamYouTubeUrl(group, youtubeChannelAllowlistByGroup, artistProfileByGroup),
+        agency: normalizeAgencyName(artistProfile?.agency),
+        badgeImageUrl: getTeamBadgeImageUrl(group, teamBadgeAssetByGroup, artistProfileByGroup),
+        representativeImageUrl: artistProfile?.representative_image_url ?? null,
+        latestRelease,
+        recentAlbums: verifiedHistory.filter((item) => item.stream === 'album'),
+        upcomingSignals,
+        sourceTimeline,
+        nextUpcomingSignal: upcomingSignals[0] ?? null,
+      };
+    })
+    .sort(compareTeamProfiles);
+
+  const teamProfileMap = new Map(teamProfiles.map((team) => [team.group, team]));
+  const longGapRadarEntries = buildLongGapRadarEntries(teamProfiles, watchlistByGroup, todayIso);
+  const rookieRadarEntries = buildRookieRadarEntries(teamProfiles, artistProfileByGroup, todayYear);
+
+  const filteredReleases = releaseCatalog;
+  const filteredUpcoming = dedupedUpcomingCandidates;
+  const filteredUpcomingSignals = filteredUpcoming
+    .flatMap((item) => expandUpcomingCandidate(item))
+    .sort((left, right) => left.dateValue.getTime() - right.dateValue.getTime());
+  const nearestUpcomingJumpSignal = filteredUpcomingSignals.find((item) => item.isoDate >= todayIso) ?? null;
+  const weeklyDigestReferenceDate = filteredReleases[0]?.dateValue ?? null;
+  const weeklyDigestWindowStart = weeklyDigestReferenceDate ? getDateDaysBefore(weeklyDigestReferenceDate, 6) : null;
+  const weeklyDigestRows =
+    weeklyDigestReferenceDate && weeklyDigestWindowStart
+      ? buildWeeklyDigestRows(
+          filteredReleases.filter((item) => {
+            const time = item.dateValue.getTime();
+            return time >= weeklyDigestWindowStart.getTime() && time <= weeklyDigestReferenceDate.getTime();
+          }),
+          WEEKLY_DIGEST_MAX_ITEMS,
+        )
+      : [];
+
+  return {
+    now,
+    todayIso,
+    todayYear,
+    artistProfiles,
+    artistProfileByGroup,
+    artistProfileBySlug,
+    releaseCatalogRaw,
+    releaseCatalog,
+    releaseCatalogByGroup,
+    releaseHistoryRows,
+    releaseDetailsCatalog,
+    releaseDetailsByKey,
+    releaseArtworkByKey,
+    releaseEnrichmentByKey,
+    watchlistByGroup,
+    youtubeChannelAllowlistByGroup,
+    verifiedReleaseHistory,
+    verifiedReleaseHistoryByGroup,
+    releaseGroups,
+    upcomingCandidates,
+    dedupedUpcomingCandidates,
+    rawUpcomingByGroup,
+    upcomingByGroup,
+    searchIndexByGroup,
+    teamProfiles,
+    teamProfileMap,
+    longGapRadarEntries,
+    rookieRadarEntries,
+    filteredReleases,
+    filteredUpcoming,
+    filteredUpcomingSignals,
+    nearestUpcomingJumpSignal,
+    weeklyDigestRows,
+  };
+}
+
+function buildEntityLatestReleaseSummary(team) {
+  if (!team.latestRelease) {
+    return null;
+  }
+
+  return {
+    release_title: team.latestRelease.title,
+    release_date: team.latestRelease.date || null,
+    stream: team.latestRelease.stream,
+    release_kind: team.latestRelease.releaseKind || null,
+  };
+}
+
+function buildEntityNextUpcomingSummary(team) {
+  const next = team.nextUpcomingSignal;
+  if (!next) {
+    return null;
+  }
+
+  return {
+    headline: next.headline,
+    scheduled_date: next.scheduled_date ?? null,
+    scheduled_month: next.scheduled_month ?? null,
+    date_precision: getUpcomingDatePrecisionValue(next),
+    date_status: next.date_status,
+    confidence_score: next.confidence ?? null,
+    release_format: next.release_format ?? null,
+  };
+}
+
+function buildSearchExpected(query, state, limit = 8) {
+  const needle = createSearchNeedle(query);
+  if (!needle) {
+    return { entities: [], releases: [], upcoming: [] };
+  }
+
+  const entityMatches = state.teamProfiles
+    .filter((team) => matchesSearchIndex(state.searchIndexByGroup.get(team.group), needle))
+    .map((team) => {
+      const profile = state.artistProfileByGroup.get(team.group);
+      const primaryNames = [team.displayName, team.group, team.slug];
+      const nonPrimaryAliases = [...new Set([...(profile?.aliases ?? []), ...(profile?.search_aliases ?? [])])].filter(
+        (alias) => !primaryNames.includes(alias),
+      );
+      const exactPrimary = findExactMatch(primaryNames, needle);
+      const exactAlias = findExactMatch(nonPrimaryAliases, needle);
+      const partialAlias = findPartialMatch(nonPrimaryAliases, needle);
+
+      let matchReason = 'partial';
+      let matchedAlias = null;
+      let score = 100;
+
+      if (exactPrimary) {
+        matchReason = 'display_name_exact';
+        matchedAlias = exactPrimary;
+        score = 400;
+      } else if (exactAlias) {
+        matchReason = 'alias_exact';
+        matchedAlias = exactAlias;
+        score = 300;
+      } else if (partialAlias) {
+        matchReason = 'alias_partial';
+        matchedAlias = partialAlias;
+        score = 200;
+      }
+
+      return {
+        entity_slug: team.slug,
+        display_name: team.displayName,
+        canonical_name: team.group,
+        agency_name: team.agency || null,
+        match_reason: matchReason,
+        matched_alias: matchedAlias,
+        latest_release: buildEntityLatestReleaseSummary(team),
+        next_upcoming: buildEntityNextUpcomingSummary(team),
+        score,
+      };
+    })
+    .sort(compareEntityMatches)
+    .slice(0, limit);
+
+  const releaseMatchMap = new Map();
+  for (const row of state.verifiedReleaseHistory) {
+    const normalizedTitle = normalizeSearchText(row.title);
+    if (
+      !normalizedTitle.includes(needle.normalized) &&
+      !collapseSearchText(normalizedTitle).includes(needle.compact)
+    ) {
+      continue;
+    }
+
+    const isExact = normalizedTitle === needle.normalized || collapseSearchText(normalizedTitle) === needle.compact;
+    const key = getReleaseLookupKey(row.group, row.title, row.date, row.stream);
+
+    releaseMatchMap.set(key, {
+      entity_slug: state.artistProfileByGroup.get(row.group)?.slug ?? slugifyGroup(row.group),
+      display_name: state.artistProfileByGroup.get(row.group)?.display_name ?? row.group,
+      release_title: row.title,
+      release_date: row.date,
+      stream: row.stream,
+      release_kind: row.release_kind ?? null,
+      release_format: row.release_format ?? null,
+      match_reason: isExact ? 'release_title_exact' : 'release_title_partial',
+      matched_alias: row.title,
+      score: isExact ? 300 : 100,
+    });
+  }
+
+  const exactEntityMatches = entityMatches.filter(
+    (item) => item.match_reason === 'display_name_exact' || item.match_reason === 'alias_exact',
+  );
+  for (const entity of exactEntityMatches) {
+    const team = state.teamProfiles.find((item) => item.slug === entity.entity_slug);
+    if (!team?.latestRelease?.verified) {
+      continue;
+    }
+
+    const key = getReleaseLookupKey(team.group, team.latestRelease.title, team.latestRelease.date, team.latestRelease.stream);
+    if (releaseMatchMap.has(key)) {
+      continue;
+    }
+
+    releaseMatchMap.set(key, {
+      entity_slug: entity.entity_slug,
+      display_name: entity.display_name,
+      release_title: team.latestRelease.title,
+      release_date: team.latestRelease.date,
+      stream: team.latestRelease.stream,
+      release_kind: team.latestRelease.releaseKind ?? null,
+      release_format: team.latestRelease.releaseFormat ?? null,
+      match_reason: 'entity_exact_latest_release',
+      matched_alias: entity.matched_alias ?? entity.display_name,
+      score: 200,
+    });
+  }
+
+  const releases = [...releaseMatchMap.values()].sort(compareReleaseMatches).slice(0, limit);
+
+  const upcomingMatchMap = new Map();
+  for (const row of state.dedupedUpcomingCandidates) {
+    const normalizedHeadline = normalizeSearchText(row.headline);
+    if (
+      !normalizedHeadline.includes(needle.normalized) &&
+      !collapseSearchText(normalizedHeadline).includes(needle.compact)
+    ) {
+      continue;
+    }
+
+    const isExact = normalizedHeadline === needle.normalized || collapseSearchText(normalizedHeadline) === needle.compact;
+    upcomingMatchMap.set(row.event_key ?? `${row.group}::${row.headline}`, {
+      entity_slug: state.artistProfileByGroup.get(row.group)?.slug ?? slugifyGroup(row.group),
+      display_name: state.artistProfileByGroup.get(row.group)?.display_name ?? row.group,
+      headline: row.headline,
+      scheduled_date: row.scheduled_date ?? null,
+      scheduled_month: row.scheduled_month ?? null,
+      date_precision: getUpcomingDatePrecisionValue(row),
+      date_status: row.date_status,
+      release_format: row.release_format ?? null,
+      confidence_score: row.confidence ?? null,
+      source_type: row.source_type ?? null,
+      source_url: row.source_url ?? null,
+      evidence_summary: row.evidence_summary ?? null,
+      match_reason: isExact ? 'headline_exact' : 'partial',
+      matched_alias: isExact ? row.headline : null,
+      score: isExact ? 200 : 100,
+    });
+  }
+
+  for (const entity of exactEntityMatches) {
+    const team = state.teamProfiles.find((item) => item.slug === entity.entity_slug);
+    if (!team?.nextUpcomingSignal) {
+      continue;
+    }
+
+    const row = team.nextUpcomingSignal;
+    const key = row.event_key ?? `${row.group}::${row.headline}`;
+    const current = upcomingMatchMap.get(key);
+    const candidate = {
+      entity_slug: entity.entity_slug,
+      display_name: entity.display_name,
+      headline: row.headline,
+      scheduled_date: row.scheduled_date ?? null,
+      scheduled_month: row.scheduled_month ?? null,
+      date_precision: getUpcomingDatePrecisionValue(row),
+      date_status: row.date_status,
+      release_format: row.release_format ?? null,
+      confidence_score: row.confidence ?? null,
+      source_type: row.source_type ?? null,
+      source_url: row.source_url ?? null,
+      evidence_summary: row.evidence_summary ?? null,
+      match_reason: 'entity_exact',
+      matched_alias: entity.matched_alias ?? entity.display_name,
+      score: 300,
+    };
+
+    if (!current || compareUpcomingMatches(candidate, current) < 0) {
+      upcomingMatchMap.set(key, candidate);
+    }
+  }
+
+  const upcoming = [...upcomingMatchMap.values()].sort(compareUpcomingMatches).slice(0, limit);
+
+  return {
+    entities: entityMatches.map(({ score, ...item }) => item),
+    releases: releases.map(({ score, ...item }) => item),
+    upcoming: upcoming.map(({ score, ...item }) => item),
+  };
+}
+
+function buildEntityDetailExpected(slug, state) {
+  const team = state.teamProfiles.find((item) => item.slug === slug);
+  if (!team) {
+    return null;
+  }
+
+  const allowlist = state.youtubeChannelAllowlistByGroup.get(team.group);
+  const artistProfile = state.artistProfileByGroup.get(team.group);
+
+  return {
+    identity: {
+      entity_slug: team.slug,
+      display_name: team.displayName,
+      canonical_name: team.group,
+      agency_name: team.agency || null,
+      badge_image_url: team.badgeImageUrl ?? null,
+      representative_image_url: team.representativeImageUrl ?? null,
+      debut_year: typeof artistProfile?.debut_year === 'number' ? artistProfile.debut_year : null,
+    },
+    official_links: {
+      youtube: team.youtubeUrl ?? null,
+      x: team.xUrl || null,
+      instagram: team.instagramUrl || null,
+    },
+    youtube_channels: {
+      primary_team_channel_url: allowlist?.primary_team_channel_url ?? null,
+      mv_allowlist_urls: [...(allowlist?.mv_allowlist_urls ?? [])],
+    },
+    tracking_state: {
+      tier: team.tier ?? null,
+      watch_reason: team.watchReason ?? null,
+      tracking_status: team.trackingStatus ?? null,
+    },
+    next_upcoming: buildEntityNextUpcomingSummary(team),
+    latest_release: team.latestRelease
+      ? {
+          release_title: team.latestRelease.title,
+          release_date: team.latestRelease.date || null,
+          stream: team.latestRelease.stream,
+          release_kind: team.latestRelease.releaseKind || null,
+        }
+      : null,
+    recent_albums: team.recentAlbums.map((item) => ({
+      release_title: item.title,
+      release_date: item.date,
+      stream: item.stream,
+      release_kind: item.release_kind ?? null,
+    })),
+    source_timeline: team.sourceTimeline.map((item) => ({
+      event_type: item.event_type,
+      source_type: item.source_type,
+      headline: item.headline,
+      source_url: item.source_url ?? null,
+      source_domain: item.source_domain ?? null,
+      occurred_at: item.occurred_at,
+      summary: item.summary,
+    })),
+    artist_source_url: team.artistSource || null,
+  };
+}
+
+function buildReleaseExpected(definition, state) {
+  const group = [...state.artistProfileByGroup.values()].find((row) => row.slug === definition.entitySlug)?.group ?? null;
+  if (!group) {
+    return null;
+  }
+
+  const release =
+    state.verifiedReleaseHistory.find(
+      (item) =>
+        item.group === group &&
+        item.title === definition.title &&
+        item.date === definition.date &&
+        item.stream === definition.stream,
+    ) ?? null;
+  if (!release) {
+    return null;
+  }
+
+  const displayName = state.artistProfileByGroup.get(group)?.display_name ?? group;
+  const detail = getReleaseDetail(group, release.title, release.date, release.stream, release.release_kind, state.releaseDetailsByKey);
+  const enrichment = getReleaseEnrichment(group, release.title, release.date, release.stream, release.release_kind, state.releaseEnrichmentByKey);
+  const artwork = getReleaseArtwork(group, release.title, release.date, release.stream, release.release_kind, state.releaseArtworkByKey);
+  const mvUrls = getReleaseDetailMvUrls(detail);
+
+  const credits = [];
+  for (const [role, values] of Object.entries(enrichment.credits ?? {})) {
+    if (Array.isArray(values) && values.length) {
+      credits.push({ role, names: values });
+    }
+  }
+
+  return {
+    lookup: {
+      entity_slug: definition.entitySlug,
+      release_title: release.title,
+      release_date: release.date,
+      stream: release.stream,
+      release_kind: release.release_kind ?? null,
+      display_name: displayName,
+    },
+    detail: {
+      release: {
+        entity_slug: definition.entitySlug,
+        display_name: displayName,
+        release_title: release.title,
+        release_date: release.date,
+        stream: release.stream,
+        release_kind: release.release_kind ?? null,
+      },
+      artwork: {
+        cover_image_url: artwork.cover_image_url ?? null,
+        thumbnail_image_url: artwork.thumbnail_image_url ?? null,
+        artwork_source_type: artwork.artwork_source_type ?? null,
+        artwork_source_url: artwork.artwork_source_url ?? null,
+      },
+      service_links: {
+        spotify: {
+          url: detail.spotify_url ?? null,
+          status: detail.spotify_url ? 'canonical' : 'no_link',
+        },
+        youtube_music: {
+          url: detail.youtube_music_url ?? null,
+          status: detail.youtube_music_url ? 'canonical' : 'no_link',
+        },
+      },
+      tracks: (detail.tracks ?? []).map((track) => ({
+        order: track.order,
+        title: track.title,
+        is_title_track: track.is_title_track === true,
+      })),
+      mv: {
+        url: mvUrls.canonicalUrl || null,
+        video_id: mvUrls.videoId || null,
+        status: detail.youtube_video_status ?? (mvUrls.canonicalUrl ? 'canonical' : 'no_link'),
+        provenance: detail.youtube_video_provenance ?? null,
+      },
+      credits,
+      charts: enrichment.charts ?? [],
+      notes: detail.notes ?? '',
+    },
+  };
+}
+
+function buildCalendarExpected(monthKey, state) {
+  const selectedMonthDate = monthKeyToDate(monthKey);
+  const monthReleases = state.filteredReleases.filter((item) => getMonthKey(item.dateValue) === monthKey);
+  const monthUpcomingSignals = state.filteredUpcomingSignals.filter((item) => getMonthKey(item.dateValue) === monthKey);
+  const monthMonthOnlyUpcomingRows = state.filteredUpcoming
+    .filter((item) => getUpcomingDatePrecisionValue(item) === 'month_only' && getUpcomingMonthKey(item) === monthKey)
+    .sort(compareUpcomingSignals);
+
+  const releasesByDate = groupByDate(monthReleases);
+  const upcomingByDate = groupUpcomingByDate(monthUpcomingSignals);
+  const activeDayIsos = [...new Set([...monthReleases.map((item) => item.isoDate), ...monthUpcomingSignals.map((item) => item.isoDate)])].sort();
+  const nearestUpcoming = state.filteredUpcomingSignals.find((item) => item.isoDate >= state.todayIso) ?? null;
+
+  const verifiedList = [...monthReleases].sort(compareMonthlyDashboardVerified).map((item) => ({
+    entity_slug: state.artistProfileByGroup.get(item.group)?.slug ?? slugifyGroup(item.group),
+    display_name: state.artistProfileByGroup.get(item.group)?.display_name ?? item.group,
+    release_title: item.title,
+    release_date: item.date,
+    stream: item.stream,
+    release_kind: item.release_kind ?? null,
+  }));
+
+  const scheduledList = [...monthUpcomingSignals].sort(compareMonthlyDashboardUpcoming).map((item) => ({
+    entity_slug: state.artistProfileByGroup.get(item.group)?.slug ?? slugifyGroup(item.group),
+    display_name: state.artistProfileByGroup.get(item.group)?.display_name ?? item.group,
+    headline: item.headline,
+    scheduled_date: item.scheduled_date ?? null,
+    scheduled_month: item.scheduled_month ?? null,
+    date_precision: getUpcomingDatePrecisionValue(item),
+    date_status: item.date_status,
+    confidence_score: item.confidence ?? null,
+    release_format: item.release_format ?? null,
+  }));
+
+  return {
+    summary: {
+      verified_count: monthReleases.length,
+      exact_upcoming_count: monthUpcomingSignals.length,
+      month_only_upcoming_count: monthMonthOnlyUpcomingRows.length,
+    },
+    nearest_upcoming: nearestUpcoming
+      ? {
+          entity_slug: state.artistProfileByGroup.get(nearestUpcoming.group)?.slug ?? slugifyGroup(nearestUpcoming.group),
+          display_name: state.artistProfileByGroup.get(nearestUpcoming.group)?.display_name ?? nearestUpcoming.group,
+          headline: nearestUpcoming.headline,
+          scheduled_date: nearestUpcoming.scheduled_date,
+          date_precision: getUpcomingDatePrecisionValue(nearestUpcoming),
+          date_status: nearestUpcoming.date_status,
+          confidence_score: nearestUpcoming.confidence ?? null,
+        }
+      : null,
+    days: activeDayIsos.map((iso) => ({
+      date: iso,
+      verified_releases: [...(releasesByDate.get(iso) ?? [])]
+        .sort((left, right) => {
+          const displayCompare = (state.artistProfileByGroup.get(left.group)?.display_name ?? left.group).localeCompare(
+            state.artistProfileByGroup.get(right.group)?.display_name ?? right.group,
+          );
+          if (displayCompare !== 0) {
+            return displayCompare;
+          }
+          return left.title.localeCompare(right.title);
+        })
+        .map((item) => ({
+          entity_slug: state.artistProfileByGroup.get(item.group)?.slug ?? slugifyGroup(item.group),
+          display_name: state.artistProfileByGroup.get(item.group)?.display_name ?? item.group,
+          release_title: item.title,
+          stream: item.stream,
+          release_kind: item.release_kind ?? null,
+          release_date: item.date,
+        })),
+      exact_upcoming: [...(upcomingByDate.get(iso) ?? [])]
+        .sort(compareMonthlyDashboardUpcoming)
+        .map((item) => ({
+          entity_slug: state.artistProfileByGroup.get(item.group)?.slug ?? slugifyGroup(item.group),
+          display_name: state.artistProfileByGroup.get(item.group)?.display_name ?? item.group,
+          headline: item.headline,
+          scheduled_date: item.scheduled_date ?? null,
+          date_precision: getUpcomingDatePrecisionValue(item),
+          date_status: item.date_status,
+          confidence_score: item.confidence ?? null,
+          release_format: item.release_format ?? null,
+        })),
+    })),
+    month_only_upcoming: monthMonthOnlyUpcomingRows.map((item) => ({
+      entity_slug: state.artistProfileByGroup.get(item.group)?.slug ?? slugifyGroup(item.group),
+      display_name: state.artistProfileByGroup.get(item.group)?.display_name ?? item.group,
+      headline: item.headline,
+      scheduled_month: item.scheduled_month ?? null,
+      date_precision: getUpcomingDatePrecisionValue(item),
+      date_status: item.date_status,
+      confidence_score: item.confidence ?? null,
+      release_format: item.release_format ?? null,
+    })),
+    verified_list: verifiedList,
+    scheduled_list: scheduledList,
+  };
+}
+
+function buildRadarExpected(state) {
+  return {
+    featured_upcoming: state.nearestUpcomingJumpSignal
+      ? {
+          entity_slug: state.artistProfileByGroup.get(state.nearestUpcomingJumpSignal.group)?.slug ?? slugifyGroup(state.nearestUpcomingJumpSignal.group),
+          display_name: state.artistProfileByGroup.get(state.nearestUpcomingJumpSignal.group)?.display_name ?? state.nearestUpcomingJumpSignal.group,
+          headline: state.nearestUpcomingJumpSignal.headline,
+          scheduled_date: state.nearestUpcomingJumpSignal.scheduled_date,
+          date_precision: getUpcomingDatePrecisionValue(state.nearestUpcomingJumpSignal),
+          date_status: state.nearestUpcomingJumpSignal.date_status,
+          confidence_score: state.nearestUpcomingJumpSignal.confidence ?? null,
+          release_format: state.nearestUpcomingJumpSignal.release_format ?? null,
+        }
+      : null,
+    weekly_upcoming: state.weeklyDigestRows.map((item) => ({
+      entity_slug: state.artistProfileByGroup.get(item.group)?.slug ?? slugifyGroup(item.group),
+      display_name: state.artistProfileByGroup.get(item.group)?.display_name ?? item.group,
+      release_title: item.title,
+      release_date: item.date,
+      stream: item.stream,
+      release_kind: item.release_kind ?? null,
+      release_format: item.release_format ?? null,
+    })),
+    change_feed: state.filteredReleases.slice(0, 10).map((item) => ({
+      entity_slug: state.artistProfileByGroup.get(item.group)?.slug ?? slugifyGroup(item.group),
+      display_name: state.artistProfileByGroup.get(item.group)?.display_name ?? item.group,
+      release_title: item.title,
+      release_date: item.date,
+      stream: item.stream,
+      release_kind: item.release_kind ?? null,
+      release_format: item.release_format ?? null,
+    })),
+    long_gap: state.longGapRadarEntries.map((item) => ({
+      entity_slug: state.artistProfileByGroup.get(item.group)?.slug ?? slugifyGroup(item.group),
+      display_name: state.artistProfileByGroup.get(item.group)?.display_name ?? item.group,
+      watch_reason: item.watchReason,
+      latest_release: item.latestRelease
+        ? {
+            release_title: item.latestRelease.title,
+            release_date: item.latestRelease.date || null,
+            stream: item.latestRelease.stream,
+            release_kind: item.latestRelease.releaseKind || null,
+          }
+        : null,
+      gap_days: item.gapDays,
+      has_upcoming_signal: item.hasUpcomingSignal,
+      latest_signal: item.latestSignal
+        ? {
+            headline: item.latestSignal.headline,
+            scheduled_date: item.latestSignal.scheduled_date ?? null,
+            scheduled_month: item.latestSignal.scheduled_month ?? null,
+            date_precision: getUpcomingDatePrecisionValue(item.latestSignal),
+            date_status: item.latestSignal.date_status,
+            release_format: item.latestSignal.release_format ?? null,
+            confidence_score: item.latestSignal.confidence ?? null,
+          }
+        : null,
+    })),
+    rookie: state.rookieRadarEntries.map((item) => ({
+      entity_slug: state.artistProfileByGroup.get(item.group)?.slug ?? slugifyGroup(item.group),
+      display_name: state.artistProfileByGroup.get(item.group)?.display_name ?? item.group,
+      debut_year: item.debutYear ?? null,
+      latest_release: item.latestRelease
+        ? {
+            release_title: item.latestRelease.title,
+            release_date: item.latestRelease.date || null,
+            stream: item.latestRelease.stream,
+            release_kind: item.latestRelease.releaseKind || null,
+          }
+        : null,
+      has_upcoming_signal: item.hasUpcomingSignal,
+      latest_signal: item.latestSignal
+        ? {
+            headline: item.latestSignal.headline,
+            scheduled_date: item.latestSignal.scheduled_date ?? null,
+            scheduled_month: item.latestSignal.scheduled_month ?? null,
+            date_precision: getUpcomingDatePrecisionValue(item.latestSignal),
+            date_status: item.latestSignal.date_status,
+            release_format: item.latestSignal.release_format ?? null,
+            confidence_score: item.latestSignal.confidence ?? null,
+          }
+        : null,
+    })),
+  };
+}
+
+function getValueType(value) {
+  if (value === null) {
+    return 'null';
+  }
+  if (Array.isArray(value)) {
+    return 'array';
+  }
+  return typeof value;
+}
+
+function collectShapeMismatches(expected, actual, path = 'data', mismatches = []) {
+  const expectedType = getValueType(expected);
+  const actualType = getValueType(actual);
+
+  if (expectedType === 'array') {
+    if (actualType !== 'array') {
+      mismatches.push({ path, expected_type: expectedType, actual_type: actualType, message: 'Type mismatch' });
+      return mismatches;
+    }
+
+    if (expected.length > 0 && actual.length > 0) {
+      collectShapeMismatches(expected[0], actual[0], `${path}[0]`, mismatches);
+    }
+    return mismatches;
+  }
+
+  if (expectedType === 'object') {
+    if (actualType !== 'object') {
+      mismatches.push({ path, expected_type: expectedType, actual_type: actualType, message: 'Type mismatch' });
+      return mismatches;
+    }
+
+    for (const key of Object.keys(expected)) {
+      if (!(key in actual)) {
+        mismatches.push({ path: `${path}.${key}`, expected_type: getValueType(expected[key]), actual_type: 'missing', message: 'Missing key' });
+        continue;
+      }
+      collectShapeMismatches(expected[key], actual[key], `${path}.${key}`, mismatches);
+    }
+    return mismatches;
+  }
+
+  if (expected !== null && actualType !== expectedType) {
+    mismatches.push({ path, expected_type: expectedType, actual_type: actualType, message: 'Type mismatch' });
+  }
+  return mismatches;
+}
+
+function addMismatch(result, category, detail) {
+  result.mismatch_categories.add(category);
+  result.mismatches.push({ category, ...detail });
+}
+
+function comparePrimitive(result, category, path, expected, actual) {
+  if (expected !== actual) {
+    addMismatch(result, category, { path, expected, actual });
+  }
+}
+
+function normalizeEntitySignature(item) {
+  if (!item) {
+    return null;
+  }
+
+  return {
+    entity_slug: item.entity_slug ?? null,
+    display_name: item.display_name ?? null,
+    match_reason: item.match_reason ?? null,
+    matched_alias: item.matched_alias ?? null,
+    latest_release: item.latest_release
+      ? {
+          release_title: item.latest_release.release_title ?? null,
+          release_date: item.latest_release.release_date ?? null,
+          stream: item.latest_release.stream ?? null,
+        }
+      : null,
+    next_upcoming: item.next_upcoming
+      ? {
+          headline: item.next_upcoming.headline ?? null,
+          scheduled_date: item.next_upcoming.scheduled_date ?? null,
+          scheduled_month: item.next_upcoming.scheduled_month ?? null,
+          date_precision: item.next_upcoming.date_precision ?? null,
+          date_status: item.next_upcoming.date_status ?? null,
+        }
+      : null,
+  };
+}
+
+function normalizeReleaseSearchSignature(item) {
+  if (!item) {
+    return null;
+  }
+
+  return {
+    entity_slug: item.entity_slug ?? null,
+    display_name: item.display_name ?? null,
+    release_title: item.release_title ?? null,
+    release_date: item.release_date ?? null,
+    stream: item.stream ?? null,
+    match_reason: item.match_reason ?? null,
+    matched_alias: item.matched_alias ?? null,
+  };
+}
+
+function normalizeUpcomingSearchSignature(item) {
+  if (!item) {
+    return null;
+  }
+
+  return {
+    entity_slug: item.entity_slug ?? null,
+    display_name: item.display_name ?? null,
+    headline: item.headline ?? null,
+    scheduled_date: item.scheduled_date ?? null,
+    scheduled_month: item.scheduled_month ?? null,
+    date_precision: item.date_precision ?? null,
+    date_status: item.date_status ?? null,
+    match_reason: item.match_reason ?? null,
+    matched_alias: item.matched_alias ?? null,
+  };
+}
+
+function compareSearchCase(expected, actual, input) {
+  const result = {
+    mismatch_categories: new Set(),
+    mismatches: [],
+  };
+
+  const shapeMismatches = collectShapeMismatches(expected, actual);
+  if (shapeMismatches.length) {
+    addMismatch(result, 'field-shape mismatches', { path: 'data', shape_mismatches: shapeMismatches.slice(0, 20) });
+  }
+
+  for (const segment of ['entities', 'releases', 'upcoming']) {
+    const expectedRows = expected[segment] ?? [];
+    const actualRows = actual?.[segment] ?? [];
+    if (expectedRows.length !== actualRows.length) {
+      addMismatch(result, 'missing rows or segments', {
+        path: `data.${segment}`,
+        expected_count: expectedRows.length,
+        actual_count: actualRows.length,
+      });
+    }
+  }
+
+  const entityCount = Math.max(expected.entities.length, actual?.entities?.length ?? 0);
+  for (let index = 0; index < entityCount; index += 1) {
+    const left = normalizeEntitySignature(expected.entities[index]);
+    const right = normalizeEntitySignature(actual?.entities?.[index]);
+    if (JSON.stringify(left) === JSON.stringify(right)) {
+      continue;
+    }
+
+    if ((left?.match_reason ?? null) !== (right?.match_reason ?? null) || (left?.matched_alias ?? null) !== (right?.matched_alias ?? null)) {
+      addMismatch(result, 'alias-match differences', { path: `data.entities[${index}]`, expected: left, actual: right, query: input });
+    }
+
+    if (JSON.stringify(left?.latest_release ?? null) !== JSON.stringify(right?.latest_release ?? null)) {
+      addMismatch(result, 'latest-release or next-upcoming drift', {
+        path: `data.entities[${index}].latest_release`,
+        expected: left?.latest_release ?? null,
+        actual: right?.latest_release ?? null,
+      });
+    }
+
+    if (JSON.stringify(left?.next_upcoming ?? null) !== JSON.stringify(right?.next_upcoming ?? null)) {
+      const category =
+        (left?.next_upcoming?.date_precision ?? null) !== (right?.next_upcoming?.date_precision ?? null)
+          ? 'exact-vs-month-only drift'
+          : 'latest-release or next-upcoming drift';
+      addMismatch(result, category, {
+        path: `data.entities[${index}].next_upcoming`,
+        expected: left?.next_upcoming ?? null,
+        actual: right?.next_upcoming ?? null,
+      });
+    }
+  }
+
+  const releaseCount = Math.max(expected.releases.length, actual?.releases?.length ?? 0);
+  for (let index = 0; index < releaseCount; index += 1) {
+    const left = normalizeReleaseSearchSignature(expected.releases[index]);
+    const right = normalizeReleaseSearchSignature(actual?.releases?.[index]);
+    if (JSON.stringify(left) === JSON.stringify(right)) {
+      continue;
+    }
+
+    if ((left?.match_reason ?? null) !== (right?.match_reason ?? null) || (left?.matched_alias ?? null) !== (right?.matched_alias ?? null)) {
+      addMismatch(result, 'alias-match differences', { path: `data.releases[${index}]`, expected: left, actual: right, query: input });
+    } else {
+      addMismatch(result, 'missing rows or segments', { path: `data.releases[${index}]`, expected: left, actual: right });
+    }
+  }
+
+  const upcomingCount = Math.max(expected.upcoming.length, actual?.upcoming?.length ?? 0);
+  for (let index = 0; index < upcomingCount; index += 1) {
+    const left = normalizeUpcomingSearchSignature(expected.upcoming[index]);
+    const right = normalizeUpcomingSearchSignature(actual?.upcoming?.[index]);
+    if (JSON.stringify(left) === JSON.stringify(right)) {
+      continue;
+    }
+
+    if ((left?.match_reason ?? null) !== (right?.match_reason ?? null) || (left?.matched_alias ?? null) !== (right?.matched_alias ?? null)) {
+      addMismatch(result, 'alias-match differences', { path: `data.upcoming[${index}]`, expected: left, actual: right, query: input });
+    }
+
+    const leftPrecision = left?.date_precision ?? null;
+    const rightPrecision = right?.date_precision ?? null;
+    const category =
+      leftPrecision !== rightPrecision || (left?.scheduled_date ?? null) !== (right?.scheduled_date ?? null)
+        ? 'exact-vs-month-only drift'
+        : 'missing rows or segments';
+    addMismatch(result, category, { path: `data.upcoming[${index}]`, expected: left, actual: right });
+  }
+
+  return result;
+}
+
+function normalizeReleaseSummary(item) {
+  if (!item) {
+    return null;
+  }
+
+  return {
+    release_title: item.release_title ?? null,
+    release_date: item.release_date ?? null,
+    stream: item.stream ?? null,
+    release_kind: item.release_kind ?? null,
+  };
+}
+
+function normalizeUpcomingSummary(item) {
+  if (!item) {
+    return null;
+  }
+
+  return {
+    headline: item.headline ?? null,
+    scheduled_date: item.scheduled_date ?? null,
+    scheduled_month: item.scheduled_month ?? null,
+    date_precision: item.date_precision ?? null,
+    date_status: item.date_status ?? null,
+    release_format: item.release_format ?? null,
+  };
+}
+
+function compareEntityDetailCase(expected, actual) {
+  const result = {
+    mismatch_categories: new Set(),
+    mismatches: [],
+  };
+
+  const shapeMismatches = collectShapeMismatches(expected, actual);
+  if (shapeMismatches.length) {
+    addMismatch(result, 'field-shape mismatches', { path: 'data', shape_mismatches: shapeMismatches.slice(0, 20) });
+  }
+
+  for (const pathEntry of [
+    ['data.identity.display_name', expected.identity.display_name, actual?.identity?.display_name],
+    ['data.identity.canonical_name', expected.identity.canonical_name, actual?.identity?.canonical_name],
+    ['data.identity.agency_name', expected.identity.agency_name, actual?.identity?.agency_name],
+    ['data.official_links.youtube', expected.official_links.youtube, actual?.official_links?.youtube],
+    ['data.official_links.x', expected.official_links.x, actual?.official_links?.x],
+    ['data.official_links.instagram', expected.official_links.instagram, actual?.official_links?.instagram],
+    ['data.tracking_state.tier', expected.tracking_state.tier, actual?.tracking_state?.tier],
+    ['data.tracking_state.watch_reason', expected.tracking_state.watch_reason, actual?.tracking_state?.watch_reason],
+    ['data.tracking_state.tracking_status', expected.tracking_state.tracking_status, actual?.tracking_state?.tracking_status],
+    ['data.artist_source_url', expected.artist_source_url, actual?.artist_source_url],
+  ]) {
+    const [pathValue, left, right] = pathEntry;
+    if (left !== right) {
+      addMismatch(result, 'missing rows or segments', { path: pathValue, expected: left, actual: right });
+    }
+  }
+
+  const expectedLatest = normalizeReleaseSummary(expected.latest_release);
+  const actualLatest = normalizeReleaseSummary(actual?.latest_release);
+  if (JSON.stringify(expectedLatest) !== JSON.stringify(actualLatest)) {
+    addMismatch(result, 'latest-release or next-upcoming drift', {
+      path: 'data.latest_release',
+      expected: expectedLatest,
+      actual: actualLatest,
+    });
+  }
+
+  const expectedUpcoming = normalizeUpcomingSummary(expected.next_upcoming);
+  const actualUpcoming = normalizeUpcomingSummary(actual?.next_upcoming);
+  if (JSON.stringify(expectedUpcoming) !== JSON.stringify(actualUpcoming)) {
+    addMismatch(
+      result,
+      (expectedUpcoming?.date_precision ?? null) !== (actualUpcoming?.date_precision ?? null)
+        ? 'exact-vs-month-only drift'
+        : 'latest-release or next-upcoming drift',
+      {
+        path: 'data.next_upcoming',
+        expected: expectedUpcoming,
+        actual: actualUpcoming,
+      },
+    );
+  }
+
+  const expectedAlbums = expected.recent_albums.map((item) => `${item.release_title}|${item.release_date}|${item.stream}`);
+  const actualAlbums = (actual?.recent_albums ?? []).map((item) => `${item.release_title}|${item.release_date}|${item.stream}`);
+  if (JSON.stringify(expectedAlbums) !== JSON.stringify(actualAlbums)) {
+    addMismatch(result, 'missing rows or segments', {
+      path: 'data.recent_albums',
+      expected: expectedAlbums,
+      actual: actualAlbums,
+    });
+  }
+
+  const expectedTimeline = expected.source_timeline.map((item) => `${item.event_type}|${item.headline}|${item.source_type}|${item.source_url ?? ''}`);
+  const actualTimeline = (actual?.source_timeline ?? []).map((item) => `${item.headline}|${item.source_type}|${item.source_url ?? ''}`);
+  if (JSON.stringify(expectedTimeline) !== JSON.stringify(actualTimeline)) {
+    addMismatch(result, 'missing rows or segments', {
+      path: 'data.source_timeline',
+      expected: expectedTimeline.slice(0, 10),
+      actual: actualTimeline.slice(0, 10),
+    });
+  }
+
+  return result;
+}
+
+function compareReleaseDetailCase(expected, actual) {
+  const result = {
+    mismatch_categories: new Set(),
+    mismatches: [],
+  };
+
+  const lookupShapeMismatches = collectShapeMismatches(expected.lookup, actual?.lookup);
+  const detailShapeMismatches = collectShapeMismatches(expected.detail, actual?.detail);
+  const shapeMismatches = [...lookupShapeMismatches, ...detailShapeMismatches];
+  if (shapeMismatches.length) {
+    addMismatch(result, 'field-shape mismatches', { path: 'data', shape_mismatches: shapeMismatches.slice(0, 20) });
+  }
+
+  const expectedLookup = normalizeReleaseSummary(expected.lookup);
+  const actualLookup = normalizeReleaseSummary(actual?.lookup?.release);
+  if (JSON.stringify(expectedLookup) !== JSON.stringify(actualLookup)) {
+    addMismatch(result, 'missing rows or segments', {
+      path: 'data.lookup.release',
+      expected: expectedLookup,
+      actual: actualLookup,
+    });
+  }
+
+  const expectedArtwork = expected.detail.artwork;
+  const actualArtwork = actual?.detail?.artwork ?? null;
+  if (JSON.stringify(expectedArtwork) !== JSON.stringify(actualArtwork)) {
+    addMismatch(result, 'missing rows or segments', {
+      path: 'data.detail.artwork',
+      expected: expectedArtwork,
+      actual: actualArtwork,
+    });
+  }
+
+  for (const serviceType of ['spotify', 'youtube_music']) {
+    const expectedService = expected.detail.service_links[serviceType];
+    const actualService = actual?.detail?.service_links?.[serviceType] ?? null;
+    if (JSON.stringify(expectedService) !== JSON.stringify(actualService)) {
+      addMismatch(result, 'missing rows or segments', {
+        path: `data.detail.service_links.${serviceType}`,
+        expected: expectedService,
+        actual: actualService,
+      });
+    }
+  }
+
+  const expectedTracks = expected.detail.tracks.map((track) => `${track.order}|${track.title}|${track.is_title_track}`);
+  const actualTracks = (actual?.detail?.tracks ?? []).map((track) => `${track.order}|${track.title}|${track.is_title_track}`);
+  if (JSON.stringify(expectedTracks) !== JSON.stringify(actualTracks)) {
+    addMismatch(result, 'title-track / MV-state drift', {
+      path: 'data.detail.tracks',
+      expected: expectedTracks,
+      actual: actualTracks,
+    });
+  }
+
+  if (JSON.stringify(expected.detail.mv) !== JSON.stringify(actual?.detail?.mv ?? null)) {
+    addMismatch(result, 'title-track / MV-state drift', {
+      path: 'data.detail.mv',
+      expected: expected.detail.mv,
+      actual: actual?.detail?.mv ?? null,
+    });
+  }
+
+  const expectedCredits = expected.detail.credits;
+  const actualCredits = actual?.detail?.credits ?? [];
+  if (JSON.stringify(expectedCredits) !== JSON.stringify(actualCredits)) {
+    addMismatch(result, 'missing rows or segments', {
+      path: 'data.detail.credits',
+      expected: expectedCredits,
+      actual: actualCredits,
+    });
+  }
+
+  const expectedCharts = expected.detail.charts;
+  const actualCharts = actual?.detail?.charts ?? [];
+  if (JSON.stringify(expectedCharts) !== JSON.stringify(actualCharts)) {
+    addMismatch(result, 'missing rows or segments', {
+      path: 'data.detail.charts',
+      expected: expectedCharts,
+      actual: actualCharts,
+    });
+  }
+
+  if ((expected.detail.notes ?? '') !== (actual?.detail?.notes ?? '')) {
+    addMismatch(result, 'missing rows or segments', {
+      path: 'data.detail.notes',
+      expected: expected.detail.notes ?? '',
+      actual: actual?.detail?.notes ?? '',
+    });
+  }
+
+  return result;
+}
+
+function calendarReleaseSignature(item) {
+  return `${item.entity_slug}|${item.release_title}|${item.release_date ?? ''}|${item.stream}`;
+}
+
+function calendarUpcomingSignature(item) {
+  return `${item.entity_slug}|${item.headline}|${item.scheduled_date ?? ''}|${item.scheduled_month ?? ''}|${item.date_precision}|${item.date_status}`;
+}
+
+function compareCalendarCase(expected, actual) {
+  const result = {
+    mismatch_categories: new Set(),
+    mismatches: [],
+  };
+
+  const shapeMismatches = collectShapeMismatches(expected, actual);
+  if (shapeMismatches.length) {
+    addMismatch(result, 'field-shape mismatches', { path: 'data', shape_mismatches: shapeMismatches.slice(0, 20) });
+  }
+
+  if (JSON.stringify(expected.summary) !== JSON.stringify(actual?.summary ?? null)) {
+    addMismatch(result, 'missing rows or segments', {
+      path: 'data.summary',
+      expected: expected.summary,
+      actual: actual?.summary ?? null,
+    });
+  }
+
+  const expectedNearest = expected.nearest_upcoming ? calendarUpcomingSignature(expected.nearest_upcoming) : null;
+  const actualNearest = actual?.nearest_upcoming ? calendarUpcomingSignature(actual.nearest_upcoming) : null;
+  if (expectedNearest !== actualNearest) {
+    const category =
+      expected?.nearest_upcoming?.date_precision !== actual?.nearest_upcoming?.date_precision
+        ? 'exact-vs-month-only drift'
+        : 'latest-release or next-upcoming drift';
+    addMismatch(result, category, {
+      path: 'data.nearest_upcoming',
+      expected: expected.nearest_upcoming,
+      actual: actual?.nearest_upcoming ?? null,
+    });
+  }
+
+  const expectedDays = expected.days.map((day) => ({
+    date: day.date,
+    verified_releases: day.verified_releases.map(calendarReleaseSignature),
+    exact_upcoming: day.exact_upcoming.map(calendarUpcomingSignature),
+  }));
+  const actualDays = (actual?.days ?? []).map((day) => ({
+    date: day.date,
+    verified_releases: (day.verified_releases ?? []).map(calendarReleaseSignature),
+    exact_upcoming: (day.exact_upcoming ?? []).map(calendarUpcomingSignature),
+  }));
+  if (JSON.stringify(expectedDays) !== JSON.stringify(actualDays)) {
+    addMismatch(result, 'missing rows or segments', {
+      path: 'data.days',
+      expected: expectedDays,
+      actual: actualDays,
+    });
+  }
+
+  const expectedMonthOnly = expected.month_only_upcoming.map(calendarUpcomingSignature);
+  const actualMonthOnly = (actual?.month_only_upcoming ?? []).map(calendarUpcomingSignature);
+  if (JSON.stringify(expectedMonthOnly) !== JSON.stringify(actualMonthOnly)) {
+    addMismatch(result, 'exact-vs-month-only drift', {
+      path: 'data.month_only_upcoming',
+      expected: expectedMonthOnly,
+      actual: actualMonthOnly,
+    });
+  }
+
+  const expectedVerifiedList = expected.verified_list.map(calendarReleaseSignature);
+  const actualVerifiedList = (actual?.verified_list ?? []).map(calendarReleaseSignature);
+  if (JSON.stringify(expectedVerifiedList) !== JSON.stringify(actualVerifiedList)) {
+    addMismatch(result, 'missing rows or segments', {
+      path: 'data.verified_list',
+      expected: expectedVerifiedList,
+      actual: actualVerifiedList,
+    });
+  }
+
+  const expectedScheduledList = expected.scheduled_list.map(calendarUpcomingSignature);
+  const actualScheduledList = (actual?.scheduled_list ?? []).map(calendarUpcomingSignature);
+  if (JSON.stringify(expectedScheduledList) !== JSON.stringify(actualScheduledList)) {
+    addMismatch(result, 'exact-vs-month-only drift', {
+      path: 'data.scheduled_list',
+      expected: expectedScheduledList,
+      actual: actualScheduledList,
+    });
+  }
+
+  return result;
+}
+
+function radarUpcomingSignature(item) {
+  return `${item.entity_slug}|${item.headline}|${item.scheduled_date ?? ''}|${item.scheduled_month ?? ''}|${item.date_precision}|${item.date_status}`;
+}
+
+function radarReleaseSignature(item) {
+  return `${item.entity_slug}|${item.release_title}|${item.release_date}|${item.stream}`;
+}
+
+function radarLongGapSignature(item) {
+  const latestRelease = item.latest_release
+    ? `${item.latest_release.release_title}|${item.latest_release.release_date}|${item.latest_release.stream}`
+    : 'null';
+  const latestSignal = item.latest_signal ? radarUpcomingSignature(item.latest_signal) : 'null';
+  return `${item.entity_slug}|${item.watch_reason}|${latestRelease}|${item.gap_days}|${item.has_upcoming_signal}|${latestSignal}`;
+}
+
+function radarRookieSignature(item) {
+  const latestRelease = item.latest_release
+    ? `${item.latest_release.release_title}|${item.latest_release.release_date}|${item.latest_release.stream}`
+    : 'null';
+  const latestSignal = item.latest_signal ? radarUpcomingSignature(item.latest_signal) : 'null';
+  return `${item.entity_slug}|${item.debut_year}|${latestRelease}|${item.has_upcoming_signal}|${latestSignal}`;
+}
+
+function compareRadarCase(expected, actual) {
+  const result = {
+    mismatch_categories: new Set(),
+    mismatches: [],
+  };
+
+  const shapeMismatches = collectShapeMismatches(expected, actual);
+  if (shapeMismatches.length) {
+    addMismatch(result, 'field-shape mismatches', { path: 'data', shape_mismatches: shapeMismatches.slice(0, 20) });
+  }
+
+  const expectedFeatured = expected.featured_upcoming ? radarUpcomingSignature(expected.featured_upcoming) : null;
+  const actualFeatured = actual?.featured_upcoming ? radarUpcomingSignature(actual.featured_upcoming) : null;
+  if (expectedFeatured !== actualFeatured) {
+    addMismatch(result, 'radar eligibility drift', {
+      path: 'data.featured_upcoming',
+      expected: expected.featured_upcoming,
+      actual: actual?.featured_upcoming ?? null,
+    });
+  }
+
+  const expectedWeekly = expected.weekly_upcoming.map(radarReleaseSignature);
+  const actualWeekly = (actual?.weekly_upcoming ?? []).map((item) =>
+    item.release_title ? radarReleaseSignature(item) : radarUpcomingSignature(item),
+  );
+  if (JSON.stringify(expectedWeekly) !== JSON.stringify(actualWeekly)) {
+    addMismatch(result, 'radar eligibility drift', {
+      path: 'data.weekly_upcoming',
+      expected: expectedWeekly,
+      actual: actualWeekly,
+    });
+  }
+
+  const expectedFeed = expected.change_feed.map(radarReleaseSignature);
+  const actualFeed = (actual?.change_feed ?? []).map((item) =>
+    item.release_title ? radarReleaseSignature(item) : `${item.kind ?? 'unknown'}|${item.entity_slug ?? ''}|${item.headline ?? ''}|${item.release_title ?? ''}`,
+  );
+  if (JSON.stringify(expectedFeed) !== JSON.stringify(actualFeed)) {
+    addMismatch(result, 'radar eligibility drift', {
+      path: 'data.change_feed',
+      expected: expectedFeed,
+      actual: actualFeed,
+    });
+  }
+
+  const expectedLongGap = expected.long_gap.map(radarLongGapSignature);
+  const actualLongGap = (actual?.long_gap ?? []).map(radarLongGapSignature);
+  if (JSON.stringify(expectedLongGap) !== JSON.stringify(actualLongGap)) {
+    addMismatch(result, 'radar eligibility drift', {
+      path: 'data.long_gap',
+      expected: expectedLongGap,
+      actual: actualLongGap,
+    });
+  }
+
+  const expectedRookie = expected.rookie.map(radarRookieSignature);
+  const actualRookie = (actual?.rookie ?? []).map(radarRookieSignature);
+  if (JSON.stringify(expectedRookie) !== JSON.stringify(actualRookie)) {
+    addMismatch(result, 'radar eligibility drift', {
+      path: 'data.rookie',
+      expected: expectedRookie,
+      actual: actualRookie,
+    });
+  }
+
+  return result;
+}
+
+function buildSummaryLines(caseResults) {
+  const bySurface = new Map();
+  const byCategory = new Map();
+
+  for (const caseResult of caseResults) {
+    const surface = bySurface.get(caseResult.surface) ?? { total: 0, clean: 0, drift: 0 };
+    surface.total += 1;
+    if (caseResult.clean) {
+      surface.clean += 1;
+    } else {
+      surface.drift += 1;
+    }
+    bySurface.set(caseResult.surface, surface);
+
+    for (const category of caseResult.mismatch_categories) {
+      byCategory.set(category, (byCategory.get(category) ?? 0) + 1);
+    }
+  }
+
+  const lines = [];
+  for (const [surface, stats] of bySurface) {
+    lines.push(`${surface}: clean ${stats.clean}/${stats.total}, drift ${stats.drift}/${stats.total}`);
+  }
+  for (const [category, count] of [...byCategory.entries()].sort((left, right) => right[1] - left[1])) {
+    lines.push(`${category}: ${count} case(s)`);
+  }
+  return lines;
+}
+
+function limitSnapshot(value, depth = 0) {
+  if (depth > 4) {
+    return '[truncated]';
+  }
+
+  if (Array.isArray(value)) {
+    return value.slice(0, 12).map((item) => limitSnapshot(item, depth + 1));
+  }
+
+  if (isRecord(value)) {
+    const next = {};
+    for (const [key, child] of Object.entries(value)) {
+      next[key] = limitSnapshot(child, depth + 1);
+    }
+    return next;
+  }
+
+  return value;
+}
+
+async function injectJson(app, url) {
+  const response = await app.inject({ method: 'GET', url });
+  let body = null;
+  try {
+    body = response.json();
+  } catch {
+    body = null;
+  }
+
+  return {
+    statusCode: response.statusCode,
+    body,
+  };
+}
+
+function buildCaseReport(surface, input, expectedSnapshot, actualSnapshot, comparison, meta = {}) {
+  const mismatchCategories = [...comparison.mismatch_categories];
+  return {
+    surface,
+    input,
+    clean: mismatchCategories.length === 0,
+    mismatch_categories: mismatchCategories,
+    mismatches: comparison.mismatches.slice(0, 25),
+    expected_snapshot: limitSnapshot(expectedSnapshot),
+    actual_snapshot: limitSnapshot(actualSnapshot),
+    ...meta,
+  };
+}
+
+function readLinkedParityReport() {
+  if (!fs.existsSync(PARITY_REPORT_PATH)) {
+    return {
+      exists: false,
+      path: path.relative(REPO_ROOT, PARITY_REPORT_PATH),
+    };
+  }
+
+  const report = loadJson(PARITY_REPORT_PATH);
+  return {
+    exists: true,
+    path: path.relative(REPO_ROOT, PARITY_REPORT_PATH),
+    clean: report.clean,
+    generated_at: report.generated_at,
+    summary_lines: report.summary_lines ?? [],
+  };
+}
+
+function runSelfCheck() {
+  const searchComparison = compareSearchCase(
+    {
+      entities: [
+        {
+          entity_slug: 'yena',
+          display_name: 'YENA',
+          canonical_name: 'YENA',
+          match_reason: 'alias_exact',
+          matched_alias: '최예나',
+          latest_release: null,
+          next_upcoming: null,
+        },
+      ],
+      releases: [],
+      upcoming: [],
+    },
+    {
+      entities: [
+        {
+          entity_slug: 'yena',
+          display_name: 'YENA',
+          canonical_name: 'YENA',
+          match_reason: 'partial',
+          matched_alias: null,
+          latest_release: null,
+          next_upcoming: null,
+        },
+      ],
+      releases: [],
+      upcoming: [],
+    },
+    '최예나',
+  );
+  assert(searchComparison.mismatch_categories.has('alias-match differences'));
+
+  const calendarComparison = compareCalendarCase(
+    {
+      summary: {
+        verified_count: 0,
+        exact_upcoming_count: 0,
+        month_only_upcoming_count: 1,
+      },
+      nearest_upcoming: null,
+      days: [],
+      month_only_upcoming: [
+        {
+          entity_slug: 'and-team',
+          display_name: '&TEAM',
+          headline: 'Month only',
+          scheduled_month: '2026-04',
+          date_precision: 'month_only',
+          date_status: 'scheduled',
+          confidence_score: 0.7,
+          release_format: 'ep',
+        },
+      ],
+      verified_list: [],
+      scheduled_list: [],
+    },
+    {
+      summary: {
+        verified_count: 0,
+        exact_upcoming_count: 1,
+        month_only_upcoming_count: 0,
+      },
+      nearest_upcoming: null,
+      days: [],
+      month_only_upcoming: [],
+      verified_list: [],
+      scheduled_list: [
+        {
+          entity_slug: 'and-team',
+          display_name: '&TEAM',
+          headline: 'Exact date',
+          scheduled_date: '2026-04-07',
+          scheduled_month: '2026-04',
+          date_precision: 'exact',
+          date_status: 'scheduled',
+          confidence_score: 0.7,
+          release_format: 'ep',
+        },
+      ],
+    },
+  );
+  assert(calendarComparison.mismatch_categories.has('exact-vs-month-only drift'));
+
+  const releaseComparison = compareReleaseDetailCase(
+    {
+      lookup: {
+        entity_slug: 'ive',
+        release_title: 'REVIVE+',
+        release_date: '2026-02-23',
+        stream: 'album',
+        release_kind: 'ep',
+        display_name: 'IVE',
+      },
+      detail: {
+        release: {
+          entity_slug: 'ive',
+          display_name: 'IVE',
+          release_title: 'REVIVE+',
+          release_date: '2026-02-23',
+          stream: 'album',
+          release_kind: 'ep',
+        },
+        artwork: {},
+        service_links: {
+          spotify: { url: null, status: 'no_link' },
+          youtube_music: { url: null, status: 'no_link' },
+        },
+        tracks: [{ order: 1, title: 'BLACKHOLE', is_title_track: true }],
+        mv: { url: null, video_id: null, status: 'unresolved', provenance: null },
+        credits: [],
+        charts: [],
+        notes: '',
+      },
+    },
+    {
+      lookup: {
+        release: {
+          entity_slug: 'ive',
+          display_name: 'IVE',
+          release_title: 'REVIVE+',
+          release_date: '2026-02-23',
+          stream: 'album',
+          release_kind: 'ep',
+        },
+      },
+      detail: {
+        release: {
+          entity_slug: 'ive',
+          display_name: 'IVE',
+          release_title: 'REVIVE+',
+          release_date: '2026-02-23',
+          stream: 'album',
+          release_kind: 'ep',
+        },
+        artwork: {},
+        service_links: {
+          spotify: { url: null, status: 'no_link' },
+          youtube_music: { url: null, status: 'no_link' },
+        },
+        tracks: [{ order: 1, title: 'BLACKHOLE', is_title_track: false }],
+        mv: { url: null, video_id: null, status: 'manual_override', provenance: null },
+        credits: [],
+        charts: [],
+        notes: '',
+      },
+    },
+  );
+  assert(releaseComparison.mismatch_categories.has('title-track / MV-state drift'));
+
+  const radarComparison = compareRadarCase(
+    {
+      featured_upcoming: null,
+      weekly_upcoming: [],
+      change_feed: [],
+      long_gap: [],
+      rookie: [{ entity_slug: 'yena', display_name: 'YENA', debut_year: 2021, latest_release: null, has_upcoming_signal: false, latest_signal: null }],
+    },
+    {
+      featured_upcoming: null,
+      weekly_upcoming: [],
+      change_feed: [],
+      long_gap: [],
+      rookie: [],
+    },
+  );
+  assert(radarComparison.mismatch_categories.has('radar eligibility drift'));
+
+  return {
+    passed: true,
+  };
+}
+
+async function buildSearchCaseReport(app, state, query) {
+  const expected = buildSearchExpected(query, state);
+  const actualResponse = await injectJson(app, `/v1/search?q=${encodeURIComponent(query)}`);
+  const actualData = actualResponse.body?.data ?? null;
+  const comparison =
+    actualResponse.statusCode === 200
+      ? compareSearchCase(expected, actualData, query)
+      : {
+          mismatch_categories: new Set(['missing rows or segments']),
+          mismatches: [{ category: 'missing rows or segments', path: 'response.statusCode', expected: 200, actual: actualResponse.statusCode }],
+        };
+
+  return buildCaseReport('search', { q: query }, expected, actualData, comparison, {
+    actual_status_code: actualResponse.statusCode,
+  });
+}
+
+async function buildEntityCaseReport(app, state, slug) {
+  const expected = buildEntityDetailExpected(slug, state);
+  const actualResponse = await injectJson(app, `/v1/entities/${slug}`);
+  const actualData = actualResponse.body?.data ?? null;
+  const comparison =
+    actualResponse.statusCode === 200 && expected
+      ? compareEntityDetailCase(expected, actualData)
+      : {
+          mismatch_categories: new Set(['missing rows or segments']),
+          mismatches: [{ category: 'missing rows or segments', path: 'response.statusCode', expected: 200, actual: actualResponse.statusCode }],
+        };
+
+  return buildCaseReport('entity_detail', { slug }, expected, actualData, comparison, {
+    actual_status_code: actualResponse.statusCode,
+  });
+}
+
+async function buildReleaseCaseReport(app, state, definition) {
+  const expected = buildReleaseExpected(definition, state);
+  const lookupUrl = `/v1/releases/lookup?entity_slug=${encodeURIComponent(definition.entitySlug)}&title=${encodeURIComponent(
+    definition.title,
+  )}&date=${definition.date}&stream=${definition.stream}`;
+  const lookupResponse = await injectJson(app, lookupUrl);
+  const lookupData = lookupResponse.body?.data ?? null;
+
+  let detailResponse = { statusCode: 0, body: null };
+  if (lookupResponse.statusCode === 200 && lookupData?.canonical_path) {
+    detailResponse = await injectJson(app, lookupData.canonical_path);
+  }
+
+  const actual = {
+    lookup: lookupData,
+    detail: detailResponse.body?.data ?? null,
+  };
+
+  const comparison =
+    lookupResponse.statusCode === 200 && detailResponse.statusCode === 200 && expected
+      ? compareReleaseDetailCase(expected, actual)
+      : {
+          mismatch_categories: new Set(['missing rows or segments']),
+          mismatches: [
+            {
+              category: 'missing rows or segments',
+              path: 'lookup.statusCode',
+              expected: 200,
+              actual: lookupResponse.statusCode,
+            },
+            {
+              category: 'missing rows or segments',
+              path: 'detail.statusCode',
+              expected: 200,
+              actual: detailResponse.statusCode,
+            },
+          ],
+        };
+
+  return buildCaseReport('release_detail', definition, expected, actual, comparison, {
+    lookup_status_code: lookupResponse.statusCode,
+    detail_status_code: detailResponse.statusCode,
+  });
+}
+
+async function buildCalendarCaseReport(app, state, month) {
+  const expected = buildCalendarExpected(month, state);
+  const actualResponse = await injectJson(app, `/v1/calendar/month?month=${month}`);
+  const actualData = actualResponse.body?.data ?? null;
+  const comparison =
+    actualResponse.statusCode === 200
+      ? compareCalendarCase(expected, actualData)
+      : {
+          mismatch_categories: new Set(['missing rows or segments']),
+          mismatches: [{ category: 'missing rows or segments', path: 'response.statusCode', expected: 200, actual: actualResponse.statusCode }],
+        };
+
+  return buildCaseReport('calendar_month', { month }, expected, actualData, comparison, {
+    actual_status_code: actualResponse.statusCode,
+  });
+}
+
+async function buildRadarCaseReport(app, state) {
+  const expected = buildRadarExpected(state);
+  const actualResponse = await injectJson(app, '/v1/radar');
+  const actualData = actualResponse.body?.data ?? null;
+  const comparison =
+    actualResponse.statusCode === 200
+      ? compareRadarCase(expected, actualData)
+      : {
+          mismatch_categories: new Set(['missing rows or segments']),
+          mismatches: [{ category: 'missing rows or segments', path: 'response.statusCode', expected: 200, actual: actualResponse.statusCode }],
+        };
+
+  return buildCaseReport('radar', { surface: 'default' }, expected, actualData, comparison, {
+    actual_status_code: actualResponse.statusCode,
+  });
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const state = createBaselineState();
+  const linkedParityReport = readLinkedParityReport();
+  const selfCheck = runSelfCheck();
+
+  const app = buildApp();
+  await app.ready();
+
+  try {
+    const caseResults = [];
+
+    for (const query of SEARCH_CASES) {
+      caseResults.push(await buildSearchCaseReport(app, state, query));
+    }
+    for (const slug of ENTITY_CASES) {
+      caseResults.push(await buildEntityCaseReport(app, state, slug));
+    }
+    for (const definition of RELEASE_CASES) {
+      caseResults.push(await buildReleaseCaseReport(app, state, definition));
+    }
+    for (const month of CALENDAR_CASES) {
+      caseResults.push(await buildCalendarCaseReport(app, state, month));
+    }
+    caseResults.push(await buildRadarCaseReport(app, state));
+
+    const summaryLines = buildSummaryLines(caseResults);
+    const clean = caseResults.every((item) => item.clean);
+
+    const report = {
+      generated_at: new Date().toISOString(),
+      clean,
+      linked_parity_report: linkedParityReport,
+      self_check: selfCheck,
+      coverage: {
+        search: SEARCH_CASES,
+        entity_detail: ENTITY_CASES,
+        release_detail: RELEASE_CASES,
+        calendar_month: CALENDAR_CASES,
+        radar: ['default'],
+      },
+      summary_lines: summaryLines,
+      cases: caseResults,
+    };
+
+    fs.mkdirSync(path.dirname(args.reportPath), { recursive: true });
+    fs.writeFileSync(args.reportPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+
+    console.log(JSON.stringify({ clean, report_path: path.resolve(args.reportPath) }));
+    for (const line of summaryLines) {
+      console.log(line);
+    }
+  } finally {
+    await app.close();
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/backend/sql/README.md
+++ b/backend/sql/README.md
@@ -35,6 +35,8 @@ cd backend
 npm run projection:refresh
 cd ..
 python3 build_backend_json_parity_report.py
+cd backend
+npm run shadow:verify
 ```
 
 ## 규칙
@@ -48,3 +50,4 @@ python3 build_backend_json_parity_report.py
 - release pipeline dual-write summary는 `backend/reports/release_pipeline_db_sync_summary.json`에 남긴다.
 - projection refresh summary는 `backend/reports/projection_refresh_summary.json`에 남긴다.
 - backend-vs-JSON parity report는 `backend/reports/backend_json_parity_report.json`에 남긴다.
+- endpoint shadow-read report는 `backend/reports/backend_shadow_read_report.json`에 남긴다.


### PR DESCRIPTION
## Summary
- add a repeatable backend shadow-read harness that injects live Fastify read routes and compares them against current shipped web/JSON baselines
- write a machine-readable report with endpoint coverage, drift categories, and linked parity-report context
- document the new `npm run shadow:verify` workflow in backend and root docs

## Verification
- `cd backend && source ~/.config/idol-song-app/neon.env && npm run shadow:verify`
- `git diff --check`

Closes #176