### PR TITLE
Add explicit backend CORS/origin handling for web consumers

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ npm run dev
 - search surface만 backend로 붙여보려면 `VITE_API_BASE_URL=http://localhost:3213 VITE_SEARCH_SOURCE=api npm run dev`
 - calendar/month surface source switch만 열어보려면 `VITE_API_BASE_URL=http://localhost:3213 VITE_CALENDAR_MONTH_SOURCE=api npm run dev`
 - radar surface source switch만 열어보려면 `VITE_API_BASE_URL=http://localhost:3213 VITE_RADAR_SOURCE=api npm run dev`
+- browser에서 separate API base URL을 쓸 때 backend는 `APP_ENV`와 `WEB_ALLOWED_ORIGINS`를 같이 맞춰야 한다. production 기본 origin은 `https://iamsomething.github.io`다.
 - coexistence window 동안 `?searchSource=api`, `?entityDetailSource=api`, `?releaseDetailSource=api`, `?calendarMonthSource=api`, `?radarSource=api` 같은 query override를 붙여 local source 선택을 강제로 바꿀 수 있음
 - `VITE_PRIMARY_SURFACE_SOURCE=api`를 켜면 cut-over surface의 기본 read path는 backend가 되고, committed JSON은 fallback으로만 남는다.
 - `web/.env.example`에는 Pages / preview rehearsal에서 쓰는 source env baseline이 들어 있다.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,5 +3,6 @@ DATABASE_URL_POOLED=postgresql://user:password@your-neon-pooler-host/neondb?sslm
 DATABASE_URL=postgresql://user:password@your-neon-direct-host/neondb?sslmode=require
 PORT=3000
 APP_TIMEZONE=Asia/Seoul
+WEB_ALLOWED_ORIGINS=
 LOG_LEVEL=debug
 WORKER_CADENCE_LABEL=local-manual

--- a/backend/.env.preview.example
+++ b/backend/.env.preview.example
@@ -3,5 +3,6 @@ DATABASE_URL_POOLED=postgresql://user:password@your-preview-neon-pooler-host/neo
 DATABASE_URL=postgresql://user:password@your-preview-neon-direct-host/neondb?sslmode=require
 PORT=3213
 APP_TIMEZONE=Asia/Seoul
+WEB_ALLOWED_ORIGINS=https://idol-song-app-preview.example.com
 LOG_LEVEL=debug
 WORKER_CADENCE_LABEL=preview-manual

--- a/backend/.env.production.example
+++ b/backend/.env.production.example
@@ -3,5 +3,6 @@ DATABASE_URL_POOLED=postgresql://user:password@your-production-neon-pooler-host/
 DATABASE_URL=postgresql://user:password@your-production-neon-direct-host/neondb?sslmode=require
 PORT=3000
 APP_TIMEZONE=Asia/Seoul
+WEB_ALLOWED_ORIGINS=
 LOG_LEVEL=info
 WORKER_CADENCE_LABEL=production-scheduled

--- a/backend/README.md
+++ b/backend/README.md
@@ -51,7 +51,7 @@ PORT=3000 APP_TIMEZONE=Asia/Seoul npm run start
 
 - `/v1/*` read endpoint는 공통 success envelope `meta + data`를 사용한다.
 - success `meta`에는 최소 `request_id`, `generated_at`, `timezone`, `route`, `source`가 포함된다.
-- error는 공통 `meta + error` shape로 내려가고 code는 `invalid_request`, `not_found`, `stale_projection`, `internal_error`를 기본으로 쓴다.
+- error는 공통 `meta + error` shape로 내려가고 code는 `invalid_request`, `not_found`, `disallowed_origin`, `stale_projection`, `internal_error`를 기본으로 쓴다.
 - helper entrypoint는 `backend/src/lib/api.ts`다.
 
 ## Normalization Helpers
@@ -94,6 +94,17 @@ preview에서 달라지면 안 되는 것:
 - endpoint shape
 - field type / enum domain
 - date precision / MV / service-link semantics
