### PR TITLE
Add mobile selector and adapter scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ python3 sync_release_pipeline_to_neon.py
 - feature-gate layer: `mobile/src/config/featureGates.ts`
 - dataset-source layer: `mobile/src/services/datasetSource.ts`, `mobile/assets/datasets/README.md`
 - token/theme layer: `mobile/src/tokens/`, `mobile/src/tokens/theme.tsx`
+- selector/adapter layer: `mobile/src/selectors/`, `mobile/src/types/displayModels.ts`, `mobile/src/types/rawData.ts`
 - quality baseline: `mobile/eslint.config.js`, `mobile/jest.config.js`, `mobile/src/features/route-shell.smoke.test.tsx`, `mobile/src/config/runtime.test.ts`
 - CI gate: `.github/workflows/mobile-quality.yml`
 - bundled asset baseline: `mobile/assets/`, `mobile/assets/README.md`, `mobile/src/utils/assetRegistry.ts`

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -32,6 +32,10 @@
   - bundled static data vs preview remote data selection layer
 - `src/tokens/`
   - semantic token constants + theme provider + `useAppTheme()` access convention
+- `src/selectors/`
+  - raw dataset -> display model selector/adapter scaffold
+- `src/types/`
+  - raw dataset contract type + display model type baseline
 - `src/utils/assetRegistry.ts`
   - local bundled asset lookup entrypoint
 - `eas.json`
@@ -139,6 +143,31 @@ profile 차이는 아래 범위로만 제한한다.
     - `MobileThemeProvider`
     - `useAppTheme()`
 - later components/screens는 raw visual constant 대신 `useAppTheme()` 또는 token module을 통해 값에 접근한다.
+
+## selector / adapter baseline
+
+- entrypoint는 `src/selectors/index.ts`에 둔다.
+- 역할 분리
+  - `src/types/rawData.ts`
+    - 현재 static JSON contract type
+  - `src/types/displayModels.ts`
+    - 화면이 직접 받는 display model type
+  - `src/selectors/context.ts`
+    - raw dataset index/context 생성
+  - `src/selectors/adapters.ts`
+    - nullable field, fallback, derived rule을 display model로 변환
+  - `src/selectors/index.ts`
+    - later screen이 재사용할 shared selector 함수
+- 현재 scaffold selector
+  - `selectTeamSummaryBySlug`
+  - `selectLatestReleaseSummaryBySlug`
+  - `selectRecentReleaseSummariesBySlug`
+  - `selectUpcomingEventsBySlug`
+  - `selectReleaseDetailById`
+- 규칙
+  - 화면은 raw JSON shape를 직접 읽지 않는다.
+  - selector는 fallback을 포함한 최종 display model만 반환한다.
+  - 공통 normalize/id 생성 규칙은 `src/selectors/normalize.ts`에서 공유한다.
 
 ## env / validation 규칙
 

--- a/mobile/src/README.md
+++ b/mobile/src/README.md
@@ -8,12 +8,17 @@
   - `runtime.ts`: mobile profile / env validation
 - `features/`: 화면 composition / binding
 - `selectors/`: display model selector / adapter
+  - `context.ts`: dataset -> indexed selector context
+  - `adapters.ts`: raw JSON -> display model 변환 규칙
+  - `index.ts`: shared selectors entrypoint
 - `services/`: data source / external handoff / helper
   - `datasetSource.ts`: bundled-static vs preview-remote source selector
 - `tokens/`: design token / theme
   - `theme.tsx`: theme provider + `useAppTheme()` access convention
   - `colors.ts`, `spacing.ts`, `radii.ts`, `typography.ts`, `sizes.ts`, `elevation.ts`, `motion.ts`
 - `types/`: shared TypeScript model
+  - `displayModels.ts`: screen-facing display model types
+  - `rawData.ts`: current static dataset contract types
 - `utils/`: framework-agnostic helper
   - `assetRegistry.ts`: bundled placeholder/service/badge asset entrypoint
 

