### PR TITLE
feat: enrich import dry-run summaries

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -206,7 +206,18 @@ set +a
 python3 import_json_to_neon.py --dry-run --summary-path /tmp/idol-song-app-import-dry-run.json
 ```
 
-dry-run에서는 DB write를 commit하지 않고, summary에 `mode=dry_run`, `dry_run`, `db_row_counts_before`, `db_row_counts_after`, `db_unchanged`, `operation_counts`를 함께 남긴다.
+dry-run에서는 DB write를 commit하지 않고, summary에 아래 필드를 함께 남긴다.
+
+- `mode=dry_run`, `dry_run`, `db_row_counts_before`, `db_row_counts_after`, `db_unchanged`
+- `operation_counts`
+- `table_counts`
+  - table별 `payload_rows`, `db_rows_before`, `db_rows_after`, `projected_db_rows_after`, `insert_candidates`, `update_candidates`
+- `anomalies`
+  - `counts`: duplicate / dropped / missing-FK / unresolved / stale review task count
+  - `by_table`: table별 duplicate / dropped / missing-FK sample count
+  - `samples`: missing-FK sample, unresolved mapping, unresolved review link 샘플
+- `dry_run_review`
+  - dry-run이 보장하는 것과 보장하지 않는 것, 먼저 볼 review 순서
 
 입력 우선순위:
 

--- a/backend/reports/json_to_neon_import_dry_run_summary.json
+++ b/backend/reports/json_to_neon_import_dry_run_summary.json
@@ -1,0 +1,415 @@
+{
+  "generated_at": "2026-03-08T07:47:57.515874+00:00",
+  "source_counts": {
+    "artist_profiles": 117,
+    "team_badge_assets": 77,
+    "youtube_allowlists": 108,
+    "release_details": 117,
+    "release_history_groups": 116,
+    "release_history_rows": 1770,
+    "release_artwork": 117,
+    "upcoming_candidates": 71,
+    "watchlist": 117,
+    "release_detail_overrides": 67,
+    "manual_review_queue": 67,
+    "mv_manual_review_queue": 34,
+    "releases_rollup": 81
+  },
+  "source_duplicates": {
+    "entity_aliases": 1,
+    "youtube_channels": 25,
+    "upcoming_signals": 12
+  },
+  "dropped_records": {},
+  "dropped_missing_fk_samples": {},
+  "unresolved_release_mappings": [],
+  "unresolved_review_links": [],
+  "entity_type_counts": {
+    "group": 105,
+    "project": 1,
+    "unit": 4,
+    "solo": 7
+  },
+  "samples": {
+    "entities": [
+      "and-team",
+      "g-i-dle",
+      "82major",
+      "8turn",
+      "ab6ix"
+    ],
+    "releases": [
+      "&TEAM | 2022-11-21 | song | Under the skin",
+      "&TEAM | 2022-12-06 | album | First Howling : ME",
+      "&TEAM | 2023-05-07 | song | Blind Love",
+      "&TEAM | 2023-06-14 | album | First Howling : WE",
+      "&TEAM | 2023-11-15 | album | First Howling : NOW"
+    ],
+    "upcoming_signals": [
+      "BABYMONSTER’s B-Side Track From Two Years Ago Makes a Reverse Chart Run… Reappears on ‘M Countdown’ → Live Clip Released",
+      "BLACKPINK’s New Title Track Is ‘GO’.. YG “Created with Great Care”",
+      "BIGBANG Returns for 20th Anniversary… Global Tour with YG confirmed",
+      "BIGBANG Returns for 20th Anniversary… Global Tour with YG confirmed",
+      "YG to Launch First New Boy Group in 6 Years Since TREASURE… Rookie Girl Group Project Also in Full Swing"
+    ],
+    "review_tasks": [
+      "upcoming_signal",
+      "upcoming_signal",
+      "upcoming_signal",
+      "upcoming_signal",
+      "upcoming_signal"
+    ]
+  },
+  "stale_pruned": {
+    "review_tasks": 0
+  },
+  "operation_counts": {
+    "entities": {
+      "updated": 117
+    },
+    "entity_aliases": {
+      "updated": 168
+    },
+    "entity_official_links": {
+      "updated": 429
+    },
+    "youtube_channels": {
+      "updated": 86
+    },
+    "entity_youtube_channels": {
+      "updated": 111
+    },
+    "releases": {
+      "updated": 1771
+    },
+    "release_artwork": {
+      "updated": 117
+    },
+    "tracks": {
+      "updated": 497
+    },
+    "release_service_links": {
+      "updated": 351
+    },
+    "track_service_links": {},
+    "upcoming_signals": {
+      "updated": 59
+    },
+    "upcoming_signal_sources": {
+      "updated": 71
+    },
+    "entity_tracking_state": {
+      "updated": 117
+    },
+    "review_tasks": {
+      "updated": 101
+    },
+    "release_link_overrides": {
+      "updated": 75
+    }
+  },
+  "dry_run": {
+    "enabled": true,
+    "writes_committed": false,
+    "stale_pruned_preview": {
+      "review_tasks": 0
+    }
+  },
+  "db_row_counts": {
+    "entities": 117,
+    "entity_aliases": 168,
+    "entity_official_links": 429,
+    "youtube_channels": 86,
+    "entity_youtube_channels": 111,
+    "releases": 1771,
+    "release_artwork": 117,
+    "tracks": 497,
+    "release_service_links": 351,
+    "track_service_links": 0,
+    "upcoming_signals": 130,
+    "upcoming_signal_sources": 71,
+    "entity_tracking_state": 117,
+    "review_tasks": 101,
+    "release_link_overrides": 75
+  },
+  "db_row_counts_before": {
+    "entities": 117,
+    "entity_aliases": 168,
+    "entity_official_links": 429,
+    "youtube_channels": 86,
+    "entity_youtube_channels": 111,
+    "releases": 1771,
+    "release_artwork": 117,
+    "tracks": 497,
+    "release_service_links": 351,
+    "track_service_links": 0,
+    "upcoming_signals": 130,
+    "upcoming_signal_sources": 71,
+    "entity_tracking_state": 117,
+    "review_tasks": 101,
+    "release_link_overrides": 75
+  },
+  "db_row_counts_after": {
+    "entities": 117,
+    "entity_aliases": 168,
+    "entity_official_links": 429,
+    "youtube_channels": 86,
+    "entity_youtube_channels": 111,
+    "releases": 1771,
+    "release_artwork": 117,
+    "tracks": 497,
+    "release_service_links": 351,
+    "track_service_links": 0,
+    "upcoming_signals": 130,
+    "upcoming_signal_sources": 71,
+    "entity_tracking_state": 117,
+    "review_tasks": 101,
+    "release_link_overrides": 75
+  },
+  "db_unchanged": true,
+  "critical_checks": {
+    "entity_type_counts": {
+      "group": 105,
+      "project": 1,
+      "solo": 7,
+      "unit": 4
+    },
+    "upcoming_date_precision_counts": {
+      "exact": 13,
+      "month_only": 35,
+      "unknown": 82
+    },
+    "youtube_mv_status_counts": {
+      "manual_override": 25,
+      "needs_review": 2,
+      "relation_match": 1,
+      "unresolved": 89
+    },
+    "title_track_rows": 61,
+    "hangul_alias_rows": 153
+  },
+  "mode": "dry_run",
+  "summary_path": "backend/reports/json_to_neon_import_dry_run_summary.json",
+  "table_source_counts": {
+    "entities": 117,
+    "entity_aliases": 168,
+    "entity_official_links": 429,
+    "youtube_channels": 86,
+    "entity_youtube_channels": 111,
+    "releases": 1771,
+    "release_artwork": 117,
+    "tracks": 497,
+    "release_service_links": 351,
+    "track_service_links": 0,
+    "upcoming_signals": 59,
+    "upcoming_signal_sources": 71,
+    "entity_tracking_state": 117,
+    "review_tasks": 101,
+    "release_link_overrides": 75
+  },
+  "table_counts": {
+    "entities": {
+      "payload_rows": 117,
+      "db_rows_before": 117,
+      "db_rows_after": 117,
+      "projected_db_rows_after": 117,
+      "insert_candidates": 0,
+      "update_candidates": 117
+    },
+    "entity_aliases": {
+      "payload_rows": 168,
+      "db_rows_before": 168,
+      "db_rows_after": 168,
+      "projected_db_rows_after": 168,
+      "insert_candidates": 0,
+      "update_candidates": 168
+    },
+    "entity_official_links": {
+      "payload_rows": 429,
+      "db_rows_before": 429,
+      "db_rows_after": 429,
+      "projected_db_rows_after": 429,
+      "insert_candidates": 0,
+      "update_candidates": 429
+    },
+    "youtube_channels": {
+      "payload_rows": 86,
+      "db_rows_before": 86,
+      "db_rows_after": 86,
+      "projected_db_rows_after": 86,
+      "insert_candidates": 0,
+      "update_candidates": 86
+    },
+    "entity_youtube_channels": {
+      "payload_rows": 111,
+      "db_rows_before": 111,
+      "db_rows_after": 111,
+      "projected_db_rows_after": 111,
+      "insert_candidates": 0,
+      "update_candidates": 111
+    },
+    "releases": {
+      "payload_rows": 1771,
+      "db_rows_before": 1771,
+      "db_rows_after": 1771,
+      "projected_db_rows_after": 1771,
+      "insert_candidates": 0,
+      "update_candidates": 1771
+    },
+    "release_artwork": {
+      "payload_rows": 117,
+      "db_rows_before": 117,
+      "db_rows_after": 117,
+      "projected_db_rows_after": 117,
+      "insert_candidates": 0,
+      "update_candidates": 117
+    },
+    "tracks": {
+      "payload_rows": 497,
+      "db_rows_before": 497,
+      "db_rows_after": 497,
+      "projected_db_rows_after": 497,
+      "insert_candidates": 0,
+      "update_candidates": 497
+    },
+    "release_service_links": {
+      "payload_rows": 351,
+      "db_rows_before": 351,
+      "db_rows_after": 351,
+      "projected_db_rows_after": 351,
+      "insert_candidates": 0,
+      "update_candidates": 351
+    },
+    "track_service_links": {
+      "payload_rows": 0,
+      "db_rows_before": 0,
+      "db_rows_after": 0,
+      "projected_db_rows_after": 0,
+      "insert_candidates": 0,
+      "update_candidates": 0
+    },
+    "upcoming_signals": {
+      "payload_rows": 59,
+      "db_rows_before": 130,
+      "db_rows_after": 130,
+      "projected_db_rows_after": 130,
+      "insert_candidates": 0,
+      "update_candidates": 59
+    },
+    "upcoming_signal_sources": {
+      "payload_rows": 71,
+      "db_rows_before": 71,
+      "db_rows_after": 71,
+      "projected_db_rows_after": 71,
+      "insert_candidates": 0,
+      "update_candidates": 71
+    },
+    "entity_tracking_state": {
+      "payload_rows": 117,
+      "db_rows_before": 117,
+      "db_rows_after": 117,
+      "projected_db_rows_after": 117,
+      "insert_candidates": 0,
+      "update_candidates": 117
+    },
+    "review_tasks": {
+      "payload_rows": 101,
+      "db_rows_before": 101,
+      "db_rows_after": 101,
+      "projected_db_rows_after": 101,
+      "insert_candidates": 0,
+      "update_candidates": 101
+    },
+    "release_link_overrides": {
+      "payload_rows": 75,
+      "db_rows_before": 75,
+      "db_rows_after": 75,
+      "projected_db_rows_after": 75,
+      "insert_candidates": 0,
+      "update_candidates": 75
+    }
+  },
+  "anomalies": {
+    "counts": {
+      "source_duplicates_total": 38,
+      "dropped_records_total": 0,
+      "missing_fk_tables": 0,
+      "missing_fk_sample_total": 0,
+      "unresolved_release_mappings": 0,
+      "unresolved_review_links": 0,
+      "stale_review_tasks": 0
+    },
+    "by_table": {
+      "source_duplicates": {
+        "entities": 0,
+        "entity_aliases": 1,
+        "entity_official_links": 0,
+        "youtube_channels": 25,
+        "entity_youtube_channels": 0,
+        "releases": 0,
+        "release_artwork": 0,
+        "tracks": 0,
+        "release_service_links": 0,
+        "track_service_links": 0,
+        "upcoming_signals": 12,
+        "upcoming_signal_sources": 0,
+        "entity_tracking_state": 0,
+        "review_tasks": 0,
+        "release_link_overrides": 0
+      },
+      "dropped_records": {
+        "entities": 0,
+        "entity_aliases": 0,
+        "entity_official_links": 0,
+        "youtube_channels": 0,
+        "entity_youtube_channels": 0,
+        "releases": 0,
+        "release_artwork": 0,
+        "tracks": 0,
+        "release_service_links": 0,
+        "track_service_links": 0,
+        "upcoming_signals": 0,
+        "upcoming_signal_sources": 0,
+        "entity_tracking_state": 0,
+        "review_tasks": 0,
+        "release_link_overrides": 0
+      },
+      "missing_fk_sample_counts": {
+        "entities": 0,
+        "entity_aliases": 0,
+        "entity_official_links": 0,
+        "youtube_channels": 0,
+        "entity_youtube_channels": 0,
+        "releases": 0,
+        "release_artwork": 0,
+        "tracks": 0,
+        "release_service_links": 0,
+        "track_service_links": 0,
+        "upcoming_signals": 0,
+        "upcoming_signal_sources": 0,
+        "entity_tracking_state": 0,
+        "review_tasks": 0,
+        "release_link_overrides": 0
+      }
+    },
+    "samples": {
+      "dropped_missing_fk_samples": {},
+      "unresolved_release_mappings": [],
+      "unresolved_review_links": []
+    }
+  },
+  "dry_run_review": {
+    "guarantees": [
+      "payload rows, insert candidates, update candidates, projected post-import row counts, and anomaly buckets are computed without committing writes",
+      "db_rows_before and db_rows_after reflect the live database state around the dry run and should remain unchanged"
+    ],
+    "limitations": [
+      "dry-run does not commit writes or refresh downstream projections",
+      "projected_db_rows_after is an import estimate based on insert candidates and stale review-task pruning, not a committed post-run fact"
+    ],
+    "recommended_checks": [
+      "review anomalies.counts first, then inspect anomalies.by_table for concentrated problem buckets",
+      "compare table_counts.projected_db_rows_after against payload_rows to spot unexpected insert volume"
+    ]
+  }
+}

--- a/import_json_to_neon.py
+++ b/import_json_to_neon.py
@@ -2139,6 +2139,86 @@ def fetch_critical_counts(connection: "psycopg.Connection[Any]") -> Dict[str, An
     return critical
 
 
+def build_table_count_summary(
+    payload: Dict[str, Any],
+    summary: Dict[str, Any],
+    before_counts: Dict[str, int],
+    after_counts: Dict[str, int],
+) -> Dict[str, Dict[str, Any]]:
+    stale_review_task_preview = int(summary.get("stale_pruned", {}).get("review_tasks", 0))
+    table_counts: Dict[str, Dict[str, Any]] = {}
+
+    for table in TARGET_TABLES:
+        operation_counts = summary["operation_counts"].get(table, {})
+        inserted = int(operation_counts.get("inserted", 0))
+        updated = int(operation_counts.get("updated", 0))
+        projected_after = before_counts.get(table, 0) + inserted
+        if table == "review_tasks":
+            projected_after = max(0, projected_after - stale_review_task_preview)
+
+        table_counts[table] = {
+            "payload_rows": len(payload["tables"][table]),
+            "db_rows_before": before_counts.get(table, 0),
+            "db_rows_after": after_counts.get(table, 0),
+            "projected_db_rows_after": projected_after,
+            "insert_candidates": inserted,
+            "update_candidates": updated,
+        }
+
+    return table_counts
+
+
+def build_anomaly_summary(summary: Dict[str, Any]) -> Dict[str, Any]:
+    source_duplicates = {table: int(summary["source_duplicates"].get(table, 0)) for table in TARGET_TABLES}
+    dropped_records = {table: int(summary["dropped_records"].get(table, 0)) for table in TARGET_TABLES}
+    missing_fk_sample_counts = {
+        table: len(summary["dropped_missing_fk_samples"].get(table, []))
+        for table in TARGET_TABLES
+    }
+
+    return {
+        "counts": {
+            "source_duplicates_total": sum(source_duplicates.values()),
+            "dropped_records_total": sum(dropped_records.values()),
+            "missing_fk_tables": sum(1 for count in missing_fk_sample_counts.values() if count > 0),
+            "missing_fk_sample_total": sum(missing_fk_sample_counts.values()),
+            "unresolved_release_mappings": len(summary["unresolved_release_mappings"]),
+            "unresolved_review_links": len(summary["unresolved_review_links"]),
+            "stale_review_tasks": int(summary.get("stale_pruned", {}).get("review_tasks", 0)),
+        },
+        "by_table": {
+            "source_duplicates": source_duplicates,
+            "dropped_records": dropped_records,
+            "missing_fk_sample_counts": missing_fk_sample_counts,
+        },
+        "samples": {
+            "dropped_missing_fk_samples": {
+                table: rows[:5]
+                for table, rows in summary["dropped_missing_fk_samples"].items()
+            },
+            "unresolved_release_mappings": summary["unresolved_release_mappings"][:25],
+            "unresolved_review_links": summary["unresolved_review_links"][:25],
+        },
+    }
+
+
+def build_dry_run_review_summary() -> Dict[str, List[str]]:
+    return {
+        "guarantees": [
+            "payload rows, insert candidates, update candidates, projected post-import row counts, and anomaly buckets are computed without committing writes",
+            "db_rows_before and db_rows_after reflect the live database state around the dry run and should remain unchanged",
+        ],
+        "limitations": [
+            "dry-run does not commit writes or refresh downstream projections",
+            "projected_db_rows_after is an import estimate based on insert candidates and stale review-task pruning, not a committed post-run fact",
+        ],
+        "recommended_checks": [
+            "review anomalies.counts first, then inspect anomalies.by_table for concentrated problem buckets",
+            "compare table_counts.projected_db_rows_after against payload_rows to spot unexpected insert volume",
+        ],
+    }
+
+
 def sanitize_summary(summary: Dict[str, Any]) -> Dict[str, Any]:
     sanitized = dict(summary)
     sanitized["source_duplicates"] = dict(summary["source_duplicates"])
@@ -2204,6 +2284,10 @@ def main() -> None:
     summary["mode"] = "dry_run" if args.dry_run else "apply"
     summary["summary_path"] = display_path(Path(args.summary_path))
     summary["table_source_counts"] = {table: len(rows) for table, rows in payload["tables"].items()}
+    summary["table_counts"] = build_table_count_summary(payload, summary, before_counts, after_counts)
+    summary["anomalies"] = build_anomaly_summary(summary)
+    if args.dry_run:
+        summary["dry_run_review"] = build_dry_run_review_summary()
     write_summary(Path(args.summary_path), sanitize_summary(summary))
 
     print(


### PR DESCRIPTION
## Summary\n- enrich import dry-run summaries with projected table counts and anomaly rollups\n- add dry-run review guidance to the summary artifact and backend docs\n- commit a representative dry-run summary artifact for migration review\n\n## Verification\n- python3 -m py_compile import_json_to_neon.py\n- python3 import_json_to_neon.py --dry-run --summary-path backend/reports/json_to_neon_import_dry_run_summary.json\n- python dry-run summary assertions\n- git diff --check\n\nCloses #296