+
+## Web CORS / Allowed Origins
+
+- backend는 browser cross-origin read를 명시적으로 허용한다.
+- 기본 production web origin은 `https://iamsomething.github.io`다.
+- `APP_ENV=development`에서는 위 origin에 더해 `localhost/127.0.0.1`의 Vite 기본 포트(`4173`, `5173`)를 허용한다.
+- `APP_ENV=preview`와 `APP_ENV=production`에서는 기본적으로 `https://iamsomething.github.io`만 허용하고, 추가 web consumer가 있으면 `WEB_ALLOWED_ORIGINS`에 comma-separated origin list로 넣는다.
+- `WEB_ALLOWED_ORIGINS`에는 full page URL이 아니라 origin을 넣는 것이 원칙이지만, 실수로 path가 붙어도 loader가 origin만 추출한다.
+- `Origin` 헤더가 없는 서버-사이드/CLI 요청은 그대로 허용한다.
+- 허용되지 않은 browser origin은 `403 disallowed_origin`으로 명시적으로 거절한다.
+- allowed origin request는 `Access-Control-Allow-Origin`, `Access-Control-Allow-Methods`, `Access-Control-Allow-Headers`, `Access-Control-Max-Age`, `Vary: Origin`을 명시적으로 반환한다.
 
 ## JSON Baseline Import
 

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,4 +1,4 @@
-import Fastify, { type FastifyInstance } from 'fastify';
+import Fastify, { type FastifyInstance, type FastifyReply } from 'fastify';
 
 import { loadConfig, type AppConfig } from './config.js';
 import { ReadApiError, buildReadErrorEnvelope } from './lib/api.js';
@@ -17,11 +17,93 @@ export type BuildAppOptions = {
   db?: DbPool;
 };
 
