### PR TITLE
Refresh backend projections and verification artifacts after Neon sync

### DIFF
--- a/.github/workflows/weekly-kpop-scan.yml
+++ b/.github/workflows/weekly-kpop-scan.yml
@@ -27,6 +27,15 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "npm"
+          cache-dependency-path: |
+            backend/package-lock.json
+            web/package-lock.json
+
       - name: Install Python dependencies
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
@@ -36,6 +45,11 @@ jobs:
           if [ -n "${DATABASE_URL:-}" ]; then
             pip install -r backend/requirements-import.txt
           fi
+
+      - name: Install backend dependencies
+        if: ${{ secrets.DATABASE_URL != '' }}
+        working-directory: backend
+        run: npm ci
 
       - name: Rebuild watchlist and scan future candidates
         env:
@@ -51,17 +65,19 @@ jobs:
           if [ -n "${DATABASE_URL:-}" ]; then
             python sync_upcoming_pipeline_to_neon.py --summary-path /tmp/upcoming-pipeline-db-sync-summary.json
             python sync_release_pipeline_to_neon.py --summary-path /tmp/release-pipeline-db-sync-summary.json
+            (
+              cd backend
+              npm run projection:refresh
+            )
+            python build_backend_json_parity_report.py
+            (
+              cd backend
+              npm run shadow:verify
+            )
           else
-            echo "DATABASE_URL not configured; skipping upcoming/release pipeline DB sync."
+            echo "DATABASE_URL not configured; skipping upcoming/release pipeline DB sync and post-sync backend verification."
           fi
           python build_release_change_log.py
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "24"
-          cache: "npm"
-          cache-dependency-path: web/package-lock.json
 
       - name: Install web dependencies
         working-directory: web
@@ -79,6 +95,6 @@ jobs:
           fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add tracking_watchlist.json tracking_watchlist.csv upcoming_release_candidates.json upcoming_release_candidates.csv manual_review_queue.json manual_review_queue.csv mv_manual_review_queue.json mv_manual_review_queue.csv web/src/data/watchlist.json web/src/data/upcomingCandidates.json web/src/data/releases.json web/src/data/releaseArtwork.json web/src/data/releaseDetails.json web/src/data/releaseChangeLog.json
+          git add tracking_watchlist.json tracking_watchlist.csv upcoming_release_candidates.json upcoming_release_candidates.csv manual_review_queue.json manual_review_queue.csv mv_manual_review_queue.json mv_manual_review_queue.csv web/src/data/watchlist.json web/src/data/upcomingCandidates.json web/src/data/releases.json web/src/data/releaseArtwork.json web/src/data/releaseDetails.json web/src/data/releaseChangeLog.json backend/reports/projection_refresh_summary.json backend/reports/backend_json_parity_report.json backend/reports/backend_shadow_read_report.json
           git commit -m "chore: refresh upcoming scan data"
           git push

--- a/backend/README.md
+++ b/backend/README.md
@@ -200,6 +200,14 @@ python3 sync_upcoming_pipeline_to_neon.py
 - `web/src/data/watchlist.json`
 - `web/src/data/upcomingCandidates.json`
 
+scheduled workflow `weekly-kpop-scan.yml`에서 `DATABASE_URL`이 설정돼 있으면, release/upcoming dual-write 뒤에 아래 체인이 같은 run 안에서 이어진다.
+
+- `npm run projection:refresh`
+- `python build_backend_json_parity_report.py`
+- `npm run shadow:verify`
+
+그래서 canonical write가 끝난 뒤 projection과 backend-vs-JSON evidence도 같은 자동화 체인에서 같이 최신화된다.
+
 ## Projection Refresh
 
 canonical table import 또는 dual-write 이후 product-facing read model projection을 다시 만들려면 아래 명령을 사용한다.

