### PR TITLE
Add backend deploy workflow

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -1,0 +1,107 @@
+name: Backend Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: Deploy target
+        required: true
+        type: choice
+        options:
+          - preview
+          - production
+        default: preview
+  push:
+    branches:
+      - main
+    paths:
+      - "backend/**"
+      - ".github/workflows/backend-deploy.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  deploy-preview:
+    if: github.event_name == 'push' || github.event.inputs.target == 'preview'
+    runs-on: ubuntu-latest
+    environment:
+      name: preview
+      url: ${{ vars.BACKEND_PUBLIC_URL }}
+    concurrency:
+      group: backend-deploy-preview
+      cancel-in-progress: false
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "npm"
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Install backend dependencies
+        working-directory: backend
+        run: npm ci
+
+      - name: Build backend
+        working-directory: backend
+        run: npm run build
+
+      - name: Run backend tests
+        working-directory: backend
+        run: npm run test
+
+      - name: Deploy preview backend
+        env:
+          BACKEND_DEPLOY_TARGET: preview
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
+          RAILWAY_ENVIRONMENT_ID: ${{ vars.RAILWAY_ENVIRONMENT_ID }}
+          RAILWAY_SERVICE_ID: ${{ vars.RAILWAY_SERVICE_ID }}
+        run: node ./backend/scripts/deploy-backend.mjs
+
+  deploy-production:
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'production'
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: ${{ vars.BACKEND_PUBLIC_URL }}
+    concurrency:
+      group: backend-deploy-production
+      cancel-in-progress: false
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "npm"
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Install backend dependencies
+        working-directory: backend
+        run: npm ci
+
+      - name: Build backend
+        working-directory: backend
+        run: npm run build
+
+      - name: Run backend tests
+        working-directory: backend
+        run: npm run test
+
+      - name: Deploy production backend
+        env:
+          BACKEND_DEPLOY_TARGET: production
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
+          RAILWAY_ENVIRONMENT_ID: ${{ vars.RAILWAY_ENVIRONMENT_ID }}
+          RAILWAY_SERVICE_ID: ${{ vars.RAILWAY_SERVICE_ID }}
+        run: node ./backend/scripts/deploy-backend.mjs

--- a/README.md
+++ b/README.md
@@ -222,6 +222,17 @@ npm run build
 - `web/dist`를 GitHub Pages에 배포
 - `main` 브랜치의 웹 변경 사항을 자동 반영
 
+### Deploy Backend
+
+파일: `.github/workflows/backend-deploy.yml`
+
+- preview backend는 `main`의 backend 관련 변경 시 자동 deploy
+- production backend는 `workflow_dispatch`에서 수동 승격
+- 두 경로 모두 backend `npm ci`, `npm run build`, `npm run test`를 선행한 뒤 Railway CLI deploy를 실행
+- GitHub Environment `preview`, `production`에 `RAILWAY_TOKEN`, `RAILWAY_PROJECT_ID`, `RAILWAY_ENVIRONMENT_ID`, `RAILWAY_SERVICE_ID`, `BACKEND_PUBLIC_URL`를 설정해야 함
+
+backend deploy topology와 rehearsal 규칙은 `docs/specs/backend/preview-staging-backend-path.md`, 운영 entrypoint는 `backend/README.md`에 정리돼 있습니다.
+
 ## 현재 방향
 
 이 저장소는 `K-pop 발매 캘린더`에서 끝나는 프로젝트가 아니라, 앞으로 아래 방향으로 확장할 수 있습니다.

--- a/backend/README.md
+++ b/backend/README.md
@@ -95,6 +95,55 @@ preview에서 달라지면 안 되는 것:
 - field type / enum domain
 - date precision / MV / service-link semantics
 
