### PR TITLE
Handle backend runtime fatal failures

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -68,6 +68,17 @@ PORT=3000 APP_TIMEZONE=Asia/Seoul npm run start
 - `backend/src/server.ts`는 `SIGINT`, `SIGTERM`에서 `app.close()`를 호출해 Fastify와 DB pool을 함께 정리한다.
 - later worker / one-off script / test가 pool을 직접 만들면 종료 시 `closeDbPool()` 또는 `pool.end()`를 명시적으로 호출해야 한다.
 
+## Runtime-Fatal Failure Policy
+
+- request-scoped read API error와 process-level fatal failure는 구분한다.
+- request-scoped failure는 `backend/src/app.ts`의 error envelope를 따른다.
+- process-level fatal failure는 `backend/src/runtime-failures.ts`가 담당한다.
+- `uncaughtException`과 `unhandledRejection`은 recoverable 상태로 취급하지 않는다.
+- 위 두 failure class는 structured fatal log를 먼저 남긴 뒤 같은 graceful shutdown 경로로 들어간다.
+- runtime-fatal path의 종료 코드는 항상 `1`이다.
+- shutdown이 `5초` 안에 끝나지 않으면 `Graceful shutdown timed out; forcing process exit`를 남기고 강제 종료한다.
+- verification은 `backend/src/runtime-failures.test.ts`에서 `uncaughtException`, `unhandledRejection`, forced-timeout path를 각각 spawn 기반으로 확인한다.
+
 ## Preview / Staging Baseline
 
 preview rehearsal은 production과 분리된 DB / API / worker 경로를 기준으로 진행한다.