--- a/mobile/src/selectors/adapters.ts
+++ b/mobile/src/selectors/adapters.ts
@@ -1,0 +1,263 @@
+import type {
+  ArtistProfileRaw,
+  ReleaseArtworkRaw,
+  ReleaseDetailRaw,
+  ReleaseHistoryEntryRaw,
+  TeamBadge,
+  TeamSummaryModel,
+  ReleaseSummaryModel,
+  UpcomingEventModel,
+  UpcomingCandidateRaw,
+  YoutubeChannelAllowlistRaw,
+  ReleaseDetailModel,
+  TrackModel,
+  ReleaseStreamCollectionRaw,
+} from '../types';
+
+import {
+  buildMonogram,
+  buildReleaseId,
+  normalizeReleaseKind,
+  normalizeReleaseStream,
+  normalizeSearchToken,
+  normalizeUpcomingConfidence,
+  normalizeUpcomingDatePrecision,
+  normalizeUpcomingSourceType,
+  normalizeUpcomingStatus,
+} from './normalize';
+
+function resolveDisplayName(profile: ArtistProfileRaw): string {
+  return profile.display_name?.trim() || profile.group;
+}
+
+function resolveArtistSourceUrl(profile: ArtistProfileRaw): string | undefined {
+  return profile.artist_source_url ?? profile.artist_source ?? undefined;
+}
+
+export function adaptTeamBadge(profile: ArtistProfileRaw): TeamBadge | undefined {
+  const displayName = resolveDisplayName(profile);
+  const imageUrl = profile.badge_image_url ?? profile.representative_image_url ?? undefined;
+
+  if (imageUrl) {
+    return {
+      imageUrl,
+      label: displayName,
+    };
+  }
+
+  return {
+    monogram: buildMonogram(displayName),
+    label: displayName,
+  };
+}
+
+export function buildTeamSearchTokens(profile: ArtistProfileRaw): string[] {
+  const candidates = [
+    profile.group,
+    profile.display_name,
+    ...(profile.aliases ?? []),
+    ...(profile.search_aliases ?? []),
+  ].filter((value): value is string => Boolean(value?.trim()));
+
+  return Array.from(new Set(candidates.map(normalizeSearchToken).filter(Boolean)));
+}
+
+export function adaptTeamSummary(
+  profile: ArtistProfileRaw,
+  allowlist?: YoutubeChannelAllowlistRaw,
+): TeamSummaryModel {
+  const displayName = resolveDisplayName(profile);
+  const youtubeChannelUrls = Array.from(
+    new Set(
+      [
+        allowlist?.primary_team_channel_url,
+        profile.official_youtube_url,
+        ...(allowlist?.channels
+          ?.filter((channel) => channel.display_in_team_links)
+          .map((channel) => channel.channel_url) ?? []),
+      ].filter((value): value is string => Boolean(value)),
+    ),
+  );
+
+  return {
+    slug: profile.slug,
+    group: profile.group,
+    displayName,
+    agency: profile.agency ?? undefined,
+    badge: adaptTeamBadge(profile),
+    representativeImageUrl: profile.representative_image_url ?? undefined,
+    officialYoutubeUrl: youtubeChannelUrls[0],
+    officialXUrl: profile.official_x_url ?? undefined,
+    officialInstagramUrl: profile.official_instagram_url ?? undefined,
+    youtubeChannelUrls,
+    artistSourceUrl: resolveArtistSourceUrl(profile),
+    searchTokens: buildTeamSearchTokens(profile),
+  };
+}
+
+type ReleaseAdapterInput = {
+  group: string;
+  displayGroup: string;
+  releaseTitle: string;
+  releaseDate: string;
+  releaseKind?: string | null;
+  stream?: string | null;
+  sourceUrl?: string | null;
+  contextTags?: string[] | null;
+  artwork?: ReleaseArtworkRaw;
+  detail?: ReleaseDetailRaw;
+  representativeSongTitle?: string | null;
+};
+
+export function adaptReleaseSummary(input: ReleaseAdapterInput): ReleaseSummaryModel {
+  const stream = normalizeReleaseStream(input.stream);
+  const id = buildReleaseId(input.group, input.releaseTitle, input.releaseDate, stream);
+
+  return {
+    id,
+    group: input.group,
+    displayGroup: input.displayGroup,
+    releaseTitle: input.releaseTitle,
+    releaseDate: input.releaseDate,
+    releaseKind: normalizeReleaseKind(input.releaseKind),
+    stream,
+    representativeSongTitle: input.representativeSongTitle ?? undefined,
+    spotifyUrl: input.detail?.spotify_url ?? undefined,
+    youtubeMusicUrl: input.detail?.youtube_music_url ?? undefined,
+    youtubeMvUrl: input.detail?.youtube_video_url ?? undefined,
+    coverImageUrl: input.artwork?.cover_image_url ?? undefined,
+    sourceUrl: input.sourceUrl ?? undefined,
+    contextTags: input.contextTags ?? [],
+  };
+}
+
+export function adaptReleaseHistoryEntry(
+  group: string,
+  displayGroup: string,
+  release: ReleaseHistoryEntryRaw,
+  artwork?: ReleaseArtworkRaw,
+  detail?: ReleaseDetailRaw,
+): ReleaseSummaryModel {
+  return adaptReleaseSummary({
+    group,
+    displayGroup,
+    releaseTitle: release.title,
+    releaseDate: release.date,
+    releaseKind: release.release_kind ?? release.release_format,
+    stream: release.stream,
+    sourceUrl: release.source,
+    contextTags: release.context_tags,
+    artwork,
+    detail,
+    representativeSongTitle: detail?.tracks?.find((track) => track.is_title_track)?.title ?? null,
+  });
+}
+
+export function adaptLatestReleaseStreams(
+  group: string,
+  displayGroup: string,
+  collection: ReleaseStreamCollectionRaw,
+  artworkByReleaseId: Map<string, ReleaseArtworkRaw>,
+  detailByReleaseId: Map<string, ReleaseDetailRaw>,
+): ReleaseSummaryModel[] {
+  const candidates = [
+    collection.latest_song
+      ? {
+          stream: 'song',
+          release: collection.latest_song,
+          representativeSongTitle: collection.latest_song.title,
+        }
+      : null,
+    collection.latest_album
+      ? {
+          stream: 'album',
+          release: collection.latest_album,
+          representativeSongTitle: null,
+        }
+      : null,
+  ].filter(Boolean) as {
+    stream: 'song' | 'album';
+    release: NonNullable<ReleaseStreamCollectionRaw['latest_song']>;
+    representativeSongTitle: string | null;
+  }[];
+
+  return candidates.map(({ stream, release, representativeSongTitle }) => {
+    const releaseId = buildReleaseId(group, release.title, release.date, stream);
+    return adaptReleaseSummary({
+      group,
+      displayGroup,
+      releaseTitle: release.title,
+      releaseDate: release.date,
+      releaseKind: release.release_kind ?? release.release_format,
+      stream,
+      sourceUrl: release.source,
+      contextTags: release.context_tags,
+      artwork: artworkByReleaseId.get(releaseId),
+      detail: detailByReleaseId.get(releaseId),
+      representativeSongTitle,
+    });
+  });
+}
+
+export function adaptUpcomingEvent(
+  group: string,
+  displayGroup: string,
+  upcoming: UpcomingCandidateRaw,
+): UpcomingEventModel {
+  const datePrecision = normalizeUpcomingDatePrecision(upcoming.date_precision);
+  const scheduledDate = upcoming.scheduled_date ?? undefined;
+  const scheduledMonth = upcoming.scheduled_month ?? undefined;
+
+  return {
+    id: buildReleaseId(group, upcoming.headline, scheduledDate ?? scheduledMonth ?? 'unknown', 'album'),
+    group,
+    displayGroup,
+    scheduledDate,
+    scheduledMonth,
+    datePrecision,
+    headline: upcoming.headline,
+    releaseLabel: upcoming.release_label ?? undefined,
+    status: normalizeUpcomingStatus(upcoming.date_status),
+    confidence: normalizeUpcomingConfidence(upcoming.confidence),
+    sourceType: normalizeUpcomingSourceType(upcoming.source_type),
+    sourceUrl: upcoming.source_url ?? undefined,
+  };
+}
+
+export function adaptTrack(track: NonNullable<ReleaseDetailRaw['tracks']>[number]): TrackModel {
+  return {
+    order: track.order,
+    title: track.title,
+    isTitleTrack: track.is_title_track ?? undefined,
+    spotifyUrl: track.spotify_url ?? undefined,
+    youtubeMusicUrl: track.youtube_music_url ?? undefined,
+  };
+}
+
+export function adaptReleaseDetail(
+  group: string,
+  displayGroup: string,
+  detail: ReleaseDetailRaw,
+  artwork?: ReleaseArtworkRaw,
+): ReleaseDetailModel {
+  const stream = normalizeReleaseStream(detail.stream);
+
+  return {
+    id: buildReleaseId(group, detail.release_title, detail.release_date, stream),
+    group,
+    displayGroup,
+    releaseTitle: detail.release_title,
+    releaseDate: detail.release_date,
+    releaseKind: detail.release_kind ?? undefined,
+    stream,
+    coverImageUrl: artwork?.cover_image_url ?? undefined,
+    spotifyUrl: detail.spotify_url ?? undefined,
+    youtubeMusicUrl: detail.youtube_music_url ?? undefined,
+    youtubeVideoId: detail.youtube_video_id ?? undefined,
+    youtubeVideoUrl: detail.youtube_video_url ?? undefined,
+    youtubeVideoStatus: detail.youtube_video_status as ReleaseDetailModel['youtubeVideoStatus'],
+    youtubeVideoProvenance: detail.youtube_video_provenance ?? undefined,
+    notes: detail.notes ?? undefined,
+    tracks: (detail.tracks ?? []).map(adaptTrack),
+  };
+}

