### PR TITLE
Add mobile handoff service layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ python3 sync_release_pipeline_to_neon.py
 - feature-gate layer: `mobile/src/config/featureGates.ts`
 - dataset-source layer: `mobile/src/services/datasetSource.ts`, `mobile/assets/datasets/README.md`
 - storage/cache layer: `mobile/src/services/storage.ts`, `mobile/src/services/datasetCache.ts`, `mobile/src/services/recentQueries.ts`
+- external handoff layer: `mobile/src/services/handoff.ts`
 - token/theme layer: `mobile/src/tokens/`, `mobile/src/tokens/theme.tsx`
 - selector/adapter layer: `mobile/src/selectors/`, `mobile/src/types/displayModels.ts`, `mobile/src/types/rawData.ts`
 - quality baseline: `mobile/eslint.config.js`, `mobile/jest.config.js`, `mobile/src/features/route-shell.smoke.test.tsx`, `mobile/src/config/runtime.test.ts`

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -39,6 +39,8 @@
   - static dataset artifact reuse용 cache entry helper
 - `src/services/recentQueries.ts`
   - search recent-query persistence helper
+- `src/services/handoff.ts`
+  - canonical-open / search-fallback / browser-fallback handoff service layer
 - `src/tokens/`
   - semantic token constants + theme provider + `useAppTheme()` access convention
 - `src/selectors/`
@@ -205,6 +207,20 @@ profile 차이는 아래 범위로만 제한한다.
 - build version / dataset version / commit hash는 `src/config/debugMetadata.ts`를 통해 읽는다.
 - main tab이나 user-facing surface에는 진입 링크를 두지 않는다.
 - production profile에서는 route가 열려도 debug-only 안내만 보여준다.
+
+## external handoff baseline
+
+- shared handoff entrypoint는 `src/services/handoff.ts`에 둔다.
+- 지원 서비스
+  - `spotify`
+  - `youtubeMusic`
+  - `youtubeMv`
+- 규칙
+  - canonical URL이 안전하고 지원되는 경우 `mode = canonical`
+  - canonical URL이 없거나 지원되지 않으면 `mode = searchFallback`
+  - browser-safe fallback이 있으면 `browserFallback` target을 같이 유지한다.
+  - handoff 실패는 silent drop이 아니라 retryable failure result로 반환한다.
+  - later service button / detail screen은 `Linking.openURL`을 직접 호출하지 않고 이 service layer를 통해 연다.
 
 ## dataset-source baseline
 

--- a/mobile/src/README.md
+++ b/mobile/src/README.md
@@ -17,6 +17,7 @@
   - `storage.ts`: `AsyncStorage` adapter + namespaced key/value helper
   - `datasetCache.ts`: static dataset artifact cache entry helper
   - `recentQueries.ts`: recent-query persistence helper
+  - `handoff.ts`: canonical-open / search-fallback / browser-fallback resolver + opener
 - `tokens/`: design token / theme
   - `theme.tsx`: theme provider + `useAppTheme()` access convention
   - `colors.ts`, `spacing.ts`, `radii.ts`, `typography.ts`, `sizes.ts`, `elevation.ts`, `motion.ts`
@@ -33,3 +34,9 @@ storage 관련 규칙:
 - `AsyncStorage`를 직접 화면에서 호출하지 않는다.
 - dataset cache와 recent query는 모두 `services/storage.ts` namespace 규칙을 공유한다.
 - later feature는 raw storage key를 직접 만들지 않고 service helper를 통해 접근한다.
+
+handoff 관련 규칙:
+
+- later UI는 raw `Linking.openURL`을 직접 호출하지 않는다.
+- canonical URL validation, search fallback URL builder, browser fallback choice는 `services/handoff.ts`에서 중앙화한다.
+- 실패는 explicit result object로 돌려서 UI가 toast/inline feedback을 붙일 수 있게 한다.

