### PR TITLE
Add mobile failure policy handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ python3 sync_release_pipeline_to_neon.py
 - shared module scaffold: `mobile/src/`
 - package/runtime baseline: `mobile/package.json`, `mobile/app.config.ts`, `mobile/eas.json`, `mobile/tsconfig.json`
 - env/runtime config layer: `mobile/.env.example`, `mobile/src/config/runtime.ts`
+- failure-policy layer: `mobile/src/services/datasetFailurePolicy.ts`
 - debug metadata helper/surface: `mobile/src/config/debugMetadata.ts`, `mobile/app/debug/metadata.tsx`
 - feature-gate layer: `mobile/src/config/featureGates.ts`
 - dataset-source layer: `mobile/src/services/datasetSource.ts`, `mobile/assets/datasets/README.md`

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -33,6 +33,8 @@
   - gate registry / helper / off fallback definition
 - `src/services/datasetSource.ts`
   - bundled static data vs preview remote data selection layer
+- `src/services/datasetFailurePolicy.ts`
+  - runtime misconfiguration / remote dataset unavailable fallback policy
 - `src/services/storage.ts`
   - `AsyncStorage` 기반 key-value storage adapter / namespace / shared key convention
 - `src/services/datasetCache.ts`
@@ -198,13 +200,28 @@ profile 차이는 아래 범위로만 제한한다.
 - `EXPO_PUBLIC_BUILD_VERSION`
   - debug metadata와 Expo config version에 쓰는 explicit build version override다.
 - invalid config
-  - `app.config.ts` 단계와 `src/config/runtime.ts` 단계에서 둘 다 명시적으로 실패시킨다.
-  - silent fallback으로 숨기지 않는다.
+  - `app.config.ts` 단계에서는 invalid env를 명시적으로 fail-fast 시킨다.
+  - 앱 runtime에서는 `src/config/runtime.ts`의 safe degraded mode로 내려가서 bundled-only config를 쓴다.
+  - later UI는 degraded state와 issue message를 표시할 수 있어야 한다.
+
+## mobile failure policy baseline
+
+- entrypoint는 `src/config/runtime.ts`와 `src/services/datasetFailurePolicy.ts`다.
+- runtime config payload가 없거나 invalid면:
+  - app crash 대신 `mode = degraded`
+  - `remoteRefresh = false`
+  - `analytics = false`
+  - bundled/static dataset path만 허용
+- preview remote dataset이 unavailable/invalid면:
+  - 가능한 경우 `last-known-good` cache로 fallback
+  - cache가 불완전하면 bundled dataset으로 fallback
+- later UI는 `normal`과 `degraded`를 명시적으로 구분해 badge/banner/toast를 붙일 수 있어야 한다.
 
 ## debug metadata surface
 
 - internal metadata route는 `app/debug/metadata.tsx`에 둔다.
 - build version / dataset version / commit hash는 `src/config/debugMetadata.ts`를 통해 읽는다.
+- runtime degraded 여부와 runtime issue message도 같은 route에서 확인 가능해야 한다.
 - main tab이나 user-facing surface에는 진입 링크를 두지 않는다.
 - production profile에서는 route가 열려도 debug-only 안내만 보여준다.
 