--- a/mobile/src/selectors/context.ts
+++ b/mobile/src/selectors/context.ts
@@ -1,0 +1,66 @@
+import type {
+  ArtistProfileRaw,
+  MobileRawDataset,
+  ReleaseArtworkRaw,
+  ReleaseDetailRaw,
+  ReleaseHistoryGroupRaw,
+  ReleaseStreamCollectionRaw,
+  YoutubeChannelAllowlistRaw,
+} from '../types';
+
+import { buildReleaseId, normalizeReleaseStream } from './normalize';
+
+export type MobileSelectorContext = {
+  dataset: MobileRawDataset;
+  profilesBySlug: Map<string, ArtistProfileRaw>;
+  profilesByGroup: Map<string, ArtistProfileRaw>;
+  releaseCollectionsByGroup: Map<string, ReleaseStreamCollectionRaw>;
+  releaseHistoryByGroup: Map<string, ReleaseHistoryGroupRaw>;
+  upcomingByGroup: Map<string, MobileRawDataset['upcomingCandidates']>;
+  allowlistsByGroup: Map<string, YoutubeChannelAllowlistRaw>;
+  artworkByReleaseId: Map<string, ReleaseArtworkRaw>;
+  detailByReleaseId: Map<string, ReleaseDetailRaw>;
+};
+
+export function createSelectorContext(dataset: MobileRawDataset): MobileSelectorContext {
+  const profilesBySlug = new Map(dataset.artistProfiles.map((profile) => [profile.slug, profile]));
+  const profilesByGroup = new Map(dataset.artistProfiles.map((profile) => [profile.group, profile]));
+  const releaseCollectionsByGroup = new Map(dataset.releases.map((entry) => [entry.group, entry]));
+  const releaseHistoryByGroup = new Map(dataset.releaseHistory.map((entry) => [entry.group, entry]));
+  const upcomingByGroup = new Map<string, MobileRawDataset['upcomingCandidates']>();
+  const allowlistsByGroup = new Map(dataset.youtubeChannelAllowlists.map((entry) => [entry.group, entry]));
+
+  for (const upcoming of dataset.upcomingCandidates) {
+    const existing = upcomingByGroup.get(upcoming.group) ?? [];
+    existing.push(upcoming);
+    upcomingByGroup.set(upcoming.group, existing);
+  }
+
+  const artworkByReleaseId = new Map<string, ReleaseArtworkRaw>();
+  for (const artwork of dataset.releaseArtwork) {
+    artworkByReleaseId.set(
+      buildReleaseId(artwork.group, artwork.release_title, artwork.release_date, normalizeReleaseStream(artwork.stream)),
+      artwork,
+    );
+  }
+
+  const detailByReleaseId = new Map<string, ReleaseDetailRaw>();
+  for (const detail of dataset.releaseDetails) {
+    detailByReleaseId.set(
+      buildReleaseId(detail.group, detail.release_title, detail.release_date, normalizeReleaseStream(detail.stream)),
+      detail,
+    );
+  }
+
+  return {
+    dataset,
+    profilesBySlug,
+    profilesByGroup,
+    releaseCollectionsByGroup,
+    releaseHistoryByGroup,
+    upcomingByGroup,
+    allowlistsByGroup,
+    artworkByReleaseId,
+    detailByReleaseId,
+  };
+}

