### PR TITLE
Add mobile storage and cache foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ python3 sync_release_pipeline_to_neon.py
 - env/runtime config layer: `mobile/.env.example`, `mobile/src/config/runtime.ts`
 - feature-gate layer: `mobile/src/config/featureGates.ts`
 - dataset-source layer: `mobile/src/services/datasetSource.ts`, `mobile/assets/datasets/README.md`
+- storage/cache layer: `mobile/src/services/storage.ts`, `mobile/src/services/datasetCache.ts`, `mobile/src/services/recentQueries.ts`
 - token/theme layer: `mobile/src/tokens/`, `mobile/src/tokens/theme.tsx`
 - selector/adapter layer: `mobile/src/selectors/`, `mobile/src/types/displayModels.ts`, `mobile/src/types/rawData.ts`
 - quality baseline: `mobile/eslint.config.js`, `mobile/jest.config.js`, `mobile/src/features/route-shell.smoke.test.tsx`, `mobile/src/config/runtime.test.ts`

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -30,6 +30,12 @@
   - gate registry / helper / off fallback definition
 - `src/services/datasetSource.ts`
   - bundled static data vs preview remote data selection layer
+- `src/services/storage.ts`
+  - `AsyncStorage` 기반 key-value storage adapter / namespace / shared key convention
+- `src/services/datasetCache.ts`
+  - static dataset artifact reuse용 cache entry helper
+- `src/services/recentQueries.ts`
+  - search recent-query persistence helper
 - `src/tokens/`
   - semantic token constants + theme provider + `useAppTheme()` access convention
 - `src/selectors/`
@@ -204,6 +210,26 @@ profile 차이는 아래 범위로만 제한한다.
   - 위 3조건이 모두 맞을 때만 선택된다.
 - field contract
   - bundled source와 preview remote source는 같은 artifact id / field contract를 유지해야 한다.
+
+## storage / cache baseline
+
+- lightweight storage choice는 `@react-native-async-storage/async-storage`로 고정한다.
+- 공통 namespace는 `idol-song-app/mobile/v1`이다.
+- shared foundation entrypoint
+  - `src/services/storage.ts`
+    - storage adapter binding
+    - namespaced key builder
+    - JSON read/write/remove helper
+  - `src/services/datasetCache.ts`
+    - dataset artifact cache entry
+    - source kind / dataset version 분리 key
+  - `src/services/recentQueries.ts`
+    - recent query read/write/clear
+- 규칙
+  - 화면은 `AsyncStorage`를 직접 호출하지 않는다.
+  - static dataset reuse cache는 dataset contract id + source kind + dataset version + artifact id 기준으로 분리한다.
+  - recent query persistence는 같은 namespace/key 규칙을 재사용한다.
+  - later search/calendar/entity screen은 ad hoc local-storage key를 새로 만들지 않는다.
 
 ## feature-gate baseline
 

