### PR TITLE
Add mobile Expo Router shell

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -2,7 +2,7 @@
 
 이 디렉터리는 `Expo + React Native + Expo Router` 기반 모바일 앱 워크스페이스다.
 
-현재 단계는 workspace bootstrap만 포함한다.
+현재 단계는 workspace bootstrap과 router shell까지만 포함한다.
 
 - route/layout expectations는 `docs/specs/mobile/expo-implementation-guide.md`를 따른다.
 - route/param 계약은 `docs/specs/mobile/route-param-contracts.md`를 따른다.
@@ -11,7 +11,7 @@
 ## 현재 포함 범위
 
 - `app/`
-  - Expo Router 기준 route shell 위치
+  - Expo Router root layout / tab shell / detail placeholder route
 - `src/`
   - components / features / selectors / services / tokens / types / utils 구역
 - `.env.example`
@@ -109,6 +109,7 @@ profile 차이는 아래 범위로만 제한한다.
 ## 아직 없는 것
 
 - 실제 screen/layout 구현
+- selector/adapter binding
 - backend integration
 
 위 항목은 후속 모바일 foundation 이슈에서 추가한다.

--- a/mobile/app/(tabs)/_layout.tsx
+++ b/mobile/app/(tabs)/_layout.tsx
@@ -1,0 +1,26 @@
+import { Tabs } from 'expo-router';
+
+export default function TabsLayout() {
+  return (
+    <Tabs initialRouteName="calendar" screenOptions={{ headerTitleAlign: 'center' }}>
+      <Tabs.Screen
+        name="calendar"
+        options={{
+          title: 'Calendar',
+        }}
+      />
+      <Tabs.Screen
+        name="radar"
+        options={{
+          title: 'Radar',
+        }}
+      />
+      <Tabs.Screen
+        name="search"
+        options={{
+          title: 'Search',
+        }}
+      />
+    </Tabs>
+  );
+}

--- a/mobile/app/(tabs)/calendar.tsx
+++ b/mobile/app/(tabs)/calendar.tsx
@@ -1,0 +1,41 @@
+import { StyleSheet, Text, View } from 'react-native';
+
+export default function CalendarTabScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.eyebrow}>TAB SHELL</Text>
+      <Text style={styles.title}>Calendar</Text>
+      <Text style={styles.body}>
+        Date detail and filter flows stay inside this screen as sheet state. Dedicated routes are not
+        added in v1.
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    paddingHorizontal: 24,
+    backgroundColor: '#f7f6f2',
+  },
+  eyebrow: {
+    marginBottom: 8,
+    fontSize: 12,
+    fontWeight: '600',
+    letterSpacing: 1.2,
+    color: '#87634d',
+  },
+  title: {
+    marginBottom: 12,
+    fontSize: 28,
+    fontWeight: '700',
+    color: '#1f1b17',
+  },
+  body: {
+    fontSize: 16,
+    lineHeight: 24,
+    color: '#5e554d',
+  },
+});

--- a/mobile/app/(tabs)/radar.tsx
+++ b/mobile/app/(tabs)/radar.tsx
@@ -1,0 +1,41 @@
+import { StyleSheet, Text, View } from 'react-native';
+
+export default function RadarTabScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.eyebrow}>TAB SHELL</Text>
+      <Text style={styles.title}>Radar</Text>
+      <Text style={styles.body}>
+        Featured upcoming, weekly picks, long-gap, rookie, and change-feed sections will land inside
+        this tab without changing the top-level route structure.
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    paddingHorizontal: 24,
+    backgroundColor: '#f7f6f2',
+  },
+  eyebrow: {
+    marginBottom: 8,
+    fontSize: 12,
+    fontWeight: '600',
+    letterSpacing: 1.2,
+    color: '#87634d',
+  },
+  title: {
+    marginBottom: 12,
+    fontSize: 28,
+    fontWeight: '700',
+    color: '#1f1b17',
+  },
+  body: {
+    fontSize: 16,
+    lineHeight: 24,
+    color: '#5e554d',
+  },
+});

--- a/mobile/app/(tabs)/search.tsx
+++ b/mobile/app/(tabs)/search.tsx
@@ -1,0 +1,41 @@
+import { StyleSheet, Text, View } from 'react-native';
+
+export default function SearchTabScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.eyebrow}>TAB SHELL</Text>
+      <Text style={styles.title}>Search</Text>
+      <Text style={styles.body}>
+        Search query state stays local to this screen in v1. Permanent query route params are not
+        introduced yet.
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    paddingHorizontal: 24,
+    backgroundColor: '#f7f6f2',
+  },
+  eyebrow: {
+    marginBottom: 8,
+    fontSize: 12,
+    fontWeight: '600',
+    letterSpacing: 1.2,
+    color: '#87634d',
+  },
+  title: {
+    marginBottom: 12,
+    fontSize: 28,
+    fontWeight: '700',
+    color: '#1f1b17',
+  },
+  body: {
+    fontSize: 16,
+    lineHeight: 24,
+    color: '#5e554d',
+  },
+});

--- a/mobile/app/README.md
+++ b/mobile/app/README.md
@@ -1,19 +1,24 @@
 # App Routes
 
-이 디렉터리는 Expo Router route 파일이 들어갈 위치다.
+이 디렉터리는 Expo Router route 파일이 들어가는 위치다.
 
-예정 구조:
+현재 포함 범위:
 
