### PR TITLE
Add shared API response envelope for backend read routes

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -47,6 +47,13 @@ PORT=3000 APP_TIMEZONE=Asia/Seoul npm run start
 - 정본 schema는 plain SQL로 관리한다.
 - apply / verify 도구는 SQL 실행 보조에만 사용한다.
 
+## Read API Envelope
+
+- `/v1/*` read endpoint는 공통 success envelope `meta + data`를 사용한다.
+- success `meta`에는 최소 `request_id`, `generated_at`, `timezone`, `route`, `source`가 포함된다.
+- error는 공통 `meta + error` shape로 내려가고 code는 `invalid_request`, `not_found`, `stale_projection`, `internal_error`를 기본으로 쓴다.
+- helper entrypoint는 `backend/src/lib/api.ts`다.
+
 ## DB Lifecycle
 
 - API runtime은 `backend/src/lib/db.ts`의 `createDbPool()`을 공용 entrypoint로 사용한다.

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,6 +1,7 @@
 import Fastify, { type FastifyInstance } from 'fastify';
 
 import { loadConfig, type AppConfig } from './config.js';
+import { ReadApiError, buildReadErrorEnvelope } from './lib/api.js';
 import { closeDbPool, createDbPool, type DbPool } from './lib/db.js';
 import { registerCalendarRoutes } from './routes/calendar.js';
 import { registerEntityRoutes } from './routes/entities.js';