--- a/mobile/app/debug/metadata.tsx
+++ b/mobile/app/debug/metadata.tsx
@@ -6,6 +6,8 @@ import { getDebugMetadata, isDebugMetadataAvailable } from '../../src/config/deb
 const metadata = getDebugMetadata();
 const rows = [
   ['Profile', metadata.profile],
+  ['Runtime mode', metadata.runtimeMode],
+  ['Runtime issues', metadata.runtimeIssues.length > 0 ? metadata.runtimeIssues.join(' | ') : 'None'],
   ['Build version', metadata.buildVersion],
   ['Dataset version', metadata.datasetVersion ?? 'Unavailable'],
   ['Commit hash', metadata.commitSha ?? 'Unavailable'],

--- a/mobile/src/README.md
+++ b/mobile/src/README.md
@@ -5,8 +5,8 @@
 - `components/`: 표시 컴포넌트
 - `config/`: validated runtime config accessor
   - `featureGates.ts`: gate registry / fallback metadata / helper
-  - `runtime.ts`: mobile profile / env validation
-  - `debugMetadata.ts`: debug-only build/dataset/commit metadata helper
+  - `runtime.ts`: mobile profile / env validation + safe degraded runtime state
+  - `debugMetadata.ts`: debug-only build/dataset/commit/runtime-state metadata helper
 - `features/`: 화면 composition / binding
 - `selectors/`: display model selector / adapter
   - `context.ts`: dataset -> indexed selector context
@@ -14,6 +14,7 @@
   - `index.ts`: shared selectors entrypoint
 - `services/`: data source / external handoff / helper
   - `datasetSource.ts`: bundled-static vs preview-remote source selector
+  - `datasetFailurePolicy.ts`: remote unavailable / misconfig degraded-mode fallback policy
   - `storage.ts`: `AsyncStorage` adapter + namespaced key/value helper
   - `datasetCache.ts`: static dataset artifact cache entry helper
   - `recentQueries.ts`: recent-query persistence helper
@@ -40,3 +41,9 @@ handoff 관련 규칙:
 - later UI는 raw `Linking.openURL`을 직접 호출하지 않는다.
 - canonical URL validation, search fallback URL builder, browser fallback choice는 `services/handoff.ts`에서 중앙화한다.
 - 실패는 explicit result object로 돌려서 UI가 toast/inline feedback을 붙일 수 있게 한다.
+
+failure-policy 관련 규칙:
+
+- runtime config parse failure는 crash 대신 degraded state로 내려간다.
+- preview remote dataset failure는 `datasetFailurePolicy.ts`에서 `preview-remote-cache` 또는 `bundled-static` fallback으로 resolve한다.
+- later UI는 `mode = normal | degraded`와 issue list를 직접 소비할 수 있어야 한다.

--- a/mobile/src/config/debugMetadata.test.ts
+++ b/mobile/src/config/debugMetadata.test.ts
@@ -1,4 +1,4 @@
-import type { MobileRuntimeConfig } from './runtime';
+import type { MobileRuntimeConfig, RuntimeConfigState } from './runtime';
 import { getDebugMetadata, isDebugMetadataAvailable } from './debugMetadata';
 
 const previewRuntimeConfig: MobileRuntimeConfig = {
@@ -28,10 +28,18 @@ const previewRuntimeConfig: MobileRuntimeConfig = {
   },
 };
 
+const previewRuntimeState: RuntimeConfigState = {
+  mode: 'normal',
+  config: previewRuntimeConfig,
+  issues: [],
+};
+
 describe('debug metadata helpers', () => {
   test('returns the stable debug metadata fields for preview builds', () => {
-    expect(getDebugMetadata(previewRuntimeConfig)).toEqual({
+    expect(getDebugMetadata(previewRuntimeState)).toEqual({
       profile: 'preview',
+      runtimeMode: 'normal',
+      runtimeIssues: [],
       buildVersion: '0.1.0',
       datasetVersion: 'preview-v1',
       commitSha: 'abc123',

--- a/mobile/src/config/debugMetadata.ts
+++ b/mobile/src/config/debugMetadata.ts
@@ -1,7 +1,14 @@
-import { getRuntimeConfig, type MobileRuntimeConfig } from './runtime';
+import {
+  getRuntimeConfig,
+  getRuntimeConfigState,
+  type MobileRuntimeConfig,
+  type RuntimeConfigState,
+} from './runtime';
 
 export type MobileDebugMetadata = {
   profile: MobileRuntimeConfig['profile'];
+  runtimeMode: RuntimeConfigState['mode'];
+  runtimeIssues: string[];
   buildVersion: string;
   datasetVersion: string | null;
   commitSha: string | null;
@@ -15,9 +22,15 @@ export function isDebugMetadataAvailable(runtimeConfig: MobileRuntimeConfig = ge
   return runtimeConfig.profile !== 'production';
 }
 
-export function getDebugMetadata(runtimeConfig: MobileRuntimeConfig = getRuntimeConfig()): MobileDebugMetadata {
+export function getDebugMetadata(
+  runtimeState: RuntimeConfigState = getRuntimeConfigState(),
+): MobileDebugMetadata {
+  const runtimeConfig = runtimeState.config;
+
   return {
     profile: runtimeConfig.profile,
+    runtimeMode: runtimeState.mode,
+    runtimeIssues: runtimeState.issues.map((issue) => issue.message),
     buildVersion: runtimeConfig.build.version,
     datasetVersion: runtimeConfig.dataSource.datasetVersion,
     commitSha: runtimeConfig.build.commitSha,

--- a/mobile/src/config/runtime.test.ts
+++ b/mobile/src/config/runtime.test.ts
@@ -1,4 +1,4 @@
-import { parseRuntimeConfig } from './runtime';
+import { parseRuntimeConfig, resolveRuntimeConfigState } from './runtime';
 
 jest.mock('expo-constants', () => ({
   __esModule: true,
@@ -167,5 +167,66 @@ describe('parseRuntimeConfig', () => {
         },
       }),
     ).toThrow('build.version');
+  });
+
+  test('degrades safely when runtime config payload is missing', () => {
+    const state = resolveRuntimeConfigState(null, 'preview', '0.3.0');
+
+    expect(state.mode).toBe('degraded');
+    expect(state.config.profile).toBe('preview');
+    expect(state.config.dataSource.mode).toBe('preview-static');
+    expect(state.config.featureGates.remoteRefresh).toBe(false);
+    expect(state.config.services.analyticsWriteKey).toBeNull();
+    expect(state.config.build.version).toBe('0.3.0');
+    expect(state.issues).toEqual([
+      expect.objectContaining({
+        kind: 'missing_runtime_config',
+      }),
+    ]);
+  });
+
+  test('degrades safely when runtime config payload is invalid', () => {
+    const state = resolveRuntimeConfigState(
+      {
+        profile: 'preview',
+        dataSource: {
+          mode: 'preview-static',
+          remoteDatasetUrl: null,
+          datasetVersion: null,
+        },
+        services: {
+          apiBaseUrl: null,
+          analyticsWriteKey: null,
+        },
+        logging: {
+          level: 'debug',
+        },
+        featureGates: {
+          radar: true,
+          analytics: true,
+          remoteRefresh: true,
+          mvEmbed: true,
+          shareActions: true,
+        },
+        build: {
+          version: '0.1.0',
+          commitSha: null,
+        },
+      },
+      'preview',
+      '0.1.0',
+    );
+
+    expect(state.mode).toBe('degraded');
+    expect(state.config.profile).toBe('preview');
+    expect(state.config.dataSource.remoteDatasetUrl).toBeNull();
+    expect(state.config.featureGates.analytics).toBe(false);
+    expect(state.config.featureGates.remoteRefresh).toBe(false);
+    expect(state.issues).toEqual([
+      expect.objectContaining({
+        kind: 'invalid_runtime_config',
+        message: expect.stringContaining('remoteDatasetUrl'),
+      }),
+    ]);
   });
 });

--- a/mobile/src/config/runtime.ts
+++ b/mobile/src/config/runtime.ts
@@ -37,6 +37,19 @@ export type MobileRuntimeConfig = {
   };
 };
 
+export type RuntimeConfigIssueKind = 'missing_runtime_config' | 'invalid_runtime_config';
+
+export type RuntimeConfigIssue = {
+  kind: RuntimeConfigIssueKind;
+  message: string;
+};
+
+export type RuntimeConfigState = {
+  mode: 'normal' | 'degraded';
+  config: MobileRuntimeConfig;
+  issues: RuntimeConfigIssue[];
+};
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
@@ -100,6 +113,14 @@ function readDataSourceMode(value: unknown): DataSourceMode {
   }
 
   throw new Error('Invalid runtime config field: dataSource.mode has an unsupported value.');
+}
+
+function readProfileHint(value: unknown): MobileProfile | null {
+  if (value === 'development' || value === 'preview' || value === 'production') {
+    return value;
+  }
+
+  return null;
 }
 
 function readOptionalUrl(value: unknown, fieldName: string): string | null {
@@ -188,15 +209,93 @@ export function parseRuntimeConfig(input: unknown): MobileRuntimeConfig {
   return config;
 }
 
-let cachedConfig: MobileRuntimeConfig | null = null;
-
-export function getRuntimeConfig(): MobileRuntimeConfig {
-  if (cachedConfig) {
-    return cachedConfig;
+function getDefaultLoggingLevel(profile: MobileProfile): LoggingLevel {
+  if (profile === 'production') {
+    return 'error';
   }
 
-  const extra = Constants.expoConfig?.extra;
+  return profile === 'preview' ? 'debug' : 'verbose';
+}
+
+function buildDegradedRuntimeConfig(
+  profile: MobileProfile,
+  buildVersion: string | null,
+): MobileRuntimeConfig {
+  return {
+    profile,
+    dataSource: {
+      mode: EXPECTED_MODE_BY_PROFILE[profile],
+      remoteDatasetUrl: null,
+      datasetVersion: null,
+    },
+    services: {
+      apiBaseUrl: null,
+      analyticsWriteKey: null,
+    },
+    logging: {
+      level: getDefaultLoggingLevel(profile),
+    },
+    featureGates: {
+      radar: true,
+      analytics: false,
+      remoteRefresh: false,
+      mvEmbed: true,
+      shareActions: true,
+    },
+    build: {
+      version: buildVersion ?? '0.1.0',
+      commitSha: null,
+    },
+  };
+}
+
+export function resolveRuntimeConfigState(
+  input: unknown,
+  profileHint: MobileProfile | null = null,
+  buildVersion: string | null = null,
+): RuntimeConfigState {
+  try {
+    return {
+      mode: 'normal',
+      config: parseRuntimeConfig(input),
+      issues: [],
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown runtime config failure.';
+
+    return {
+      mode: 'degraded',
+      config: buildDegradedRuntimeConfig(profileHint ?? 'production', buildVersion),
+      issues: [
+        {
+          kind: input == null ? 'missing_runtime_config' : 'invalid_runtime_config',
+          message,
+        },
+      ],
+    };
+  }
+}
+
+let cachedState: RuntimeConfigState | null = null;
+
+export function resetRuntimeConfigState(): void {
+  cachedState = null;
+}
+
+export function getRuntimeConfigState(): RuntimeConfigState {
+  if (cachedState) {
+    return cachedState;
+  }
+
+  const expoConfig = Constants.expoConfig;
+  const extra = expoConfig?.extra;
+  const profileHint = isRecord(extra) ? readProfileHint(extra.mobileProfile) : null;
   const runtimeConfig = isRecord(extra) ? extra.runtimeConfig : null;
-  cachedConfig = parseRuntimeConfig(runtimeConfig);
-  return cachedConfig;
+
+  cachedState = resolveRuntimeConfigState(runtimeConfig, profileHint, expoConfig?.version ?? null);
+  return cachedState;
+}
+
+export function getRuntimeConfig(): MobileRuntimeConfig {
+  return getRuntimeConfigState().config;
 }

--- a/mobile/src/services/datasetFailurePolicy.test.ts
+++ b/mobile/src/services/datasetFailurePolicy.test.ts
@@ -1,0 +1,182 @@
+import type { RuntimeConfigState } from '../config/runtime';
+import {
+  resetStorageAdapter,
+  setStorageAdapter,
+  type KeyValueStorageAdapter,
+} from './storage';
+import type { PreviewRemoteDatasetSelection } from './datasetSource';
+import { writeDatasetCacheEntry } from './datasetCache';
+import { resolveDatasetFailurePolicy } from './datasetFailurePolicy';
+
+function createMemoryStorage(): KeyValueStorageAdapter {
+  const values = new Map<string, string>();
+
+  return {
+    async getItem(key) {
+      return values.has(key) ? values.get(key) ?? null : null;
+    },
+    async setItem(key, value) {
+      values.set(key, value);
+    },
+    async removeItem(key) {
+      values.delete(key);
+    },
+  };
+}
+
+function createRuntimeState(mode: RuntimeConfigState['mode'] = 'normal'): RuntimeConfigState {
+  return {
+    mode,
+    config: {
+      profile: 'preview',
+      dataSource: {
+        mode: 'preview-static',
+        remoteDatasetUrl: mode === 'normal' ? 'https://example.com/dataset.json' : null,
+        datasetVersion: 'preview-v2',
+      },
+      services: {
+        apiBaseUrl: null,
+        analyticsWriteKey: null,
+      },
+      logging: {
+        level: 'debug',
+      },
+      featureGates: {
+        radar: true,
+        analytics: false,
+        remoteRefresh: mode === 'normal',
+        mvEmbed: true,
+        shareActions: true,
+      },
+      build: {
+        version: '0.1.0',
+        commitSha: 'test-sha',
+      },
+    },
+    issues:
+      mode === 'degraded'
+        ? [
+            {
+              kind: 'invalid_runtime_config',
+              message: 'Runtime config only allows remoteRefresh in the preview profile.',
+            },
+          ]
+        : [],
+  };
+}
+
+function createPreviewSelection(): PreviewRemoteDatasetSelection {
+  return {
+    kind: 'preview-remote',
+    reason: 'preview_remote_enabled',
+    contractId: 'idol-song-mobile-static-v1',
+    datasetVersion: 'preview-v2',
+    mixingAllowed: false,
+    remoteDatasetUrl: 'https://example.com/dataset.json',
+    artifacts: [
+      {
+        id: 'artistProfiles',
+        freshnessClass: 'stable-profile',
+        relativePath: 'artistProfiles.json',
+      },
+      {
+        id: 'releases',
+        freshnessClass: 'rolling-release',
+        relativePath: 'releases.json',
+      },
+    ],
+  };
+}
+
+describe('dataset failure policy', () => {
+  beforeEach(() => {
+    setStorageAdapter(createMemoryStorage());
+  });
+
+  afterEach(() => {
+    resetStorageAdapter();
+  });
+
+  test('falls back to bundled degraded mode when runtime config is already degraded', async () => {
+    const policy = await resolveDatasetFailurePolicy({
+      runtimeState: createRuntimeState('degraded'),
+    });
+
+    expect(policy.mode).toBe('degraded');
+    expect(policy.activeSource).toBe('bundled-static');
+    expect(policy.selection.kind).toBe('bundled-static');
+    expect(policy.selection.reason).toBe('runtime_degraded');
+    expect(policy.issues).toEqual([
+      expect.objectContaining({
+        kind: 'invalid_runtime_config',
+      }),
+    ]);
+  });
+
+  test('stays in normal mode when preview remote dataset is available', async () => {
+    const selection = createPreviewSelection();
+    const policy = await resolveDatasetFailurePolicy({
+      runtimeState: createRuntimeState('normal'),
+      selection,
+      remoteAvailability: {
+        status: 'available',
+      },
+    });
+
+    expect(policy.mode).toBe('normal');
+    expect(policy.activeSource).toBe('preview-remote');
+    expect(policy.selection).toEqual(selection);
+    expect(policy.issues).toEqual([]);
+  });
+
+  test('falls back to last-known-good remote cache when remote dataset is unavailable', async () => {
+    const selection = createPreviewSelection();
+    await writeDatasetCacheEntry('artistProfiles', { rows: 1 }, selection, '2026-03-08T00:00:00.000Z');
+    await writeDatasetCacheEntry('releases', { rows: 2 }, selection, '2026-03-08T00:00:00.000Z');
+
+    const policy = await resolveDatasetFailurePolicy({
+      runtimeState: createRuntimeState('normal'),
+      selection,
+      remoteAvailability: {
+        status: 'unavailable',
+        message: 'Fetch failed with 503.',
+      },
+    });
+
+    expect(policy.mode).toBe('degraded');
+    expect(policy.activeSource).toBe('preview-remote-cache');
+    expect(policy.selection).toEqual(selection);
+    expect(policy.cachedArtifactIds).toEqual(['artistProfiles', 'releases']);
+    expect(policy.issues).toEqual([
+      {
+        kind: 'remote_dataset_unavailable',
+        message: 'Fetch failed with 503.',
+      },
+    ]);
+  });
+
+  test('falls back to bundled dataset when remote dataset is invalid and cache is incomplete', async () => {
+    const selection = createPreviewSelection();
+    await writeDatasetCacheEntry('artistProfiles', { rows: 1 }, selection, '2026-03-08T00:00:00.000Z');
+
+    const policy = await resolveDatasetFailurePolicy({
+      runtimeState: createRuntimeState('normal'),
+      selection,
+      remoteAvailability: {
+        status: 'invalid',
+      },
+    });
+
+    expect(policy.mode).toBe('degraded');
+    expect(policy.activeSource).toBe('bundled-static');
+    expect(policy.selection.kind).toBe('bundled-static');
+    expect(policy.selection.reason).toBe('remote_unavailable');
+    expect(policy.cachedArtifactIds).toEqual(['artistProfiles']);
+    expect(policy.issues).toEqual([
+      {
+        kind: 'remote_dataset_invalid',
+        message: 'Preview remote dataset payload is invalid.',
+      },
+    ]);
+  });
+});

--- a/mobile/src/services/datasetFailurePolicy.ts
+++ b/mobile/src/services/datasetFailurePolicy.ts
@@ -1,0 +1,152 @@
+import {
+  getRuntimeConfigState,
+  type RuntimeConfigIssue,
+  type RuntimeConfigState,
+} from '../config/runtime';
+import {
+  createBundledDatasetSelection,
+  isRemoteDatasetSelection,
+  selectDatasetSource,
+  type DatasetArtifactId,
+  type DatasetSelection,
+  type PreviewRemoteDatasetSelection,
+} from './datasetSource';
+import { readDatasetCacheEntry } from './datasetCache';
+
+export type RemoteDatasetAvailability =
+  | {
+      status: 'available';
+    }
+  | {
+      status: 'unavailable' | 'invalid';
+      message?: string;
+    };
+
+export type DatasetFailurePolicyIssueKind =
+  | RuntimeConfigIssue['kind']
+  | 'remote_dataset_unavailable'
+  | 'remote_dataset_invalid';
+
+export type DatasetFailurePolicyIssue = {
+  kind: DatasetFailurePolicyIssueKind;
+  message: string;
+};
+
+export type DatasetFailurePolicy = {
+  mode: 'normal' | 'degraded';
+  activeSource: 'bundled-static' | 'preview-remote' | 'preview-remote-cache';
+  selection: DatasetSelection;
+  cachedArtifactIds: DatasetArtifactId[];
+  issues: DatasetFailurePolicyIssue[];
+};
+
+function toFailurePolicyIssues(issues: RuntimeConfigIssue[]): DatasetFailurePolicyIssue[] {
+  return issues.map((issue) => ({
+    kind: issue.kind,
+    message: issue.message,
+  }));
+}
+
+async function readCachedArtifactIds(
+  selection: PreviewRemoteDatasetSelection,
+): Promise<DatasetArtifactId[]> {
+  const cachedArtifactIds = await Promise.all(
+    selection.artifacts.map(async (artifact) => {
+      const entry = await readDatasetCacheEntry(artifact.id, selection);
+      return entry ? artifact.id : null;
+    }),
+  );
+
+  return cachedArtifactIds.filter((artifactId): artifactId is DatasetArtifactId => artifactId !== null);
+}
+
+function hasCompleteCachedDataset(
+  selection: PreviewRemoteDatasetSelection,
+  cachedArtifactIds: DatasetArtifactId[],
+): boolean {
+  return (
+    selection.artifacts.length > 0 &&
+    cachedArtifactIds.length === selection.artifacts.length
+  );
+}
+
+export async function resolveDatasetFailurePolicy(options: {
+  runtimeState?: RuntimeConfigState;
+  selection?: DatasetSelection;
+  remoteAvailability?: RemoteDatasetAvailability;
+} = {}): Promise<DatasetFailurePolicy> {
+  const runtimeState = options.runtimeState ?? getRuntimeConfigState();
+
+  if (runtimeState.mode === 'degraded') {
+    return {
+      mode: 'degraded',
+      activeSource: 'bundled-static',
+      selection: createBundledDatasetSelection(
+        runtimeState.config.dataSource.datasetVersion,
+        'runtime_degraded',
+      ),
+      cachedArtifactIds: [],
+      issues: toFailurePolicyIssues(runtimeState.issues),
+    };
+  }
+
+  const selection = options.selection ?? selectDatasetSource(runtimeState.config);
+  const remoteAvailability = options.remoteAvailability ?? { status: 'available' as const };
+
+  if (!isRemoteDatasetSelection(selection)) {
+    return {
+      mode: 'normal',
+      activeSource: 'bundled-static',
+      selection,
+      cachedArtifactIds: [],
+      issues: [],
+    };
+  }
+
+  if (remoteAvailability.status === 'available') {
+    return {
+      mode: 'normal',
+      activeSource: 'preview-remote',
+      selection,
+      cachedArtifactIds: [],
+      issues: [],
+    };
+  }
+
+  const cachedArtifactIds = await readCachedArtifactIds(selection);
+  const issueKind =
+    remoteAvailability.status === 'invalid' ? 'remote_dataset_invalid' : 'remote_dataset_unavailable';
+  const issueMessage =
+    remoteAvailability.message ??
+    (remoteAvailability.status === 'invalid'
+      ? 'Preview remote dataset payload is invalid.'
+      : 'Preview remote dataset is unavailable.');
+
+  if (hasCompleteCachedDataset(selection, cachedArtifactIds)) {
+    return {
+      mode: 'degraded',
+      activeSource: 'preview-remote-cache',
+      selection,
+      cachedArtifactIds,
+      issues: [
+        {
+          kind: issueKind,
+          message: issueMessage,
+        },
+      ],
+    };
+  }
+
+  return {
+    mode: 'degraded',
+    activeSource: 'bundled-static',
+    selection: createBundledDatasetSelection(selection.datasetVersion, 'remote_unavailable'),
+    cachedArtifactIds,
+    issues: [
+      {
+        kind: issueKind,
+        message: issueMessage,
+      },
+    ],
+  };
+}

--- a/mobile/src/services/datasetSource.ts
+++ b/mobile/src/services/datasetSource.ts
@@ -29,7 +29,7 @@ type DatasetSelectionBase = {
 
 export type BundledDatasetSelection = DatasetSelectionBase & {
   kind: 'bundled-static';
-  reason: 'profile_default' | 'preview_remote_disabled';
+  reason: 'profile_default' | 'preview_remote_disabled' | 'runtime_degraded' | 'remote_unavailable';
   bundledBasePath: string;
 };
 
@@ -87,7 +87,7 @@ export const DATASET_ARTIFACTS: DatasetArtifactDescriptor[] = [
   },
 ];
 
-function toBundledSelection(
+export function createBundledDatasetSelection(
   datasetVersion: string | null,
   reason: BundledDatasetSelection['reason'],
 ): BundledDatasetSelection {
@@ -128,7 +128,7 @@ export function selectDatasetSource(
     };
   }
 
-  return toBundledSelection(
+  return createBundledDatasetSelection(
     runtimeConfig.dataSource.datasetVersion,
     runtimeConfig.profile === 'preview' ? 'preview_remote_disabled' : 'profile_default',
   );


### PR DESCRIPTION
## Summary
- add a safe degraded runtime-config state instead of crashing blindly on invalid runtime payloads
- add mobile dataset failure-policy handling for remote unavailable/invalid cases with last-known-good cache and bundled fallback
- surface runtime degraded metadata in the hidden debug route and document the failure-policy baseline

## Verification
- cd mobile && npm run lint
- cd mobile && npm run typecheck
- cd mobile && npm run test
- git diff --check

Closes #257