### PR TITLE
Add mobile dataset source layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ python3 sync_release_pipeline_to_neon.py
 - package/runtime baseline: `mobile/package.json`, `mobile/app.config.ts`, `mobile/eas.json`, `mobile/tsconfig.json`
 - env/runtime config layer: `mobile/.env.example`, `mobile/src/config/runtime.ts`
 - feature-gate layer: `mobile/src/config/featureGates.ts`
+- dataset-source layer: `mobile/src/services/datasetSource.ts`, `mobile/assets/datasets/README.md`
 - quality baseline: `mobile/eslint.config.js`, `mobile/jest.config.js`, `mobile/src/features/route-shell.smoke.test.tsx`, `mobile/src/config/runtime.test.ts`
 - CI gate: `.github/workflows/mobile-quality.yml`
 - bundled asset baseline: `mobile/assets/`, `mobile/assets/README.md`, `mobile/src/utils/assetRegistry.ts`

--- a/mobile/.env.example
+++ b/mobile/.env.example
@@ -2,6 +2,7 @@ APP_ENV=development
 
 # Optional service endpoints
 EXPO_PUBLIC_API_BASE_URL=
+# preview profile에서만 사용
 EXPO_PUBLIC_REMOTE_DATASET_URL=
 
 # Optional metadata

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -28,6 +28,8 @@
   - 앱 런타임에서 쓰는 validated config accessor
 - `src/config/featureGates.ts`
   - gate registry / helper / off fallback definition
+- `src/services/datasetSource.ts`
+  - bundled static data vs preview remote data selection layer
 - `src/utils/assetRegistry.ts`
   - local bundled asset lookup entrypoint
 - `eas.json`
@@ -119,8 +121,11 @@ profile 차이는 아래 범위로만 제한한다.
   - `development`, `preview`, `production`만 허용한다.
 - `EXPO_PUBLIC_API_BASE_URL`, `EXPO_PUBLIC_REMOTE_DATASET_URL`
   - 값이 있으면 absolute `http(s)` URL이어야 한다.
+- `EXPO_PUBLIC_REMOTE_DATASET_URL`
+  - `APP_ENV=preview`에서만 허용한다.
 - `EXPO_PUBLIC_ENABLE_REMOTE_REFRESH=true`
   - 이 경우 `EXPO_PUBLIC_REMOTE_DATASET_URL`이 필수다.
+  - preview profile에서만 허용한다.
 - `EXPO_PUBLIC_ENABLE_ANALYTICS=true`
   - 이 경우 `EXPO_PUBLIC_ANALYTICS_WRITE_KEY`가 필수다.
 - `EXPO_PUBLIC_ENABLE_SHARE_ACTIONS`
@@ -128,6 +133,23 @@ profile 차이는 아래 범위로만 제한한다.
 - invalid config
   - `app.config.ts` 단계와 `src/config/runtime.ts` 단계에서 둘 다 명시적으로 실패시킨다.
   - silent fallback으로 숨기지 않는다.
+
+## dataset-source baseline
+
+- selector entrypoint는 `src/services/datasetSource.ts`에 둔다.
+- single-source rule
+  - 한 build/runtime 조합은 하나의 dataset source만 고른다.
+  - bundled static과 preview remote를 동시에 섞지 않는다.
+- bundled source
+  - 기본값이다.
+  - v1 계약 경로는 `mobile/assets/datasets/v1/` 기준으로 잡는다.
+- preview remote source
+  - `APP_ENV=preview`
+  - `EXPO_PUBLIC_ENABLE_REMOTE_REFRESH=true`
+  - `EXPO_PUBLIC_REMOTE_DATASET_URL` provided
+  - 위 3조건이 모두 맞을 때만 선택된다.
+- field contract
+  - bundled source와 preview remote source는 같은 artifact id / field contract를 유지해야 한다.
 
 ## feature-gate baseline
 
@@ -161,6 +183,8 @@ profile 차이는 아래 범위로만 제한한다.
   - Spotify / YouTube Music / YouTube MV icon baseline
 - `mobile/assets/badges/`
   - group / solo / label fallback
