### PR TITLE
Backfill canonical entity visual identity metadata

### DIFF
--- a/backend/sql/migrations/0003_entity_visual_identity_metadata.sql
+++ b/backend/sql/migrations/0003_entity_visual_identity_metadata.sql
@@ -1,0 +1,213 @@
+alter table entities
+  add column if not exists badge_image_url text,
+  add column if not exists badge_source_url text,
+  add column if not exists badge_source_label text,
+  add column if not exists badge_kind text;
+
+drop materialized view if exists entity_detail_projection;
+
+create materialized view entity_detail_projection as
+with official_link_summary as (
+  select
+    eol.entity_id,
+    max(eol.url) filter (where eol.link_type = 'youtube') as youtube_url,
+    max(eol.url) filter (where eol.link_type = 'x') as x_url,
+    max(eol.url) filter (where eol.link_type = 'instagram') as instagram_url,
+    max(eol.url) filter (where eol.link_type = 'artist_source') as artist_source_url
+  from entity_official_links eol
+  group by eol.entity_id
+),
+youtube_channel_summary as (
+  select
+    eyc.entity_id,
+    min(yc.canonical_channel_url) filter (where eyc.channel_role in ('primary_team_channel', 'both')) as primary_team_channel_url,
+    coalesce(
+      array_agg(distinct yc.canonical_channel_url order by yc.canonical_channel_url)
+        filter (where eyc.channel_role in ('mv_allowlist', 'both')),
+      '{}'::text[]
+    ) as mv_allowlist_urls
+  from entity_youtube_channels eyc
+  join youtube_channels yc on yc.id = eyc.youtube_channel_id
+  group by eyc.entity_id
+),
+latest_release as (
+  select distinct on (r.entity_id)
+    r.entity_id,
+    r.id as release_id,
+    r.release_title,
+    r.release_date,
+    r.stream,
+    r.release_kind
+  from releases r
+  order by
+    r.entity_id,
+    r.release_date desc,
+    case when r.stream = 'album' then 0 else 1 end,
+    r.release_title asc
+),
+next_upcoming as (
+  select distinct on (u.entity_id)
+    u.entity_id,
+    u.id as upcoming_signal_id,
+    u.headline,
+    u.scheduled_date,
+    u.scheduled_month,
+    u.date_precision,
+    u.date_status,
+    u.release_format,
+    u.confidence_score,
+    u.latest_seen_at
+  from upcoming_signals u
+  where
+    u.is_active = true
+    and u.date_precision = 'exact'
+    and u.scheduled_date >= timezone('Asia/Seoul', now())::date
+  order by
+    u.entity_id,
+    u.scheduled_date asc,
+    u.confidence_score desc nulls last,
+    u.latest_seen_at desc nulls last,
+    u.id
+),
+recent_albums as (
+  select
+    ranked.entity_id,
+    jsonb_agg(
+      jsonb_build_object(
+        'release_id', ranked.release_id::text,
+        'release_title', ranked.release_title,
+        'release_date', ranked.release_date::text,
+        'stream', ranked.stream,
+        'release_kind', ranked.release_kind
+      )
+      order by ranked.release_date desc, ranked.release_title asc
+    ) as recent_albums
+  from (
+    select
+      r.entity_id,
+      r.id as release_id,
+      r.release_title,
+      r.release_date,
+      r.stream,
+      r.release_kind,
+      row_number() over (
+        partition by r.entity_id
+        order by r.release_date desc, r.release_title asc
+      ) as release_rank
+    from releases r
+    where r.stream = 'album'
+  ) ranked
+  where ranked.release_rank <= 12
+  group by ranked.entity_id
+),
+source_timeline as (
+  select
+    timeline.entity_id,
+    jsonb_agg(timeline.payload order by timeline.sort_at desc, timeline.sort_headline asc) as source_timeline
+  from (
+    select
+      us.entity_id,
+      coalesce(uss.published_at, us.latest_seen_at, us.first_seen_at, now()) as sort_at,
+      us.headline as sort_headline,
+      row_number() over (
+        partition by us.entity_id
+        order by coalesce(uss.published_at, us.latest_seen_at, us.first_seen_at, now()) desc, us.headline asc
+      ) as timeline_rank,
+      jsonb_build_object(
+        'headline', us.headline,
+        'scheduled_date', us.scheduled_date::text,
+        'scheduled_month', us.scheduled_month::text,
+        'date_precision', us.date_precision,
+        'date_status', us.date_status,
+        'release_format', us.release_format,
+        'confidence_score', us.confidence_score,
+        'source_type', uss.source_type,
+        'source_url', uss.source_url,
+        'source_domain', uss.source_domain,
+        'published_at', coalesce(uss.published_at, us.latest_seen_at, us.first_seen_at)
+      ) as payload
+    from upcoming_signals us
+    left join upcoming_signal_sources uss on uss.upcoming_signal_id = us.id
+    where us.is_active = true
+  ) timeline
+  where timeline.timeline_rank <= 12
+  group by timeline.entity_id
+)
+select
+  e.id as entity_id,
+  e.slug as entity_slug,
+  jsonb_build_object(
+    'identity', jsonb_build_object(
+      'entity_slug', e.slug,
+      'display_name', e.display_name,
+      'canonical_name', e.canonical_name,
+      'entity_type', e.entity_type,
+      'agency_name', e.agency_name,
+      'debut_year', e.debut_year,
+      'badge_image_url', e.badge_image_url,
+      'badge_source_url', e.badge_source_url,
+      'badge_source_label', e.badge_source_label,
+      'badge_kind', e.badge_kind,
+      'representative_image_url', e.representative_image_url,
+      'representative_image_source', e.representative_image_source
+    ),
+    'official_links', jsonb_strip_nulls(
+      jsonb_build_object(
+        'youtube', ols.youtube_url,
+        'x', ols.x_url,
+        'instagram', ols.instagram_url
+      )
+    ),
+    'youtube_channels', jsonb_build_object(
+      'primary_team_channel_url', ycs.primary_team_channel_url,
+      'mv_allowlist_urls', to_jsonb(coalesce(ycs.mv_allowlist_urls, '{}'::text[]))
+    ),
+    'tracking_state', jsonb_build_object(
+      'tier', ets.tier,
+      'watch_reason', ets.watch_reason,
+      'tracking_status', ets.tracking_status
+    ),
+    'next_upcoming', case
+      when nu.entity_id is null then null
+      else jsonb_build_object(
+        'upcoming_signal_id', nu.upcoming_signal_id::text,
+        'headline', nu.headline,
+        'scheduled_date', nu.scheduled_date::text,
+        'scheduled_month', nu.scheduled_month::text,
+        'date_precision', nu.date_precision,
+        'date_status', nu.date_status,
+        'release_format', nu.release_format,
+        'confidence_score', nu.confidence_score,
+        'latest_seen_at', nu.latest_seen_at
+      )
+    end,
+    'latest_release', case
+      when lr.entity_id is null then null
+      else jsonb_build_object(
+        'release_id', lr.release_id::text,
+        'release_title', lr.release_title,
+        'release_date', lr.release_date::text,
+        'stream', lr.stream,
+        'release_kind', lr.release_kind
+      )
+    end,
+    'recent_albums', coalesce(ra.recent_albums, '[]'::jsonb),
+    'source_timeline', coalesce(st.source_timeline, '[]'::jsonb),
+    'artist_source_url', ols.artist_source_url
+  ) as payload,
+  now() as generated_at
+from entities e
+left join entity_tracking_state ets on ets.entity_id = e.id
+left join official_link_summary ols on ols.entity_id = e.id
+left join youtube_channel_summary ycs on ycs.entity_id = e.id
+left join latest_release lr on lr.entity_id = e.id
+left join next_upcoming nu on nu.entity_id = e.id
+left join recent_albums ra on ra.entity_id = e.id
+left join source_timeline st on st.entity_id = e.id
+with no data;
+
+create unique index if not exists idx_entity_detail_projection_entity_id
+  on entity_detail_projection (entity_id);
+
+create unique index if not exists idx_entity_detail_projection_slug
+  on entity_detail_projection (entity_slug);