--- a/mobile/src/selectors/index.test.ts
+++ b/mobile/src/selectors/index.test.ts
@@ -1,0 +1,201 @@
+import type { MobileRawDataset } from '../types';
+
+import {
+  createSelectorContext,
+  selectLatestReleaseSummaryBySlug,
+  selectRecentReleaseSummariesBySlug,
+  selectReleaseDetailById,
+  selectTeamSummaryBySlug,
+  selectUpcomingEventsBySlug,
+} from './index';
+import { buildReleaseId } from './normalize';
+
+const dataset: MobileRawDataset = {
+  artistProfiles: [
+    {
+      slug: 'yena',
+      group: 'YENA',
+      display_name: 'YENA',
+      aliases: ['최예나'],
+      search_aliases: ['예나'],
+      agency: 'YUE HUA Entertainment',
+      official_youtube_url: 'https://www.youtube.com/@YENA_OFFICIAL',
+      official_x_url: 'https://x.com/YENA_OFFICIAL',
+      official_instagram_url: 'https://www.instagram.com/yena.official/',
+      representative_image_url: null,
+      artist_source_url: 'https://musicbrainz.org/artist/example-yena',
+    },
+    {
+      slug: 'blackpink',
+      group: 'BLACKPINK',
+      display_name: 'BLACKPINK',
+      aliases: ['블랙핑크'],
+      search_aliases: ['블핑'],
+      agency: 'YG Entertainment',
+      official_youtube_url: 'https://www.youtube.com/@BLACKPINK',
+      representative_image_url: 'https://example.com/blackpink.jpg',
+    },
+  ],
+  releases: [
+    {
+      group: 'YENA',
+      latest_song: {
+        title: 'Drama Queen',
+        date: '2026-03-11',
+        source: 'https://musicbrainz.org/release-group/drama-queen',
+        release_kind: 'single',
+        context_tags: [],
+      },
+      latest_album: {
+        title: 'LOVE CATCHER',
+        date: '2026-03-11',
+        source: 'https://musicbrainz.org/release-group/love-catcher',
+        release_kind: 'ep',
+        context_tags: [],
+      },
+    },
+  ],
+  upcomingCandidates: [
+    {
+      group: 'YENA',
+      scheduled_date: '2026-03-11',
+      scheduled_month: '2026-03',
+      date_precision: 'exact',
+      date_status: 'confirmed',
+      headline: "최예나, 3월 11일 컴백 확정",
+      release_label: 'LOVE CATCHER',
+      source_type: 'news_rss',
+      source_url: 'https://example.com/yena-news',
+      confidence: 0.84,
+    },
+    {
+      group: 'YENA',
+      scheduled_month: '2026-04',
+      date_precision: 'month_only',
+      date_status: 'scheduled',
+      headline: 'YENA spring follow-up rumored',
+      source_type: 'official_social',
+      source_url: 'https://example.com/yena-social',
+      confidence: 0.41,
+    },
+  ],
+  releaseArtwork: [
+    {
+      group: 'YENA',
+      release_title: 'LOVE CATCHER',
+      release_date: '2026-03-11',
+      stream: 'album',
+      cover_image_url: 'https://example.com/love-catcher.jpg',
+    },
+  ],
+  releaseDetails: [
+    {
+      group: 'YENA',
+      release_title: 'LOVE CATCHER',
+      release_date: '2026-03-11',
+      stream: 'album',
+      release_kind: 'ep',
+      spotify_url: 'https://open.spotify.com/album/love-catcher',
+      youtube_music_url: 'https://music.youtube.com/playlist?list=love-catcher',
+      youtube_video_status: 'manual_override',
+      notes: 'Representative EP detail.',
+      tracks: [
+        {
+          order: 1,
+          title: 'Drama Queen',
+          is_title_track: true,
+        },
+        {
+          order: 2,
+          title: 'Love Catcher',
+          is_title_track: false,
+        },
+      ],
+    },
+  ],
+  releaseHistory: [
+    {
+      group: 'YENA',
+      releases: [
+        {
+          title: 'LOVE CATCHER',
+          date: '2026-03-11',
+          source: 'https://musicbrainz.org/release-group/love-catcher',
+          release_kind: 'ep',
+          stream: 'album',
+          context_tags: [],
+        },
+        {
+          title: 'NEMONEMO',
+          date: '2025-09-01',
+          source: 'https://musicbrainz.org/release-group/nemonemo',
+          release_kind: 'single',
+          stream: 'song',
+          context_tags: [],
+        },
+      ],
+    },
+  ],
+  youtubeChannelAllowlists: [
+    {
+      group: 'YENA',
+      primary_team_channel_url: 'https://www.youtube.com/@YENA_PRIMARY',
+      channels: [
+        {
+          channel_url: 'https://www.youtube.com/@YENA_PRIMARY',
+          display_in_team_links: true,
+        },
+      ],
+    },
+  ],
+};
+
+describe('mobile selector/adapters scaffold', () => {
+  test('builds a team summary with link and badge fallbacks', () => {
+    const summary = selectTeamSummaryBySlug(dataset, 'yena');
+
+    expect(summary).not.toBeNull();
+    expect(summary?.displayName).toBe('YENA');
+    expect(summary?.officialYoutubeUrl).toBe('https://www.youtube.com/@YENA_PRIMARY');
+    expect(summary?.badge?.monogram).toBe('YE');
+    expect(summary?.searchTokens).toContain('최예나');
+  });
+
+  test('selects the latest release summary from shared stream logic', () => {
+    const release = selectLatestReleaseSummaryBySlug(dataset, 'yena');
+
+    expect(release).not.toBeNull();
+    expect(release?.releaseTitle).toBe('Drama Queen');
+    expect(release?.stream).toBe('song');
+  });
+
+  test('returns recent release history rows as normalized summary models', () => {
+    const releases = selectRecentReleaseSummariesBySlug(dataset, 'yena', 2);
+
+    expect(releases).toHaveLength(2);
+    expect(releases[0]?.releaseTitle).toBe('LOVE CATCHER');
+    expect(releases[0]?.coverImageUrl).toBe('https://example.com/love-catcher.jpg');
+  });
+
+  test('sorts group upcoming rows by exact date before month-only rows', () => {
+    const upcoming = selectUpcomingEventsBySlug(dataset, 'yena');
+
+    expect(upcoming).toHaveLength(2);
+    expect(upcoming[0]?.datePrecision).toBe('exact');
+    expect(upcoming[0]?.confidence).toBe('high');
+    expect(upcoming[1]?.datePrecision).toBe('month_only');
+    expect(upcoming[1]?.confidence).toBe('low');
+  });
+
+  test('resolves a release detail model by normalized release id', () => {
+    const context = createSelectorContext(dataset);
+    const releaseId = buildReleaseId('YENA', 'LOVE CATCHER', '2026-03-11', 'album');
+    const detail = selectReleaseDetailById(context, releaseId);
+
+    expect(detail).not.toBeNull();
+    expect(detail?.releaseTitle).toBe('LOVE CATCHER');
+    expect(detail?.coverImageUrl).toBe('https://example.com/love-catcher.jpg');
+    expect(detail?.tracks[0]?.isTitleTrack).toBe(true);
+    expect(detail?.youtubeVideoStatus).toBe('manual_override');
+  });
+});

