### PR TITLE
Add mobile CI quality workflow

### DIFF
--- a/.github/workflows/mobile-quality.yml
+++ b/.github/workflows/mobile-quality.yml
@@ -1,0 +1,52 @@
+name: Mobile Quality
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "mobile/**"
+      - ".github/workflows/mobile-quality.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "mobile/**"
+      - ".github/workflows/mobile-quality.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mobile-quality-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: mobile
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "npm"
+          cache-dependency-path: mobile/package-lock.json
+
+      - name: Install mobile dependencies
+        run: npm ci
+
+      - name: Run mobile lint
+        run: npm run lint
+
+      - name: Run mobile typecheck
+        run: npm run typecheck
+
+      - name: Run mobile tests
+        run: npm run test

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ python3 sync_release_pipeline_to_neon.py
 - package/runtime baseline: `mobile/package.json`, `mobile/app.config.ts`, `mobile/eas.json`, `mobile/tsconfig.json`
 - env/runtime config layer: `mobile/.env.example`, `mobile/src/config/runtime.ts`
 - quality baseline: `mobile/eslint.config.js`, `mobile/jest.config.js`, `mobile/app/route-shell.smoke.test.tsx`, `mobile/src/config/runtime.test.ts`
+- CI gate: `.github/workflows/mobile-quality.yml`
 - implementation guide: `docs/specs/mobile/expo-implementation-guide.md`
 
 Hydration dry-run 예시:

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -28,6 +28,8 @@
   - Expo build profile baseline
 - `tsconfig.json`
   - TypeScript baseline
+- `.github/workflows/mobile-quality.yml`
+  - mobile lint / typecheck / test CI gate
 
 ## 로컬 시작 기준
 
@@ -135,6 +137,8 @@ profile 차이는 아래 범위로만 제한한다.
   - strict TypeScript gate
 - `npm run test`
   - runtime config unit test + route shell smoke test baseline
+- `.github/workflows/mobile-quality.yml`
+  - `mobile/**` 변경과 workflow 변경에만 반응하는 CI gate
 
 현재 test 범위는 얇게 시작한다.
 


### PR DESCRIPTION
## Summary
- add a dedicated mobile CI workflow for lint, typecheck, and baseline tests
- scope triggers to `mobile/**` and the workflow file itself so unrelated web/backend changes do not fire the job
- document the mobile CI gate in the root/mobile README entries

## Verification
- `cd mobile && npm ci`
- `cd mobile && npm run lint`
- `cd mobile && npm run typecheck`
- `cd mobile && npm run test`
- `git diff --check`

Closes #248