+- `mobile/assets/datasets/`
+  - bundled dataset path contract 문서
 - later screen work는 raw asset path 대신 `src/utils/assetRegistry.ts`를 우선 사용한다.
 
 ## verification baseline

--- a/mobile/app.config.ts
+++ b/mobile/app.config.ts
@@ -167,6 +167,14 @@ function buildRuntimeConfig(profile: MobileProfile, profileConfig: ProfileConfig
     throw new Error('EXPO_PUBLIC_REMOTE_DATASET_URL is required when EXPO_PUBLIC_ENABLE_REMOTE_REFRESH is enabled.');
   }
 
+  if (profile !== 'preview' && featureGates.remoteRefresh) {
+    throw new Error('EXPO_PUBLIC_ENABLE_REMOTE_REFRESH is only supported for APP_ENV=preview.');
+  }
+
+  if (profile !== 'preview' && remoteDatasetUrl) {
+    throw new Error('EXPO_PUBLIC_REMOTE_DATASET_URL is only supported for APP_ENV=preview.');
+  }
+
   if (featureGates.analytics && !analyticsWriteKey) {
     throw new Error('EXPO_PUBLIC_ANALYTICS_WRITE_KEY is required when EXPO_PUBLIC_ENABLE_ANALYTICS is enabled.');
   }

--- a/mobile/assets/datasets/README.md
+++ b/mobile/assets/datasets/README.md
@@ -1,0 +1,16 @@
+# Bundled Dataset Contract
+
+모바일 v1의 bundled dataset base path는 `mobile/assets/datasets/v1/`이다.
+
+이 이슈 범위에서는 실제 JSON snapshot을 복사하지 않고, source-selection layer가 참조할 고정 경로 계약만 먼저 연다.
+
+후속 dataset packaging 작업은 아래 파일명을 기준으로 채운다.
+
+- `artistProfiles.json`
+- `releases.json`
+- `releaseArtwork.json`
+- `releaseDetails.json`
+- `releaseHistory.json`
+- `watchlist.json`
+- `upcomingCandidates.json`
+- `teamBadgeAssets.json`

--- a/mobile/src/README.md
+++ b/mobile/src/README.md
@@ -5,12 +5,14 @@
 - `components/`: 표시 컴포넌트
 - `config/`: validated runtime config accessor
   - `featureGates.ts`: gate registry / fallback metadata / helper
+  - `runtime.ts`: mobile profile / env validation
 - `features/`: 화면 composition / binding
 - `selectors/`: display model selector / adapter
-- `services/`: external handoff / helper
+- `services/`: data source / external handoff / helper
+  - `datasetSource.ts`: bundled-static vs preview-remote source selector
 - `tokens/`: design token / theme
 - `types/`: shared TypeScript model
 - `utils/`: framework-agnostic helper
   - `assetRegistry.ts`: bundled placeholder/service/badge asset entrypoint
 
-현재는 bootstrap 단계라 placeholder directory만 둔다.
+현재는 bootstrap 단계지만 config/service foundation은 실제 모듈로 열어둔다.

--- a/mobile/src/config/runtime.test.ts
+++ b/mobile/src/config/runtime.test.ts
@@ -103,4 +103,34 @@ describe('parseRuntimeConfig', () => {
       }),
     ).toThrow('remoteDatasetUrl');
   });
+
+  test('rejects remote dataset settings outside preview profile', () => {
+    expect(() =>
+      parseRuntimeConfig({
+        profile: 'production',
+        dataSource: {
+          mode: 'production-static',
+          remoteDatasetUrl: 'https://example.com/dataset.json',
+          datasetVersion: 'preview-v1',
+        },
+        services: {
+          apiBaseUrl: null,
+          analyticsWriteKey: null,
+        },
+        logging: {
+          level: 'error',
+        },
+        featureGates: {
+          radar: true,
+          analytics: false,
+          remoteRefresh: false,
+          mvEmbed: true,
+          shareActions: true,
+        },
+        build: {
+          commitSha: null,
+        },
+      }),
+    ).toThrow('remoteDatasetUrl');
+  });
 });

--- a/mobile/src/config/runtime.ts
+++ b/mobile/src/config/runtime.ts
@@ -4,6 +4,12 @@ export type MobileProfile = 'development' | 'preview' | 'production';
 export type LoggingLevel = 'verbose' | 'debug' | 'error';
 export type DataSourceMode = 'bundled-static' | 'preview-static' | 'production-static';
 