--- a/mobile/jest.setup.ts
+++ b/mobile/jest.setup.ts
@@ -1,2 +1,5 @@
-// Reserved for future global test setup. Keep this file explicit so later mobile work
-// has one place to register shared mocks and custom matchers.
+import mockAsyncStorage from '@react-native-async-storage/async-storage/jest/async-storage-mock';
+
+// Register shared native mocks once so service/config tests can stay focused on
+// app behavior instead of per-file native module setup.
+jest.mock('@react-native-async-storage/async-storage', () => mockAsyncStorage);

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -8,6 +8,7 @@
       "name": "idol-song-app-mobile",
       "version": "0.1.0",
       "dependencies": {
+        "@react-native-async-storage/async-storage": "2.2.0",
         "@react-navigation/native": "^7.1.28",
         "expo": "~55.0.5",
         "expo-constants": "~55.0.7",
@@ -3375,6 +3376,18 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.2.0.tgz",
+      "integrity": "sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==",
+      "license": "MIT",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.65 <1.0"
       }
     },
     "node_modules/@react-native/assets-registry": {
@@ -9114,6 +9127,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
@@ -11354,6 +11376,18 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
       "license": "MIT"
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -20,6 +20,7 @@
     "config:production": "cross-env APP_ENV=production expo config --json"
   },
   "dependencies": {
+    "@react-native-async-storage/async-storage": "2.2.0",
     "@react-navigation/native": "^7.1.28",
     "expo": "~55.0.5",
     "expo-constants": "~55.0.7",

--- a/mobile/src/README.md
+++ b/mobile/src/README.md
@@ -13,6 +13,9 @@
   - `index.ts`: shared selectors entrypoint
 - `services/`: data source / external handoff / helper
   - `datasetSource.ts`: bundled-static vs preview-remote source selector
+  - `storage.ts`: `AsyncStorage` adapter + namespaced key/value helper
+  - `datasetCache.ts`: static dataset artifact cache entry helper
+  - `recentQueries.ts`: recent-query persistence helper
 - `tokens/`: design token / theme
   - `theme.tsx`: theme provider + `useAppTheme()` access convention
   - `colors.ts`, `spacing.ts`, `radii.ts`, `typography.ts`, `sizes.ts`, `elevation.ts`, `motion.ts`
@@ -23,3 +26,9 @@
   - `assetRegistry.ts`: bundled placeholder/service/badge asset entrypoint
 
 현재는 bootstrap 단계지만 config/service foundation은 실제 모듈로 열어둔다.
+
+storage 관련 규칙:
+
+- `AsyncStorage`를 직접 화면에서 호출하지 않는다.
+- dataset cache와 recent query는 모두 `services/storage.ts` namespace 규칙을 공유한다.
+- later feature는 raw storage key를 직접 만들지 않고 service helper를 통해 접근한다.

--- a/mobile/src/services/datasetCache.ts
+++ b/mobile/src/services/datasetCache.ts
@@ -1,0 +1,65 @@
+import {
+  type DatasetArtifactId,
+  type DatasetSelection,
+  selectDatasetSource,
+} from './datasetSource';
+import {
+  buildDatasetCacheKey,
+  readStoredJson,
+  removeStoredJson,
+  writeStoredJson,
+} from './storage';
+
+export type DatasetCacheEntry<T> = {
+  artifactId: DatasetArtifactId;
+  contractId: DatasetSelection['contractId'];
+  datasetVersion: string | null;
+  sourceKind: DatasetSelection['kind'];
+  cachedAt: string;
+  value: T;
+};
+
+export function getDatasetCacheKey(
+  artifactId: DatasetArtifactId,
+  selection: DatasetSelection = selectDatasetSource(),
+): string {
+  return buildDatasetCacheKey(
+    selection.contractId,
+    selection.kind,
+    selection.datasetVersion,
+    artifactId,
+  );
+}
+
+export async function readDatasetCacheEntry<T>(
+  artifactId: DatasetArtifactId,
+  selection: DatasetSelection = selectDatasetSource(),
+): Promise<DatasetCacheEntry<T> | null> {
+  return readStoredJson<DatasetCacheEntry<T>>(getDatasetCacheKey(artifactId, selection));
+}
+
+export async function writeDatasetCacheEntry<T>(
+  artifactId: DatasetArtifactId,
+  value: T,
+  selection: DatasetSelection = selectDatasetSource(),
+  cachedAt: string = new Date().toISOString(),
+): Promise<DatasetCacheEntry<T>> {
+  const entry: DatasetCacheEntry<T> = {
+    artifactId,
+    contractId: selection.contractId,
+    datasetVersion: selection.datasetVersion,
+    sourceKind: selection.kind,
+    cachedAt,
+    value,
+  };
+
+  await writeStoredJson(getDatasetCacheKey(artifactId, selection), entry);
+  return entry;
+}
+
+export async function clearDatasetCacheEntry(
+  artifactId: DatasetArtifactId,
+  selection: DatasetSelection = selectDatasetSource(),
+): Promise<void> {
+  await removeStoredJson(getDatasetCacheKey(artifactId, selection));
+}

--- a/mobile/src/services/recentQueries.ts
+++ b/mobile/src/services/recentQueries.ts
@@ -1,0 +1,44 @@
+import { MOBILE_STORAGE_KEYS, RECENT_QUERY_LIMIT, readStoredJson, removeStoredJson, writeStoredJson } from './storage';
+
+function normalizeQuery(value: string): string {
+  return value.trim().replace(/\s+/g, ' ');
+}
+
+function comparisonKey(value: string): string {
+  return normalizeQuery(value).normalize('NFKC').toLowerCase();
+}
+
+export async function readRecentQueries(): Promise<string[]> {
+  const stored = await readStoredJson<unknown>(MOBILE_STORAGE_KEYS.recentQueries);
+
+  if (!Array.isArray(stored)) {
+    return [];
+  }
+
+  return stored
+    .filter((item): item is string => typeof item === 'string')
+    .map(normalizeQuery)
+    .filter(Boolean)
+    .slice(0, RECENT_QUERY_LIMIT);
+}
+
+export async function persistRecentQuery(query: string): Promise<string[]> {
+  const normalized = normalizeQuery(query);
+
+  if (!normalized) {
+    return readRecentQueries();
+  }
+
+  const existing = await readRecentQueries();
+  const next = [
+    normalized,
+    ...existing.filter((item) => comparisonKey(item) !== comparisonKey(normalized)),
+  ].slice(0, RECENT_QUERY_LIMIT);
+
+  await writeStoredJson(MOBILE_STORAGE_KEYS.recentQueries, next);
+  return next;
+}
+
+export async function clearRecentQueries(): Promise<void> {
+  await removeStoredJson(MOBILE_STORAGE_KEYS.recentQueries);
+}

--- a/mobile/src/services/storage.test.ts
+++ b/mobile/src/services/storage.test.ts
@@ -1,0 +1,126 @@
+import {
+  MOBILE_STORAGE_KEYS,
+  RECENT_QUERY_LIMIT,
+  buildDatasetCacheKey,
+  resetStorageAdapter,
+  setStorageAdapter,
+  type KeyValueStorageAdapter,
+} from './storage';
+import {
+  clearDatasetCacheEntry,
+  getDatasetCacheKey,
+  readDatasetCacheEntry,
+  writeDatasetCacheEntry,
+} from './datasetCache';
+import { clearRecentQueries, persistRecentQuery, readRecentQueries } from './recentQueries';
+import type { DatasetSelection } from './datasetSource';
+
+function createMemoryStorage(): KeyValueStorageAdapter {
+  const values = new Map<string, string>();
+
+  return {
+    async getItem(key) {
+      return values.has(key) ? values.get(key) ?? null : null;
+    },
+    async setItem(key, value) {
+      values.set(key, value);
+    },
+    async removeItem(key) {
+      values.delete(key);
+    },
+  };
+}
+
+const bundledSelection: DatasetSelection = {
+  kind: 'bundled-static',
+  reason: 'profile_default',
+  contractId: 'idol-song-mobile-static-v1',
+  datasetVersion: 'v1',
+  mixingAllowed: false,
+  bundledBasePath: 'mobile/assets/datasets/v1',
+  artifacts: [],
+};
+
+const previewSelection: DatasetSelection = {
+  kind: 'preview-remote',
+  reason: 'preview_remote_enabled',
+  contractId: 'idol-song-mobile-static-v1',
+  datasetVersion: 'preview-v2',
+  mixingAllowed: false,
+  remoteDatasetUrl: 'https://example.com/dataset.json',
+  artifacts: [],
+};
+
+describe('mobile storage foundations', () => {
+  beforeEach(() => {
+    setStorageAdapter(createMemoryStorage());
+  });
+
+  afterEach(() => {
+    resetStorageAdapter();
+  });
+
+  test('builds namespaced dataset cache keys', () => {
+    expect(buildDatasetCacheKey('idol-song-mobile-static-v1', 'bundled-static', 'v1', 'releases')).toBe(
+      'idol-song-app/mobile/v1/dataset-cache/idol-song-mobile-static-v1/bundled-static/v1/releases',
+    );
+    expect(buildDatasetCacheKey('idol-song-mobile-static-v1', 'bundled-static', null, 'releases')).toBe(
+      'idol-song-app/mobile/v1/dataset-cache/idol-song-mobile-static-v1/bundled-static/unversioned/releases',
+    );
+  });
+
+  test('round-trips dataset cache entries and isolates source selections', async () => {
+    await writeDatasetCacheEntry('releases', { rows: 10 }, bundledSelection, '2026-03-08T00:00:00.000Z');
+    await writeDatasetCacheEntry('releases', { rows: 12 }, previewSelection, '2026-03-08T01:00:00.000Z');
+
+    await expect(readDatasetCacheEntry<{ rows: number }>('releases', bundledSelection)).resolves.toEqual({
+      artifactId: 'releases',
+      contractId: bundledSelection.contractId,
+      datasetVersion: bundledSelection.datasetVersion,
+      sourceKind: bundledSelection.kind,
+      cachedAt: '2026-03-08T00:00:00.000Z',
+      value: { rows: 10 },
+    });
+
+    await expect(readDatasetCacheEntry<{ rows: number }>('releases', previewSelection)).resolves.toEqual({
+      artifactId: 'releases',
+      contractId: previewSelection.contractId,
+      datasetVersion: previewSelection.datasetVersion,
+      sourceKind: previewSelection.kind,
+      cachedAt: '2026-03-08T01:00:00.000Z',
+      value: { rows: 12 },
+    });
+
+    await clearDatasetCacheEntry('releases', bundledSelection);
+    await expect(readDatasetCacheEntry('releases', bundledSelection)).resolves.toBeNull();
+    await expect(readDatasetCacheEntry('releases', previewSelection)).resolves.not.toBeNull();
+    expect(getDatasetCacheKey('releases', bundledSelection)).not.toBe(getDatasetCacheKey('releases', previewSelection));
+  });
+
+  test('persists recent queries with dedupe, trim, and limit handling', async () => {
+    await persistRecentQuery('  투바투 ');
+    await persistRecentQuery('최예나');
+    await persistRecentQuery('투바투');
+
+    const queriesAfterDedupe = await readRecentQueries();
+    expect(queriesAfterDedupe).toEqual(['투바투', '최예나']);
+
+    for (let index = 0; index < RECENT_QUERY_LIMIT + 2; index += 1) {
+      await persistRecentQuery(`query ${index}`);
+    }
+
+    const limitedQueries = await readRecentQueries();
+    expect(limitedQueries).toHaveLength(RECENT_QUERY_LIMIT);
+    expect(limitedQueries[0]).toBe(`query ${RECENT_QUERY_LIMIT + 1}`);
+    expect(limitedQueries.at(-1)).toBe('query 2');
+  });
+
+  test('clears recent queries from the shared storage key', async () => {
+    await persistRecentQuery('YENA');
+    expect(await readRecentQueries()).toEqual(['YENA']);
+
+    await clearRecentQueries();
+    expect(await readRecentQueries()).toEqual([]);
+    expect(MOBILE_STORAGE_KEYS.recentQueries).toBe('idol-song-app/mobile/v1/search/recent-queries');
+  });
+});

--- a/mobile/src/services/storage.ts
+++ b/mobile/src/services/storage.ts
@@ -1,0 +1,62 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export type KeyValueStorageAdapter = Pick<typeof AsyncStorage, 'getItem' | 'setItem' | 'removeItem'>;
+
+export const MOBILE_STORAGE_NAMESPACE = 'idol-song-app/mobile/v1';
+export const RECENT_QUERY_LIMIT = 10;
+
+let storageAdapter: KeyValueStorageAdapter = AsyncStorage;
+
+function buildNamespacedKey(scope: string, key: string): string {
+  return `${MOBILE_STORAGE_NAMESPACE}/${scope}/${key}`;
+}
+
+export const MOBILE_STORAGE_KEYS = {
+  recentQueries: buildNamespacedKey('search', 'recent-queries'),
+} as const;
+
+export function getStorageAdapter(): KeyValueStorageAdapter {
+  return storageAdapter;
+}
+
+export function setStorageAdapter(nextAdapter: KeyValueStorageAdapter): void {
+  storageAdapter = nextAdapter;
+}
+
+export function resetStorageAdapter(): void {
+  storageAdapter = AsyncStorage;
+}
+
+export function buildDatasetCacheKey(
+  contractId: string,
+  sourceKind: string,
+  datasetVersion: string | null,
+  artifactId: string,
+): string {
+  return buildNamespacedKey(
+    'dataset-cache',
+    `${contractId}/${sourceKind}/${datasetVersion ?? 'unversioned'}/${artifactId}`,
+  );
+}
+
+export async function readStoredJson<T>(storageKey: string): Promise<T | null> {
+  const raw = await storageAdapter.getItem(storageKey);
+
+  if (raw === null) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+}
+
+export async function writeStoredJson(storageKey: string, value: unknown): Promise<void> {
+  await storageAdapter.setItem(storageKey, JSON.stringify(value));
+}
+
+export async function removeStoredJson(storageKey: string): Promise<void> {
+  await storageAdapter.removeItem(storageKey);
+}


### PR DESCRIPTION
## Summary
- add an AsyncStorage-backed mobile storage foundation with shared namespaced JSON helpers
- add dataset cache and recent-query persistence helpers for later screen reuse
- document the storage/cache convention and cover it with mobile tests

## Verification
- cd mobile && npm install
- cd mobile && npm run lint
- cd mobile && npm run typecheck
- cd mobile && npm run test
- git diff --check

Closes #252