--- a/backend/reports/backend_json_parity_report.json
+++ b/backend/reports/backend_json_parity_report.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-03-07T07:38:47.525631+00:00",
+  "generated_at": "2026-03-08T06:56:34.451182+00:00",
   "clean": false,
   "summary_lines": [
     "entity alias/search coverage: clean (mismatched entities=0)",
@@ -12,18 +12,18 @@
     "review-required counts: clean (review_type_counts_match=True, youtube_mv_status_counts_match=True)"
   ],
   "source_snapshot_counts": {
-    "artist_profiles": 116,
+    "artist_profiles": 117,
     "youtube_allowlists": 108,
     "release_details": 117,
     "upcoming_candidates": 71,
-    "watchlist": 116,
+    "watchlist": 117,
     "manual_review_queue": 67,
     "mv_manual_review_queue": 34
   },
   "checks": {
     "entity_alias_search_coverage": {
-      "source_entity_count": 116,
-      "db_entity_count": 116,
+      "source_entity_count": 117,
+      "db_entity_count": 117,
       "mismatched_entities_count": 0,
       "mismatches": [],
       "clean": true
@@ -68,13 +68,13 @@
     },
     "upcoming_counts_and_nearest": {
       "source": {
-        "total": 71,
+        "total": 59,
         "precision_counts": {
-          "exact": 7,
-          "month_only": 21,
-          "unknown": 43
+          "unknown": 39,
+          "exact": 6,
+          "month_only": 14
         },
-        "future_exact_count": 7,
+        "future_exact_count": 6,
         "nearest_exact": {
           "slug": "yena",
           "scheduled_date": "2026-03-11",
@@ -84,22 +84,22 @@
         "month_buckets": {
           "exact": {
             "2026-03": 4,
-            "2026-04": 3
+            "2026-04": 2
           },
           "month_only": {
-            "2026-03": 10,
-            "2026-04": 11
+            "2026-03": 4,
+            "2026-04": 10
           }
         }
       },
       "db": {
-        "total": 71,
+        "total": 59,
         "precision_counts": {
-          "month_only": 21,
-          "unknown": 43,
-          "exact": 7
+          "month_only": 14,
+          "unknown": 39,
+          "exact": 6
         },
-        "future_exact_count": 7,
+        "future_exact_count": 6,
         "nearest_exact": {
           "slug": "yena",
           "scheduled_date": "2026-03-11",
@@ -109,11 +109,11 @@
         "month_buckets": {
           "exact": {
             "2026-03": 4,
-            "2026-04": 3
+            "2026-04": 2
           },
           "month_only": {
-            "2026-03": 10,
-            "2026-04": 11
+            "2026-03": 4,
+            "2026-04": 10
           }
         }
       },

--- a/backend/reports/backend_shadow_read_report.json
+++ b/backend/reports/backend_shadow_read_report.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-03-08T06:33:50.930Z",
+  "generated_at": "2026-03-08T06:56:37.284Z",
   "clean": false,
   "linked_parity_report": {
     "exists": true,

--- a/backend/reports/projection_refresh_summary.json
+++ b/backend/reports/projection_refresh_summary.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-03-08T06:24:39.705Z",
+  "generated_at": "2026-03-08T06:55:30.704Z",
   "row_counts": {
     "entity_search_documents": 117,
     "calendar_month_projection": 216,


### PR DESCRIPTION
## Summary\n- run backend projection refresh and parity/shadow verification after scheduled Neon DB sync\n- install backend Node dependencies in the workflow when DATABASE_URL is configured\n- commit refreshed backend report artifacts alongside scan outputs\n\n## Verification\n- cd backend && npm ci\n- cd backend && source ~/.config/idol-song-app/neon.env && npm run projection:refresh\n- source ~/.config/idol-song-app/neon.env && python3 build_backend_json_parity_report.py\n- cd backend && source ~/.config/idol-song-app/neon.env && npm run shadow:verify\n- git diff --check\n\nCloses #294