### PR TITLE
Onboard XLOV with Korean alias coverage

### DIFF
--- a/artist_socials_structured_2026-03-04.json
+++ b/artist_socials_structured_2026-03-04.json
@@ -826,6 +826,20 @@
     "note": ""
   },
   {
+    "artist": "XLOV",
+    "tier": "longtail",
+    "parent_group": null,
+    "x_url": "https://x.com/XLOV_official",
+    "x_source": "manual_verified",
+    "instagram_url": "https://www.instagram.com/xlov_official/",
+    "instagram_source": "manual_verified",
+    "completeness": "both",
+    "original_status": "manual_seed",
+    "wikidata_id": null,
+    "wikidata_source": null,
+    "note": "manual_seed_2026_03_07"
+  },
+  {
     "artist": "ZEROBASEONE",
     "tier": "core",
     "parent_group": null,

--- a/build_tracking_watchlist.py
+++ b/build_tracking_watchlist.py
@@ -26,6 +26,7 @@ SEARCH_QUERY_OVERRIDE = {
     "izna": ['"izna" kpop comeback'],
     "woo!ah!": ['"woo!ah!" comeback'],
     "xikers": ['"xikers" comeback'],
+    "XLOV": ['"XLOV" kpop comeback', '"엑스러브" 컴백', '"xluv" comeback kpop'],
 }
 
 LONG_GAP_DAYS = 365

--- a/group_latest_release_since_2025-06-01_mb.json
+++ b/group_latest_release_since_2025-06-01_mb.json
@@ -1443,6 +1443,28 @@
     "artist_source": "https://musicbrainz.org/artist/9b779913-3d52-4ab7-bf38-889c2dcabbd1"
   },
   {
+    "group": "XLOV",
+    "artist_name_mb": "XLOV",
+    "artist_mbid": "92449998-96fa-45b5-8a67-abb5ff975aa1",
+    "latest_song": {
+      "title": "I ONE",
+      "date": "2025-06-13",
+      "source": "https://musicbrainz.org/release-group/f4743ab2-e6d6-41f7-bf09-6c5090cf4cf0",
+      "release_kind": "single",
+      "release_format": "single",
+      "context_tags": []
+    },
+    "latest_album": {
+      "title": "UXLXVE",
+      "date": "2025-11-05",
+      "source": "https://musicbrainz.org/release-group/01b29180-b871-4122-bf4c-1758800d6333",
+      "release_kind": "ep",
+      "release_format": "ep",
+      "context_tags": []
+    },
+    "artist_source": "https://musicbrainz.org/artist/92449998-96fa-45b5-8a67-abb5ff975aa1"
+  },
+  {
     "group": "YOUNG POSSE",
     "artist_name_mb": "YOUNG POSSE",
     "artist_mbid": "427150d2-674f-47b2-a1a1-7bb4a9e0d070",

--- a/map_latest_releases_musicbrainz.py
+++ b/map_latest_releases_musicbrainz.py
@@ -31,6 +31,7 @@ ALIASES = {
     "NCT 127": ["NCT 127"],
     "NCT DREAM": ["NCT DREAM"],
     "NCT WISH": ["NCT WISH"],
+    "XLOV": ["XLOV", "엑스러브", "xluv"],
     "QWER": ["QWER"],
     "IVE": ["IVE"],
     "WJSN": ["WJSN", "Cosmic Girls", "우주소녀"],
@@ -44,6 +45,7 @@ QUERY_OVERRIDE = {
     "woo!ah!": 'artist:"wooah"',
     "The KingDom": 'artist:"The KingDom"',
     "SAY MY NAME": 'artist:"SAY MY NAME"',
+    "XLOV": 'artist:"XLOV"',
     "IVE": 'artist:"IVE"',
     "WJSN": 'alias:"WJSN"',
 }

--- a/tracking_watchlist.json
+++ b/tracking_watchlist.json
@@ -1589,6 +1589,22 @@
     ]
   },
   {
+    "group": "XLOV",
+    "tier": "longtail",
+    "watch_reason": "recent_release",
+    "tracking_status": "recent_release",
+    "latest_release_title": "UXLXVE",
+    "latest_release_date": "2025-11-05",
+    "latest_release_kind": "ep",
+    "x_url": "https://x.com/XLOV_official",
+    "instagram_url": "https://www.instagram.com/xlov_official/",
+    "search_terms": [
+      "\"XLOV\" kpop comeback",
+      "\"엑스러브\" 컴백",
+      "\"xluv\" comeback kpop"
+    ]
+  },
+  {
     "group": "YENA",
     "tier": "longtail",
     "watch_reason": "manual_watch",

--- a/verified_release_history_mb.json
+++ b/verified_release_history_mb.json
@@ -16263,6 +16263,41 @@
     ]
   },
   {
+    "group": "XLOV",
+    "artist_name_mb": "XLOV",
+    "artist_mbid": "92449998-96fa-45b5-8a67-abb5ff975aa1",
+    "artist_source": "https://musicbrainz.org/artist/92449998-96fa-45b5-8a67-abb5ff975aa1",
+    "releases": [
+      {
+        "title": "UXLXVE",
+        "date": "2025-11-05",
+        "source": "https://musicbrainz.org/release-group/01b29180-b871-4122-bf4c-1758800d6333",
+        "release_kind": "ep",
+        "release_format": "ep",
+        "context_tags": [],
+        "stream": "album"
+      },
+      {
+        "title": "I ONE",
+        "date": "2025-06-13",
+        "source": "https://musicbrainz.org/release-group/f4743ab2-e6d6-41f7-bf09-6c5090cf4cf0",
+        "release_kind": "single",
+        "release_format": "single",
+        "context_tags": [],
+        "stream": "song"
+      },
+      {
+        "title": "I’mma Be",
+        "date": "2025-01-07",
+        "source": "https://musicbrainz.org/release-group/f52cc6b6-7f92-4acc-8e28-501e81081fc8",
+        "release_kind": "single",
+        "release_format": "single",
+        "context_tags": [],
+        "stream": "song"
+      }
+    ]
+  },
+  {
     "group": "YENA",
     "artist_name_mb": "YENA",
     "artist_mbid": "745c5b92-325f-451d-bd52-e6b95229c776",

--- a/web/src/data/artistProfiles.json
+++ b/web/src/data/artistProfiles.json
@@ -1798,6 +1798,23 @@
     ]
   },
   {
+    "slug": "xlov",
+    "group": "XLOV",
+    "display_name": "XLOV",
+    "aliases": [],
+    "agency": "257 Entertainment",
+    "official_youtube_url": "https://www.youtube.com/@XLOV_official",
+    "official_x_url": "https://x.com/XLOV_official",
+    "official_instagram_url": "https://www.instagram.com/xlov_official/",
+    "representative_image_url": null,
+    "representative_image_source": null,
+    "search_aliases": [
+      "엑스러브",
+      "xluv"
+    ],
+    "debut_year": 2025
+  },
+  {
     "slug": "yena",
     "group": "YENA",
     "display_name": "YENA",

--- a/web/src/data/releaseHistory.json
+++ b/web/src/data/releaseHistory.json
@@ -16263,6 +16263,41 @@
     ]
   },
   {
+    "group": "XLOV",
+    "artist_name_mb": "XLOV",
+    "artist_mbid": "92449998-96fa-45b5-8a67-abb5ff975aa1",
+    "artist_source": "https://musicbrainz.org/artist/92449998-96fa-45b5-8a67-abb5ff975aa1",
+    "releases": [
+      {
+        "title": "UXLXVE",
+        "date": "2025-11-05",
+        "source": "https://musicbrainz.org/release-group/01b29180-b871-4122-bf4c-1758800d6333",
+        "release_kind": "ep",
+        "release_format": "ep",
+        "context_tags": [],
+        "stream": "album"
+      },
+      {
+        "title": "I ONE",
+        "date": "2025-06-13",
+        "source": "https://musicbrainz.org/release-group/f4743ab2-e6d6-41f7-bf09-6c5090cf4cf0",
+        "release_kind": "single",
+        "release_format": "single",
+        "context_tags": [],
+        "stream": "song"
+      },
+      {
+        "title": "I’mma Be",
+        "date": "2025-01-07",
+        "source": "https://musicbrainz.org/release-group/f52cc6b6-7f92-4acc-8e28-501e81081fc8",
+        "release_kind": "single",
+        "release_format": "single",
+        "context_tags": [],
+        "stream": "song"
+      }
+    ]
+  },
+  {
     "group": "YENA",
     "artist_name_mb": "YENA",
     "artist_mbid": "745c5b92-325f-451d-bd52-e6b95229c776",

--- a/web/src/data/releases.json
+++ b/web/src/data/releases.json
@@ -1443,6 +1443,28 @@
     "artist_source": "https://musicbrainz.org/artist/9b779913-3d52-4ab7-bf38-889c2dcabbd1"
   },
   {
+    "group": "XLOV",
+    "artist_name_mb": "XLOV",
+    "artist_mbid": "92449998-96fa-45b5-8a67-abb5ff975aa1",
+    "latest_song": {
+      "title": "I ONE",
+      "date": "2025-06-13",
+      "source": "https://musicbrainz.org/release-group/f4743ab2-e6d6-41f7-bf09-6c5090cf4cf0",
+      "release_kind": "single",
+      "release_format": "single",
+      "context_tags": []
+    },
+    "latest_album": {
+      "title": "UXLXVE",
+      "date": "2025-11-05",
+      "source": "https://musicbrainz.org/release-group/01b29180-b871-4122-bf4c-1758800d6333",
+      "release_kind": "ep",
+      "release_format": "ep",
+      "context_tags": []
+    },
+    "artist_source": "https://musicbrainz.org/artist/92449998-96fa-45b5-8a67-abb5ff975aa1"
+  },
+  {
     "group": "YOUNG POSSE",
     "artist_name_mb": "YOUNG POSSE",
     "artist_mbid": "427150d2-674f-47b2-a1a1-7bb4a9e0d070",

--- a/web/src/data/watchlist.json
+++ b/web/src/data/watchlist.json
@@ -1589,6 +1589,22 @@
     ]
   },
   {
+    "group": "XLOV",
+    "tier": "longtail",
+    "watch_reason": "recent_release",
+    "tracking_status": "recent_release",
+    "latest_release_title": "UXLXVE",
+    "latest_release_date": "2025-11-05",
+    "latest_release_kind": "ep",
+    "x_url": "https://x.com/XLOV_official",
+    "instagram_url": "https://www.instagram.com/xlov_official/",
+    "search_terms": [
+      "\"XLOV\" kpop comeback",
+      "\"엑스러브\" 컴백",
+      "\"xluv\" comeback kpop"
+    ]
+  },
+  {
     "group": "YENA",
     "tier": "longtail",
     "watch_reason": "manual_watch",


### PR DESCRIPTION
## Summary
- onboard XLOV with Korean alias coverage and official social links
- backfill verified release, watchlist, and release history rows without regenerating unrelated datasets
- explicitly support `xluv` search terms while leaving upcoming empty because no reliable future signal was found as of 2026-03-07

## Verification
- `cd web && npm run build`
- `cd web && npm run lint`
- `node` spot-check for `XLOV`, `엑스러브`, `xluv`
- `git diff --check`

Closes #193