--- a/mobile/src/selectors/index.ts
+++ b/mobile/src/selectors/index.ts
@@ -1,0 +1,131 @@
+import type {
+  MobileRawDataset,
+  ReleaseDetailModel,
+  ReleaseSummaryModel,
+  TeamSummaryModel,
+  UpcomingEventModel,
+} from '../types';
+
+import {
+  adaptLatestReleaseStreams,
+  adaptReleaseDetail,
+  adaptReleaseHistoryEntry,
+  adaptTeamSummary,
+  adaptUpcomingEvent,
+} from './adapters';
+import { createSelectorContext, type MobileSelectorContext } from './context';
+import { buildReleaseId, compareIsoDateDescending, compareUpcomingDate } from './normalize';
+
+export { createSelectorContext } from './context';
+export * from './adapters';
+export * from './normalize';
+
+function resolveContext(input: MobileSelectorContext | MobileRawDataset): MobileSelectorContext {
+  return 'profilesBySlug' in input ? input : createSelectorContext(input);
+}
+
+export function selectTeamSummaryBySlug(
+  input: MobileSelectorContext | MobileRawDataset,
+  slug: string,
+): TeamSummaryModel | null {
+  const context = resolveContext(input);
+  const profile = context.profilesBySlug.get(slug);
+
+  if (!profile) {
+    return null;
+  }
+
+  return adaptTeamSummary(profile, context.allowlistsByGroup.get(profile.group));
+}
+
+export function selectLatestReleaseSummaryBySlug(
+  input: MobileSelectorContext | MobileRawDataset,
+  slug: string,
+): ReleaseSummaryModel | null {
+  const context = resolveContext(input);
+  const team = selectTeamSummaryBySlug(context, slug);
+
+  if (!team) {
+    return null;
+  }
+
+  const releaseCollection = context.releaseCollectionsByGroup.get(team.group);
+  if (!releaseCollection) {
+    return null;
+  }
+
+  const candidates = adaptLatestReleaseStreams(
+    team.group,
+    team.displayName,
+    releaseCollection,
+    context.artworkByReleaseId,
+    context.detailByReleaseId,
+  ).sort((left, right) => compareIsoDateDescending(left.releaseDate, right.releaseDate));
+
+  return candidates[0] ?? null;
+}
+
+export function selectRecentReleaseSummariesBySlug(
+  input: MobileSelectorContext | MobileRawDataset,
+  slug: string,
+  limit = 12,
+): ReleaseSummaryModel[] {
+  const context = resolveContext(input);
+  const team = selectTeamSummaryBySlug(context, slug);
+
+  if (!team) {
+    return [];
+  }
+
+  const history = context.releaseHistoryByGroup.get(team.group);
+  if (!history) {
+    return [];
+  }
+
+  return [...history.releases]
+    .sort((left, right) => compareIsoDateDescending(left.date, right.date))
+    .slice(0, limit)
+    .map((release) => {
+      const releaseId = buildReleaseId(team.group, release.title, release.date, release.stream ?? 'album');
+      return adaptReleaseHistoryEntry(
+        team.group,
+        team.displayName,
+        release,
+        context.artworkByReleaseId.get(releaseId),
+        context.detailByReleaseId.get(releaseId),
+      );
+    });
+}
+
+export function selectUpcomingEventsBySlug(
+  input: MobileSelectorContext | MobileRawDataset,
+  slug: string,
+): UpcomingEventModel[] {
+  const context = resolveContext(input);
+  const team = selectTeamSummaryBySlug(context, slug);
+
+  if (!team) {
+    return [];
+  }
+
+  return (context.upcomingByGroup.get(team.group) ?? [])
+    .map((upcoming) => adaptUpcomingEvent(team.group, team.displayName, upcoming))
+    .sort(compareUpcomingDate);
+}
+
+export function selectReleaseDetailById(
+  input: MobileSelectorContext | MobileRawDataset,
+  releaseId: string,
+): ReleaseDetailModel | null {
+  const context = resolveContext(input);
+  const detail = context.detailByReleaseId.get(releaseId);
+
+  if (!detail) {
+    return null;
+  }
+
+  const team = context.profilesByGroup.get(detail.group);
+  const displayGroup = team?.display_name?.trim() || detail.group;
+
+  return adaptReleaseDetail(detail.group, displayGroup, detail, context.artworkByReleaseId.get(releaseId));
+}