--- a/backend/src/runtime-failure.fixture.ts
+++ b/backend/src/runtime-failure.fixture.ts
@@ -1,0 +1,64 @@
+import { registerRuntimeFailureHandlers, type RuntimeFailureApp } from './runtime-failures.js';
+
+type FailureMode = 'uncaughtException' | 'unhandledRejection' | 'hangingRejection';
+
+function writeLog(level: 'info' | 'error' | 'fatal', payload: Record<string, unknown>, message: string) {
+  console.log(
+    JSON.stringify({
+      level,
+      message,
+      ...payload,
+    }),
+  );
+}
+
+function createFixtureApp(mode: FailureMode): RuntimeFailureApp {
+  return {
+    log: {
+      info(payload, message) {
+        writeLog('info', payload, message);
+      },
+      error(payload, message) {
+        writeLog('error', payload, message);
+      },
+      fatal(payload, message) {
+        writeLog('fatal', payload, message);
+      },
+    },
+    async close() {
+      writeLog('info', { fixture_close_started: true }, 'Fixture close started');
+
+      if (mode === 'hangingRejection') {
+        await new Promise(() => undefined);
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      writeLog('info', { fixture_close_finished: true }, 'Fixture close finished');
+    },
+  };
+}
+
+async function main() {
+  const mode = process.argv[2] as FailureMode | undefined;
+  if (!mode) {
+    throw new Error('Missing runtime failure fixture mode');
+  }
+
+  registerRuntimeFailureHandlers({
+    app: createFixtureApp(mode),
+    shutdownTimeoutMs: 50,
+  });
+
+  if (mode === 'uncaughtException') {
+    setTimeout(() => {
+      throw new Error('fixture uncaught exception');
+    }, 0);
+    return;
+  }
+
+  setTimeout(() => {
+    Promise.reject(new Error(mode === 'hangingRejection' ? 'fixture hanging rejection' : 'fixture unhandled rejection'));
+  }, 0);
+}
+
+void main();

--- a/backend/src/runtime-failures.test.ts
+++ b/backend/src/runtime-failures.test.ts
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+type FailureMode = 'uncaughtException' | 'unhandledRejection' | 'hangingRejection';
+
+type SpawnResult = {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+};
+
+const backendRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const tsxBinary = resolve(backendRoot, 'node_modules/.bin/tsx');
+const fixturePath = resolve(backendRoot, 'src/runtime-failure.fixture.ts');
+
+async function runFixture(mode: FailureMode): Promise<SpawnResult> {
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn(tsxBinary, [fixturePath, mode], {
+      cwd: backendRoot,
+      env: process.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+
+    child.on('error', reject);
+    child.on('close', (code) => {
+      resolvePromise({
+        code,
+        stdout,
+        stderr,
+      });
+    });
+  });
+}
+
+test('uncaughtException path logs fatal classification and exits deterministically', async () => {
+  const result = await runFixture('uncaughtException');
+
+  assert.equal(result.code, 1);
+  assert.match(result.stdout, /"failure_class":"uncaughtException"/);
+  assert.match(result.stdout, /Runtime fatal exception detected/);
+  assert.match(result.stdout, /Graceful shutdown finished after runtime-fatal failure/);
+});
+
+test('unhandledRejection path logs fatal classification and exits deterministically', async () => {
+  const result = await runFixture('unhandledRejection');
+
+  assert.equal(result.code, 1);
+  assert.match(result.stdout, /"failure_class":"unhandledRejection"/);
+  assert.match(result.stdout, /Runtime fatal rejection detected/);
+  assert.match(result.stdout, /Graceful shutdown finished after runtime-fatal failure/);
+});
+
+test('runtime fatal shutdown timeout forces process exit', async () => {
+  const result = await runFixture('hangingRejection');
+
+  assert.equal(result.code, 1);
+  assert.match(result.stdout, /"failure_class":"unhandledRejection"/);
+  assert.match(result.stdout, /Graceful shutdown timed out; forcing process exit/);
+});

--- a/backend/src/runtime-failures.ts
+++ b/backend/src/runtime-failures.ts
@@ -1,0 +1,172 @@
+const SHUTDOWN_SIGNALS = ['SIGINT', 'SIGTERM'] as const;
+const DEFAULT_SHUTDOWN_TIMEOUT_MS = 5_000;
+
+type RuntimeFailureLogger = {
+  info(payload: Record<string, unknown>, message: string): void;
+  error(payload: Record<string, unknown>, message: string): void;
+  fatal(payload: Record<string, unknown>, message: string): void;
+};
+
+export type RuntimeFailureApp = {
+  close(): Promise<void>;
+  log: RuntimeFailureLogger;
+};
+
+type RuntimeFailureEvent =
+  | { kind: 'signal'; signal: NodeJS.Signals }
+  | { kind: 'uncaughtException'; error: unknown }
+  | { kind: 'unhandledRejection'; reason: unknown };
+
+export type RegisterRuntimeFailureHandlersOptions = {
+  app: RuntimeFailureApp;
+  processObject?: NodeJS.Process;
+  shutdownTimeoutMs?: number;
+};
+
+function isErrorLike(value: unknown): value is Error {
+  return value instanceof Error;
+}
+
+function buildFailurePayload(event: RuntimeFailureEvent, exitCode: number): Record<string, unknown> {
+  switch (event.kind) {
+    case 'signal':
+      return {
+        shutdown_reason: 'signal',
+        signal: event.signal,
+        exit_code: exitCode,
+      };
+    case 'uncaughtException':
+      return isErrorLike(event.error)
+        ? {
+            failure_class: 'uncaughtException',
+            err: event.error,
+            exit_code: exitCode,
+          }
+        : {
+            failure_class: 'uncaughtException',
+            thrown_value: event.error,
+            exit_code: exitCode,
+          };
+    case 'unhandledRejection':
+      return isErrorLike(event.reason)
+        ? {
+            failure_class: 'unhandledRejection',
+            err: event.reason,
+            exit_code: exitCode,
+          }
+        : {
+            failure_class: 'unhandledRejection',
+            rejection_reason: event.reason,
+            exit_code: exitCode,
+          };
+  }
+}
+
+function createStartMessage(event: RuntimeFailureEvent): string {
+  return event.kind === 'signal'
+    ? 'Starting graceful shutdown'
+    : 'Starting graceful shutdown after runtime-fatal failure';
+}
+
+function createCompleteMessage(event: RuntimeFailureEvent): string {
+  return event.kind === 'signal'
+    ? 'Graceful shutdown finished'
+    : 'Graceful shutdown finished after runtime-fatal failure';
+}
+
+function createFailureMessage(event: RuntimeFailureEvent): string {
+  switch (event.kind) {
+    case 'signal':
+      return 'Graceful shutdown failed';
+    case 'uncaughtException':
+      return 'Runtime fatal exception detected';
+    case 'unhandledRejection':
+      return 'Runtime fatal rejection detected';
+  }
+}
+
+export function registerRuntimeFailureHandlers({
+  app,
+  processObject = process,
+  shutdownTimeoutMs = DEFAULT_SHUTDOWN_TIMEOUT_MS,
+}: RegisterRuntimeFailureHandlersOptions): void {
+  let shutdownPromise: Promise<never> | null = null;
+  let forcedExitTimer: NodeJS.Timeout | null = null;
+
+  const clearForcedExitTimer = () => {
+    if (!forcedExitTimer) {
+      return;
+    }
+
+    clearTimeout(forcedExitTimer);
+    forcedExitTimer = null;
+  };
+
+  const exitProcess = (code: number): never => {
+    clearForcedExitTimer();
+    processObject.exit(code);
+    throw new Error('Unreachable');
+  };
+
+  const startShutdown = (event: RuntimeFailureEvent): Promise<never> => {
+    if (shutdownPromise) {
+      return shutdownPromise;
+    }
+
+    const exitCode = event.kind === 'signal' ? 0 : 1;
+
+    shutdownPromise = (async () => {
+      const payload = buildFailurePayload(event, exitCode);
+
+      if (event.kind === 'signal') {
+        app.log.info(payload, createStartMessage(event));
+      } else {
+        app.log.fatal(payload, createFailureMessage(event));
+        app.log.info(payload, createStartMessage(event));
+      }
+
+      forcedExitTimer = setTimeout(() => {
+        app.log.error(
+          {
+            ...payload,
+            shutdown_timeout_ms: shutdownTimeoutMs,
+          },
+          'Graceful shutdown timed out; forcing process exit',
+        );
+        processObject.exit(1);
+      }, shutdownTimeoutMs);
+
+      try {
+        await app.close();
+        app.log.info(payload, createCompleteMessage(event));
+        return exitProcess(exitCode);
+      } catch (error) {
+        app.log.error(
+          {
+            ...payload,
+            err: isErrorLike(error) ? error : undefined,
+            shutdown_error: isErrorLike(error) ? undefined : error,
+          },
+          'Graceful shutdown failed',
+        );
+        return exitProcess(1);
+      }
+    })();
+
+    return shutdownPromise;
+  };
+
+  for (const signal of SHUTDOWN_SIGNALS) {
+    processObject.on(signal, () => {
+      void startShutdown({ kind: 'signal', signal });
+    });
+  }
+
+  processObject.on('uncaughtException', (error) => {
+    void startShutdown({ kind: 'uncaughtException', error });
+  });
+
+  processObject.on('unhandledRejection', (reason) => {
+    void startShutdown({ kind: 'unhandledRejection', reason });
+  });
+}

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,47 +1,11 @@
-import type { FastifyInstance } from 'fastify';
-
 import { buildApp } from './app.js';
 import { loadConfig } from './config.js';
-
-const SHUTDOWN_SIGNALS = ['SIGINT', 'SIGTERM'] as const;
-
-function registerShutdownHandlers(app: FastifyInstance): void {
-  let shutdownPromise: Promise<never> | null = null;
-
-  const startShutdown = (signal: NodeJS.Signals): Promise<never> => {
-    if (shutdownPromise) {
-      return shutdownPromise;
-    }
-
-    shutdownPromise = (async () => {
-      app.log.info({ signal }, 'Starting graceful shutdown');
-
-      try {
-        await app.close();
-        app.log.info({ signal }, 'Graceful shutdown finished');
-        process.exit(0);
-      } catch (error) {
-        app.log.error({ err: error, signal }, 'Graceful shutdown failed');
-        process.exit(1);
-      }
-
-      throw new Error('Unreachable');
-    })();
-
-    return shutdownPromise;
-  };
-
-  for (const signal of SHUTDOWN_SIGNALS) {
-    process.on(signal, () => {
-      void startShutdown(signal);
-    });
-  }
-}
+import { registerRuntimeFailureHandlers } from './runtime-failures.js';
 
 async function main(): Promise<void> {
   const config = loadConfig();
   const app = buildApp({ config });
-  registerShutdownHandlers(app);
+  registerRuntimeFailureHandlers({ app });
 
   try {
     await app.listen({


### PR DESCRIPTION
## Summary
- add centralized runtime-fatal handling for uncaught exceptions and unhandled promise rejections
- reuse graceful shutdown with a fail-safe timeout and explicit fatal log classification
- add spawn-based verification for uncaught, rejected, and forced-timeout shutdown paths

Closes #301