--- a/mobile/src/services/handoff.test.ts
+++ b/mobile/src/services/handoff.test.ts
@@ -1,0 +1,210 @@
+import {
+  buildServiceSearchFallbackUrl,
+  openServiceHandoff,
+  resolveServiceHandoff,
+  resolveServiceHandoffGroup,
+  type HandoffLinkingAdapter,
+} from './handoff';
+
+function createLinkingAdapter({
+  canOpen = async () => true,
+  open = async () => undefined,
+}: {
+  canOpen?: (url: string) => Promise<boolean>;
+  open?: (url: string) => Promise<unknown>;
+} = {}): HandoffLinkingAdapter {
+  return {
+    canOpenURL: canOpen,
+    openURL: open,
+  };
+}
+
+describe('mobile external handoff service', () => {
+  test('builds service search fallback URLs with the expected service endpoints', () => {
+    expect(buildServiceSearchFallbackUrl('spotify', 'IVE REVIVE+')).toBe(
+      'https://open.spotify.com/search/IVE%20REVIVE%2B',
+    );
+    expect(buildServiceSearchFallbackUrl('youtubeMusic', 'IVE REVIVE+')).toBe(
+      'https://music.youtube.com/search?q=IVE%20REVIVE%2B',
+    );
+    expect(buildServiceSearchFallbackUrl('youtubeMv', 'IVE REVIVE+')).toBe(
+      'https://www.youtube.com/results?search_query=IVE%20REVIVE%2B%20official%20mv',
+    );
+  });
+
+  test('prefers canonical service URLs when they are safe and supported', () => {
+    const handoff = resolveServiceHandoff({
+      service: 'spotify',
+      query: 'BLACKPINK DEADLINE',
+      canonicalUrl: 'https://open.spotify.com/album/12345',
+    });
+
+    expect('ok' in handoff).toBe(false);
+    if ('ok' in handoff) {
+      throw new Error('Expected a handoff resolution, not a failure state.');
+    }
+
+    expect(handoff.mode).toBe('canonical');
+    expect(handoff.primaryUrl).toBe('https://open.spotify.com/album/12345');
+    expect(handoff.searchFallbackUrl).toBe('https://open.spotify.com/search/BLACKPINK%20DEADLINE');
+    expect(handoff.browserFallbackUrl).toBe('https://open.spotify.com/search/BLACKPINK%20DEADLINE');
+  });
+
+  test('normalizes YouTube MV ids and short URLs into canonical watch URLs', () => {
+    const fromId = resolveServiceHandoff({
+      service: 'youtubeMv',
+      query: 'BLACKPINK DEADLINE',
+      canonicalUrl: '2GJfWMYCWY0',
+    });
+    const fromShortUrl = resolveServiceHandoff({
+      service: 'youtubeMv',
+      query: 'BLACKPINK DEADLINE',
+      canonicalUrl: 'https://youtu.be/2GJfWMYCWY0',
+    });
+
+    if ('ok' in fromId || 'ok' in fromShortUrl) {
+      throw new Error('Expected canonical MV resolutions.');
+    }
+
+    expect(fromId.primaryUrl).toBe('https://www.youtube.com/watch?v=2GJfWMYCWY0');
+    expect(fromShortUrl.primaryUrl).toBe('https://www.youtube.com/watch?v=2GJfWMYCWY0');
+  });
+
+  test('falls back to service search when canonical URL is missing or unsupported', () => {
+    const handoff = resolveServiceHandoff({
+      service: 'youtubeMusic',
+      query: 'YENA LOVE CATCHER',
+      canonicalUrl: 'https://example.com/not-youtube-music',
+    });
+
+    expect('ok' in handoff).toBe(false);
+    if ('ok' in handoff) {
+      throw new Error('Expected a handoff resolution.');
+    }
+
+    expect(handoff.mode).toBe('searchFallback');
+    expect(handoff.primaryUrl).toBe('https://music.youtube.com/search?q=YENA%20LOVE%20CATCHER');
+    expect(handoff.browserFallbackUrl).toBeNull();
+  });
+
+  test('returns an explicit unavailable result when there is no canonical URL and no query', () => {
+    const handoff = resolveServiceHandoff({
+      service: 'spotify',
+      query: '   ',
+      canonicalUrl: null,
+    });
+
+    expect(handoff).toMatchObject({
+      ok: false,
+      code: 'handoff_unavailable',
+      feedback: {
+        retryable: false,
+      },
+    });
+  });
+
+  test('opens the canonical target when the primary URL can be opened', async () => {
+    const handoff = resolveServiceHandoff({
+      service: 'spotify',
+      query: 'BLACKPINK DEADLINE',
+      canonicalUrl: 'https://open.spotify.com/album/12345',
+    });
+
+    const opened: string[] = [];
+    const result = await openServiceHandoff(
+      handoff,
+      createLinkingAdapter({
+        canOpen: async () => true,
+        open: async (url) => {
+          opened.push(url);
+        },
+      }),
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      service: 'spotify',
+      mode: 'canonical',
+      target: 'primary',
+      openedUrl: 'https://open.spotify.com/album/12345',
+    });
+    expect(opened).toEqual(['https://open.spotify.com/album/12345']);
+  });
+
+  test('uses browser fallback when the primary target cannot be opened', async () => {
+    const handoff = resolveServiceHandoff({
+      service: 'spotify',
+      query: 'BLACKPINK DEADLINE',
+      canonicalUrl: 'https://open.spotify.com/album/12345',
+      browserFallbackUrl: 'https://example.com/browser-safe-spotify',
+    });
+
+    if ('ok' in handoff) {
+      throw new Error('Expected a handoff resolution.');
+    }
+
+    const opened: string[] = [];
+    const result = await openServiceHandoff(
+      handoff,
+      createLinkingAdapter({
+        canOpen: async (url) => url === 'https://example.com/browser-safe-spotify',
+        open: async (url) => {
+          opened.push(url);
+        },
+      }),
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      service: 'spotify',
+      mode: 'canonical',
+      target: 'browserFallback',
+      openedUrl: 'https://example.com/browser-safe-spotify',
+    });
+    expect(opened).toEqual(['https://example.com/browser-safe-spotify']);
+  });
+
+  test('returns retryable failure metadata when no handoff target can be opened', async () => {
+    const handoff = resolveServiceHandoff({
+      service: 'youtubeMusic',
+      query: 'YENA LOVE CATCHER',
+      canonicalUrl: null,
+    });
+
+    const result = await openServiceHandoff(
+      handoff,
+      createLinkingAdapter({
+        canOpen: async () => false,
+      }),
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: 'handoff_open_failed',
+      feedback: {
+        retryable: true,
+      },
+    });
+  });
+
+  test('builds a stable service group for later button layers', () => {
+    const group = resolveServiceHandoffGroup({
+      query: 'IVE REVIVE+',
+      spotifyUrl: 'https://open.spotify.com/album/revive',
+      youtubeMusicUrl: null,
+      youtubeMvUrl: '2GJfWMYCWY0',
+    });
+
+    expect('ok' in group.spotify).toBe(false);
+    expect('ok' in group.youtubeMusic).toBe(false);
+    expect('ok' in group.youtubeMv).toBe(false);
+
+    if ('ok' in group.spotify || 'ok' in group.youtubeMusic || 'ok' in group.youtubeMv) {
+      throw new Error('Expected group handoffs to resolve to reusable handoff definitions.');
+    }
+
+    expect(group.spotify.mode).toBe('canonical');
+    expect(group.youtubeMusic.mode).toBe('searchFallback');
+    expect(group.youtubeMv.primaryUrl).toBe('https://www.youtube.com/watch?v=2GJfWMYCWY0');
+  });
+});

