### PR TITLE
Add backend graceful DB shutdown lifecycle

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -47,6 +47,13 @@ PORT=3000 APP_TIMEZONE=Asia/Seoul npm run start
 - 정본 schema는 plain SQL로 관리한다.
 - apply / verify 도구는 SQL 실행 보조에만 사용한다.
 
+## DB Lifecycle
+
+- API runtime은 `backend/src/lib/db.ts`의 `createDbPool()`을 공용 entrypoint로 사용한다.
+- `buildApp()`가 pool을 직접 만들었든 주입받았든, shutdown은 `app.close()` 한 곳으로 수렴시키고 내부에서 `closeDbPool()`까지 처리한다.
+- `backend/src/server.ts`는 `SIGINT`, `SIGTERM`에서 `app.close()`를 호출해 Fastify와 DB pool을 함께 정리한다.
+- later worker / one-off script / test가 pool을 직접 만들면 종료 시 `closeDbPool()` 또는 `pool.end()`를 명시적으로 호출해야 한다.
+
 ## Preview / Staging Baseline
 
 preview rehearsal은 production과 분리된 DB / API / worker 경로를 기준으로 진행한다.

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,7 +1,7 @@
 import Fastify, { type FastifyInstance } from 'fastify';
 
 import { loadConfig, type AppConfig } from './config.js';
-import { createDbPool, type DbPool } from './lib/db.js';
+import { closeDbPool, createDbPool, type DbPool } from './lib/db.js';
 import { registerCalendarRoutes } from './routes/calendar.js';
 import { registerEntityRoutes } from './routes/entities.js';
 import { registerHealthRoute } from './routes/health.js';
@@ -24,7 +24,7 @@ export function buildApp(options: BuildAppOptions = {}): FastifyInstance {
   });
 
   app.addHook('onClose', async () => {
-    await db.end();
+    await closeDbPool(db);
   });
 
   registerHealthRoute(app);

--- a/backend/src/lib/db.ts
+++ b/backend/src/lib/db.ts
@@ -16,6 +16,10 @@ export function createDbPool(config: AppConfig): DbPool {
   });
 }
 
+export async function closeDbPool(pool: DbPool): Promise<void> {
+  await pool.end();
+}
+
 export async function pingDatabase(pool: DbQueryable): Promise<void> {
   await pool.query('select 1');
 }

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,9 +1,47 @@
+import type { FastifyInstance } from 'fastify';
+
 import { buildApp } from './app.js';
 import { loadConfig } from './config.js';
+
+const SHUTDOWN_SIGNALS = ['SIGINT', 'SIGTERM'] as const;
+
+function registerShutdownHandlers(app: FastifyInstance): void {
+  let shutdownPromise: Promise<never> | null = null;
+
+  const startShutdown = (signal: NodeJS.Signals): Promise<never> => {
+    if (shutdownPromise) {
+      return shutdownPromise;
+    }
+
+    shutdownPromise = (async () => {
+      app.log.info({ signal }, 'Starting graceful shutdown');
+
+      try {
+        await app.close();
+        app.log.info({ signal }, 'Graceful shutdown finished');
+        process.exit(0);
+      } catch (error) {
+        app.log.error({ err: error, signal }, 'Graceful shutdown failed');
+        process.exit(1);
+      }
+
+      throw new Error('Unreachable');
+    })();
+
+    return shutdownPromise;
+  };
+
+  for (const signal of SHUTDOWN_SIGNALS) {
+    process.on(signal, () => {
+      void startShutdown(signal);
+    });
+  }
+}
 
 async function main(): Promise<void> {
   const config = loadConfig();
   const app = buildApp({ config });
+  registerShutdownHandlers(app);
 
   try {
     await app.listen({
@@ -12,6 +50,7 @@ async function main(): Promise<void> {
     });
   } catch (error) {
     app.log.error(error);
+    await app.close().catch(() => undefined);
     process.exit(1);
   }
 }


### PR DESCRIPTION
## Summary
- add a shared DB close helper for backend runtime use
- route shutdown through Fastify app close so pool cleanup is centralized
- add SIGINT/SIGTERM graceful shutdown handling and worker/test guidance

Closes #219