+## Backend Deploy Path
+
+repo-level backend deploy entrypoint는 아래 workflow다.
+
+- `.github/workflows/backend-deploy.yml`
+
+역할 분리:
+
+- `preview`
+  - `main`에 backend 관련 변경이 들어오면 자동 deploy
+  - 같은 workflow를 `workflow_dispatch`로 수동 재실행할 수도 있음
+- `production`
+  - `workflow_dispatch`에서 `target=production`일 때만 deploy
+  - preview rehearsal이 끝난 뒤 명시적으로 승격하는 용도
+
+GitHub Environment baseline:
+
+- `preview`
+- `production`
+
+각 GitHub Environment에 아래 값을 같은 이름으로 넣는다.
+
+- secret: `RAILWAY_TOKEN`
+- variable: `RAILWAY_PROJECT_ID`
+- variable: `RAILWAY_ENVIRONMENT_ID`
+- variable: `RAILWAY_SERVICE_ID`
+- variable: `BACKEND_PUBLIC_URL`
+
+deploy helper는 아래 스크립트다.
+
+- `backend/scripts/deploy-backend.mjs`
+
+manual dry-run 예시:
+
+```bash
+BACKEND_DEPLOY_TARGET=preview \
+RAILWAY_TOKEN=dummy \
+RAILWAY_PROJECT_ID=project-id \
+RAILWAY_ENVIRONMENT_ID=environment-id \
+RAILWAY_SERVICE_ID=service-id \
+node backend/scripts/deploy-backend.mjs --dry-run
+```
+
+web API origin guidance:
+
+- preview rehearsal web/local build는 preview backend public URL을 `VITE_API_BASE_URL`에 넣는다.
+- production Pages build는 production backend public URL을 repo variable `VITE_API_BASE_URL`에 넣는다.
+- browser access를 열려면 backend 쪽 `WEB_ALLOWED_ORIGINS`도 해당 consumer origin과 같이 맞춰야 한다.
+
 ## Web CORS / Allowed Origins
 
 - backend는 browser cross-origin read를 명시적으로 허용한다.