--- a/mobile/src/selectors/normalize.ts
+++ b/mobile/src/selectors/normalize.ts
@@ -1,0 +1,148 @@
+import type {
+  ReleaseKind,
+  ReleaseStream,
+  UpcomingConfidence,
+  UpcomingDatePrecision,
+  UpcomingStatus,
+  UpcomingSourceType,
+} from '../types';
+
+function collapseWhitespace(value: string): string {
+  return value.trim().replace(/\s+/g, ' ');
+}
+
+export function normalizeSearchToken(value: string): string {
+  return collapseWhitespace(value)
+    .toLowerCase()
+    .replace(/[×]/g, 'x')
+    .replace(/[_-]/g, ' ')
+    .replace(/[^\p{L}\p{N}\s]/gu, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export function buildReleaseId(group: string, releaseTitle: string, releaseDate: string, stream: string): string {
+  const parts = [group, releaseTitle, releaseDate, stream]
+    .map((value) => normalizeSearchToken(value).replace(/\s+/g, '-'))
+    .filter(Boolean);
+
+  return parts.join('--');
+}
+
+export function buildMonogram(label: string): string {
+  const tokens = collapseWhitespace(label)
+    .split(' ')
+    .map((token) => token.replace(/[^\p{L}\p{N}]/gu, ''))
+    .filter(Boolean);
+
+  if (tokens.length === 0) {
+    return '?';
+  }
+
+  if (tokens.length === 1) {
+    return tokens[0].slice(0, 2).toUpperCase();
+  }
+
+  return tokens
+    .slice(0, 2)
+    .map((token) => token[0]!.toUpperCase())
+    .join('');
+}
+
+export function normalizeReleaseKind(value?: string | null): ReleaseKind | string | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const normalized = normalizeSearchToken(value).replace(/\s+/g, '-');
+  const knownKinds: ReleaseKind[] = ['single', 'mini', 'album', 'ep', 'ost', 'collab'];
+
+  return knownKinds.includes(normalized as ReleaseKind) ? (normalized as ReleaseKind) : value;
+}
+
+export function normalizeReleaseStream(value?: string | null): ReleaseStream {
+  return value === 'song' ? 'song' : 'album';
+}
+
+export function normalizeUpcomingDatePrecision(value?: string | null): UpcomingDatePrecision {
+  if (value === 'exact' || value === 'month_only' || value === 'unknown') {
+    return value;
+  }
+
+  return 'unknown';
+}
+
+export function normalizeUpcomingStatus(value?: string | null): UpcomingStatus | undefined {
+  if (value === 'scheduled' || value === 'confirmed' || value === 'rumor') {
+    return value;
+  }
+
+  return undefined;
+}
+
+export function normalizeUpcomingSourceType(value?: string | null): UpcomingSourceType {
+  if (
+    value === 'agency_notice' ||
+    value === 'weverse_notice' ||
+    value === 'official_social' ||
+    value === 'news_rss' ||
+    value === 'database' ||
+    value === 'pending'
+  ) {
+    return value;
+  }
+
+  return 'news_rss';
+}
+
+export function normalizeUpcomingConfidence(value?: number | string | null): UpcomingConfidence | undefined {
+  if (value == null) {
+    return undefined;
+  }
+
+  if (typeof value === 'string') {
+    if (value === 'low' || value === 'medium' || value === 'high') {
+      return value;
+    }
+    return undefined;
+  }
+
+  if (value >= 0.8) {
+    return 'high';
+  }
+
+  if (value >= 0.5) {
+    return 'medium';
+  }
+
+  return 'low';
+}
+
+export function compareIsoDateDescending(left?: string | null, right?: string | null): number {
+  const leftTime = left ? Date.parse(left) : 0;
+  const rightTime = right ? Date.parse(right) : 0;
+
+  return rightTime - leftTime;
+}
+
+export function compareUpcomingDate(left: { scheduledDate?: string; scheduledMonth?: string; datePrecision: UpcomingDatePrecision }, right: { scheduledDate?: string; scheduledMonth?: string; datePrecision: UpcomingDatePrecision }): number {
+  const precisionRank: Record<UpcomingDatePrecision, number> = {
+    exact: 0,
+    month_only: 1,
+    unknown: 2,
+  };
+
+  if (precisionRank[left.datePrecision] !== precisionRank[right.datePrecision]) {
+    return precisionRank[left.datePrecision] - precisionRank[right.datePrecision];
+  }
+
+  if (left.scheduledDate && right.scheduledDate) {
+    return Date.parse(left.scheduledDate) - Date.parse(right.scheduledDate);
+  }
+
+  if (left.scheduledMonth && right.scheduledMonth) {
+    return left.scheduledMonth.localeCompare(right.scheduledMonth);
+  }
+
+  return 0;
+}

--- a/mobile/src/types/displayModels.ts
+++ b/mobile/src/types/displayModels.ts
@@ -1,0 +1,87 @@
+export type ReleaseKind = 'single' | 'mini' | 'album' | 'ep' | 'ost' | 'collab';
+export type ReleaseStream = 'song' | 'album';
+export type UpcomingDatePrecision = 'exact' | 'month_only' | 'unknown';
+export type UpcomingStatus = 'scheduled' | 'confirmed' | 'rumor';
+export type UpcomingConfidence = 'low' | 'medium' | 'high';
+export type UpcomingSourceType = 'agency_notice' | 'weverse_notice' | 'official_social' | 'news_rss' | 'database' | 'pending';
+export type YoutubeVideoStatus = 'relation_match' | 'manual_override' | 'needs_review' | 'no_mv' | 'unresolved';
+
+export interface TeamBadge {
+  imageUrl?: string;
+  monogram?: string;
+  label: string;
+}
+
+export interface TeamSummaryModel {
+  slug: string;
+  group: string;
+  displayName: string;
+  agency?: string;
+  badge?: TeamBadge;
+  representativeImageUrl?: string;
+  officialYoutubeUrl?: string;
+  officialXUrl?: string;
+  officialInstagramUrl?: string;
+  youtubeChannelUrls: string[];
+  artistSourceUrl?: string;
+  searchTokens: string[];
+}
+
+export interface ReleaseSummaryModel {
+  id: string;
+  group: string;
+  displayGroup: string;
+  releaseTitle: string;
+  releaseDate: string;
+  releaseKind?: ReleaseKind | string;
+  stream?: ReleaseStream;
+  representativeSongTitle?: string;
+  spotifyUrl?: string;
+  youtubeMusicUrl?: string;
+  youtubeMvUrl?: string;
+  coverImageUrl?: string;
+  sourceUrl?: string;
+  contextTags: string[];
+}
+
+export interface UpcomingEventModel {
+  id: string;
+  group: string;
+  displayGroup: string;
+  scheduledDate?: string;
+  scheduledMonth?: string;
+  datePrecision: UpcomingDatePrecision;
+  headline: string;
+  releaseLabel?: string;
+  status?: UpcomingStatus;
+  confidence?: UpcomingConfidence;
+  sourceType: UpcomingSourceType;
+  sourceUrl?: string;
+}
+
+export interface TrackModel {
+  order: number;
+  title: string;
+  isTitleTrack?: boolean;
+  spotifyUrl?: string;
+  youtubeMusicUrl?: string;
+}
+
+export interface ReleaseDetailModel {
+  id: string;
+  group: string;
+  displayGroup: string;
+  releaseTitle: string;
+  releaseDate: string;
+  releaseKind?: string;
+  stream?: ReleaseStream;
+  coverImageUrl?: string;
+  spotifyUrl?: string;
+  youtubeMusicUrl?: string;
+  youtubeVideoId?: string;
+  youtubeVideoUrl?: string;
+  youtubeVideoStatus?: YoutubeVideoStatus;
+  youtubeVideoProvenance?: string;
+  notes?: string;
+  tracks: TrackModel[];
+}

--- a/mobile/src/types/index.ts
+++ b/mobile/src/types/index.ts
@@ -1,1 +1,2 @@
-export {};
+export * from './displayModels';
+export * from './rawData';

--- a/mobile/src/types/rawData.ts
+++ b/mobile/src/types/rawData.ts
@@ -1,0 +1,116 @@
+export type LatestReleaseStreamRaw = {
+  title: string;
+  date: string;
+  source?: string | null;
+  release_kind?: string | null;
+  release_format?: string | null;
+  context_tags?: string[] | null;
+};
+
+export type ArtistProfileRaw = {
+  slug: string;
+  group: string;
+  display_name?: string | null;
+  aliases?: string[] | null;
+  search_aliases?: string[] | null;
+  agency?: string | null;
+  badge_image_url?: string | null;
+  representative_image_url?: string | null;
+  official_youtube_url?: string | null;
+  official_x_url?: string | null;
+  official_instagram_url?: string | null;
+  artist_source_url?: string | null;
+  artist_source?: string | null;
+};
+
+export type ReleaseStreamCollectionRaw = {
+  group: string;
+  latest_song?: LatestReleaseStreamRaw | null;
+  latest_album?: LatestReleaseStreamRaw | null;
+  artist_source?: string | null;
+};
+
+export type UpcomingCandidateRaw = {
+  group: string;
+  scheduled_date?: string | null;
+  scheduled_month?: string | null;
+  date_precision?: string | null;
+  date_status?: string | null;
+  headline: string;
+  release_label?: string | null;
+  source_type?: string | null;
+  source_url?: string | null;
+  confidence?: number | string | null;
+};
+
+export type ReleaseArtworkRaw = {
+  group: string;
+  release_title: string;
+  release_date: string;
+  stream: string;
+  cover_image_url?: string | null;
+};
+
+export type TrackRaw = {
+  order: number;
+  title: string;
+  is_title_track?: boolean | null;
+  spotify_url?: string | null;
+  youtube_music_url?: string | null;
+};
+
+export type ReleaseDetailRaw = {
+  group: string;
+  release_title: string;
+  release_date: string;
+  stream: string;
+  release_kind?: string | null;
+  tracks?: TrackRaw[] | null;
+  spotify_url?: string | null;
+  youtube_music_url?: string | null;
+  youtube_video_id?: string | null;
+  youtube_video_url?: string | null;
+  youtube_video_status?: string | null;
+  youtube_video_provenance?: string | null;
+  notes?: string | null;
+};
+
+export type ReleaseHistoryEntryRaw = {
+  title: string;
+  date: string;
+  source?: string | null;
+  release_kind?: string | null;
+  release_format?: string | null;
+  context_tags?: string[] | null;
+  stream?: string | null;
+};
+
+export type ReleaseHistoryGroupRaw = {
+  group: string;
+  releases: ReleaseHistoryEntryRaw[];
+};
+
+export type YoutubeChannelRaw = {
+  channel_url: string;
+  channel_label?: string | null;
+  owner_type?: string | null;
+  allow_mv_uploads?: boolean | null;
+  display_in_team_links?: boolean | null;
+};
+
+export type YoutubeChannelAllowlistRaw = {
+  group: string;
+  primary_team_channel_url?: string | null;
+  mv_allowlist_urls?: string[] | null;
+  channels?: YoutubeChannelRaw[] | null;
+};
+
+export type MobileRawDataset = {
+  artistProfiles: ArtistProfileRaw[];
+  releases: ReleaseStreamCollectionRaw[];
+  upcomingCandidates: UpcomingCandidateRaw[];
+  releaseArtwork: ReleaseArtworkRaw[];
+  releaseDetails: ReleaseDetailRaw[];
+  releaseHistory: ReleaseHistoryGroupRaw[];
+  youtubeChannelAllowlists: YoutubeChannelAllowlistRaw[];
+};


### PR DESCRIPTION
## Summary
- add shared mobile display-model types and raw dataset contract types
- add selector context, normalize helpers, and shared adapters so screens do not read raw JSON directly
- add unit tests for team summary, latest release, release history, upcoming sorting, and release detail selection

## Verification
- cd mobile && npm run lint
- cd mobile && npm run typecheck
- cd mobile && npm run test
- git diff --check

Closes #255