+const ACCESS_CONTROL_ALLOW_METHODS = 'GET,OPTIONS';
+const DEFAULT_ACCESS_CONTROL_ALLOW_HEADERS = 'Content-Type';
+
+function appendVaryHeader(reply: FastifyReply, value: string): void {
+  const current = reply.getHeader('Vary');
+
+  if (typeof current !== 'string' || current.length === 0) {
+    reply.header('Vary', value);
+    return;
+  }
+
+  const tokens = current
+    .split(',')
+    .map((token) => token.trim())
+    .filter((token) => token.length > 0);
+
+  if (!tokens.includes(value)) {
+    reply.header('Vary', [...tokens, value].join(', '));
+  }
+}
+
+function getRequestOrigin(request: { headers: Record<string, unknown> }): string | null {
+  const raw = request.headers.origin;
+
+  if (typeof raw !== 'string') {
+    return null;
+  }
+
+  const normalized = raw.trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
+function getRequestedAccessControlHeaders(request: { headers: Record<string, unknown> }): string {
+  const raw = request.headers['access-control-request-headers'];
+
+  if (Array.isArray(raw)) {
+    return raw.join(', ');
+  }
+
+  if (typeof raw === 'string' && raw.trim().length > 0) {
+    return raw.trim();
+  }
+
+  return DEFAULT_ACCESS_CONTROL_ALLOW_HEADERS;
+}
+
+function applyCorsHeaders(reply: FastifyReply, origin: string, requestedHeaders: string): void {
+  reply.header('Access-Control-Allow-Origin', origin);
+  reply.header('Access-Control-Allow-Methods', ACCESS_CONTROL_ALLOW_METHODS);
+  reply.header('Access-Control-Allow-Headers', requestedHeaders);
+  reply.header('Access-Control-Max-Age', '600');
+  appendVaryHeader(reply, 'Origin');
+  appendVaryHeader(reply, 'Access-Control-Request-Headers');
+}
+
 export function buildApp(options: BuildAppOptions = {}): FastifyInstance {
   const config = options.config ?? loadConfig();
   const db = options.db ?? createDbPool(config);
   const app = Fastify({
     logger: true,
+  });
+
+  app.addHook('onRequest', async (request, reply) => {
+    const origin = getRequestOrigin(request);
+
+    if (!origin) {
+      return;
+    }
+
+    appendVaryHeader(reply, 'Origin');
+
+    if (!config.allowedWebOrigins.includes(origin)) {
+      return reply
+        .code(403)
+        .send(
+          buildReadErrorEnvelope(request, config.appTimezone, 'disallowed_origin', 'Origin is not allowed.', {
+            app_env: config.appEnv,
+            origin,
+          }),
+        );
+    }
+
+    applyCorsHeaders(reply, origin, getRequestedAccessControlHeaders(request));
+
+    if (request.method === 'OPTIONS') {
+      return reply.code(204).send();
+    }
   });
 
   app.setErrorHandler((error, request, reply) => {

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -1,11 +1,22 @@
 export type DatabaseMode = 'pooled' | 'direct';
+export type AppEnv = 'development' | 'preview' | 'production';
 
 export type AppConfig = {
+  appEnv: AppEnv;
   port: number;
   appTimezone: string;
   databaseUrl: string;
   databaseMode: DatabaseMode;
+  allowedWebOrigins: string[];
 };
+
+const PRODUCTION_WEB_ORIGIN = 'https://iamsomething.github.io';
+const DEVELOPMENT_WEB_ORIGINS = [
+  'http://localhost:4173',
+  'http://127.0.0.1:4173',
+  'http://localhost:5173',
+  'http://127.0.0.1:5173',
+];
 
 function parsePort(raw: string | undefined): number {
   if (!raw) {
@@ -21,7 +32,62 @@ function parsePort(raw: string | undefined): number {
   return parsed;
 }
 
+function parseAppEnv(raw: string | undefined): AppEnv {
+  if (!raw) {
+    return 'development';
+  }
+
+  const normalized = raw.trim().toLowerCase();
+
+  if (normalized === 'development' || normalized === 'preview' || normalized === 'production') {
+    return normalized;
+  }
+
+  throw new Error(`Invalid APP_ENV: ${raw}`);
+}
+
+function normalizeWebOrigin(raw: string, source: string): string {
+  let url: URL;
+
+  try {
+    url = new URL(raw.trim());
+  } catch {
+    throw new Error(`Invalid ${source}: ${raw}`);
+  }
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error(`Invalid ${source}: ${raw}`);
+  }
+
+  return url.origin;
+}
+
+function parseAllowedWebOrigins(raw: string | undefined): string[] {
+  if (!raw) {
+    return [];
+  }
+
+  return raw
+    .split(',')
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0)
+    .map((value) => normalizeWebOrigin(value, 'WEB_ALLOWED_ORIGINS'));
+}
+
+function buildDefaultAllowedWebOrigins(appEnv: AppEnv): string[] {
+  if (appEnv === 'development') {
+    return [PRODUCTION_WEB_ORIGIN, ...DEVELOPMENT_WEB_ORIGINS];
+  }
+
+  return [PRODUCTION_WEB_ORIGIN];
+}
+
+function dedupeOrigins(origins: string[]): string[] {
+  return [...new Set(origins)];
+}
+
 export function loadConfig(env: NodeJS.ProcessEnv = process.env): AppConfig {
+  const appEnv = parseAppEnv(env.APP_ENV);
   const pooledUrl = env.DATABASE_URL_POOLED?.trim();
   const directUrl = env.DATABASE_URL?.trim();
   const databaseUrl = pooledUrl || directUrl;
@@ -31,9 +97,14 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): AppConfig {
   }
 
   return {
+    appEnv,
     port: parsePort(env.PORT),
     appTimezone: env.APP_TIMEZONE?.trim() || 'Asia/Seoul',
     databaseUrl,
     databaseMode: pooledUrl ? 'pooled' : 'direct',
+    allowedWebOrigins: dedupeOrigins([
+      ...buildDefaultAllowedWebOrigins(appEnv),
+      ...parseAllowedWebOrigins(env.WEB_ALLOWED_ORIGINS),
+    ]),
   };
 }

--- a/backend/src/lib/api.ts
+++ b/backend/src/lib/api.ts
@@ -3,6 +3,7 @@ import type { FastifyRequest } from 'fastify';
 export type ReadApiErrorCode =
   | 'invalid_request'
   | 'not_found'
+  | 'disallowed_origin'
   | 'stale_projection'
   | 'internal_error'
   | 'not_implemented';

--- a/docs/specs/backend/preview-staging-backend-path.md
+++ b/docs/specs/backend/preview-staging-backend-path.md
@@ -125,6 +125,7 @@ preview와 production은 최소 아래 구성을 분리한다.
 | `DATABASE_URL_POOLED` | preview pooled URL | production pooled URL |
 | `PORT` | preview service port | production service port |
 | `APP_TIMEZONE` | `Asia/Seoul` | `Asia/Seoul` |
+| `WEB_ALLOWED_ORIGINS` | preview web consumer origin list | production extra web consumer origin list |
 | `LOG_LEVEL` | `debug` 또는 `info` | `info` 또는 `warn` |
 | `WORKER_CADENCE_LABEL` | preview cadence label | production cadence label |
 
@@ -134,6 +135,7 @@ preview와 production은 최소 아래 구성을 분리한다.
 - preview API는 production DB URL을 읽지 않는다.
 - preview worker는 production cron과 다른 cadence를 가져도 된다.
 - timezone rule은 preview/production 모두 `Asia/Seoul`로 고정한다.
+- production 기본 web origin은 `https://iamsomething.github.io`이고, preview/prod에서 추가 origin이 필요하면 `WEB_ALLOWED_ORIGINS`로만 연다.
 
 ## 7. Rehearsal Sequence
 


### PR DESCRIPTION
## Summary\n- add environment-aware backend allowed-origin parsing with explicit preview/production overrides\n- add Fastify CORS/origin handling for allowed origins, preflight, and explicit disallowed-origin responses\n- document WEB_ALLOWED_ORIGINS in backend env examples and preview/production runbooks\n\nCloses #293