### PR TITLE
Add shared normalization helpers for import and API

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -54,6 +54,13 @@ PORT=3000 APP_TIMEZONE=Asia/Seoul npm run start
 - error는 공통 `meta + error` shape로 내려가고 code는 `invalid_request`, `not_found`, `stale_projection`, `internal_error`를 기본으로 쓴다.
 - helper entrypoint는 `backend/src/lib/api.ts`다.
 
+## Normalization Helpers
+
+- import / dual-write Python 경로는 `canonical_normalization.py`를 공통 entrypoint로 사용한다.
+- backend read route는 `backend/src/lib/normalization.ts`를 공통 entrypoint로 사용한다.
+- release lookup, slug path, search-alias normalization은 ad hoc trim/lower 구현을 새로 만들지 않는다.
+- SQL projection의 `projection_normalize_text()`는 위 helper들과 같은 의미론을 유지해야 한다.
+
 ## DB Lifecycle
 
 - API runtime은 `backend/src/lib/db.ts`의 `createDbPool()`을 공용 entrypoint로 사용한다.

--- a/backend/src/lib/normalization.ts
+++ b/backend/src/lib/normalization.ts
@@ -1,0 +1,76 @@
+export type SearchNeedle = {
+  raw: string;
+  normalized: string;
+  compact: string;
+};
+
+export type ReleaseLookupKey = {
+  entity_slug: string;
+  normalized_release_title: string;
+  release_date: string;
+  stream: string;
+};
+
+export function normalizeLookupText(value: string): string {
+  return value
+    .normalize('NFKC')
+    .replace(/[×✕]/g, 'x')
+    .replace(/&/g, ' and ')
+    .toLowerCase()
+    .replace(/['’`]/g, '');
+}
+
+export function collapseNormalizedText(value: string): string {
+  return value
+    .replace(/[^a-z0-9ㄱ-ㅎㅏ-ㅣ가-힣]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export function normalizeAliasValue(value: string): string {
+  return collapseNormalizedText(normalizeLookupText(value));
+}
+
+export function compactNormalizedAlias(value: string): string {
+  return value.replace(/\s+/g, '');
+}
+
+export function buildSearchNeedle(raw: string): SearchNeedle | null {
+  const normalized = normalizeAliasValue(raw);
+  if (!normalized) {
+    return null;
+  }
+
+  return {
+    raw,
+    normalized,
+    compact: compactNormalizedAlias(normalized),
+  };
+}
+
+export function normalizeSlugValue(value: string): string {
+  return value
+    .normalize('NFKC')
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^[-_]+|[-_]+$/g, '');
+}
+
+export function normalizeReleaseLookupTitle(value: string): string {
+  return normalizeAliasValue(value);
+}
+
+export function buildReleaseLookupKey(
+  entitySlug: string,
+  releaseTitle: string,
+  releaseDate: string,
+  stream: string,
+): ReleaseLookupKey {
+  return {
+    entity_slug: normalizeSlugValue(entitySlug),
+    normalized_release_title: normalizeReleaseLookupTitle(releaseTitle),
+    release_date: releaseDate.trim(),
+    stream: stream.trim().toLowerCase(),
+  };
+}

--- a/backend/src/routes/entities.ts
+++ b/backend/src/routes/entities.ts
@@ -3,6 +3,7 @@ import type { FastifyInstance } from 'fastify';
 import { buildReadDataEnvelope, routeError } from '../lib/api.js';
 import type { AppConfig } from '../config.js';
 import type { DbQueryable } from '../lib/db.js';
+import { normalizeSlugValue } from '../lib/normalization.js';
 
 type EntityRouteContext = {
   config: AppConfig;
@@ -275,7 +276,14 @@ function normalizeEntityDetailPayload(payload: unknown, slug: string): EntityDet
 
 export function registerEntityRoutes(app: FastifyInstance, context: EntityRouteContext): void {
   app.get('/v1/entities/:slug/channels', async (request) => {
-    const { slug } = request.params as EntitySlugParams;
+    const { slug: rawSlug } = request.params as EntitySlugParams;
+    const slug = normalizeSlugValue(rawSlug);
+
+    if (!slug) {
+      throw routeError(400, 'invalid_request', 'slug path parameter must contain a valid entity slug.', {
+        slug: rawSlug,
+      });
+    }
 
     const result = await context.db.query<EntityChannelRow>(
       `
@@ -344,7 +352,14 @@ export function registerEntityRoutes(app: FastifyInstance, context: EntityRouteC
   });
 
   app.get('/v1/entities/:slug', async (request) => {
-    const { slug } = request.params as EntitySlugParams;
+    const { slug: rawSlug } = request.params as EntitySlugParams;
+    const slug = normalizeSlugValue(rawSlug);
+
+    if (!slug) {
+      throw routeError(400, 'invalid_request', 'slug path parameter must contain a valid entity slug.', {
+        slug: rawSlug,
+      });
+    }
 
     const result = await context.db.query<EntityDetailProjectionRow>(
       `

--- a/backend/src/routes/releases.ts
+++ b/backend/src/routes/releases.ts
@@ -3,6 +3,7 @@ import type { FastifyInstance } from 'fastify';
 import { buildReadDataEnvelope, routeError } from '../lib/api.js';
 import type { AppConfig } from '../config.js';
 import type { DbQueryable } from '../lib/db.js';
+import { buildReleaseLookupKey } from '../lib/normalization.js';
 
 type ReleaseRouteContext = {
   config: AppConfig;
@@ -243,10 +244,6 @@ function buildLookupData(row: ReleaseDetailProjectionRow): ReleaseLookupData | n
   };
 }
 
-function normalizeLegacyReleaseTitle(value: string): string {
-  return value.trim();
-}
-
 export function registerReleaseRoutes(app: FastifyInstance, context: ReleaseRouteContext): void {
   app.get('/v1/releases/lookup', async (request) => {
     const { entity_slug, title, date, stream } = request.query as ReleaseLookupQuery;
@@ -255,8 +252,8 @@ export function registerReleaseRoutes(app: FastifyInstance, context: ReleaseRout
       throw routeError(400, 'invalid_request', 'entity_slug, title, date, and stream query parameters are required.');
     }
 
-    const normalizedTitle = normalizeLegacyReleaseTitle(title);
-    if (!ISO_DATE_PATTERN.test(date) || !VALID_STREAMS.has(stream) || normalizedTitle.length === 0) {
+    const lookup = buildReleaseLookupKey(entity_slug, title, date, stream);
+    if (!ISO_DATE_PATTERN.test(lookup.release_date) || !VALID_STREAMS.has(lookup.stream) || lookup.entity_slug.length === 0 || lookup.normalized_release_title.length === 0) {
       throw routeError(
         400,
         'invalid_request',
@@ -289,7 +286,7 @@ export function registerReleaseRoutes(app: FastifyInstance, context: ReleaseRout
           and stream = $4
         limit 1
       `,
-      [entity_slug, normalizedTitle, date, stream]
+      [lookup.entity_slug, lookup.normalized_release_title, lookup.release_date, lookup.stream]
     );
 
     const row = result.rows[0];

--- a/backend/src/routes/search.ts
+++ b/backend/src/routes/search.ts
@@ -3,6 +3,7 @@ import type { FastifyInstance } from 'fastify';
 import { buildReadDataEnvelope, routeError } from '../lib/api.js';
 import type { AppConfig } from '../config.js';
 import type { DbQueryable } from '../lib/db.js';
+import { buildSearchNeedle, compactNormalizedAlias, normalizeAliasValue, type SearchNeedle } from '../lib/normalization.js';
 
 type SearchRouteContext = {
   config: AppConfig;
@@ -74,12 +75,6 @@ type EntitySearchPayload = {
   } | null;
 };
 
-type SearchNeedle = {
-  raw: string;
-  normalized: string;
-  compact: string;
-};
-
 type EntityMatch = {
   entity_id: string;
   entity_slug: string;
@@ -149,35 +144,6 @@ function asNumber(value: unknown): number | null {
   }
 
   return null;
-}
-
-function normalizeSearchText(value: string): string {
-  return value
-    .normalize('NFKC')
-    .replace(/[×✕]/g, 'x')
-    .replace(/&/g, ' and ')
-    .toLowerCase()
-    .replace(/['’`]/g, '')
-    .replace(/[^a-z0-9ㄱ-ㅎㅏ-ㅣ가-힣]+/g, ' ')
-    .replace(/\s+/g, ' ')
-    .trim();
-}
-
-function collapseSearchText(value: string): string {
-  return value.replace(/\s+/g, '');
-}
-
-function buildSearchNeedle(raw: string): SearchNeedle | null {
-  const normalized = normalizeSearchText(raw);
-  if (!normalized) {
-    return null;
-  }
-
-  return {
-    raw,
-    normalized,
-    compact: collapseSearchText(normalized),
-  };
 }
 
 function toIsoString(value: Date | string | undefined): string {
@@ -277,12 +243,12 @@ function normalizeEntityPayload(payload: unknown): EntitySearchPayload | null {
 
 function findExactMatch(values: string[], needle: SearchNeedle): string | null {
   for (const value of values) {
-    const normalized = normalizeSearchText(value);
+    const normalized = normalizeAliasValue(value);
     if (!normalized) {
       continue;
     }
 
-    if (normalized === needle.normalized || collapseSearchText(normalized) === needle.compact) {
+    if (normalized === needle.normalized || compactNormalizedAlias(normalized) === needle.compact) {
       return value;
     }
   }
@@ -292,12 +258,12 @@ function findExactMatch(values: string[], needle: SearchNeedle): string | null {
 
 function findPartialMatch(values: string[], needle: SearchNeedle): string | null {
   for (const value of values) {
-    const normalized = normalizeSearchText(value);
+    const normalized = normalizeAliasValue(value);
     if (!normalized) {
       continue;
     }
 
-    if (normalized.includes(needle.normalized) || collapseSearchText(normalized).includes(needle.compact)) {
+    if (normalized.includes(needle.normalized) || compactNormalizedAlias(normalized).includes(needle.compact)) {
       return value;
     }
   }
@@ -478,8 +444,8 @@ export function registerSearchRoutes(app: FastifyInstance, context: SearchRouteC
 
     const releaseMatchMap = new Map<string, ReleaseMatch>();
     for (const row of releaseTitleResult.rows) {
-      const normalizedTitle = normalizeSearchText(row.release_title);
-      const isExact = normalizedTitle === needle.normalized || collapseSearchText(normalizedTitle) === needle.compact;
+      const normalizedTitle = normalizeAliasValue(row.release_title);
+      const isExact = normalizedTitle === needle.normalized || compactNormalizedAlias(normalizedTitle) === needle.compact;
 
       releaseMatchMap.set(row.release_id, {
         release_id: row.release_id,
@@ -589,8 +555,8 @@ export function registerSearchRoutes(app: FastifyInstance, context: SearchRouteC
 
     const upcomingMatchMap = new Map<string, UpcomingMatch>();
     for (const row of upcomingTitleResult.rows) {
-      const normalizedHeadline = normalizeSearchText(row.headline);
-      const isExact = normalizedHeadline === needle.normalized || collapseSearchText(normalizedHeadline) === needle.compact;
+      const normalizedHeadline = normalizeAliasValue(row.headline);
+      const isExact = normalizedHeadline === needle.normalized || compactNormalizedAlias(normalizedHeadline) === needle.compact;
 
       upcomingMatchMap.set(row.upcoming_signal_id, {
         upcoming_signal_id: row.upcoming_signal_id,

--- a/canonical_normalization.py
+++ b/canonical_normalization.py
@@ -1,0 +1,46 @@
+import re
+import unicodedata
+from typing import Tuple
+
+
+def normalize_lookup_text(value: str) -> str:
+    return (
+        unicodedata.normalize("NFKC", value)
+        .replace("×", "x")
+        .replace("✕", "x")
+        .replace("&", " and ")
+        .lower()
+        .replace("'", "")
+        .replace("’", "")
+        .replace("`", "")
+    )
+
+
+def collapse_normalized_text(value: str) -> str:
+    collapsed = re.sub(r"[^a-z0-9\u3131-\u318e\uac00-\ud7a3]+", " ", value)
+    collapsed = re.sub(r"\s+", " ", collapsed).strip()
+    return collapsed
+
+
+def normalize_alias_value(value: str) -> str:
+    return collapse_normalized_text(normalize_lookup_text(value))
+
+
+def normalize_release_lookup_title(value: str) -> str:
+    return normalize_alias_value(value)
+
+
+def normalize_slug_value(value: str) -> str:
+    normalized = unicodedata.normalize("NFKC", value).lower()
+    normalized = re.sub(r"[^a-z0-9_-]+", "-", normalized)
+    normalized = re.sub(r"-{2,}", "-", normalized)
+    return normalized.strip("-_")
+
+
+def build_release_lookup_key(entity_slug: str, release_title: str, release_date: str, stream: str) -> Tuple[str, str, str, str]:
+    return (
+        normalize_slug_value(entity_slug),
+        normalize_release_lookup_title(release_title),
+        release_date.strip(),
+        stream.strip().lower(),
+    )

--- a/import_json_to_neon.py
+++ b/import_json_to_neon.py
@@ -2,7 +2,6 @@ import argparse
 import json
 import os
 import re
-import unicodedata
 import uuid
 from collections import Counter
 from datetime import date, datetime, timezone
@@ -10,6 +9,8 @@ from email.utils import parsedate_to_datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 from urllib.parse import urlsplit, urlunsplit
+
+import canonical_normalization
 
 try:
     import psycopg
@@ -138,26 +139,15 @@ def normalize_url(value: Any) -> Optional[str]:
 
 
 def normalize_search_text(value: str) -> str:
-    return (
-        unicodedata.normalize("NFKC", value)
-        .replace("×", "x")
-        .replace("✕", "x")
-        .replace("&", " and ")
-        .lower()
-        .replace("'", "")
-        .replace("’", "")
-        .replace("`", "")
-    )
+    return canonical_normalization.normalize_lookup_text(value)
 
 
 def collapse_normalized_text(value: str) -> str:
-    collapsed = re.sub(r"[^a-z0-9\u3131-\u318e\uac00-\ud7a3]+", " ", value)
-    collapsed = re.sub(r"\s+", " ", collapsed).strip()
-    return collapsed
+    return canonical_normalization.collapse_normalized_text(value)
 
 
 def normalize_text(value: str) -> str:
-    return collapse_normalized_text(normalize_search_text(value))
+    return canonical_normalization.normalize_alias_value(value)
 
 
 def stable_uuid(kind: str, *parts: Any) -> uuid.UUID:
@@ -249,7 +239,7 @@ def classify_alias_type(alias: str, source: str) -> str:
 
 
 def release_key(group: str, release_title: str, release_date: str, stream: str) -> Tuple[str, str, str, str]:
-    return (group, normalize_text(release_title), release_date, stream)
+    return canonical_normalization.build_release_lookup_key(group, release_title, release_date, stream)
 
 
 def pretty_release_key(group: str, release_title: str, release_date: str, stream: str) -> str:
@@ -518,7 +508,8 @@ def build_entity_rows(
     entity_ids: Dict[str, uuid.UUID] = {}
 
     for profile in sorted(artist_profiles, key=lambda row: row["group"].casefold()):
-        entity_id = stable_uuid("entity", profile["slug"])
+        normalized_slug = canonical_normalization.normalize_slug_value(profile["slug"])
+        entity_id = stable_uuid("entity", normalized_slug)
         watchlist_row = watchlist_by_group.get(profile["group"], {})
         metadata = group_metadata.get(profile["group"], {})
 
@@ -526,7 +517,7 @@ def build_entity_rows(
         entity_rows.append(
             {
                 "id": entity_id,
-                "slug": profile["slug"],
+                "slug": normalized_slug,
                 "canonical_name": profile["group"],
                 "display_name": profile.get("display_name") or profile["group"],
                 "entity_type": infer_entity_type(profile),


### PR DESCRIPTION
## Summary
- add shared normalization helpers for Python import/dual-write code and backend read routes
- route entity slug, search query, and release lookup inputs through the shared helpers
- document that Python, TypeScript, and SQL normalization paths must stay semantically aligned

## Verification
- python3 -m py_compile canonical_normalization.py import_json_to_neon.py sync_release_pipeline_to_neon.py sync_upcoming_pipeline_to_neon.py
- cd backend && npm run build
- helper parity spot-check in Python and Node
- runtime checks: GET /v1/entities/YENA, GET /v1/releases/lookup?entity_slug=IVE&title=REVIVE%2B&date=2026-02-23&stream=ALBUM
- git diff --check

Closes #225