@@ -21,6 +22,31 @@ export function buildApp(options: BuildAppOptions = {}): FastifyInstance {
   const db = options.db ?? createDbPool(config);
   const app = Fastify({
     logger: true,
+  });
+
+  app.setErrorHandler((error, request, reply) => {
+    if (error instanceof ReadApiError) {
+      return reply
+        .code(error.statusCode)
+        .send(buildReadErrorEnvelope(request, config.appTimezone, error.code, error.message, error.meta));
+    }
+
+    request.log.error({ err: error }, 'Unhandled request error');
+    return reply
+      .code(500)
+      .send(buildReadErrorEnvelope(request, config.appTimezone, 'internal_error', 'Unexpected server error.'));
+  });
+
+  app.setNotFoundHandler((request, reply) => {
+    if (request.url.startsWith('/v1/')) {
+      return reply
+        .code(404)
+        .send(buildReadErrorEnvelope(request, config.appTimezone, 'not_found', 'Route not found.'));
+    }
+
+    return reply.code(404).send({
+      error: 'Not Found',
+    });
   });
 
   app.addHook('onClose', async () => {

--- a/backend/src/lib/api.ts
+++ b/backend/src/lib/api.ts
@@ -1,0 +1,92 @@
+import type { FastifyRequest } from 'fastify';
+
+export type ReadApiErrorCode =
+  | 'invalid_request'
+  | 'not_found'
+  | 'stale_projection'
+  | 'internal_error'
+  | 'not_implemented';
+
+export class ReadApiError extends Error {
+  readonly statusCode: number;
+  readonly code: ReadApiErrorCode;
+  readonly meta: Record<string, unknown>;
+
+  constructor(statusCode: number, code: ReadApiErrorCode, message: string, meta: Record<string, unknown> = {}) {
+    super(message);
+    this.name = 'ReadApiError';
+    this.statusCode = statusCode;
+    this.code = code;
+    this.meta = meta;
+  }
+}
+
+export function routeError(
+  statusCode: number,
+  code: ReadApiErrorCode,
+  message: string,
+  meta: Record<string, unknown> = {},
+): ReadApiError {
+  return new ReadApiError(statusCode, code, message, meta);
+}
+
+function buildGeneratedAt(value?: Date | string): string {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (typeof value === 'string' && value.length > 0) {
+    const parsed = new Date(value);
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed.toISOString();
+    }
+  }
+
+  return new Date().toISOString();
+}
+
+function getRoutePath(request: FastifyRequest): string {
+  return request.routeOptions.url || request.url;
+}
+
+export function buildReadDataEnvelope<T>(
+  request: FastifyRequest,
+  timezone: string,
+  data: T,
+  meta: Record<string, unknown> = {},
+  generatedAt?: Date | string,
+) {
+  return {
+    meta: {
+      request_id: request.id,
+      generated_at: buildGeneratedAt(generatedAt),
+      timezone,
+      route: getRoutePath(request),
+      source: 'backend',
+      ...meta,
+    },
+    data,
+  };
+}
+
+export function buildReadErrorEnvelope(
+  request: FastifyRequest,
+  timezone: string,
+  code: ReadApiErrorCode,
+  message: string,
+  meta: Record<string, unknown> = {},
+) {
+  return {
+    meta: {
+      generated_at: buildGeneratedAt(),
+      timezone,
+      request_id: request.id,
+      route: getRoutePath(request),
+      ...meta,
+    },
+    error: {
+      code,
+      message,
+    },
+  };
+}

--- a/backend/src/lib/not-implemented.ts
+++ b/backend/src/lib/not-implemented.ts
@@ -1,13 +1,12 @@
-export function buildNotImplementedEnvelope(route: string, timezone: string) {
-  return {
-    meta: {
-      route,
-      generated_at: new Date().toISOString(),
-      timezone,
-    },
-    error: {
-      code: 'not_implemented',
-      message: 'Route shell is registered but not implemented yet.',
-    },
-  };
+import type { FastifyRequest } from 'fastify';
+
+import { buildReadErrorEnvelope } from './api.js';
+
+export function buildNotImplementedEnvelope(request: FastifyRequest, timezone: string) {
+  return buildReadErrorEnvelope(
+    request,
+    timezone,
+    'not_implemented',
+    'Route shell is registered but not implemented yet.',
+  );
 }

--- a/backend/src/routes/calendar.ts
+++ b/backend/src/routes/calendar.ts
@@ -1,5 +1,6 @@
 import type { FastifyInstance } from 'fastify';
 
+import { buildReadDataEnvelope, routeError } from '../lib/api.js';
 import type { AppConfig } from '../config.js';
 import type { DbQueryable } from '../lib/db.js';
 
@@ -251,36 +252,15 @@ function normalizeCalendarMonthPayload(payload: unknown): CalendarMonthData | nu
 }
 
 export function registerCalendarRoutes(app: FastifyInstance, context: CalendarRouteContext): void {
-  app.get('/v1/calendar/month', async (request, reply) => {
+  app.get('/v1/calendar/month', async (request) => {
     const { month } = request.query as CalendarMonthQuery;
 
     if (!month) {
-      return reply.code(400).send({
-        meta: {
-          route: '/v1/calendar/month',
-          generated_at: new Date().toISOString(),
-          timezone: context.config.appTimezone,
-        },
-        error: {
-          code: 'invalid_request',
-          message: 'month query parameter is required (YYYY-MM).',
-        },
-      });
+      throw routeError(400, 'invalid_request', 'month query parameter is required (YYYY-MM).');
     }
 
     if (!MONTH_KEY_PATTERN.test(month)) {
-      return reply.code(400).send({
-        meta: {
-          route: '/v1/calendar/month',
-          generated_at: new Date().toISOString(),
-          timezone: context.config.appTimezone,
-          month,
-        },
-        error: {
-          code: 'invalid_request',
-          message: 'month query parameter must use YYYY-MM format.',
-        },
-      });
+      throw routeError(400, 'invalid_request', 'month query parameter must use YYYY-MM format.', { month });
     }
 
     const result = await context.db.query<CalendarMonthProjectionRow>(
@@ -295,43 +275,16 @@ export function registerCalendarRoutes(app: FastifyInstance, context: CalendarRo
 
     const row = result.rows[0];
     if (!row) {
-      return reply.code(404).send({
-        meta: {
-          route: '/v1/calendar/month',
-          generated_at: new Date().toISOString(),
-          timezone: context.config.appTimezone,
-          month,
-        },
-        error: {
-          code: 'calendar_month_not_found',
-          message: 'No calendar projection matched the supplied month.',
-        },
-      });
+      throw routeError(404, 'not_found', 'No calendar projection matched the supplied month.', { month });
     }
 
     const data = normalizeCalendarMonthPayload(row.payload);
     if (!data) {
-      return reply.code(500).send({
-        meta: {
-          route: '/v1/calendar/month',
-          generated_at: new Date().toISOString(),
-          timezone: context.config.appTimezone,
-          month,
-        },
-        error: {
-          code: 'invalid_projection_payload',
-          message: 'calendar_month_projection returned an unexpected payload shape.',
-        },
+      throw routeError(500, 'stale_projection', 'calendar_month_projection returned an unexpected payload shape.', {
+        month,
       });
     }
 
-    return {
-      meta: {
-        generated_at: toIsoString(row.generated_at),
-        timezone: context.config.appTimezone,
-        month: row.month_key,
-      },
-      data,
-    };
+    return buildReadDataEnvelope(request, context.config.appTimezone, data, { month: row.month_key }, toIsoString(row.generated_at));
   });
 }

--- a/backend/src/routes/entities.ts
+++ b/backend/src/routes/entities.ts
@@ -1,8 +1,8 @@
 import type { FastifyInstance } from 'fastify';
 
+import { buildReadDataEnvelope, routeError } from '../lib/api.js';
 import type { AppConfig } from '../config.js';
 import type { DbQueryable } from '../lib/db.js';
-import { buildNotImplementedEnvelope } from '../lib/not-implemented.js';
 
 type EntityRouteContext = {
   config: AppConfig;
@@ -274,7 +274,7 @@ function normalizeEntityDetailPayload(payload: unknown, slug: string): EntityDet
 }
 
 export function registerEntityRoutes(app: FastifyInstance, context: EntityRouteContext): void {
-  app.get('/v1/entities/:slug/channels', async (request, reply) => {
+  app.get('/v1/entities/:slug/channels', async (request) => {
     const { slug } = request.params as EntitySlugParams;
 
     const result = await context.db.query<EntityChannelRow>(
@@ -309,27 +309,10 @@ export function registerEntityRoutes(app: FastifyInstance, context: EntityRouteC
 
     const entity = result.rows[0];
     if (!entity) {
-      return reply.code(404).send({
-        meta: {
-          route: '/v1/entities/:slug/channels',
-          generated_at: new Date().toISOString(),
-          timezone: context.config.appTimezone,
-          slug,
-        },
-        error: {
-          code: 'entity_not_found',
-          message: 'No entity matched the supplied slug.',
-        },
-      });
+      throw routeError(404, 'not_found', 'No entity matched the supplied slug.', { slug });
     }
 
-    return {
-      meta: {
-        generated_at: new Date().toISOString(),
-        timezone: context.config.appTimezone,
-        slug,
-      },
-      data: {
+    return buildReadDataEnvelope(request, context.config.appTimezone, {
         entity: {
           entity_id: entity.entity_id,
           slug: entity.slug,
@@ -356,10 +339,11 @@ export function registerEntityRoutes(app: FastifyInstance, context: EntityRouteC
             .filter((url): url is string => url !== null),
         },
       },
-    };
+      { slug },
+    );
   });
 
-  app.get('/v1/entities/:slug', async (request, reply) => {
+  app.get('/v1/entities/:slug', async (request) => {
     const { slug } = request.params as EntitySlugParams;
 
     const result = await context.db.query<EntityDetailProjectionRow>(
@@ -374,43 +358,22 @@ export function registerEntityRoutes(app: FastifyInstance, context: EntityRouteC
 
     const row = result.rows[0];
     if (!row) {
-      return reply.code(404).send({
-        meta: {
-          route: '/v1/entities/:slug',
-          generated_at: new Date().toISOString(),
-          timezone: context.config.appTimezone,
-          entity_slug: slug,
-        },
-        error: {
-          code: 'entity_not_found',
-          message: 'No entity matched the supplied slug.',
-        },
-      });
+      throw routeError(404, 'not_found', 'No entity matched the supplied slug.', { entity_slug: slug });
     }
 
     const data = normalizeEntityDetailPayload(row.payload, slug);
     if (!data) {
-      return reply.code(500).send({
-        meta: {
-          route: '/v1/entities/:slug',
-          generated_at: new Date().toISOString(),
-          timezone: context.config.appTimezone,
-          entity_slug: slug,
-        },
-        error: {
-          code: 'invalid_projection_payload',
-          message: 'entity_detail_projection returned an unexpected payload shape.',
-        },
+      throw routeError(500, 'stale_projection', 'entity_detail_projection returned an unexpected payload shape.', {
+        entity_slug: slug,
       });
     }
 
-    return {
-      meta: {
-        generated_at: toIsoString(row.generated_at),
-        timezone: context.config.appTimezone,
-        entity_slug: slug,
-      },
+    return buildReadDataEnvelope(
+      request,
+      context.config.appTimezone,
       data,
-    };
+      { entity_slug: slug },
+      toIsoString(row.generated_at),
+    );
   });
 }

--- a/backend/src/routes/radar.ts
+++ b/backend/src/routes/radar.ts
@@ -1,5 +1,6 @@
 import type { FastifyInstance } from 'fastify';
 
+import { buildReadDataEnvelope } from '../lib/api.js';
 import type { AppConfig } from '../config.js';
 import type { DbQueryable } from '../lib/db.js';
 
@@ -68,7 +69,7 @@ function toIsoString(value: Date | string | undefined): string {
 }
 
 export function registerRadarRoutes(app: FastifyInstance, context: RadarRouteContext): void {
-  app.get('/v1/radar', async () => {
+  app.get('/v1/radar', async (request) => {
     const result = await context.db.query<RadarProjectionRow>(
       `
         select payload, generated_at
@@ -81,12 +82,12 @@ export function registerRadarRoutes(app: FastifyInstance, context: RadarRouteCon
 
     const row = result.rows[0];
 
-    return {
-      meta: {
-        generated_at: toIsoString(row?.generated_at),
-        timezone: context.config.appTimezone,
-      },
-      data: normalizeRadarPayload(row?.payload),
-    };
+    return buildReadDataEnvelope(
+      request,
+      context.config.appTimezone,
+      normalizeRadarPayload(row?.payload),
+      {},
+      toIsoString(row?.generated_at),
+    );
   });
 }

--- a/backend/src/routes/releases.ts
+++ b/backend/src/routes/releases.ts
@@ -1,5 +1,6 @@
 import type { FastifyInstance } from 'fastify';
 
+import { buildReadDataEnvelope, routeError } from '../lib/api.js';
 import type { AppConfig } from '../config.js';
 import type { DbQueryable } from '../lib/db.js';
 
@@ -247,30 +248,20 @@ function normalizeLegacyReleaseTitle(value: string): string {
 }
 
 export function registerReleaseRoutes(app: FastifyInstance, context: ReleaseRouteContext): void {
-  app.get('/v1/releases/lookup', async (request, reply) => {
+  app.get('/v1/releases/lookup', async (request) => {
     const { entity_slug, title, date, stream } = request.query as ReleaseLookupQuery;
 
     if (!entity_slug || !title || !date || !stream) {
-      return reply.code(400).send({
-        meta: {
-          route: '/v1/releases/lookup',
-          generated_at: new Date().toISOString(),
-          timezone: context.config.appTimezone,
-        },
-        error: {
-          code: 'invalid_request',
-          message: 'entity_slug, title, date, and stream query parameters are required.',
-        },
-      });
+      throw routeError(400, 'invalid_request', 'entity_slug, title, date, and stream query parameters are required.');
     }
 
     const normalizedTitle = normalizeLegacyReleaseTitle(title);
     if (!ISO_DATE_PATTERN.test(date) || !VALID_STREAMS.has(stream) || normalizedTitle.length === 0) {
-      return reply.code(400).send({
-        meta: {
-          route: '/v1/releases/lookup',
-          generated_at: new Date().toISOString(),
-          timezone: context.config.appTimezone,
+      throw routeError(
+        400,
+        'invalid_request',
+        'lookup requires a non-empty title, YYYY-MM-DD date, and stream of album or song.',
+        {
           lookup: {
             entity_slug,
             title,
@@ -278,11 +269,7 @@ export function registerReleaseRoutes(app: FastifyInstance, context: ReleaseRout
             stream,
           },
         },
-        error: {
-          code: 'invalid_request',
-          message: 'lookup requires a non-empty title, YYYY-MM-DD date, and stream of album or song.',
-        },
-      });
+      );
     }
 
     const result = await context.db.query<ReleaseDetailProjectionRow>(
@@ -307,44 +294,26 @@ export function registerReleaseRoutes(app: FastifyInstance, context: ReleaseRout
 
     const row = result.rows[0];
     if (!row) {
-      return reply.code(404).send({
-        meta: {
-          route: '/v1/releases/lookup',
-          generated_at: new Date().toISOString(),
-          timezone: context.config.appTimezone,
-          lookup: {
-            entity_slug,
-            title,
-            date,
-            stream,
-          },
-        },
-        error: {
-          code: 'release_not_found',
-          message: 'No release matched the supplied legacy lookup key.',
+      throw routeError(404, 'not_found', 'No release matched the supplied legacy lookup key.', {
+        lookup: {
+          entity_slug,
+          title,
+          date,
+          stream,
         },
       });
     }
 
     const data = buildLookupData(row);
     if (data === null) {
-      return reply.code(500).send({
-        meta: {
-          route: '/v1/releases/lookup',
-          generated_at: new Date().toISOString(),
-          timezone: context.config.appTimezone,
-        },
-        error: {
-          code: 'invalid_projection_payload',
-          message: 'release_detail_projection returned an unexpected payload shape.',
-        },
-      });
+      throw routeError(500, 'stale_projection', 'release_detail_projection returned an unexpected payload shape.');
     }
 
-    return {
-      meta: {
-        generated_at: toIsoString(row.generated_at),
-        timezone: context.config.appTimezone,
+    return buildReadDataEnvelope(
+      request,
+      context.config.appTimezone,
+      data,
+      {
         lookup: {
           entity_slug,
           title,
@@ -352,26 +321,15 @@ export function registerReleaseRoutes(app: FastifyInstance, context: ReleaseRout
           stream,
         },
       },
-      data,
-    };
+      toIsoString(row.generated_at),
+    );
   });
 
-  app.get('/v1/releases/:id', async (request, reply) => {
+  app.get('/v1/releases/:id', async (request) => {
     const { id } = request.params as ReleaseParams;
 
     if (!UUID_PATTERN.test(id)) {
-      return reply.code(400).send({
-        meta: {
-          route: '/v1/releases/:id',
-          generated_at: new Date().toISOString(),
-          timezone: context.config.appTimezone,
-          release_id: id,
-        },
-        error: {
-          code: 'invalid_request',
-          message: 'release_id must be a UUID.',
-        },
-      });
+      throw routeError(400, 'invalid_request', 'release_id must be a UUID.', { release_id: id });
     }
 
     const result = await context.db.query<ReleaseDetailProjectionRow>(
@@ -393,43 +351,22 @@ export function registerReleaseRoutes(app: FastifyInstance, context: ReleaseRout
 
     const row = result.rows[0];
     if (!row) {
-      return reply.code(404).send({
-        meta: {
-          route: '/v1/releases/:id',
-          generated_at: new Date().toISOString(),
-          timezone: context.config.appTimezone,
-          release_id: id,
-        },
-        error: {
-          code: 'release_not_found',
-          message: 'No release detail matched the supplied release_id.',
-        },
-      });
+      throw routeError(404, 'not_found', 'No release detail matched the supplied release_id.', { release_id: id });
     }
 
     const data = normalizeReleaseDetailPayload(row.payload, row.release_id);
     if (data === null) {
-      return reply.code(500).send({
-        meta: {
-          route: '/v1/releases/:id',
-          generated_at: new Date().toISOString(),
-          timezone: context.config.appTimezone,
-          release_id: row.release_id,
-        },
-        error: {
-          code: 'invalid_projection_payload',
-          message: 'release_detail_projection returned an unexpected payload shape.',
-        },
+      throw routeError(500, 'stale_projection', 'release_detail_projection returned an unexpected payload shape.', {
+        release_id: row.release_id,
       });
     }
 
-    return {
-      meta: {
-        generated_at: toIsoString(row.generated_at),
-        timezone: context.config.appTimezone,
-        release_id: row.release_id,
-      },
+    return buildReadDataEnvelope(
+      request,
+      context.config.appTimezone,
       data,
-    };
+      { release_id: row.release_id },
+      toIsoString(row.generated_at),
+    );
   });
 }

--- a/backend/src/routes/review.ts
+++ b/backend/src/routes/review.ts
@@ -1,5 +1,6 @@
 import type { FastifyInstance } from 'fastify';
 
+import { buildReadDataEnvelope } from '../lib/api.js';
 import type { AppConfig } from '../config.js';
 import type { DbQueryable } from '../lib/db.js';
 
@@ -267,7 +268,7 @@ function buildMvItem(row: MvReviewRow) {
 }
 
 export function registerReviewRoutes(app: FastifyInstance, context: ReviewRouteContext): void {
-  app.get('/v1/review/upcoming', async (_request, reply) => {
+  app.get('/v1/review/upcoming', async (request, reply) => {
     reply.header('Cache-Control', 'no-store');
 
     const result = await context.db.query<UpcomingReviewRow>(
@@ -321,19 +322,14 @@ export function registerReviewRoutes(app: FastifyInstance, context: ReviewRouteC
       `
     );
 
-    return {
-      meta: {
-        generated_at: new Date().toISOString(),
-        timezone: context.config.appTimezone,
-        total_items: result.rows.length,
-      },
-      data: {
+    return buildReadDataEnvelope(request, context.config.appTimezone, {
         items: result.rows.map(buildUpcomingItem),
       },
-    };
+      { total_items: result.rows.length },
+    );
   });
 
-  app.get('/v1/review/mv', async (_request, reply) => {
+  app.get('/v1/review/mv', async (request, reply) => {
     reply.header('Cache-Control', 'no-store');
 
     const result = await context.db.query<MvReviewRow>(
@@ -395,15 +391,10 @@ export function registerReviewRoutes(app: FastifyInstance, context: ReviewRouteC
       `
     );
 
-    return {
-      meta: {
-        generated_at: new Date().toISOString(),
-        timezone: context.config.appTimezone,
-        total_items: result.rows.length,
-      },
-      data: {
+    return buildReadDataEnvelope(request, context.config.appTimezone, {
         items: result.rows.map(buildMvItem),
       },
-    };
+      { total_items: result.rows.length },
+    );
   });
 }

--- a/backend/src/routes/search.ts
+++ b/backend/src/routes/search.ts
@@ -1,5 +1,6 @@
 import type { FastifyInstance } from 'fastify';
 
+import { buildReadDataEnvelope, routeError } from '../lib/api.js';
 import type { AppConfig } from '../config.js';
 import type { DbQueryable } from '../lib/db.js';
 
@@ -367,35 +368,19 @@ export function registerSearchRoutes(app: FastifyInstance, context: SearchRouteC
     const { q, limit: limitQuery } = request.query as SearchQuery;
 
     if (!q) {
-      return reply.code(400).send({
-        meta: {
-          route: '/v1/search',
-          generated_at: new Date().toISOString(),
-          timezone: context.config.appTimezone,
-        },
-        error: {
-          code: 'invalid_request',
-          message: 'q query parameter is required.',
-        },
-      });
+      throw routeError(400, 'invalid_request', 'q query parameter is required.');
     }
 
     const needle = buildSearchNeedle(q);
     const limit = parseSearchLimit(limitQuery);
 
     if (!needle || limit === null) {
-      return reply.code(400).send({
-        meta: {
-          route: '/v1/search',
-          generated_at: new Date().toISOString(),
-          timezone: context.config.appTimezone,
-          query: q,
-        },
-        error: {
-          code: 'invalid_request',
-          message: 'q must contain searchable text and limit must be a positive integer when supplied.',
-        },
-      });
+      throw routeError(
+        400,
+        'invalid_request',
+        'q must contain searchable text and limit must be a positive integer when supplied.',
+        { query: q },
+      );
     }
 
     reply.header('Cache-Control', 'no-store');
@@ -711,15 +696,10 @@ export function registerSearchRoutes(app: FastifyInstance, context: SearchRouteC
     const generatedAt = entityResult.rows[0]?.generated_at;
     const upcomingMatches = Array.from(upcomingMatchMap.values()).sort(compareUpcomingMatches).slice(0, limit);
 
-    return {
-      meta: {
-        generated_at: toIsoString(generatedAt),
-        timezone: context.config.appTimezone,
-        query: q,
-        normalized_query: needle.normalized,
-        limit,
-      },
-      data: {
+    return buildReadDataEnvelope(
+      request,
+      context.config.appTimezone,
+      {
         entities: entityMatches.map((item) => ({
           entity_slug: item.entity_slug,
           display_name: item.display_name,
@@ -762,6 +742,12 @@ export function registerSearchRoutes(app: FastifyInstance, context: SearchRouteC
           matched_alias: item.matched_alias,
         })),
       },
-    };
+      {
+        query: q,
+        normalized_query: needle.normalized,
+        limit,
+      },
+      toIsoString(generatedAt),
+    );
   });
 }


### PR DESCRIPTION
## Summary
- add a shared read API envelope helper for success and error responses
- centralize v1 not-found and internal error formatting in the Fastify app
- migrate calendar/search/entity/release/radar/review routes to the shared response helper

Closes #220