--- a/backend/scripts/deploy-backend.mjs
+++ b/backend/scripts/deploy-backend.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const BACKEND_DIR = path.resolve(__dirname, '..');
+
+const VALID_TARGETS = new Set(['preview', 'production']);
+
+function readRequiredEnv(name) {
+  const value = process.env[name]?.trim();
+
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+
+  return value;
+}
+
+function resolveMode(argv) {
+  if (argv.includes('--dry-run')) {
+    return 'dry-run';
+  }
+
+  return process.env.BACKEND_DEPLOY_MODE?.trim() === 'dry-run' ? 'dry-run' : 'apply';
+}
+
+function resolveTarget() {
+  const target = process.env.BACKEND_DEPLOY_TARGET?.trim();
+
+  if (!target) {
+    throw new Error('Missing required environment variable: BACKEND_DEPLOY_TARGET');
+  }
+
+  if (!VALID_TARGETS.has(target)) {
+    throw new Error(`Unsupported BACKEND_DEPLOY_TARGET: ${target}`);
+  }
+
+  return target;
+}
+
+function runCommand(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      stdio: 'inherit',
+      ...options,
+    });
+
+    child.on('error', reject);
+    child.on('exit', (code, signal) => {
+      if (signal) {
+        reject(new Error(`Command terminated by signal: ${signal}`));
+        return;
+      }
+
+      if (code !== 0) {
+        reject(new Error(`Command failed with exit code ${code}`));
+        return;
+      }
+
+      resolve();
+    });
+  });
+}
+
+async function main() {
+  const mode = resolveMode(process.argv.slice(2));
+  const target = resolveTarget();
+  const railwayToken = readRequiredEnv('RAILWAY_TOKEN');
+  const projectId = readRequiredEnv('RAILWAY_PROJECT_ID');
+  const environmentId = readRequiredEnv('RAILWAY_ENVIRONMENT_ID');
+  const serviceId = readRequiredEnv('RAILWAY_SERVICE_ID');
+
+  const args = [
+    '--yes',
+    '@railway/cli',
+    'up',
+    '--ci',
+    '--project',
+    projectId,
+    '--environment',
+    environmentId,
+    '--service',
+    serviceId,
+  ];
+
+  console.log(`backend deploy target: ${target}`);
+  console.log(`backend deploy mode: ${mode}`);
+  console.log(`backend cwd: ${BACKEND_DIR}`);
+
+  if (mode === 'dry-run') {
+    console.log(`dry-run command: npx ${args.join(' ')}`);
+    return;
+  }
+
+  await runCommand('npx', args, {
+    cwd: BACKEND_DIR,
+    env: {
+      ...process.env,
+      RAILWAY_TOKEN: railwayToken,
+    },
+  });
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/docs/specs/backend/README.md
+++ b/docs/specs/backend/README.md
@@ -18,25 +18,28 @@
 4. `preview-staging-backend-path.md`
    - preview Neon / API / worker rehearsal 경로
    - preview와 production에서 달라도 되는 것과 안 되는 것
-5. `migration-runtime-gates.md`
+5. `backend-deploy.yml` + `backend/scripts/deploy-backend.mjs`
+   - preview 자동 deploy / production 수동 deploy 경로
+   - GitHub Environment와 Railway target ID baseline
+6. `migration-runtime-gates.md`
    - latency / error / freshness / cadence gate 정의
    - cutover go/no-go에 쓰는 combined runtime report 규칙
-6. `migration-operations-runbook.md`
+7. `migration-operations-runbook.md`
    - schema/import/dual-write/projection/verification/fallback 운영 절차
    - high-risk cutover / rollback checklist
-7. `web-cutover-rollback-drills.md`
+8. `web-cutover-rollback-drills.md`
    - search/entity/release/calendar/radar surface별 rollback drill 계획
    - representative drill timing과 user-facing effect 요약
-8. `json-snapshot-demotion.md`
+9. `json-snapshot-demotion.md`
    - cut-over surface에서 JSON을 fallback/debug/export로 강등하는 runtime / delivery 규칙
    - Pages build, query override, emergency fallback window 운영 기준
-9. `shared-read-api-contracts.md`
+10. `shared-read-api-contracts.md`
    - calendar, search, entity detail, release detail, radar용 shared read contract
    - server-side derived field와 client-side allowed logic 구분
-10. `backend-migration-epic.md`
+11. `backend-migration-epic.md`
    - cross-platform migration용 backend platform 전체 방향
    - child issue 분해, dependency, target architecture, implementation order
-11. `mobile-adoption-readiness-review.md`
+12. `mobile-adoption-readiness-review.md`
    - backend contract가 mobile screen 구현을 바로 받을 수 있는지 surface별 readiness 검토
    - blocker / non-blocker / follow-up issue 기준의 gate decision
 
@@ -45,14 +48,15 @@
 1. `canonical-backend-data-model.md`
 2. `runtime-and-service-boundaries.md`
 3. `preview-staging-backend-path.md`
-4. `migration-operations-runbook.md`
-5. `migration-runtime-gates.md`
-6. `web-cutover-rollback-drills.md`
-7. `json-snapshot-demotion.md`
-8. `shared-read-api-contracts.md`
-9. `mobile-adoption-readiness-review.md`
-10. `phased-rollout-plan.md`
-11. `backend-migration-epic.md`
+4. `.github/workflows/backend-deploy.yml`
+5. `migration-operations-runbook.md`
+6. `migration-runtime-gates.md`
+7. `web-cutover-rollback-drills.md`
+8. `json-snapshot-demotion.md`
+9. `shared-read-api-contracts.md`
+10. `mobile-adoption-readiness-review.md`
+11. `phased-rollout-plan.md`
+12. `backend-migration-epic.md`
 
 ## 원칙
 

--- a/docs/specs/backend/preview-staging-backend-path.md
+++ b/docs/specs/backend/preview-staging-backend-path.md
@@ -258,6 +258,37 @@ preview cadence는 production보다 짧거나 수동 위주여도 된다.
 
 ## 10. Non-goals
 
+preview deploy automation 자체는 `.github/workflows/backend-deploy.yml`에서 맡고, 이 문서는 rehearsal topology와 운영 규칙만 다룬다.
+
+## 11. Repository Deploy Path
+
+repo-level deploy path는 아래로 고정한다.
+
+- preview backend deploy:
+  - trigger: `main`의 backend 관련 변경 push 또는 manual dispatch
+  - workflow: `.github/workflows/backend-deploy.yml`
+  - GitHub Environment: `preview`
+- production backend deploy:
+  - trigger: manual dispatch only
+  - workflow: `.github/workflows/backend-deploy.yml`
+  - GitHub Environment: `production`
+
+GitHub Environment baseline:
+
+- secret: `RAILWAY_TOKEN`
+- variable: `RAILWAY_PROJECT_ID`
+- variable: `RAILWAY_ENVIRONMENT_ID`
+- variable: `RAILWAY_SERVICE_ID`
+- variable: `BACKEND_PUBLIC_URL`
+
+배포 helper는 `backend/scripts/deploy-backend.mjs`를 사용한다.
+
+web API origin 연결 규칙:
+
+- preview rehearsal은 preview backend public URL을 web/local `VITE_API_BASE_URL`에 넣는다.
+- production Pages는 production backend public URL을 repository variable `VITE_API_BASE_URL`에 넣는다.
+- backend browser allowlist는 `WEB_ALLOWED_ORIGINS`에서 별도로 관리한다.
+
 - preview를 production과 완전히 동일한 traffic 복제로 만드는 것
 - full infra-as-code hardening
 - mobile preview build 구현


### PR DESCRIPTION
## Summary
- add a repo-level Railway deploy workflow for preview and production backend targets
- add a shared deploy helper script with explicit env contract and dry-run support
- document preview/production backend deploy roles and web API origin expectations

Closes #298