+const EXPECTED_MODE_BY_PROFILE: Record<MobileProfile, DataSourceMode> = {
+  development: 'bundled-static',
+  preview: 'preview-static',
+  production: 'production-static',
+};
+
 export type MobileRuntimeConfig = {
   profile: MobileProfile;
   dataSource: {
@@ -159,6 +165,18 @@ export function parseRuntimeConfig(input: unknown): MobileRuntimeConfig {
 
   if (config.featureGates.remoteRefresh && !config.dataSource.remoteDatasetUrl) {
     throw new Error('Runtime config requires dataSource.remoteDatasetUrl when remoteRefresh is enabled.');
+  }
+
+  if (config.dataSource.mode !== EXPECTED_MODE_BY_PROFILE[config.profile]) {
+    throw new Error('Runtime config dataSource.mode does not match the active mobile profile.');
+  }
+
+  if (config.profile !== 'preview' && config.featureGates.remoteRefresh) {
+    throw new Error('Runtime config only allows remoteRefresh in the preview profile.');
+  }
+
+  if (config.profile !== 'preview' && config.dataSource.remoteDatasetUrl) {
+    throw new Error('Runtime config only allows dataSource.remoteDatasetUrl in the preview profile.');
   }
 
   if (config.featureGates.analytics && !config.services.analyticsWriteKey) {

--- a/mobile/src/services/datasetSource.test.ts
+++ b/mobile/src/services/datasetSource.test.ts
@@ -1,0 +1,126 @@
+import type { MobileRuntimeConfig } from '../config/runtime';
+import {
+  BUNDLED_DATASET_BASE_PATH,
+  DATASET_ARTIFACTS,
+  DATASET_CONTRACT_ID,
+  isBundledDatasetSelection,
+  isRemoteDatasetSelection,
+  selectDatasetSource,
+} from './datasetSource';
+
+function buildRuntimeConfig(
+  overrides: Partial<MobileRuntimeConfig> = {},
+  dataSourceOverrides: Partial<MobileRuntimeConfig['dataSource']> = {},
+  featureGateOverrides: Partial<MobileRuntimeConfig['featureGates']> = {},
+): MobileRuntimeConfig {
+  return {
+    profile: overrides.profile ?? 'development',
+    dataSource: {
+      mode: overrides.profile === 'production' ? 'production-static' : overrides.profile === 'preview' ? 'preview-static' : 'bundled-static',
+      remoteDatasetUrl: null,
+      datasetVersion: 'v1-test',
+      ...dataSourceOverrides,
+    },
+    services: {
+      apiBaseUrl: null,
+      analyticsWriteKey: null,
+      ...overrides.services,
+    },
+    logging: {
+      level: overrides.profile === 'production' ? 'error' : 'debug',
+      ...overrides.logging,
+    },
+    featureGates: {
+      radar: true,
+      analytics: false,
+      remoteRefresh: false,
+      mvEmbed: true,
+      shareActions: true,
+      ...featureGateOverrides,
+    },
+    build: {
+      commitSha: 'test-sha',
+      ...overrides.build,
+    },
+  };
+}
+
+describe('selectDatasetSource', () => {
+  test('uses the bundled dataset for development builds', () => {
+    const selection = selectDatasetSource(buildRuntimeConfig());
+
+    expect(isBundledDatasetSelection(selection)).toBe(true);
+    if (!isBundledDatasetSelection(selection)) {
+      throw new Error('Expected bundled dataset selection.');
+    }
+
+    expect(selection.kind).toBe('bundled-static');
+    expect(selection.reason).toBe('profile_default');
+    expect(selection.bundledBasePath).toBe(BUNDLED_DATASET_BASE_PATH);
+    expect(selection.contractId).toBe(DATASET_CONTRACT_ID);
+    expect(selection.mixingAllowed).toBe(false);
+  });
+
+  test('keeps preview on bundled data when remote refresh is disabled', () => {
+    const selection = selectDatasetSource(
+      buildRuntimeConfig(
+        { profile: 'preview' },
+        {
+          mode: 'preview-static',
+          remoteDatasetUrl: 'https://example.com/dataset.json',
+        },
+      ),
+    );
+
+    expect(isBundledDatasetSelection(selection)).toBe(true);
+    expect(selection.reason).toBe('preview_remote_disabled');
+  });
+
+  test('switches preview builds to the remote dataset when explicitly enabled', () => {
+    const selection = selectDatasetSource(
+      buildRuntimeConfig(
+        { profile: 'preview' },
+        {
+          mode: 'preview-static',
+          remoteDatasetUrl: 'https://example.com/dataset.json',
+          datasetVersion: 'preview-v2',
+        },
+        {
+          remoteRefresh: true,
+        },
+      ),
+    );
+
+    expect(isRemoteDatasetSelection(selection)).toBe(true);
+    if (!isRemoteDatasetSelection(selection)) {
+      throw new Error('Expected preview remote dataset selection.');
+    }
+
+    expect(selection.kind).toBe('preview-remote');
+    expect(selection.reason).toBe('preview_remote_enabled');
+    expect(selection.remoteDatasetUrl).toBe('https://example.com/dataset.json');
+    expect(selection.datasetVersion).toBe('preview-v2');
+    expect(selection.mixingAllowed).toBe(false);
+  });
+
+  test('preserves the same artifact contract between bundled and remote selections', () => {
+    const bundled = selectDatasetSource(buildRuntimeConfig());
+    const remote = selectDatasetSource(
+      buildRuntimeConfig(
+        { profile: 'preview' },
+        {
+          mode: 'preview-static',
+          remoteDatasetUrl: 'https://example.com/dataset.json',
+        },
+        {
+          remoteRefresh: true,
+        },
+      ),
+    );
+
+    expect(bundled.contractId).toBe(DATASET_CONTRACT_ID);
+    expect(remote.contractId).toBe(DATASET_CONTRACT_ID);
+    expect(bundled.artifacts.map((artifact) => artifact.id)).toEqual(DATASET_ARTIFACTS.map((artifact) => artifact.id));
+    expect(remote.artifacts.map((artifact) => artifact.id)).toEqual(DATASET_ARTIFACTS.map((artifact) => artifact.id));
+  });
+});

--- a/mobile/src/services/datasetSource.ts
+++ b/mobile/src/services/datasetSource.ts
@@ -1,0 +1,143 @@
+import { getRuntimeConfig, type MobileRuntimeConfig } from '../config/runtime';
+
+export type DatasetContractId = 'idol-song-mobile-static-v1';
+export type DatasetSourceKind = 'bundled-static' | 'preview-remote';
+export type DatasetArtifactId =
+  | 'artistProfiles'
+  | 'releases'
+  | 'releaseArtwork'
+  | 'releaseDetails'
+  | 'releaseHistory'
+  | 'watchlist'
+  | 'upcomingCandidates'
+  | 'teamBadgeAssets';
+export type DatasetFreshnessClass = 'stable-profile' | 'rolling-release' | 'rolling-upcoming';
+
+export type DatasetArtifactDescriptor = {
+  id: DatasetArtifactId;
+  freshnessClass: DatasetFreshnessClass;
+  relativePath: string;
+};
+
+type DatasetSelectionBase = {
+  kind: DatasetSourceKind;
+  contractId: DatasetContractId;
+  datasetVersion: string | null;
+  mixingAllowed: false;
+  artifacts: DatasetArtifactDescriptor[];
+};
+
+export type BundledDatasetSelection = DatasetSelectionBase & {
+  kind: 'bundled-static';
+  reason: 'profile_default' | 'preview_remote_disabled';
+  bundledBasePath: string;
+};
+
+export type PreviewRemoteDatasetSelection = DatasetSelectionBase & {
+  kind: 'preview-remote';
+  reason: 'preview_remote_enabled';
+  remoteDatasetUrl: string;
+};
+
+export type DatasetSelection = BundledDatasetSelection | PreviewRemoteDatasetSelection;
+
+export const DATASET_CONTRACT_ID: DatasetContractId = 'idol-song-mobile-static-v1';
+export const BUNDLED_DATASET_BASE_PATH = 'mobile/assets/datasets/v1';
+
+export const DATASET_ARTIFACTS: DatasetArtifactDescriptor[] = [
+  {
+    id: 'artistProfiles',
+    freshnessClass: 'stable-profile',
+    relativePath: 'artistProfiles.json',
+  },
+  {
+    id: 'releases',
+    freshnessClass: 'rolling-release',
+    relativePath: 'releases.json',
+  },
+  {
+    id: 'releaseArtwork',
+    freshnessClass: 'stable-profile',
+    relativePath: 'releaseArtwork.json',
+  },
+  {
+    id: 'releaseDetails',
+    freshnessClass: 'stable-profile',
+    relativePath: 'releaseDetails.json',
+  },
+  {
+    id: 'releaseHistory',
+    freshnessClass: 'rolling-release',
+    relativePath: 'releaseHistory.json',
+  },
+  {
+    id: 'watchlist',
+    freshnessClass: 'rolling-upcoming',
+    relativePath: 'watchlist.json',
+  },
+  {
+    id: 'upcomingCandidates',
+    freshnessClass: 'rolling-upcoming',
+    relativePath: 'upcomingCandidates.json',
+  },
+  {
+    id: 'teamBadgeAssets',
+    freshnessClass: 'stable-profile',
+    relativePath: 'teamBadgeAssets.json',
+  },
+];
+
+function toBundledSelection(
+  datasetVersion: string | null,
+  reason: BundledDatasetSelection['reason'],
+): BundledDatasetSelection {
+  return {
+    kind: 'bundled-static',
+    reason,
+    contractId: DATASET_CONTRACT_ID,
+    datasetVersion,
+    mixingAllowed: false,
+    bundledBasePath: BUNDLED_DATASET_BASE_PATH,
+    artifacts: DATASET_ARTIFACTS,
+  };
+}
+
+function canUsePreviewRemote(config: MobileRuntimeConfig): config is MobileRuntimeConfig & {
+  profile: 'preview';
+  dataSource: MobileRuntimeConfig['dataSource'] & { remoteDatasetUrl: string };
+} {
+  return (
+    config.profile === 'preview' &&
+    config.featureGates.remoteRefresh &&
+    typeof config.dataSource.remoteDatasetUrl === 'string'
+  );
+}
+
+export function selectDatasetSource(
+  runtimeConfig: MobileRuntimeConfig = getRuntimeConfig(),
+): DatasetSelection {
+  if (canUsePreviewRemote(runtimeConfig)) {
+    return {
+      kind: 'preview-remote',
+      reason: 'preview_remote_enabled',
+      contractId: DATASET_CONTRACT_ID,
+      datasetVersion: runtimeConfig.dataSource.datasetVersion,
+      mixingAllowed: false,
+      remoteDatasetUrl: runtimeConfig.dataSource.remoteDatasetUrl,
+      artifacts: DATASET_ARTIFACTS,
+    };
+  }
+
+  return toBundledSelection(
+    runtimeConfig.dataSource.datasetVersion,
+    runtimeConfig.profile === 'preview' ? 'preview_remote_disabled' : 'profile_default',
+  );
+}
+
+export function isRemoteDatasetSelection(selection: DatasetSelection): selection is PreviewRemoteDatasetSelection {
+  return selection.kind === 'preview-remote';
+}
+
+export function isBundledDatasetSelection(selection: DatasetSelection): selection is BundledDatasetSelection {
+  return selection.kind === 'bundled-static';
+}


### PR DESCRIPTION
## Summary
- add a mobile dataset-source selection layer for bundled static data versus preview remote data
- enforce preview-only remote dataset configuration in app config and runtime parsing
- document the single-source selection rule and the bundled dataset v1 path contract

## Verification
- cd mobile && npm run lint
- cd mobile && npm run typecheck
- cd mobile && npm run test
- cd mobile && npm run config:preview
- APP_ENV=preview EXPO_PUBLIC_ENABLE_REMOTE_REFRESH=true EXPO_PUBLIC_REMOTE_DATASET_URL=https://example.com/dataset.json npx expo config --json
- APP_ENV=production EXPO_PUBLIC_REMOTE_DATASET_URL=https://example.com/dataset.json npx expo config --json
- git diff --check

Closes #251