-```text
-app/
-  _layout.tsx
-  (tabs)/
-    _layout.tsx
-    calendar.tsx
-    radar.tsx
-    search.tsx
-  artists/[slug].tsx
-  releases/[id].tsx
-```
+- `_layout.tsx`
+  - root stack shell
+- `index.tsx`
+  - 기본 진입 시 `calendar` 탭으로 redirect
+- `(tabs)/_layout.tsx`
+  - `calendar`, `radar`, `search` 탭 shell
+- `(tabs)/calendar.tsx`
+- `(tabs)/radar.tsx`
+- `(tabs)/search.tsx`
+  - 탭 placeholder screen
+- `artists/[slug].tsx`
+- `releases/[id].tsx`
+  - push detail placeholder screen
 
-현재는 workspace bootstrap 단계라 route 파일은 아직 만들지 않는다.
+경로 계약은 아래 문서를 따른다.
+
+- `docs/specs/mobile/expo-implementation-guide.md`
+- `docs/specs/mobile/route-param-contracts.md`

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -1,0 +1,12 @@
+import { Stack } from 'expo-router';
+
+export default function RootLayout() {
+  return (
+    <Stack>
+      <Stack.Screen name="index" options={{ headerShown: false }} />
+      <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+      <Stack.Screen name="artists/[slug]" options={{ title: 'Artist Detail' }} />
+      <Stack.Screen name="releases/[id]" options={{ title: 'Release Detail' }} />
+    </Stack>
+  );
+}

--- a/mobile/app/artists/[slug].tsx
+++ b/mobile/app/artists/[slug].tsx
@@ -1,0 +1,62 @@
+import { Stack, useLocalSearchParams } from 'expo-router';
+import { StyleSheet, Text, View } from 'react-native';
+
+function getSingleParam(value: string | string[] | undefined): string | null {
+  if (Array.isArray(value)) {
+    return value[0] ?? null;
+  }
+
+  return value ?? null;
+}
+
+export default function ArtistDetailPlaceholderScreen() {
+  const params = useLocalSearchParams<{ slug?: string | string[] }>();
+  const slug = getSingleParam(params.slug);
+  const isValid = typeof slug === 'string' && slug.trim().length > 0;
+
+  return (
+    <View style={styles.container}>
+      <Stack.Screen options={{ title: isValid ? slug : 'Artist Detail' }} />
+      <Text style={styles.eyebrow}>PUSH DETAIL</Text>
+      <Text style={styles.title}>Artist Detail</Text>
+      <Text style={styles.body}>
+        {isValid
+          ? `slug param is wired: ${slug}`
+          : 'Missing or invalid slug. The final screen should show a safe empty or recovery state instead of crashing.'}
+      </Text>
+      <Text style={styles.meta}>Path contract: /artists/[slug]</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    paddingHorizontal: 24,
+    backgroundColor: '#fcfbf8',
+  },
+  eyebrow: {
+    marginBottom: 8,
+    fontSize: 12,
+    fontWeight: '600',
+    letterSpacing: 1.2,
+    color: '#87634d',
+  },
+  title: {
+    marginBottom: 12,
+    fontSize: 28,
+    fontWeight: '700',
+    color: '#1f1b17',
+  },
+  body: {
+    marginBottom: 12,
+    fontSize: 16,
+    lineHeight: 24,
+    color: '#5e554d',
+  },
+  meta: {
+    fontSize: 13,
+    color: '#8a7e72',
+  },
+});

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -1,0 +1,5 @@
+import { Redirect } from 'expo-router';
+
+export default function IndexRoute() {
+  return <Redirect href="/(tabs)/calendar" />;
+}

--- a/mobile/app/releases/[id].tsx
+++ b/mobile/app/releases/[id].tsx
@@ -1,0 +1,62 @@
+import { Stack, useLocalSearchParams } from 'expo-router';
+import { StyleSheet, Text, View } from 'react-native';
+
+function getSingleParam(value: string | string[] | undefined): string | null {
+  if (Array.isArray(value)) {
+    return value[0] ?? null;
+  }
+
+  return value ?? null;
+}
+
+export default function ReleaseDetailPlaceholderScreen() {
+  const params = useLocalSearchParams<{ id?: string | string[] }>();
+  const id = getSingleParam(params.id);
+  const isValid = typeof id === 'string' && id.trim().length > 0;
+
+  return (
+    <View style={styles.container}>
+      <Stack.Screen options={{ title: isValid ? id : 'Release Detail' }} />
+      <Text style={styles.eyebrow}>PUSH DETAIL</Text>
+      <Text style={styles.title}>Release Detail</Text>
+      <Text style={styles.body}>
+        {isValid
+          ? `id param is wired: ${id}`
+          : 'Missing or invalid id. The final screen should show a safe empty or recovery state instead of crashing.'}
+      </Text>
+      <Text style={styles.meta}>Path contract: /releases/[id]</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    paddingHorizontal: 24,
+    backgroundColor: '#fcfbf8',
+  },
+  eyebrow: {
+    marginBottom: 8,
+    fontSize: 12,
+    fontWeight: '600',
+    letterSpacing: 1.2,
+    color: '#87634d',
+  },
+  title: {
+    marginBottom: 12,
+    fontSize: 28,
+    fontWeight: '700',
+    color: '#1f1b17',
+  },
+  body: {
+    marginBottom: 12,
+    fontSize: 16,
+    lineHeight: 24,
+    color: '#5e554d',
+  },
+  meta: {
+    fontSize: 13,
+    color: '#8a7e72',
+  },
+});


### PR DESCRIPTION
## Summary
- add the root Expo Router stack layout and tab shell for mobile
- add placeholder tab routes for calendar, radar, and search
- add push detail placeholder routes for artist and release paths and update mobile route docs

## Verification
- `cd mobile && npm run typecheck`
- `cd mobile && CI=1 npx expo export --platform web --output-dir /tmp/idol-song-app-mobile-router-export`
- `git diff --check`

Closes #246