--- a/mobile/src/services/handoff.ts
+++ b/mobile/src/services/handoff.ts
@@ -1,0 +1,288 @@
+import * as Linking from 'expo-linking';
+
+export type MusicService = 'spotify' | 'youtubeMusic' | 'youtubeMv';
+export type ServiceHandoffMode = 'canonical' | 'searchFallback';
+export type ServiceHandoffTarget = 'primary' | 'browserFallback';
+export type ServiceHandoffFailureCode = 'handoff_unavailable' | 'handoff_open_failed';
+
+export type ServiceHandoffResolution = {
+  service: MusicService;
+  mode: ServiceHandoffMode;
+  query: string;
+  primaryUrl: string;
+  browserFallbackUrl: string | null;
+  searchFallbackUrl: string;
+};
+
+export type ServiceHandoffFailure = {
+  ok: false;
+  code: ServiceHandoffFailureCode;
+  service: MusicService;
+  mode: ServiceHandoffMode;
+  target: ServiceHandoffTarget | null;
+  attemptedUrl: string | null;
+  feedback: {
+    level: 'warning';
+    retryable: boolean;
+    message:
+      | 'No canonical or search fallback handoff is available yet.'
+      | 'External handoff failed. Keep the current route stack and show retry feedback.';
+  };
+};
+
+export type ServiceHandoffSuccess = {
+  ok: true;
+  service: MusicService;
+  mode: ServiceHandoffMode;
+  target: ServiceHandoffTarget;
+  openedUrl: string;
+};
+
+export type ServiceHandoffResult = ServiceHandoffSuccess | ServiceHandoffFailure;
+
+export type HandoffLinkingAdapter = {
+  canOpenURL(url: string): Promise<boolean>;
+  openURL(url: string): Promise<unknown>;
+};
+
+const DEFAULT_LINKING_ADAPTER: HandoffLinkingAdapter = {
+  canOpenURL: Linking.canOpenURL,
+  openURL: Linking.openURL,
+};
+
+function isServiceHandoffFailure(
+  handoff: ServiceHandoffResolution | ServiceHandoffFailure,
+): handoff is ServiceHandoffFailure {
+  return 'ok' in handoff;
+}
+
+const CANONICAL_HOSTS: Record<MusicService, Set<string>> = {
+  spotify: new Set(['open.spotify.com']),
+  youtubeMusic: new Set(['music.youtube.com']),
+  youtubeMv: new Set(['www.youtube.com', 'youtube.com', 'm.youtube.com', 'youtu.be']),
+};
+
+function normalizeQuery(query: string): string {
+  return query.trim().replace(/\s+/g, ' ');
+}
+
+function tryParseUrl(value: string | null | undefined): URL | null {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    return new URL(value);
+  } catch {
+    return null;
+  }
+}
+
+function extractYouTubeVideoId(value: string): string | null {
+  if (/^[a-zA-Z0-9_-]{11}$/.test(value)) {
+    return value;
+  }
+
+  const parsed = tryParseUrl(value);
+  if (!parsed) {
+    return null;
+  }
+
+  if (parsed.hostname === 'youtu.be') {
+    const candidate = parsed.pathname.replace(/^\/+/, '').split('/')[0];
+    return /^[a-zA-Z0-9_-]{11}$/.test(candidate) ? candidate : null;
+  }
+
+  if (!CANONICAL_HOSTS.youtubeMv.has(parsed.hostname)) {
+    return null;
+  }
+
+  const watchId = parsed.searchParams.get('v');
+  if (watchId && /^[a-zA-Z0-9_-]{11}$/.test(watchId)) {
+    return watchId;
+  }
+
+  const pathParts = parsed.pathname.split('/').filter(Boolean);
+  const shortsId = pathParts[0] === 'shorts' ? pathParts[1] : null;
+  return shortsId && /^[a-zA-Z0-9_-]{11}$/.test(shortsId) ? shortsId : null;
+}
+
+export function buildServiceSearchFallbackUrl(service: MusicService, query: string): string {
+  const normalizedQuery = normalizeQuery(query);
+  const encodedQuery = encodeURIComponent(normalizedQuery);
+
+  if (service === 'spotify') {
+    return `https://open.spotify.com/search/${encodedQuery}`;
+  }
+
+  if (service === 'youtubeMusic') {
+    return `https://music.youtube.com/search?q=${encodedQuery}`;
+  }
+
+  return `https://www.youtube.com/results?search_query=${encodeURIComponent(`${normalizedQuery} official mv`)}`;
+}
+
+export function normalizeCanonicalServiceUrl(service: MusicService, value: string | null | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+
+  if (service === 'youtubeMv') {
+    const videoId = extractYouTubeVideoId(value);
+    return videoId ? `https://www.youtube.com/watch?v=${videoId}` : null;
+  }
+
+  const parsed = tryParseUrl(value);
+  if (!parsed || parsed.protocol !== 'https:') {
+    return null;
+  }
+
+  if (!CANONICAL_HOSTS[service].has(parsed.hostname)) {
+    return null;
+  }
+
+  return parsed.toString();
+}
+
+function normalizeBrowserFallbackUrl(service: MusicService, value: string | null | undefined): string | null {
+  const normalizedCanonical = normalizeCanonicalServiceUrl(service, value);
+  if (normalizedCanonical) {
+    return normalizedCanonical;
+  }
+
+  const parsed = tryParseUrl(value);
+  if (!parsed || parsed.protocol !== 'https:') {
+    return null;
+  }
+
+  return parsed.toString();
+}
+
+export function resolveServiceHandoff(input: {
+  service: MusicService;
+  query: string;
+  canonicalUrl?: string | null;
+  browserFallbackUrl?: string | null;
+}): ServiceHandoffResolution | ServiceHandoffFailure {
+  const query = normalizeQuery(input.query);
+  const searchFallbackUrl = buildServiceSearchFallbackUrl(input.service, query);
+  const canonicalUrl = normalizeCanonicalServiceUrl(input.service, input.canonicalUrl);
+  const browserFallbackUrl = normalizeBrowserFallbackUrl(input.service, input.browserFallbackUrl);
+
+  if (canonicalUrl) {
+    return {
+      service: input.service,
+      mode: 'canonical',
+      query,
+      primaryUrl: canonicalUrl,
+      browserFallbackUrl:
+        browserFallbackUrl && browserFallbackUrl !== canonicalUrl ? browserFallbackUrl : searchFallbackUrl,
+      searchFallbackUrl,
+    };
+  }
+
+  if (!query) {
+    return {
+      ok: false,
+      code: 'handoff_unavailable',
+      service: input.service,
+      mode: 'searchFallback',
+      target: null,
+      attemptedUrl: null,
+      feedback: {
+        level: 'warning',
+        retryable: false,
+        message: 'No canonical or search fallback handoff is available yet.',
+      },
+    };
+  }
+
+  return {
+    service: input.service,
+    mode: 'searchFallback',
+    query,
+    primaryUrl: searchFallbackUrl,
+    browserFallbackUrl: browserFallbackUrl && browserFallbackUrl !== searchFallbackUrl ? browserFallbackUrl : null,
+    searchFallbackUrl,
+  };
+}
+
+export async function openServiceHandoff(
+  handoff: ServiceHandoffResolution | ServiceHandoffFailure,
+  adapter: HandoffLinkingAdapter = DEFAULT_LINKING_ADAPTER,
+): Promise<ServiceHandoffResult> {
+  if (isServiceHandoffFailure(handoff)) {
+    return handoff;
+  }
+
+  const resolvedHandoff: ServiceHandoffResolution = handoff;
+  const attempts: { target: ServiceHandoffTarget; url: string }[] = [
+    { target: 'primary', url: resolvedHandoff.primaryUrl },
+  ];
+
+  if (
+    resolvedHandoff.browserFallbackUrl &&
+    resolvedHandoff.browserFallbackUrl !== resolvedHandoff.primaryUrl
+  ) {
+    attempts.push({ target: 'browserFallback', url: resolvedHandoff.browserFallbackUrl });
+  }
+
+  for (const attempt of attempts) {
+    try {
+      const canOpen = await adapter.canOpenURL(attempt.url);
+      if (!canOpen) {
+        continue;
+      }
+
+      await adapter.openURL(attempt.url);
+      return {
+        ok: true,
+        service: resolvedHandoff.service,
+        mode: resolvedHandoff.mode,
+        target: attempt.target,
+        openedUrl: attempt.url,
+      };
+    } catch {
+      continue;
+    }
+  }
+
+  return {
+    ok: false,
+    code: 'handoff_open_failed',
+    service: resolvedHandoff.service,
+    mode: resolvedHandoff.mode,
+    target: attempts.length > 1 ? 'browserFallback' : 'primary',
+    attemptedUrl: attempts.at(-1)?.url ?? resolvedHandoff.primaryUrl,
+    feedback: {
+      level: 'warning',
+      retryable: true,
+      message: 'External handoff failed. Keep the current route stack and show retry feedback.',
+    },
+  };
+}
+
+export function resolveServiceHandoffGroup(input: {
+  query: string;
+  spotifyUrl?: string | null;
+  youtubeMusicUrl?: string | null;
+  youtubeMvUrl?: string | null;
+}): Record<MusicService, ServiceHandoffResolution | ServiceHandoffFailure> {
+  return {
+    spotify: resolveServiceHandoff({
+      service: 'spotify',
+      query: input.query,
+      canonicalUrl: input.spotifyUrl,
+    }),
+    youtubeMusic: resolveServiceHandoff({
+      service: 'youtubeMusic',
+      query: input.query,
+      canonicalUrl: input.youtubeMusicUrl,
+    }),
+    youtubeMv: resolveServiceHandoff({
+      service: 'youtubeMv',
+      query: input.query,
+      canonicalUrl: input.youtubeMvUrl,
+    }),
+  };
+}


### PR DESCRIPTION
## Summary
- add a shared mobile handoff service for canonical-open, search-fallback, and browser-fallback resolution
- add explicit success/failure result objects so later UI can attach retry feedback without reimplementing logic
- document the handoff foundation in the mobile workspace docs

## Verification
- cd mobile && npm run lint
- cd mobile && npm run typecheck
- cd mobile && npm run test
- git diff --check

Closes #256