--- a/backend/src/routes/entities.ts
+++ b/backend/src/routes/entities.ts
@@ -42,7 +42,11 @@ type IdentityBlock = {
   agency_name: string | null;
   debut_year: number | null;
   badge_image_url: string | null;
+  badge_source_url: string | null;
+  badge_source_label: string | null;
+  badge_kind: string | null;
   representative_image_url: string | null;
+  representative_image_source: string | null;
 };
 
 type TrackingStateBlock = {
@@ -250,7 +254,11 @@ function normalizeEntityDetailPayload(payload: unknown, slug: string): EntityDet
       agency_name: asNullableString(identityValue.agency_name),
       debut_year: asNullableNumber(identityValue.debut_year),
       badge_image_url: asNullableString(identityValue.badge_image_url),
+      badge_source_url: asNullableString(identityValue.badge_source_url),
+      badge_source_label: asNullableString(identityValue.badge_source_label),
+      badge_kind: asNullableString(identityValue.badge_kind),
       representative_image_url: asNullableString(identityValue.representative_image_url),
+      representative_image_source: asNullableString(identityValue.representative_image_source),
     },
     official_links: {
       youtube: asNullableString(officialLinks.youtube),

--- a/docs/specs/backend/canonical-backend-data-model.md
+++ b/docs/specs/backend/canonical-backend-data-model.md
@@ -94,6 +94,10 @@
 | `entity_type` | `text` | `group | solo | unit | project` |
 | `agency_name` | `text null` | text first, agency table later |
 | `debut_year` | `int null` | optional seed |
+| `badge_image_url` | `text null` | canonical badge/avatar asset URL when available |
+| `badge_source_url` | `text null` | source page/channel for badge asset provenance |
+| `badge_source_label` | `text null` | human-readable provenance label |
+| `badge_kind` | `text null` | current seed kind, e.g. `official_channel_avatar` |
 | `representative_image_url` | `text null` | team hero / badge fallback |
 | `representative_image_source` | `text null` | provenance |
 | `created_at` | `timestamptz` | audit |

--- a/docs/specs/backend/shared-read-api-contracts.md
+++ b/docs/specs/backend/shared-read-api-contracts.md
@@ -291,7 +291,11 @@
       "agency_name": "BIGHIT MUSIC",
       "debut_year": 2019,
       "badge_image_url": "https://...",
-      "representative_image_url": "https://..."
+      "badge_source_url": "https://www.youtube.com/@TXT_bighit",
+      "badge_source_label": "Official YouTube channel avatar",
+      "badge_kind": "official_channel_avatar",
+      "representative_image_url": "https://...",
+      "representative_image_source": "artistProfiles.representative_image_url"
     },
     "official_links": {
       "youtube": "https://www.youtube.com/@TXT_bighit",

--- a/import_json_to_neon.py
+++ b/import_json_to_neon.py
@@ -25,6 +25,7 @@ ROOT = Path(__file__).resolve().parent
 BACKEND_REPORTS_DIR = ROOT / "backend" / "reports"
 DEFAULT_SUMMARY_PATH = BACKEND_REPORTS_DIR / "json_to_neon_import_summary.json"
 ARTIST_PROFILES_PATH = ROOT / "web" / "src" / "data" / "artistProfiles.json"
+TEAM_BADGE_ASSETS_PATH = ROOT / "web" / "src" / "data" / "teamBadgeAssets.json"
 YOUTUBE_ALLOWLISTS_PATH = ROOT / "web" / "src" / "data" / "youtubeChannelAllowlists.json"
 RELEASE_DETAILS_PATH = ROOT / "web" / "src" / "data" / "releaseDetails.json"
 RELEASE_HISTORY_PATH = ROOT / "web" / "src" / "data" / "releaseHistory.json"
@@ -501,6 +502,7 @@ def build_group_metadata(
 
 def build_entity_rows(
     artist_profiles: Sequence[Dict[str, Any]],
+    team_badge_assets_by_group: Dict[str, Dict[str, Any]],
     watchlist_by_group: Dict[str, Dict[str, Any]],
     group_metadata: Dict[str, Dict[str, Optional[str]]],
 ) -> Tuple[List[Dict[str, Any]], Dict[str, uuid.UUID]]:
@@ -512,6 +514,7 @@ def build_entity_rows(
         entity_id = stable_uuid("entity", normalized_slug)
         watchlist_row = watchlist_by_group.get(profile["group"], {})
         metadata = group_metadata.get(profile["group"], {})
+        badge_asset = team_badge_assets_by_group.get(profile["group"], {})
 
         entity_ids[profile["group"]] = entity_id
         entity_rows.append(
@@ -523,6 +526,10 @@ def build_entity_rows(
                 "entity_type": infer_entity_type(profile),
                 "agency_name": optional_text(profile.get("agency")),
                 "debut_year": profile.get("debut_year"),
+                "badge_image_url": normalize_url(badge_asset.get("badge_image_url")),
+                "badge_source_url": normalize_url(badge_asset.get("badge_source_url")),
+                "badge_source_label": optional_text(badge_asset.get("badge_source_label")),
+                "badge_kind": optional_text(badge_asset.get("badge_kind")),
                 "representative_image_url": normalize_url(profile.get("representative_image_url")),
                 "representative_image_source": optional_text(profile.get("representative_image_source")),
                 "x_url": normalize_url(profile.get("official_x_url") or watchlist_row.get("x_url")),
@@ -1343,6 +1350,7 @@ def compare_rollup_release_refs(
 
 def build_import_payload() -> Dict[str, Any]:
     artist_profiles = load_json(ARTIST_PROFILES_PATH)
+    team_badge_assets = load_json(TEAM_BADGE_ASSETS_PATH)
     youtube_allowlists = load_json(YOUTUBE_ALLOWLISTS_PATH)
     release_details = load_json(RELEASE_DETAILS_PATH)
     release_history = load_json(RELEASE_HISTORY_PATH)
@@ -1355,6 +1363,7 @@ def build_import_payload() -> Dict[str, Any]:
     releases_rollup = load_json(RELEASES_ROLLUP_PATH)
 
     watchlist_by_group = {row["group"]: row for row in watchlist}
+    team_badge_assets_by_group = {row["group"]: row for row in team_badge_assets if optional_text(row.get("group"))}
     youtube_allowlists_by_group = {row["group"]: row for row in youtube_allowlists}
     group_metadata = build_group_metadata(release_history, releases_rollup)
 
@@ -1362,6 +1371,7 @@ def build_import_payload() -> Dict[str, Any]:
         "generated_at": datetime.now(timezone.utc).isoformat(),
         "source_counts": {
             "artist_profiles": len(artist_profiles),
+            "team_badge_assets": len(team_badge_assets),
             "youtube_allowlists": len(youtube_allowlists),
             "release_details": len(release_details),
             "release_history_groups": len(release_history),
@@ -1381,7 +1391,7 @@ def build_import_payload() -> Dict[str, Any]:
         "unresolved_review_links": [],
     }
 
-    entity_rows, entity_ids = build_entity_rows(artist_profiles, watchlist_by_group, group_metadata)
+    entity_rows, entity_ids = build_entity_rows(artist_profiles, team_badge_assets_by_group, watchlist_by_group, group_metadata)
     alias_rows = build_alias_rows(artist_profiles, entity_ids, summary)
     official_link_rows = build_official_link_rows(entity_rows, watchlist_by_group, youtube_allowlists_by_group, summary)
     youtube_channel_rows, entity_channel_rows = build_youtube_channel_rows(youtube_allowlists, entity_ids, summary)
@@ -1643,9 +1653,10 @@ def upsert_table_rows(
             """
             insert into entities (
               id, slug, canonical_name, display_name, entity_type, agency_name, debut_year,
+              badge_image_url, badge_source_url, badge_source_label, badge_kind,
               representative_image_url, representative_image_source
             )
-            values (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+            values (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
             on conflict (id) do update set
               slug = excluded.slug,
               canonical_name = excluded.canonical_name,
@@ -1653,6 +1664,10 @@ def upsert_table_rows(
               entity_type = excluded.entity_type,
               agency_name = excluded.agency_name,
               debut_year = excluded.debut_year,
+              badge_image_url = excluded.badge_image_url,
+              badge_source_url = excluded.badge_source_url,
+              badge_source_label = excluded.badge_source_label,
+              badge_kind = excluded.badge_kind,
               representative_image_url = excluded.representative_image_url,
               representative_image_source = excluded.representative_image_source,
               updated_at = now()
@@ -1666,6 +1681,10 @@ def upsert_table_rows(
                     row["entity_type"],
                     row["agency_name"],
                     row["debut_year"],
+                    row["badge_image_url"],
+                    row["badge_source_url"],
+                    row["badge_source_label"],
+                    row["badge_kind"],
                     row["representative_image_url"],
                     row["representative_image_source"],
                 )


### PR DESCRIPTION
## Summary
- add canonical badge visual-identity columns and entity-detail projection support
- import team badge asset metadata into canonical entities with explicit null handling
- expose badge and representative image metadata through entity detail payload contracts

## Verification
- python3 -m py_compile import_json_to_neon.py canonical_normalization.py
- cd backend && npm run build
- cd backend && npm run migrate:apply
- source .venv/bin/activate && python import_json_to_neon.py --summary-path /tmp/idol-song-app-228-import-summary.json
- cd backend && npm run projection:refresh
- inspect canonical entity rows and entity_detail_projection for BLACKPINK / ALLDAY PROJECT / YENA
- GET /v1/entities/blackpink badge metadata response check
- git diff --check

Closes #228