### PR TITLE
feat: freeze mobile entity detail payload

### DIFF
--- a/backend/reports/backend_shadow_read_report.json
+++ b/backend/reports/backend_shadow_read_report.json
@@ -1,11 +1,11 @@
 {
-  "generated_at": "2026-03-08T06:56:37.284Z",
+  "generated_at": "2026-03-08T09:39:51.143Z",
   "clean": false,
   "linked_parity_report": {
     "exists": true,
     "path": "backend/reports/backend_json_parity_report.json",
     "clean": false,
-    "generated_at": "2026-03-07T07:38:47.525631+00:00",
+    "generated_at": "2026-03-08T06:56:34.451182+00:00",
     "summary_lines": [
       "entity alias/search coverage: clean (mismatched entities=0)",
       "official links: clean (mismatched entities=0)",
@@ -65,15 +65,14 @@
   },
   "summary_lines": [
     "search: clean 1/5, drift 4/5",
-    "entity_detail: clean 0/4, drift 4/4",
+    "entity_detail: clean 4/4, drift 0/4",
     "release_detail: clean 0/3, drift 3/3",
     "calendar_month: clean 3/3, drift 0/3",
     "radar: clean 0/1, drift 1/1",
-    "missing rows or segments: 11 case(s)",
-    "field-shape mismatches: 9 case(s)",
-    "latest-release or next-upcoming drift: 7 case(s)",
+    "missing rows or segments: 7 case(s)",
+    "field-shape mismatches: 6 case(s)",
+    "latest-release or next-upcoming drift: 4 case(s)",
     "alias-match differences: 3 case(s)",
-    "exact-vs-month-only drift: 2 case(s)",
     "radar eligibility drift: 1 case(s)"
   ],
   "cases": [
@@ -789,97 +788,9 @@
       "input": {
         "slug": "yena"
       },
-      "clean": false,
-      "mismatch_categories": [
-        "field-shape mismatches",
-        "missing rows or segments",
-        "latest-release or next-upcoming drift"
-      ],
-      "mismatches": [
-        {
-          "category": "field-shape mismatches",
-          "path": "data",
-          "shape_mismatches": [
-            {
-              "path": "data.next_upcoming.scheduled_month",
-              "expected_type": "string",
-              "actual_type": "null",
-              "message": "Type mismatch"
-            },
-            {
-              "path": "data.source_timeline[0].event_type",
-              "expected_type": "string",
-              "actual_type": "missing",
-              "message": "Missing key"
-            },
-            {
-              "path": "data.source_timeline[0].occurred_at",
-              "expected_type": "string",
-              "actual_type": "missing",
-              "message": "Missing key"
-            },
-            {
-              "path": "data.source_timeline[0].summary",
-              "expected_type": "string",
-              "actual_type": "missing",
-              "message": "Missing key"
-            }
-          ]
-        },
-        {
-          "category": "missing rows or segments",
-          "path": "data.official_links.instagram",
-          "expected": "https://www.instagram.com/yena.jigumina/",
-          "actual": "https://www.instagram.com/yena.jigumina"
-        },
-        {
-          "category": "missing rows or segments",
-          "path": "data.artist_source_url",
-          "expected": null,
-          "actual": "https://musicbrainz.org/artist/745c5b92-325f-451d-bd52-e6b95229c776"
-        },
-        {
-          "category": "latest-release or next-upcoming drift",
-          "path": "data.latest_release",
-          "expected": null,
-          "actual": {
-            "release_title": "STAR!",
-            "release_date": "2025-11-26",
-            "stream": "song",
-            "release_kind": "single"
-          }
-        },
-        {
-          "category": "latest-release or next-upcoming drift",
-          "path": "data.next_upcoming",
-          "expected": {
-            "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
-            "scheduled_date": "2026-03-11",
-            "scheduled_month": "2026-03",
-            "date_precision": "exact",
-            "date_status": "confirmed",
-            "release_format": "ep"
-          },
-          "actual": {
-            "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
-            "scheduled_date": "2026-03-11",
-            "scheduled_month": null,
-            "date_precision": "exact",
-            "date_status": "confirmed",
-            "release_format": "ep"
-          }
-        },
-        {
-          "category": "missing rows or segments",
-          "path": "data.source_timeline",
-          "expected": [
-            "first_signal|최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스|news_rss|https://www.starnewskorea.com/music/2026/02/23/2026022315005262396"
-          ],
-          "actual": [
-            "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스|news_rss|https://www.starnewskorea.com/music/2026/02/23/2026022315005262396"
-          ]
-        }
-      ],
+      "clean": true,
+      "mismatch_categories": [],
+      "mismatches": [],
       "expected_snapshot": {
         "identity": {
           "entity_slug": "yena",
@@ -905,53 +816,89 @@
           "tracking_status": "watch_only"
         },
         "next_upcoming": {
+          "upcoming_signal_id": "yena::2026-03-11::love catcher",
           "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
           "scheduled_date": "2026-03-11",
           "scheduled_month": "2026-03",
           "date_precision": "exact",
           "date_status": "confirmed",
+          "release_format": "ep",
           "confidence_score": 0.84,
-          "release_format": "ep"
+          "latest_seen_at": "Mon, 23 Feb 2026 14:58:00 +0900",
+          "source_type": "news_rss",
+          "source_url": "https://www.starnewskorea.com/music/2026/02/23/2026022315005262396",
+          "source_domain": "starnewskorea.com",
+          "evidence_summary": "Future date reference: 2026-03-11. YENA confirmed her comeback with the 5th mini album LOVE CATCHER, scheduled for March 11 at 6 p.m. KST.",
+          "source_count": 1
         },
-        "latest_release": null,
+        "latest_release": {
+          "release_id": "YENA::STAR!::2025-11-26::song",
+          "release_title": "STAR!",
+          "release_date": "2025-11-26",
+          "stream": "song",
+          "release_kind": "single",
+          "release_format": "single",
+          "artwork": null
+        },
         "recent_albums": [
           {
+            "release_id": "YENA::Blooming Wings::2025-07-29::album",
             "release_title": "Blooming Wings",
             "release_date": "2025-07-29",
             "stream": "album",
-            "release_kind": "ep"
+            "release_kind": "ep",
+            "release_format": "ep",
+            "artwork": null
           },
           {
+            "release_id": "YENA::GOOD MORNING::2024-01-15::album",
             "release_title": "GOOD MORNING",
             "release_date": "2024-01-15",
             "stream": "album",
-            "release_kind": "ep"
+            "release_kind": "ep",
+            "release_format": "ep",
+            "artwork": null
           },
           {
+            "release_id": "YENA::SMARTPHONE::2022-08-03::album",
             "release_title": "SMARTPHONE",
             "release_date": "2022-08-03",
             "stream": "album",
-            "release_kind": "ep"
+            "release_kind": "ep",
+            "release_format": "ep",
+            "artwork": null
           },
           {
+            "release_id": "YENA::ˣ‿ˣ (SMiLEY)::2022-01-17::album",
             "release_title": "ˣ‿ˣ (SMiLEY)",
             "release_date": "2022-01-17",
             "stream": "album",
-            "release_kind": "ep"
+            "release_kind": "ep",
+            "release_format": "ep",
+            "artwork": null
           }
         ],
         "source_timeline": [
           {
-            "event_type": "first_signal",
-            "source_type": "news_rss",
+            "event_type": "official_announcement",
             "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
+            "occurred_at": "Mon, 23 Feb 2026 14:58:00 +0900",
+            "summary": "ep · confirmed · 2026-03-11",
             "source_url": "https://www.starnewskorea.com/music/2026/02/23/2026022315005262396",
+            "source_type": "news_rss",
             "source_domain": "starnewskorea.com",
-            "occurred_at": "2026-02-23T05:58:00.000Z",
-            "summary": "Future date reference: 2026-03-11. YENA confirmed her comeback with the 5th mini album LOVE CATCHER, scheduled for March 11 at 6 p.m. KST."
+            "published_at": "Mon, 23 Feb 2026 14:58:00 +0900",
+            "scheduled_date": "2026-03-11",
+            "scheduled_month": "2026-03",
+            "date_precision": "exact",
+            "date_status": "confirmed",
+            "release_format": "ep",
+            "confidence_score": 0.84,
+            "evidence_summary": "Future date reference: 2026-03-11. YENA confirmed her comeback with the 5th mini album LOVE CATCHER, scheduled for March 11 at 6 p.m. KST.",
+            "source_count": 1
           }
         ],
-        "artist_source_url": null
+        "artist_source_url": "https://musicbrainz.org/artist/745c5b92-325f-451d-bd52-e6b95229c776"
       },
       "actual_snapshot": {
         "identity": {
@@ -986,19 +933,26 @@
           "upcoming_signal_id": "135cb637-d988-5028-b221-0ec2f59f124f",
           "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
           "scheduled_date": "2026-03-11",
-          "scheduled_month": null,
+          "scheduled_month": "2026-03",
           "date_precision": "exact",
           "date_status": "confirmed",
           "release_format": "ep",
           "confidence_score": 0.84,
-          "latest_seen_at": "2026-02-23T05:58:00+00:00"
+          "latest_seen_at": "2026-02-23T05:58:00+00:00",
+          "source_type": "news_rss",
+          "source_url": "https://www.starnewskorea.com/music/2026/02/23/2026022315005262396",
+          "source_domain": "starnewskorea.com",
+          "evidence_summary": "Future date reference: 2026-03-11. YENA confirmed her comeback with the 5th mini album LOVE CATCHER, scheduled for March 11 at 6 p.m. KST.",
+          "source_count": 1
         },
         "latest_release": {
           "release_id": "0363f526-e841-560d-940d-541a4e536e4e",
           "release_title": "STAR!",
           "release_date": "2025-11-26",
           "stream": "song",
-          "release_kind": "single"
+          "release_kind": "single",
+          "release_format": "single",
+          "artwork": null
         },
         "recent_albums": [
           {
@@ -1006,43 +960,56 @@
             "release_title": "Blooming Wings",
             "release_date": "2025-07-29",
             "stream": "album",
-            "release_kind": "ep"
+            "release_kind": "ep",
+            "release_format": "ep",
+            "artwork": null
           },
           {
             "release_id": "b18e824c-d318-5848-9b08-7341982cca31",
             "release_title": "GOOD MORNING",
             "release_date": "2024-01-15",
             "stream": "album",
-            "release_kind": "ep"
+            "release_kind": "ep",
+            "release_format": "ep",
+            "artwork": null
           },
           {
             "release_id": "6f634529-e1db-506a-b4fc-f5565b54beb3",
             "release_title": "SMARTPHONE",
             "release_date": "2022-08-03",
             "stream": "album",
-            "release_kind": "ep"
+            "release_kind": "ep",
+            "release_format": "ep",
+            "artwork": null
           },
           {
             "release_id": "cc26984b-ed23-5e96-9bbd-8364ce7c037b",
             "release_title": "ˣ‿ˣ (SMiLEY)",
             "release_date": "2022-01-17",
             "stream": "album",
-            "release_kind": "ep"
+            "release_kind": "ep",
+            "release_format": "ep",
+            "artwork": null
           }
         ],
         "source_timeline": [
           {
+            "event_type": "official_announcement",
             "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
+            "occurred_at": "2026-02-23T05:58:00+00:00",
+            "summary": "ep · confirmed · 2026-03-11",
             "source_url": "https://www.starnewskorea.com/music/2026/02/23/2026022315005262396",
             "source_type": "news_rss",
             "source_domain": "starnewskorea.com",
             "published_at": "2026-02-23T05:58:00+00:00",
             "scheduled_date": "2026-03-11",
-            "scheduled_month": null,
+            "scheduled_month": "2026-03",
             "date_precision": "exact",
             "date_status": "confirmed",
             "release_format": "ep",
-            "confidence_score": 0.84
+            "confidence_score": 0.84,
+            "evidence_summary": "Future date reference: 2026-03-11. YENA confirmed her comeback with the 5th mini album LOVE CATCHER, scheduled for March 11 at 6 p.m. KST.",
+            "source_count": 1
           }
         ],
         "artist_source_url": "https://musicbrainz.org/artist/745c5b92-325f-451d-bd52-e6b95229c776"
@@ -1054,99 +1021,9 @@
       "input": {
         "slug": "blackpink"
       },
-      "clean": false,
-      "mismatch_categories": [
-        "field-shape mismatches",
-        "missing rows or segments",
-        "latest-release or next-upcoming drift",
-        "exact-vs-month-only drift"
-      ],
-      "mismatches": [
-        {
-          "category": "field-shape mismatches",
-          "path": "data",
-          "shape_mismatches": [
-            {
-              "path": "data.next_upcoming",
-              "expected_type": "object",
-              "actual_type": "null",
-              "message": "Type mismatch"
-            },
-            {
-              "path": "data.source_timeline[0].event_type",
-              "expected_type": "string",
-              "actual_type": "missing",
-              "message": "Missing key"
-            },
-            {
-              "path": "data.source_timeline[0].occurred_at",
-              "expected_type": "string",
-              "actual_type": "missing",
-              "message": "Missing key"
-            },
-            {
-              "path": "data.source_timeline[0].summary",
-              "expected_type": "string",
-              "actual_type": "missing",
-              "message": "Missing key"
-            }
-          ]
-        },
-        {
-          "category": "missing rows or segments",
-          "path": "data.official_links.instagram",
-          "expected": "https://www.instagram.com/blackpinkofficial/",
-          "actual": "https://www.instagram.com/blackpinkofficial"
-        },
-        {
-          "category": "latest-release or next-upcoming drift",
-          "path": "data.latest_release",
-          "expected": {
-            "release_title": "DEADLINE",
-            "release_date": "2026-02-26",
-            "stream": "album",
-            "release_kind": "ep"
-          },
-          "actual": {
-            "release_title": "DEADLINE",
-            "release_date": "2026-02-27",
-            "stream": "album",
-            "release_kind": "ep"
-          }
-        },
-        {
-          "category": "exact-vs-month-only drift",
-          "path": "data.next_upcoming",
-          "expected": {
-            "headline": "BLACKPINK Finally Reveals 'DEADLINE' Mini Album Release Date - TMZ",
-            "scheduled_date": "",
-            "scheduled_month": "",
-            "date_precision": "unknown",
-            "date_status": "rumor",
-            "release_format": "ep"
-          },
-          "actual": null
-        },
-        {
-          "category": "missing rows or segments",
-          "path": "data.source_timeline",
-          "expected": [
-            "first_signal|BLACKPINK Finally Reveals 'DEADLINE' Mini Album Release Date - TMZ|news_rss|https://news.google.com/rss/articles/CBMicEFVX3lxTE4waE5xc2U4eWNJaFhldTl2aGZEdGRxYl9DTVRRYnQ2Sk5rRGMtX2JHVVhiWFV3VTZJdUc1b1VoWWdmM25vcXhDb0dKSlBlanpHSlh2NDlHQ1hEMEtCalpvdkFudzNKZDJ0Y1VnVlpwOTA?oc=5",
-            "official_announcement|BLACKPINK’s New Title Track Is ‘GO’.. YG “Created with Great Care”|agency_notice|https://www.ygfamily.com/en/news/report/7378",
-            "release_verified|DEADLINE|release_catalog|https://musicbrainz.org/release-group/38204997-b295-4d09-a946-f7e119725031"
-          ],
-          "actual": [
-            "Blackpink’s Jisoo Shares Love for Album ‘Deadline,’ Talks New Netflix K-Drama: “Blinks Will Love It” - The Hollywood Reporter|news_rss|https://news.google.com/rss/articles/CBMiqwFBVV95cUxOcldhb1d6S2hhMDQxTDZndUlEa0VqLXROcEJucWkxLTZxdFNha25nckc0LWxVZ2I3MHhnVk0zX0xfM3NnRlpnaW9MemF5U3VnaTRyZWlYRVI0YmxtN1Y0T0U0WmxuZmNqVWRxeDNsaVFOeXpzNGJrSVVsSjEtMHlnMGRBT3hpNDl2RW1IelNpVzdYWTBrNXlZUFNZZHN0VHFkVG1RZERvT3k3SlE?oc=5",
-            "Blackpink's DEADLINE sells 1.46 million copies on day of release, sets new K-pop girl group record - The Korea Economic Daily Global Edition|news_rss|https://news.google.com/rss/articles/CBMiZ0FVX3lxTE94bmhvU2RuMVBXTGNpS1VMaExLUXN6c0lCekxVbm1KTy1McTNvTkUycE1KNUl1c0U3b2c5ajh3cE9WSEs0TGJwNlgyZU9LX3JHam55VVhGX3h2SDBoaUdtcGYwWmdGdHc?oc=5",
-            "Blackpink’s Jisoo Shares Love for Album ‘Deadline,’ Talks New Netflix K-Drama: “Blinks Will Love It” - The Hollywood Reporter|news_rss|https://news.google.com/rss/articles/CBMiuwFBVV95cUxQREV5ZV9pTDZyVFVyS0JqTDJEbWJGMzh0UDhwcnFKLVFFbDhmVW5rcmVrdGt5cTFkR1BHSzQ4Z0dBZG9RNFBXQVN5UlRKcGF0V1Bycm1KT2ZObWRpS0FBZll0N2RrWjlYWTZlQ3M4Nk8zc2o4dzFMcnlmTzFVMk4zcGZKUms3eFNMQzlLSzN2UERxVmZOOGVyWm90Tzh2b0tHVlJUMHdVZjU5Z0QzWWFibGhEYWtRbzRuNHBZ0gHIAUFVX3lxTFA5LVQ4Uk41RERaWnk5UXh0eC1MTEppZWVTd05yVGlNeEs0UHVKRnExQ3hBcFVsX2wyUmp3Z1U3Z0Q2R3hWcFdBU09hVHV1blJ6VHIyTEgxTnNUc0V5VmxWOUt1S2hwcm11QmRZdUY5c3dfTGZPWE5MT1IzQndIdkUzVHF6NDhCaE9ZeWc5T1JBVlg3MURjV2hrVVVuRDV5ek1LdlRTS1lSTFNCemJxa0t6VlN2bURxM3Uxb0tMRXl0dkJSU3FQbm9l?oc=5",
-            "K-Pop girl group Blackpink drops their third mini album Deadline - Indulgexpress|news_rss|https://news.google.com/rss/articles/CBMivAFBVV95cUxQVG9PNFdjS19QUkVoYU95M21Rb2l5em5EQUVZSzZrcU9qa1hYMWRQSGRnc3dJZDFUYWtBcWstQVREcEw5c3BKc2M5WHJETHB0LUlFTGI3dmFKbXdBbWRtOEZRVTVzZ29UWTRaLVJ5RnhDc25IS2ZsRVNTTXVTWnEtZENIdTVDeUVmM0ZGTXlBSnNBek1aSEs0TFJ4UndGTjVYMDdZWVhmV2tPc092MDN5WnZWYlBiNkJ5M09nbNIBygFBVV95cUxOWlFldno4Y0RLNjhoRFkxN29BT2J3WHdBaFN6THNuYk1HbEZUdzAwSzA5T0U5V3QwVWg1WDZCQUs1S0ZVdDVnSXo3TGpCeTNsZm5tS1VsRDZoVlhyR3doOFNEcVVTVEJubVJTLXNIVG5RX21xN3BEc3preXJVREU0MUVlU2JMalh1Q0QxamJhZ0xIcHFKcTNDV3V4RHFKeV9qZ0dnS2IySkJNaXBVU3lvRDA0eXhYbS1BZFdEbVZBclJQcU9UeFRhUlBB?oc=5",
-            "BLACKPINK’s New Title Track Is ‘GO’.. YG “Created with Great Care”|agency_notice|https://www.ygfamily.com/en/news/report/7378",
-            "BLACKPINK Finally Reveals 'DEADLINE' Mini Album Release Date - TMZ|news_rss|https://news.google.com/rss/articles/CBMicEFVX3lxTE4waE5xc2U4eWNJaFhldTl2aGZEdGRxYl9DTVRRYnQ2Sk5rRGMtX2JHVVhiWFV3VTZJdUc1b1VoWWdmM25vcXhDb0dKSlBlanpHSlh2NDlHQ1hEMEtCalpvdkFudzNKZDJ0Y1VnVlpwOTA?oc=5",
-            "Blackpink Sets Release Date for Comeback Album - Pitchfork|news_rss|https://news.google.com/rss/articles/CBMiekFVX3lxTE9Ucm80bHB0cUYwcHNhZkJxaWM1MnA5SnJUVzk0ZkdyQmg3b0Q2SXFudk41aXVRN1RjLURta0tvemNPdl8yaE10cVdHbkc2d3dnM3VxSDhtNWhlSGZtM3RYNzJFVThxRzhqWlFjSzR4ekNGM04tLWdWWW9n?oc=5",
-            "K-pop group Blackpink announces new mini album Deadline, out Feb 27 - CNA Lifestyle|news_rss|https://news.google.com/rss/articles/CBMirgFBVV95cUxOUFhWaFpuYnA5UDVRQmR0bHhuS2NIS2pfa255aDEzNGlFMHUzQ0p4MVRRLVVGUm13czJyclV5d3Rhd2xCakNqSmNaaDRtdkZhSWxqbk1VbWc0RzdMX3FjZ1RQTEY5RTV1czR6a3pXQmR4RS0wVVZNSHo3QllWLTBidzlESGpVNGwybzZ1Ti1Wc2VuLXE5WWk1U1Y2QlBtY1JWWXp6cjF3VGZwblhfclE?oc=5"
-          ]
-        }
-      ],
+      "clean": true,
+      "mismatch_categories": [],
+      "mismatches": [],
       "expected_snapshot": {
         "identity": {
           "entity_slug": "blackpink",
@@ -1174,92 +1051,231 @@
           "watch_reason": "recent_release",
           "tracking_status": "recent_release"
         },
-        "next_upcoming": {
-          "headline": "BLACKPINK Finally Reveals 'DEADLINE' Mini Album Release Date - TMZ",
-          "scheduled_date": "",
-          "scheduled_month": "",
-          "date_precision": "unknown",
-          "date_status": "rumor",
-          "confidence_score": 0.68,
-          "release_format": "ep"
-        },
+        "next_upcoming": null,
         "latest_release": {
+          "release_id": "BLACKPINK::DEADLINE::2026-02-27::album",
           "release_title": "DEADLINE",
-          "release_date": "2026-02-26",
+          "release_date": "2026-02-27",
           "stream": "album",
-          "release_kind": "ep"
+          "release_kind": "ep",
+          "release_format": "ep",
+          "artwork": null
         },
         "recent_albums": [
           {
+            "release_id": "BLACKPINK::DEADLINE::2026-02-27::album",
             "release_title": "DEADLINE",
             "release_date": "2026-02-27",
             "stream": "album",
-            "release_kind": "ep"
+            "release_kind": "ep",
+            "release_format": "ep",
+            "artwork": null
           },
           {
+            "release_id": "BLACKPINK::DEADLINE::2026-02-26::album",
             "release_title": "DEADLINE",
             "release_date": "2026-02-26",
             "stream": "album",
-            "release_kind": "ep"
+            "release_kind": "ep",
+            "release_format": "ep",
+            "artwork": {
+              "cover_image_url": "https://coverartarchive.org/release-group/38204997-b295-4d09-a946-f7e119725031/front",
+              "thumbnail_image_url": "https://coverartarchive.org/release-group/38204997-b295-4d09-a946-f7e119725031/front-250",
+              "artwork_source_type": "cover_art_archive",
+              "artwork_source_url": "https://coverartarchive.org/release-group/38204997-b295-4d09-a946-f7e119725031",
+              "is_placeholder": false
+            }
           },
           {
+            "release_id": "BLACKPINK::BORN PINK::2022-09-16::album",
             "release_title": "BORN PINK",
             "release_date": "2022-09-16",
             "stream": "album",
-            "release_kind": "album"
+            "release_kind": "album",
+            "release_format": "album",
+            "artwork": null
           },
           {
+            "release_id": "BLACKPINK::THE ALBUM::2020-10-02::album",
             "release_title": "THE ALBUM",
             "release_date": "2020-10-02",
             "stream": "album",
-            "release_kind": "album"
+            "release_kind": "album",
+            "release_format": "album",
+            "artwork": null
           },
           {
+            "release_id": "BLACKPINK::KILL THIS LOVE::2019-04-05::album",
             "release_title": "KILL THIS LOVE",
             "release_date": "2019-04-05",
             "stream": "album",
-            "release_kind": "ep"
+            "release_kind": "ep",
+            "release_format": "ep",
+            "artwork": null
           },
           {
+            "release_id": "BLACKPINK::SQUARE UP::2018-06-15::album",
             "release_title": "SQUARE UP",
             "release_date": "2018-06-15",
             "stream": "album",
-            "release_kind": "ep"
+            "release_kind": "ep",
+            "release_format": "ep",
+            "artwork": null
           },
           {
+            "release_id": "BLACKPINK::BLACKPINK::2017-08-29::album",
             "release_title": "BLACKPINK",
             "release_date": "2017-08-29",
             "stream": "album",
-            "release_kind": "ep"
+            "release_kind": "ep",
+            "release_format": "ep",
+            "artwork": null
           }
         ],
         "source_timeline": [
           {
             "event_type": "first_signal",
+            "headline": "Blackpink’s Jisoo Shares Love for Album ‘Deadline,’ Talks New Netflix K-Drama: “Blinks Will Love It” - The Hollywood Reporter",
+            "occurred_at": "Mon, 02 Mar 2026 15:11:07 GMT",
+            "summary": "album · rumor",
+            "source_url": "https://news.google.com/rss/articles/CBMiqwFBVV95cUxOcldhb1d6S2hhMDQxTDZndUlEa0VqLXROcEJucWkxLTZxdFNha25nckc0LWxVZ2I3MHhnVk0zX0xfM3NnRlpnaW9MemF5U3VnaTRyZWlYRVI0YmxtN1Y0T0U0WmxuZmNqVWRxeDNsaVFOeXpzNGJrSVVsSjEtMHlnMGRBT3hpNDl2RW1IelNpVzdYWTBrNXlZUFNZZHN0VHFkVG1RZERvT3k3SlE?oc=5",
             "source_type": "news_rss",
-            "headline": "BLACKPINK Finally Reveals 'DEADLINE' Mini Album Release Date - TMZ",
-            "source_url": "https://news.google.com/rss/articles/CBMicEFVX3lxTE4waE5xc2U4eWNJaFhldTl2aGZEdGRxYl9DTVRRYnQ2Sk5rRGMtX2JHVVhiWFV3VTZJdUc1b1VoWWdmM25vcXhDb0dKSlBlanpHSlh2NDlHQ1hEMEtCalpvdkFudzNKZDJ0Y1VnVlpwOTA?oc=5",
             "source_domain": "news.google.com",
-            "occurred_at": "2026-01-14T08:00:00.000Z",
-            "summary": "BLACKPINK Finally Reveals 'DEADLINE' Mini Album Release Date TMZ"
+            "published_at": "Mon, 02 Mar 2026 15:11:07 GMT",
+            "scheduled_date": null,
+            "scheduled_month": null,
+            "date_precision": "unknown",
+            "date_status": "rumor",
+            "release_format": "album",
+            "confidence_score": 0.68,
+            "evidence_summary": "Blackpink’s Jisoo Shares Love for Album ‘Deadline,’ Talks New Netflix K-Drama: “Blinks Will Love It” The Hollywood Reporter",
+            "source_count": 2
           },
           {
-            "event_type": "official_announcement",
-            "source_type": "agency_notice",
+            "event_type": "first_signal",
+            "headline": "Blackpink's DEADLINE sells 1.46 million copies on day of release, sets new K-pop girl group record - The Korea Economic Daily Global Edition",
+            "occurred_at": "Sun, 01 Mar 2026 17:47:48 GMT",
+            "summary": "rumor",
+            "source_url": "https://news.google.com/rss/articles/CBMiZ0FVX3lxTE94bmhvU2RuMVBXTGNpS1VMaExLUXN6c0lCekxVbm1KTy1McTNvTkUycE1KNUl1c0U3b2c5ajh3cE9WSEs0TGJwNlgyZU9LX3JHam55VVhGX3h2SDBoaUdtcGYwWmdGdHc?oc=5",
+            "source_type": "news_rss",
+            "source_domain": "news.google.com",
+            "published_at": "Sun, 01 Mar 2026 17:47:48 GMT",
+            "scheduled_date": null,
+            "scheduled_month": null,
+            "date_precision": "unknown",
+            "date_status": "rumor",
+            "release_format": "",
+            "confidence_score": 0.68,
+            "evidence_summary": "Blackpink's DEADLINE sells 1.46 million copies on day of release, sets new K-pop girl group record The Korea Economic Daily Global Edition",
+            "source_count": 1
+          },
+          {
+            "event_type": "first_signal",
+            "headline": "Blackpink’s Jisoo Shares Love for Album ‘Deadline,’ Talks New Netflix K-Drama: “Blinks Will Love It” - The Hollywood Reporter",
+            "occurred_at": "Sat, 28 Feb 2026 10:50:00 GMT",
+            "summary": "album · rumor",
+            "source_url": "https://news.google.com/rss/articles/CBMiuwFBVV95cUxQREV5ZV9pTDZyVFVyS0JqTDJEbWJGMzh0UDhwcnFKLVFFbDhmVW5rcmVrdGt5cTFkR1BHSzQ4Z0dBZG9RNFBXQVN5UlRKcGF0V1Bycm1KT2ZObWRpS0FBZll0N2RrWjlYWTZlQ3M4Nk8zc2o4dzFMcnlmTzFVMk4zcGZKUms3eFNMQzlLSzN2UERxVmZOOGVyWm90Tzh2b0tHVlJUMHdVZjU5Z0QzWWFibGhEYWtRbzRuNHBZ0gHIAUFVX3lxTFA5LVQ4Uk41RERaWnk5UXh0eC1MTEppZWVTd05yVGlNeEs0UHVKRnExQ3hBcFVsX2wyUmp3Z1U3Z0Q2R3hWcFdBU09hVHV1blJ6VHIyTEgxTnNUc0V5VmxWOUt1S2hwcm11QmRZdUY5c3dfTGZPWE5MT1IzQndIdkUzVHF6NDhCaE9ZeWc5T1JBVlg3MURjV2hrVVVuRDV5ek1LdlRTS1lSTFNCemJxa0t6VlN2bURxM3Uxb0tMRXl0dkJSU3FQbm9l?oc=5",
+            "source_type": "news_rss",
+            "source_domain": "news.google.com",
+            "published_at": "Sat, 28 Feb 2026 10:50:00 GMT",
+            "scheduled_date": null,
+            "scheduled_month": null,
+            "date_precision": "unknown",
+            "date_status": "rumor",
+            "release_format": "album",
+            "confidence_score": 0.68,
+            "evidence_summary": "Blackpink Sets New Record As ‘Deadline’ Tops First-Day Sales Among K-Pop Girl Groups Outlook Luxe",
+            "source_count": 2
+          },
+          {
+            "event_type": "first_signal",
+            "headline": "K-Pop girl group Blackpink drops their third mini album Deadline - Indulgexpress",
+            "occurred_at": "Sat, 28 Feb 2026 06:59:53 GMT",
+            "summary": "ep · rumor",
+            "source_url": "https://news.google.com/rss/articles/CBMivAFBVV95cUxQVG9PNFdjS19QUkVoYU95M21Rb2l5em5EQUVZSzZrcU9qa1hYMWRQSGRnc3dJZDFUYWtBcWstQVREcEw5c3BKc2M5WHJETHB0LUlFTGI3dmFKbXdBbWRtOEZRVTVzZ29UWTRaLVJ5RnhDc25IS2ZsRVNTTXVTWnEtZENIdTVDeUVmM0ZGTXlBSnNBek1aSEs0TFJ4UndGTjVYMDdZWVhmV2tPc092MDN5WnZWYlBiNkJ5M09nbNIBygFBVV95cUxOWlFldno4Y0RLNjhoRFkxN29BT2J3WHdBaFN6THNuYk1HbEZUdzAwSzA5T0U5V3QwVWg1WDZCQUs1S0ZVdDVnSXo3TGpCeTNsZm5tS1VsRDZoVlhyR3doOFNEcVVTVEJubVJTLXNIVG5RX21xN3BEc3preXJVREU0MUVlU2JMalh1Q0QxamJhZ0xIcHFKcTNDV3V4RHFKeV9qZ0dnS2IySkJNaXBVU3lvRDA0eXhYbS1BZFdEbVZBclJQcU9UeFRhUlBB?oc=5",
+            "source_type": "news_rss",
+            "source_domain": "news.google.com",
+            "published_at": "Sat, 28 Feb 2026 06:59:53 GMT",
+            "scheduled_date": null,
+            "scheduled_month": null,
+            "date_precision": "unknown",
+            "date_status": "rumor",
+            "release_format": "ep",
+            "confidence_score": 0.68,
+            "evidence_summary": "K-Pop girl group Blackpink drops their third mini album Deadline Indulgexpress",
+            "source_count": 1
+          },
+          {
+            "event_type": "first_signal",
             "headline": "BLACKPINK’s New Title Track Is ‘GO’.. YG “Created with Great Care”",
+            "occurred_at": "Fri, 06 Feb 2026 00:00:00 GMT",
+            "summary": "single · rumor",
             "source_url": "https://www.ygfamily.com/en/news/report/7378",
+            "source_type": "agency_notice",
             "source_domain": "www.ygfamily.com",
-            "occurred_at": "2026-02-06T00:00:00.000Z",
-            "summary": "BLACKPINK’s New Title Track Is ‘GO’.. YG “Created with Great Care” BLACKPINK has unveiled the tracklist for their new release. According to YG Entertainment on..."
+            "published_at": "Fri, 06 Feb 2026 00:00:00 GMT",
+            "scheduled_date": null,
+            "scheduled_month": null,
+            "date_precision": "unknown",
+            "date_status": "rumor",
+            "release_format": "single",
+            "confidence_score": 0.64,
+            "evidence_summary": "BLACKPINK’s New Title Track Is ‘GO’.. YG “Created with Great Care” BLACKPINK has unveiled the tracklist for their new release. According to YG Entertainment on...",
+            "source_count": 1
           },
           {
-            "event_type": "release_verified",
-            "source_type": "release_catalog",
-            "headline": "DEADLINE",
-            "source_url": "https://musicbrainz.org/release-group/38204997-b295-4d09-a946-f7e119725031",
-            "source_domain": "musicbrainz.org",
-            "occurred_at": "2026-02-26",
-            "summary": "Latest verified album record in the dataset for BLACKPINK, captured from the release catalog."
+            "event_type": "first_signal",
+            "headline": "BLACKPINK Finally Reveals 'DEADLINE' Mini Album Release Date - TMZ",
+            "occurred_at": "Wed, 14 Jan 2026 08:00:00 GMT",
+            "summary": "ep · rumor",
+            "source_url": "https://news.google.com/rss/articles/CBMicEFVX3lxTE4waE5xc2U4eWNJaFhldTl2aGZEdGRxYl9DTVRRYnQ2Sk5rRGMtX2JHVVhiWFV3VTZJdUc1b1VoWWdmM25vcXhDb0dKSlBlanpHSlh2NDlHQ1hEMEtCalpvdkFudzNKZDJ0Y1VnVlpwOTA?oc=5",
+            "source_type": "news_rss",
+            "source_domain": "news.google.com",
+            "published_at": "Wed, 14 Jan 2026 08:00:00 GMT",
+            "scheduled_date": null,
+            "scheduled_month": null,
+            "date_precision": "unknown",
+            "date_status": "rumor",
+            "release_format": "ep",
+            "confidence_score": 0.68,
+            "evidence_summary": "BLACKPINK Finally Reveals 'DEADLINE' Mini Album Release Date TMZ",
+            "source_count": 1
+          },
+          {
+            "event_type": "first_signal",
+            "headline": "Blackpink Sets Release Date for Comeback Album - Pitchfork",
+            "occurred_at": "Wed, 14 Jan 2026 08:00:00 GMT",
+            "summary": "album · rumor",
+            "source_url": "https://news.google.com/rss/articles/CBMiekFVX3lxTE9Ucm80bHB0cUYwcHNhZkJxaWM1MnA5SnJUVzk0ZkdyQmg3b0Q2SXFudk41aXVRN1RjLURta0tvemNPdl8yaE10cVdHbkc2d3dnM3VxSDhtNWhlSGZtM3RYNzJFVThxRzhqWlFjSzR4ekNGM04tLWdWWW9n?oc=5",
+            "source_type": "news_rss",
+            "source_domain": "news.google.com",
+            "published_at": "Wed, 14 Jan 2026 08:00:00 GMT",
+            "scheduled_date": null,
+            "scheduled_month": null,
+            "date_precision": "unknown",
+            "date_status": "rumor",
+            "release_format": "album",
+            "confidence_score": 0.68,
+            "evidence_summary": "Blackpink Sets Release Date for Comeback Album Pitchfork",
+            "source_count": 1
+          },
+          {
+            "event_type": "first_signal",
+            "headline": "K-pop group Blackpink announces new mini album Deadline, out Feb 27 - CNA Lifestyle",
+            "occurred_at": "Wed, 14 Jan 2026 08:00:00 GMT",
+            "summary": "ep · rumor",
+            "source_url": "https://news.google.com/rss/articles/CBMirgFBVV95cUxOUFhWaFpuYnA5UDVRQmR0bHhuS2NIS2pfa255aDEzNGlFMHUzQ0p4MVRRLVVGUm13czJyclV5d3Rhd2xCakNqSmNaaDRtdkZhSWxqbk1VbWc0RzdMX3FjZ1RQTEY5RTV1czR6a3pXQmR4RS0wVVZNSHo3QllWLTBidzlESGpVNGwybzZ1Ti1Wc2VuLXE5WWk1U1Y2QlBtY1JWWXp6cjF3VGZwblhfclE?oc=5",
+            "source_type": "news_rss",
+            "source_domain": "news.google.com",
+            "published_at": "Wed, 14 Jan 2026 08:00:00 GMT",
+            "scheduled_date": null,
+            "scheduled_month": null,
+            "date_precision": "unknown",
+            "date_status": "rumor",
+            "release_format": "ep",
+            "confidence_score": 0.68,
+            "evidence_summary": "K-pop group Blackpink announces new mini album Deadline, out Feb 27 CNA Lifestyle",
+            "source_count": 1
           }
         ],
         "artist_source_url": "https://musicbrainz.org/artist/48646387-1664-4c9a-9139-9bfd091b823c"
@@ -1302,7 +1318,9 @@
           "release_title": "DEADLINE",
           "release_date": "2026-02-27",
           "stream": "album",
-          "release_kind": "ep"
+          "release_kind": "ep",
+          "release_format": "ep",
+          "artwork": null
         },
         "recent_albums": [
           {
@@ -1310,54 +1328,77 @@
             "release_title": "DEADLINE",
             "release_date": "2026-02-27",
             "stream": "album",
-            "release_kind": "ep"
+            "release_kind": "ep",
+            "release_format": "ep",
+            "artwork": null
           },
           {
             "release_id": "e3526174-e804-56f2-9d50-17f9f817a351",
             "release_title": "DEADLINE",
             "release_date": "2026-02-26",
             "stream": "album",
-            "release_kind": "ep"
+            "release_kind": "ep",
+            "release_format": "ep",
+            "artwork": {
+              "cover_image_url": "https://coverartarchive.org/release-group/38204997-b295-4d09-a946-f7e119725031/front",
+              "thumbnail_image_url": "https://coverartarchive.org/release-group/38204997-b295-4d09-a946-f7e119725031/front-250",
+              "artwork_source_type": "cover_art_archive",
+              "artwork_source_url": "https://coverartarchive.org/release-group/38204997-b295-4d09-a946-f7e119725031",
+              "is_placeholder": false
+            }
           },
           {
             "release_id": "0571a361-1b4e-58ab-a628-ff715c81bada",
             "release_title": "BORN PINK",
             "release_date": "2022-09-16",
             "stream": "album",
-            "release_kind": "album"
+            "release_kind": "album",
+            "release_format": "album",
+            "artwork": null
           },
           {
             "release_id": "e0a1b8e5-7e83-515e-8cad-bf1916aeb8dd",
             "release_title": "THE ALBUM",
             "release_date": "2020-10-02",
             "stream": "album",
-            "release_kind": "album"
+            "release_kind": "album",
+            "release_format": "album",
+            "artwork": null
           },
           {
             "release_id": "6476d409-4ef3-5050-b581-a72e973ed65f",
             "release_title": "KILL THIS LOVE",
             "release_date": "2019-04-05",
             "stream": "album",
-            "release_kind": "ep"
+            "release_kind": "ep",
+            "release_format": "ep",
+            "artwork": null
           },
           {
             "release_id": "fbca20e6-f7a3-5b69-9abd-d27a36dd11d9",
             "release_title": "SQUARE UP",
             "release_date": "2018-06-15",
             "stream": "album",
-            "release_kind": "ep"
+            "release_kind": "ep",
+            "release_format": "ep",
+            "artwork": null
           },
           {
             "release_id": "756b10bf-d09a-525f-ba50-0879d91f228e",
             "release_title": "BLACKPINK",
             "release_date": "2017-08-29",
             "stream": "album",
-            "release_kind": "ep"
+            "release_kind": "ep",
+            "release_format": "ep",
+            "artwork": null
           }
         ],
         "source_timeline": [
           {
+            "event_type": "first_signal",
             "headline": "Blackpink’s Jisoo Shares Love for Album ‘Deadline,’ Talks New Netflix K-Drama: “Blinks Will Love It” - The Hollywood Reporter",
+            "occurred_at": "2026-03-02T15:11:07+00:00",
+            "summary": "album · rumor",
             "source_url": "https://news.google.com/rss/articles/CBMiqwFBVV95cUxOcldhb1d6S2hhMDQxTDZndUlEa0VqLXROcEJucWkxLTZxdFNha25nckc0LWxVZ2I3MHhnVk0zX0xfM3NnRlpnaW9MemF5U3VnaTRyZWlYRVI0YmxtN1Y0T0U0WmxuZmNqVWRxeDNsaVFOeXpzNGJrSVVsSjEtMHlnMGRBT3hpNDl2RW1IelNpVzdYWTBrNXlZUFNZZHN0VHFkVG1RZERvT3k3SlE?oc=5",
             "source_type": "news_rss",
             "source_domain": "news.google.com",
@@ -1367,10 +1408,15 @@
             "date_precision": "unknown",
             "date_status": "rumor",
             "release_format": "album",
-            "confidence_score": 0.68
+            "confidence_score": 0.68,
+            "evidence_summary": "Blackpink’s Jisoo Shares Love for Album ‘Deadline,’ Talks New Netflix K-Drama: “Blinks Will Love It” The Hollywood Reporter",
+            "source_count": 2
           },
           {
+            "event_type": "first_signal",
             "headline": "Blackpink's DEADLINE sells 1.46 million copies on day of release, sets new K-pop girl group record - The Korea Economic Daily Global Edition",
+            "occurred_at": "2026-03-01T17:47:48+00:00",
+            "summary": "rumor",
             "source_url": "https://news.google.com/rss/articles/CBMiZ0FVX3lxTE94bmhvU2RuMVBXTGNpS1VMaExLUXN6c0lCekxVbm1KTy1McTNvTkUycE1KNUl1c0U3b2c5ajh3cE9WSEs0TGJwNlgyZU9LX3JHam55VVhGX3h2SDBoaUdtcGYwWmdGdHc?oc=5",
             "source_type": "news_rss",
             "source_domain": "news.google.com",
@@ -1380,10 +1426,15 @@
             "date_precision": "unknown",
             "date_status": "rumor",
             "release_format": null,
-            "confidence_score": 0.68
+            "confidence_score": 0.68,
+            "evidence_summary": "Blackpink's DEADLINE sells 1.46 million copies on day of release, sets new K-pop girl group record The Korea Economic Daily Global Edition",
+            "source_count": 1
           },
           {
+            "event_type": "first_signal",
             "headline": "Blackpink’s Jisoo Shares Love for Album ‘Deadline,’ Talks New Netflix K-Drama: “Blinks Will Love It” - The Hollywood Reporter",
+            "occurred_at": "2026-02-28T10:50:00+00:00",
+            "summary": "album · rumor",
             "source_url": "https://news.google.com/rss/articles/CBMiuwFBVV95cUxQREV5ZV9pTDZyVFVyS0JqTDJEbWJGMzh0UDhwcnFKLVFFbDhmVW5rcmVrdGt5cTFkR1BHSzQ4Z0dBZG9RNFBXQVN5UlRKcGF0V1Bycm1KT2ZObWRpS0FBZll0N2RrWjlYWTZlQ3M4Nk8zc2o4dzFMcnlmTzFVMk4zcGZKUms3eFNMQzlLSzN2UERxVmZOOGVyWm90Tzh2b0tHVlJUMHdVZjU5Z0QzWWFibGhEYWtRbzRuNHBZ0gHIAUFVX3lxTFA5LVQ4Uk41RERaWnk5UXh0eC1MTEppZWVTd05yVGlNeEs0UHVKRnExQ3hBcFVsX2wyUmp3Z1U3Z0Q2R3hWcFdBU09hVHV1blJ6VHIyTEgxTnNUc0V5VmxWOUt1S2hwcm11QmRZdUY5c3dfTGZPWE5MT1IzQndIdkUzVHF6NDhCaE9ZeWc5T1JBVlg3MURjV2hrVVVuRDV5ek1LdlRTS1lSTFNCemJxa0t6VlN2bURxM3Uxb0tMRXl0dkJSU3FQbm9l?oc=5",
             "source_type": "news_rss",
             "source_domain": "news.google.com",
@@ -1393,10 +1444,15 @@
             "date_precision": "unknown",
             "date_status": "rumor",
             "release_format": "album",
-            "confidence_score": 0.68
+            "confidence_score": 0.68,
+            "evidence_summary": "Blackpink Sets New Record As ‘Deadline’ Tops First-Day Sales Among K-Pop Girl Groups Outlook Luxe",
+            "source_count": 2
           },
           {
+            "event_type": "first_signal",
             "headline": "K-Pop girl group Blackpink drops their third mini album Deadline - Indulgexpress",
+            "occurred_at": "2026-02-28T06:59:53+00:00",
+            "summary": "ep · rumor",
             "source_url": "https://news.google.com/rss/articles/CBMivAFBVV95cUxQVG9PNFdjS19QUkVoYU95M21Rb2l5em5EQUVZSzZrcU9qa1hYMWRQSGRnc3dJZDFUYWtBcWstQVREcEw5c3BKc2M5WHJETHB0LUlFTGI3dmFKbXdBbWRtOEZRVTVzZ29UWTRaLVJ5RnhDc25IS2ZsRVNTTXVTWnEtZENIdTVDeUVmM0ZGTXlBSnNBek1aSEs0TFJ4UndGTjVYMDdZWVhmV2tPc092MDN5WnZWYlBiNkJ5M09nbNIBygFBVV95cUxOWlFldno4Y0RLNjhoRFkxN29BT2J3WHdBaFN6THNuYk1HbEZUdzAwSzA5T0U5V3QwVWg1WDZCQUs1S0ZVdDVnSXo3TGpCeTNsZm5tS1VsRDZoVlhyR3doOFNEcVVTVEJubVJTLXNIVG5RX21xN3BEc3preXJVREU0MUVlU2JMalh1Q0QxamJhZ0xIcHFKcTNDV3V4RHFKeV9qZ0dnS2IySkJNaXBVU3lvRDA0eXhYbS1BZFdEbVZBclJQcU9UeFRhUlBB?oc=5",
             "source_type": "news_rss",
             "source_domain": "news.google.com",
@@ -1406,10 +1462,15 @@
             "date_precision": "unknown",
             "date_status": "rumor",
             "release_format": "ep",
-            "confidence_score": 0.68
+            "confidence_score": 0.68,
+            "evidence_summary": "K-Pop girl group Blackpink drops their third mini album Deadline Indulgexpress",
+            "source_count": 1
           },
           {
+            "event_type": "first_signal",
             "headline": "BLACKPINK’s New Title Track Is ‘GO’.. YG “Created with Great Care”",
+            "occurred_at": "2026-02-06T00:00:00+00:00",
+            "summary": "single · rumor",
             "source_url": "https://www.ygfamily.com/en/news/report/7378",
             "source_type": "agency_notice",
             "source_domain": "www.ygfamily.com",
@@ -1419,10 +1480,15 @@
             "date_precision": "unknown",
             "date_status": "rumor",
             "release_format": "single",
-            "confidence_score": 0.64
+            "confidence_score": 0.64,
+            "evidence_summary": "BLACKPINK’s New Title Track Is ‘GO’.. YG “Created with Great Care” BLACKPINK has unveiled the tracklist for their new release. According to YG Entertainment on...",
+            "source_count": 1
           },
           {
+            "event_type": "first_signal",
             "headline": "BLACKPINK Finally Reveals 'DEADLINE' Mini Album Release Date - TMZ",
+            "occurred_at": "2026-01-14T08:00:00+00:00",
+            "summary": "ep · rumor",
             "source_url": "https://news.google.com/rss/articles/CBMicEFVX3lxTE4waE5xc2U4eWNJaFhldTl2aGZEdGRxYl9DTVRRYnQ2Sk5rRGMtX2JHVVhiWFV3VTZJdUc1b1VoWWdmM25vcXhDb0dKSlBlanpHSlh2NDlHQ1hEMEtCalpvdkFudzNKZDJ0Y1VnVlpwOTA?oc=5",
             "source_type": "news_rss",
             "source_domain": "news.google.com",
@@ -1432,10 +1498,15 @@
             "date_precision": "unknown",
             "date_status": "rumor",
             "release_format": "ep",
-            "confidence_score": 0.68
+            "confidence_score": 0.68,
+            "evidence_summary": "BLACKPINK Finally Reveals 'DEADLINE' Mini Album Release Date TMZ",
+            "source_count": 1
           },
           {
+            "event_type": "first_signal",
             "headline": "Blackpink Sets Release Date for Comeback Album - Pitchfork",
+            "occurred_at": "2026-01-14T08:00:00+00:00",
+            "summary": "album · rumor",
             "source_url": "https://news.google.com/rss/articles/CBMiekFVX3lxTE9Ucm80bHB0cUYwcHNhZkJxaWM1MnA5SnJUVzk0ZkdyQmg3b0Q2SXFudk41aXVRN1RjLURta0tvemNPdl8yaE10cVdHbkc2d3dnM3VxSDhtNWhlSGZtM3RYNzJFVThxRzhqWlFjSzR4ekNGM04tLWdWWW9n?oc=5",
             "source_type": "news_rss",
             "source_domain": "news.google.com",
@@ -1445,10 +1516,15 @@
             "date_precision": "unknown",
             "date_status": "rumor",
             "release_format": "album",
-            "confidence_score": 0.68
+            "confidence_score": 0.68,
+            "evidence_summary": "Blackpink Sets Release Date for Comeback Album Pitchfork",
+            "source_count": 1
           },
           {
+            "event_type": "first_signal",
             "headline": "K-pop group Blackpink announces new mini album Deadline, out Feb 27 - CNA Lifestyle",
+            "occurred_at": "2026-01-14T08:00:00+00:00",
+            "summary": "ep · rumor",
             "source_url": "https://news.google.com/rss/articles/CBMirgFBVV95cUxOUFhWaFpuYnA5UDVRQmR0bHhuS2NIS2pfa255aDEzNGlFMHUzQ0p4MVRRLVVGUm13czJyclV5d3Rhd2xCakNqSmNaaDRtdkZhSWxqbk1VbWc0RzdMX3FjZ1RQTEY5RTV1czR6a3pXQmR4RS0wVVZNSHo3QllWLTBidzlESGpVNGwybzZ1Ti1Wc2VuLXE5WWk1U1Y2QlBtY1JWWXp6cjF3VGZwblhfclE?oc=5",
             "source_type": "news_rss",
             "source_domain": "news.google.com",
@@ -1458,7 +1534,9 @@
             "date_precision": "unknown",
             "date_status": "rumor",
             "release_format": "ep",
-            "confidence_score": 0.68
+            "confidence_score": 0.68,
+            "evidence_summary": "K-pop group Blackpink announces new mini album Deadline, out Feb 27 CNA Lifestyle",
+            "source_count": 1
           }
         ],
         "artist_source_url": "https://musicbrainz.org/artist/48646387-1664-4c9a-9139-9bfd091b823c"
@@ -1470,74 +1548,9 @@
       "input": {
         "slug": "and-team"
       },
-      "clean": false,
-      "mismatch_categories": [
-        "field-shape mismatches",
-        "missing rows or segments",
-        "exact-vs-month-only drift"
-      ],
-      "mismatches": [
-        {
-          "category": "field-shape mismatches",
-          "path": "data",
-          "shape_mismatches": [
-            {
-              "path": "data.next_upcoming",
-              "expected_type": "object",
-              "actual_type": "null",
-              "message": "Type mismatch"
-            },
-            {
-              "path": "data.source_timeline[0].event_type",
-              "expected_type": "string",
-              "actual_type": "missing",
-              "message": "Missing key"
-            },
-            {
-              "path": "data.source_timeline[0].occurred_at",
-              "expected_type": "string",
-              "actual_type": "missing",
-              "message": "Missing key"
-            },
-            {
-              "path": "data.source_timeline[0].summary",
-              "expected_type": "string",
-              "actual_type": "missing",
-              "message": "Missing key"
-            }
-          ]
-        },
-        {
-          "category": "missing rows or segments",
-          "path": "data.official_links.instagram",
-          "expected": "https://www.instagram.com/andteam_official/",
-          "actual": "https://www.instagram.com/andteam_official"
-        },
-        {
-          "category": "exact-vs-month-only drift",
-          "path": "data.next_upcoming",
-          "expected": {
-            "headline": "&TEAM sets April comeback with Japanese mini album ‘We on Fire’ - allkpop",
-            "scheduled_date": "",
-            "scheduled_month": "2026-04",
-            "date_precision": "month_only",
-            "date_status": "scheduled",
-            "release_format": "ep"
-          },
-          "actual": null
-        },
-        {
-          "category": "missing rows or segments",
-          "path": "data.source_timeline",
-          "expected": [
-            "release_verified|Back to Life|release_catalog|https://musicbrainz.org/release-group/159eca09-5a9a-4ee2-a1ea-56a08269229f",
-            "first_signal|&TEAM sets April comeback with Japanese mini album ‘We on Fire’ - allkpop|news_rss|https://news.google.com/rss/articles/CBMiogFBVV95cUxNdzN5MmFQbjJLQVdlcktGS1V1MkZnLUxhVDBjQnNlbmtXSkxOZTJCMjVkNXptekllbE5mY2VSanJqZXV5SGJ1T3BPM1huZWlhbWhYeGFsOW55UlFSMDlCY29BYjNDZWxWUGV1RjdNb09MRFFHbWdRdkRKanBTS3lNVS05Xy0yZzVVOGRLZF9Dc1RhT2hVRUFfMFlTX0RELUYtcHc?oc=5"
-          ],
-          "actual": [
-            "&TEAM sets April comeback with Japanese mini album ‘We on Fire’ - allkpop|news_rss|https://news.google.com/rss/articles/CBMiogFBVV95cUxNdzN5MmFQbjJLQVdlcktGS1V1MkZnLUxhVDBjQnNlbmtXSkxOZTJCMjVkNXptekllbE5mY2VSanJqZXV5SGJ1T3BPM1huZWlhbWhYeGFsOW55UlFSMDlCY29BYjNDZWxWUGV1RjdNb09MRFFHbWdRdkRKanBTS3lNVS05Xy0yZzVVOGRLZF9Dc1RhT2hVRUFfMFlTX0RELUYtcHc?oc=5"
-          ]
-        }
-      ],
+      "clean": true,
+      "mismatch_categories": [],
+      "mismatches": [],
       "expected_snapshot": {
         "identity": {
           "entity_slug": "and-team",
@@ -1565,77 +1578,102 @@
           "watch_reason": "recent_release",
           "tracking_status": "recent_release"
         },
-        "next_upcoming": {
-          "headline": "&TEAM sets April comeback with Japanese mini album ‘We on Fire’ - allkpop",
-          "scheduled_date": "",
-          "scheduled_month": "2026-04",
-          "date_precision": "month_only",
-          "date_status": "scheduled",
-          "confidence_score": 0.76,
-          "release_format": "ep"
-        },
+        "next_upcoming": null,
         "latest_release": {
+          "release_id": "&TEAM::Back to Life::2025-10-28::album",
           "release_title": "Back to Life",
           "release_date": "2025-10-28",
           "stream": "album",
-          "release_kind": "ep"
+          "release_kind": "ep",
+          "release_format": "ep",
+          "artwork": {
+            "cover_image_url": "https://coverartarchive.org/release-group/159eca09-5a9a-4ee2-a1ea-56a08269229f/front",
+            "thumbnail_image_url": "https://coverartarchive.org/release-group/159eca09-5a9a-4ee2-a1ea-56a08269229f/front-250",
+            "artwork_source_type": "cover_art_archive",
+            "artwork_source_url": "https://coverartarchive.org/release-group/159eca09-5a9a-4ee2-a1ea-56a08269229f",
+            "is_placeholder": false
+          }
         },
         "recent_albums": [
           {
+            "release_id": "&TEAM::Back to Life::2025-10-28::album",
             "release_title": "Back to Life",
             "release_date": "2025-10-28",
             "stream": "album",
-            "release_kind": "ep"
+            "release_kind": "ep",
+            "release_format": "ep",
+            "artwork": {
+              "cover_image_url": "https://coverartarchive.org/release-group/159eca09-5a9a-4ee2-a1ea-56a08269229f/front",
+              "thumbnail_image_url": "https://coverartarchive.org/release-group/159eca09-5a9a-4ee2-a1ea-56a08269229f/front-250",
+              "artwork_source_type": "cover_art_archive",
+              "artwork_source_url": "https://coverartarchive.org/release-group/159eca09-5a9a-4ee2-a1ea-56a08269229f",
+              "is_placeholder": false
+            }
           },
           {
+            "release_id": "&TEAM::Go in Blind (月狼)::2025-04-20::album",
             "release_title": "Go in Blind (月狼)",
             "release_date": "2025-04-20",
             "stream": "album",
-            "release_kind": "ep"
+            "release_kind": "ep",
+            "release_format": "ep",
+            "artwork": null
           },
           {
+            "release_id": "&TEAM::雪明かり (Yukiakari)::2024-12-17::album",
             "release_title": "雪明かり (Yukiakari)",
             "release_date": "2024-12-17",
             "stream": "album",
-            "release_kind": "album"
+            "release_kind": "album",
+            "release_format": "album",
+            "artwork": null
           },
           {
+            "release_id": "&TEAM::First Howling : NOW::2023-11-15::album",
             "release_title": "First Howling : NOW",
             "release_date": "2023-11-15",
             "stream": "album",
-            "release_kind": "album"
+            "release_kind": "album",
+            "release_format": "album",
+            "artwork": null
           },
           {
+            "release_id": "&TEAM::First Howling : WE::2023-06-14::album",
             "release_title": "First Howling : WE",
             "release_date": "2023-06-14",
             "stream": "album",
-            "release_kind": "ep"
+            "release_kind": "ep",
+            "release_format": "ep",
+            "artwork": null
           },
           {
+            "release_id": "&TEAM::First Howling : ME::2022-12-06::album",
             "release_title": "First Howling : ME",
             "release_date": "2022-12-06",
             "stream": "album",
-            "release_kind": "ep"
+            "release_kind": "ep",
+            "release_format": "ep",
+            "artwork": null
           }
         ],
         "source_timeline": [
           {
-            "event_type": "release_verified",
-            "source_type": "release_catalog",
-            "headline": "Back to Life",
-            "source_url": "https://musicbrainz.org/release-group/159eca09-5a9a-4ee2-a1ea-56a08269229f",
-            "source_domain": "musicbrainz.org",
-            "occurred_at": "2025-10-28",
-            "summary": "Latest verified album record in the dataset for &TEAM, captured from the release catalog."
-          },
-          {
-            "event_type": "first_signal",
-            "source_type": "news_rss",
+            "event_type": "date_update",
             "headline": "&TEAM sets April comeback with Japanese mini album ‘We on Fire’ - allkpop",
+            "occurred_at": "Thu, 12 Feb 2026 09:38:51 GMT",
+            "summary": "ep · scheduled · 2026-04",
             "source_url": "https://news.google.com/rss/articles/CBMiogFBVV95cUxNdzN5MmFQbjJLQVdlcktGS1V1MkZnLUxhVDBjQnNlbmtXSkxOZTJCMjVkNXptekllbE5mY2VSanJqZXV5SGJ1T3BPM1huZWlhbWhYeGFsOW55UlFSMDlCY29BYjNDZWxWUGV1RjdNb09MRFFHbWdRdkRKanBTS3lNVS05Xy0yZzVVOGRLZF9Dc1RhT2hVRUFfMFlTX0RELUYtcHc?oc=5",
+            "source_type": "news_rss",
             "source_domain": "news.google.com",
-            "occurred_at": "2026-02-12T09:38:51.000Z",
-            "summary": "Future month reference: 2026-04. &TEAM sets April comeback with Japanese mini album ‘We on Fire’ allkpop"
+            "published_at": "Thu, 12 Feb 2026 09:38:51 GMT",
+            "scheduled_date": null,
+            "scheduled_month": "2026-04",
+            "date_precision": "month_only",
+            "date_status": "scheduled",
+            "release_format": "ep",
+            "confidence_score": 0.76,
+            "evidence_summary": "Future month reference: 2026-04. &TEAM sets April comeback with Japanese mini album ‘We on Fire’ allkpop",
+            "source_count": 1
           }
         ],
         "artist_source_url": "https://musicbrainz.org/artist/bba737dc-7ec8-482d-b79f-68d949ef2c7f"
@@ -1678,7 +1716,15 @@
           "release_title": "Back to Life",
           "release_date": "2025-10-28",
           "stream": "album",
-          "release_kind": "ep"
+          "release_kind": "ep",
+          "release_format": "ep",
+          "artwork": {
+            "cover_image_url": "https://coverartarchive.org/release-group/159eca09-5a9a-4ee2-a1ea-56a08269229f/front",
+            "thumbnail_image_url": "https://coverartarchive.org/release-group/159eca09-5a9a-4ee2-a1ea-56a08269229f/front-250",
+            "artwork_source_type": "cover_art_archive",
+            "artwork_source_url": "https://coverartarchive.org/release-group/159eca09-5a9a-4ee2-a1ea-56a08269229f",
+            "is_placeholder": false
+          }
         },
         "recent_albums": [
           {
@@ -1686,57 +1732,80 @@
             "release_title": "Back to Life",
             "release_date": "2025-10-28",
             "stream": "album",
-            "release_kind": "ep"
+            "release_kind": "ep",
+            "release_format": "ep",
+            "artwork": {
+              "cover_image_url": "https://coverartarchive.org/release-group/159eca09-5a9a-4ee2-a1ea-56a08269229f/front",
+              "thumbnail_image_url": "https://coverartarchive.org/release-group/159eca09-5a9a-4ee2-a1ea-56a08269229f/front-250",
+              "artwork_source_type": "cover_art_archive",
+              "artwork_source_url": "https://coverartarchive.org/release-group/159eca09-5a9a-4ee2-a1ea-56a08269229f",
+              "is_placeholder": false
+            }
           },
           {
             "release_id": "1752455a-9838-5209-8c3e-14e7ddba6595",
             "release_title": "Go in Blind (月狼)",
             "release_date": "2025-04-20",
             "stream": "album",
-            "release_kind": "ep"
+            "release_kind": "ep",
+            "release_format": "ep",
+            "artwork": null
           },
           {
             "release_id": "4953a8e4-60a7-5eb2-95ad-9108f883211c",
             "release_title": "雪明かり (Yukiakari)",
             "release_date": "2024-12-17",
             "stream": "album",
-            "release_kind": "album"
+            "release_kind": "album",
+            "release_format": "album",
+            "artwork": null
           },
           {
             "release_id": "60649bc4-3862-5435-b11e-74efc4cd6c41",
             "release_title": "First Howling : NOW",
             "release_date": "2023-11-15",
             "stream": "album",
-            "release_kind": "album"
+            "release_kind": "album",
+            "release_format": "album",
+            "artwork": null
           },
           {
             "release_id": "1e32ea5c-2ccc-5a27-807c-d1e1b24cc39f",
             "release_title": "First Howling : WE",
             "release_date": "2023-06-14",
             "stream": "album",
-            "release_kind": "ep"
+            "release_kind": "ep",
+            "release_format": "ep",
+            "artwork": null
           },
           {
             "release_id": "e0f26669-7cae-59e0-aed7-ce93b60a1df3",
             "release_title": "First Howling : ME",
             "release_date": "2022-12-06",
             "stream": "album",
-            "release_kind": "ep"
+            "release_kind": "ep",
+            "release_format": "ep",
+            "artwork": null
           }
         ],
         "source_timeline": [
           {
+            "event_type": "date_update",
             "headline": "&TEAM sets April comeback with Japanese mini album ‘We on Fire’ - allkpop",
+            "occurred_at": "2026-02-12T09:38:51+00:00",
+            "summary": "ep · scheduled · 2026-04",
             "source_url": "https://news.google.com/rss/articles/CBMiogFBVV95cUxNdzN5MmFQbjJLQVdlcktGS1V1MkZnLUxhVDBjQnNlbmtXSkxOZTJCMjVkNXptekllbE5mY2VSanJqZXV5SGJ1T3BPM1huZWlhbWhYeGFsOW55UlFSMDlCY29BYjNDZWxWUGV1RjdNb09MRFFHbWdRdkRKanBTS3lNVS05Xy0yZzVVOGRLZF9Dc1RhT2hVRUFfMFlTX0RELUYtcHc?oc=5",
             "source_type": "news_rss",
             "source_domain": "news.google.com",
             "published_at": "2026-02-12T09:38:51+00:00",
             "scheduled_date": null,
-            "scheduled_month": "2026-04-01",
+            "scheduled_month": "2026-04",
             "date_precision": "month_only",
             "date_status": "scheduled",
             "release_format": "ep",
-            "confidence_score": 0.76
+            "confidence_score": 0.76,
+            "evidence_summary": "Future month reference: 2026-04. &TEAM sets April comeback with Japanese mini album ‘We on Fire’ allkpop",
+            "source_count": 1
           }
         ],
         "artist_source_url": "https://musicbrainz.org/artist/bba737dc-7ec8-482d-b79f-68d949ef2c7f"
@@ -1748,35 +1817,9 @@
       "input": {
         "slug": "allday-project"
       },
-      "clean": false,
-      "mismatch_categories": [
-        "missing rows or segments",
-        "latest-release or next-upcoming drift"
-      ],
-      "mismatches": [
-        {
-          "category": "missing rows or segments",
-          "path": "data.artist_source_url",
-          "expected": null,
-          "actual": "https://musicbrainz.org/artist/ce5c564c-0fbe-429c-b93b-5d7e3109cf40"
-        },
-        {
-          "category": "latest-release or next-upcoming drift",
-          "path": "data.latest_release",
-          "expected": {
-            "release_title": "ALLDAY PROJECT",
-            "release_date": "2025-12-08",
-            "stream": "watchlist",
-            "release_kind": "ep"
-          },
-          "actual": {
-            "release_title": "ALLDAY PROJECT",
-            "release_date": "2025-12-08",
-            "stream": "album",
-            "release_kind": "ep"
-          }
-        }
-      ],
+      "clean": true,
+      "mismatch_categories": [],
+      "mismatches": [],
       "expected_snapshot": {
         "identity": {
           "entity_slug": "allday-project",
@@ -1803,21 +1846,27 @@
         },
         "next_upcoming": null,
         "latest_release": {
+          "release_id": "ALLDAY PROJECT::ALLDAY PROJECT::2025-12-08::album",
           "release_title": "ALLDAY PROJECT",
           "release_date": "2025-12-08",
-          "stream": "watchlist",
-          "release_kind": "ep"
+          "stream": "album",
+          "release_kind": "ep",
+          "release_format": "ep",
+          "artwork": null
         },
         "recent_albums": [
           {
+            "release_id": "ALLDAY PROJECT::ALLDAY PROJECT::2025-12-08::album",
             "release_title": "ALLDAY PROJECT",
             "release_date": "2025-12-08",
             "stream": "album",
-            "release_kind": "ep"
+            "release_kind": "ep",
+            "release_format": "ep",
+            "artwork": null
           }
         ],
         "source_timeline": [],
-        "artist_source_url": null
+        "artist_source_url": "https://musicbrainz.org/artist/ce5c564c-0fbe-429c-b93b-5d7e3109cf40"
       },
       "actual_snapshot": {
         "identity": {
@@ -1854,7 +1903,9 @@
           "release_title": "ALLDAY PROJECT",
           "release_date": "2025-12-08",
           "stream": "album",
-          "release_kind": "ep"
+          "release_kind": "ep",
+          "release_format": "ep",
+          "artwork": null
         },
         "recent_albums": [
           {
@@ -1862,7 +1913,9 @@
             "release_title": "ALLDAY PROJECT",
             "release_date": "2025-12-08",
             "stream": "album",
-            "release_kind": "ep"
+            "release_kind": "ep",
+            "release_format": "ep",
+            "artwork": null
           }
         ],
         "source_timeline": [],

--- a/backend/reports/projection_refresh_summary.json
+++ b/backend/reports/projection_refresh_summary.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-03-08T06:55:30.704Z",
+  "generated_at": "2026-03-08T09:28:50.524Z",
   "row_counts": {
     "entity_search_documents": 117,
     "calendar_month_projection": 216,
@@ -79,51 +79,66 @@
       },
       "next_upcoming": {
         "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
+        "source_url": "https://www.starnewskorea.com/music/2026/02/23/2026022315005262396",
         "date_status": "confirmed",
+        "source_type": "news_rss",
+        "source_count": 1,
+        "source_domain": "starnewskorea.com",
         "date_precision": "exact",
         "latest_seen_at": "2026-02-23T05:58:00+00:00",
         "release_format": "ep",
         "scheduled_date": "2026-03-11",
-        "scheduled_month": null,
+        "scheduled_month": "2026-03",
         "confidence_score": 0.84,
+        "evidence_summary": "Future date reference: 2026-03-11. YENA confirmed her comeback with the 5th mini album LOVE CATCHER, scheduled for March 11 at 6 p.m. KST.",
         "upcoming_signal_id": "135cb637-d988-5028-b221-0ec2f59f124f"
       },
       "recent_albums": [
         {
           "stream": "album",
+          "artwork": null,
           "release_id": "801052f3-72e8-5b48-b401-1b0aec55a955",
           "release_date": "2025-07-29",
           "release_kind": "ep",
-          "release_title": "Blooming Wings"
+          "release_title": "Blooming Wings",
+          "release_format": "ep"
         },
         {
           "stream": "album",
+          "artwork": null,
           "release_id": "b18e824c-d318-5848-9b08-7341982cca31",
           "release_date": "2024-01-15",
           "release_kind": "ep",
-          "release_title": "GOOD MORNING"
+          "release_title": "GOOD MORNING",
+          "release_format": "ep"
         },
         {
           "stream": "album",
+          "artwork": null,
           "release_id": "6f634529-e1db-506a-b4fc-f5565b54beb3",
           "release_date": "2022-08-03",
           "release_kind": "ep",
-          "release_title": "SMARTPHONE"
+          "release_title": "SMARTPHONE",
+          "release_format": "ep"
         },
         {
           "stream": "album",
+          "artwork": null,
           "release_id": "cc26984b-ed23-5e96-9bbd-8364ce7c037b",
           "release_date": "2022-01-17",
           "release_kind": "ep",
-          "release_title": "ˣ‿ˣ (SMiLEY)"
+          "release_title": "ˣ‿ˣ (SMiLEY)",
+          "release_format": "ep"
         }
       ],
       "latest_release": {
         "stream": "song",
+        "artwork": null,
         "release_id": "0363f526-e841-560d-940d-541a4e536e4e",
         "release_date": "2025-11-26",
         "release_kind": "single",
-        "release_title": "STAR!"
+        "release_title": "STAR!",
+        "release_format": "single"
       },
       "official_links": {
         "x": "https://x.com/YENA_OFFICIAL",
@@ -137,17 +152,22 @@
       },
       "source_timeline": [
         {
+          "summary": "ep · confirmed · 2026-03-11",
           "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
+          "event_type": "official_announcement",
           "source_url": "https://www.starnewskorea.com/music/2026/02/23/2026022315005262396",
           "date_status": "confirmed",
+          "occurred_at": "2026-02-23T05:58:00+00:00",
           "source_type": "news_rss",
           "published_at": "2026-02-23T05:58:00+00:00",
+          "source_count": 1,
           "source_domain": "starnewskorea.com",
           "date_precision": "exact",
           "release_format": "ep",
           "scheduled_date": "2026-03-11",
-          "scheduled_month": null,
-          "confidence_score": 0.84
+          "scheduled_month": "2026-03",
+          "confidence_score": 0.84,
+          "evidence_summary": "Future date reference: 2026-03-11. YENA confirmed her comeback with the 5th mini album LOVE CATCHER, scheduled for March 11 at 6 p.m. KST."
         }
       ],
       "youtube_channels": {

--- a/backend/scripts/build-shadow-read-report.mjs
+++ b/backend/scripts/build-shadow-read-report.mjs
@@ -740,7 +740,7 @@ function buildUpcomingDisplayRow(rows) {
   };
 }
 
-function dedupeUpcomingCandidatesForDisplay(rows) {
+function dedupeUpcomingCandidateGroupsForDisplay(rows) {
   const exactGroups = new Map();
   const pendingGroups = new Map();
 
@@ -804,7 +804,11 @@ function dedupeUpcomingCandidatesForDisplay(rows) {
     mergedGroups.push(pendingGroup);
   }
 
-  return mergedGroups.map(buildUpcomingDisplayRow).sort(compareUpcomingSignals);
+  return mergedGroups;
+}
+
+function dedupeUpcomingCandidatesForDisplay(rows) {
+  return dedupeUpcomingCandidateGroupsForDisplay(rows).map(buildUpcomingDisplayRow).sort(compareUpcomingSignals);
 }
 
 function expandUpcomingCandidate(row) {
@@ -1728,6 +1732,251 @@ function buildEntityNextUpcomingSummary(team) {
   };
 }
 
+function buildEntityDetailNextUpcomingSummary(team) {
+  const next = team.nextUpcomingSignal;
+  if (!next) {
+    return null;
+  }
+
+  return {
+    upcoming_signal_id: next.event_key ?? `${team.slug}::${next.scheduled_date ?? next.scheduled_month ?? 'undated'}::${next.headline}`,
+    headline: next.headline,
+    scheduled_date: next.scheduled_date ?? null,
+    scheduled_month: next.scheduled_month || (next.scheduled_date ? next.scheduled_date.slice(0, 7) : null),
+    date_precision: getUpcomingDatePrecisionValue(next),
+    date_status: next.date_status,
+    release_format: next.release_format ?? null,
+    confidence_score: next.confidence ?? null,
+    latest_seen_at: next.published_at ?? null,
+    source_type: next.source_type ?? null,
+    source_url: next.source_url ?? null,
+    source_domain: next.source_domain ?? (getSourceDomain(next.source_url) || null),
+    evidence_summary: next.evidence_summary ?? null,
+    source_count: next.evidence_count ?? 1,
+  };
+}
+
+function buildEntityReleaseCardSummary(group, releaseTitle, releaseDate, stream, releaseKind, releaseFormat, releaseArtworkByKey) {
+  if (!releaseTitle || !releaseDate || !stream) {
+    return null;
+  }
+
+  const normalizedStream = normalizeReleaseStream(stream, releaseKind);
+  const artwork =
+    releaseArtworkByKey.get(getReleaseLookupKey(group, releaseTitle, releaseDate, normalizedStream)) ?? null;
+
+  return {
+    release_id: getReleaseLookupKey(group, releaseTitle, releaseDate, normalizedStream),
+    release_title: releaseTitle,
+    release_date: releaseDate,
+    stream: normalizedStream,
+    release_kind: releaseKind ?? null,
+    release_format: releaseFormat ?? null,
+    artwork: artwork
+      ? {
+          cover_image_url: artwork.cover_image_url ?? null,
+          thumbnail_image_url: artwork.thumbnail_image_url ?? null,
+          artwork_source_type: artwork.artwork_source_type ?? null,
+          artwork_source_url: artwork.artwork_source_url ?? null,
+          is_placeholder: artwork.artwork_source_type === 'placeholder',
+        }
+      : null,
+  };
+}
+
+function buildEntitySourceTimelineItem(item) {
+  return {
+    event_type: item.event_type,
+    headline: item.headline,
+    occurred_at: item.occurred_at,
+    summary: item.summary ?? null,
+    source_url: item.source_url ?? null,
+    source_type: item.source_type ?? null,
+    source_domain: item.source_domain ?? null,
+    published_at: item.occurred_at,
+    scheduled_date: null,
+    scheduled_month: null,
+    date_precision: null,
+    date_status: null,
+    release_format: null,
+    confidence_score: null,
+    evidence_summary: null,
+    source_count: null,
+  };
+}
+
+function compareEntityReleaseRows(left, right) {
+  if (left.date !== right.date) {
+    return right.date.localeCompare(left.date);
+  }
+  if (left.stream !== right.stream) {
+    return left.stream === 'album' ? -1 : 1;
+  }
+  return left.title.localeCompare(right.title);
+}
+
+function compareEntityUpcomingRows(left, right) {
+  const leftDate = left.scheduled_date ?? '';
+  const rightDate = right.scheduled_date ?? '';
+  if (leftDate !== rightDate) {
+    return leftDate.localeCompare(rightDate);
+  }
+  if ((left.confidence ?? 0) !== (right.confidence ?? 0)) {
+    return (right.confidence ?? 0) - (left.confidence ?? 0);
+  }
+  if ((left.published_at ?? '') !== (right.published_at ?? '')) {
+    return (right.published_at ?? '').localeCompare(left.published_at ?? '');
+  }
+  return left.headline.localeCompare(right.headline);
+}
+
+function normalizeOptionalText(value) {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function getComparablePublishedAt(value) {
+  const normalized = normalizeOptionalText(value);
+  if (!normalized) {
+    return Number.NEGATIVE_INFINITY;
+  }
+
+  const timestamp = Date.parse(normalized);
+  return Number.isNaN(timestamp) ? Number.NEGATIVE_INFINITY : timestamp;
+}
+
+function buildEntityDetailNextUpcomingExpected(group, state) {
+  const candidates = (state.upcomingByGroup.get(group) ?? [])
+    .filter((item) => getUpcomingDatePrecisionValue(item) === 'exact' && (item.scheduled_date ?? '') >= state.todayIso)
+    .sort(compareEntityUpcomingRows);
+  const next = candidates[0];
+
+  if (!next) {
+    return null;
+  }
+
+  return {
+    upcoming_signal_id: next.event_key ?? `${group.toLowerCase()}::${next.scheduled_date ?? next.scheduled_month ?? 'undated'}::${next.headline}`,
+    headline: next.headline,
+    scheduled_date: normalizeOptionalText(next.scheduled_date),
+    scheduled_month:
+      normalizeOptionalText(next.scheduled_month) ||
+      (normalizeOptionalText(next.scheduled_date) ? next.scheduled_date.slice(0, 7) : null),
+    date_precision: getUpcomingDatePrecisionValue(next),
+    date_status: next.date_status,
+    release_format: next.release_format ?? null,
+    confidence_score: next.confidence ?? null,
+    latest_seen_at: normalizeOptionalText(next.published_at),
+    source_type: normalizeOptionalText(next.source_type),
+    source_url: normalizeOptionalText(next.source_url),
+    source_domain: normalizeOptionalText(next.source_domain) ?? (getSourceDomain(next.source_url) || null),
+    evidence_summary: normalizeOptionalText(next.evidence_summary),
+    source_count: next.evidence_count ?? 1,
+  };
+}
+
+function buildEntityDetailLatestReleaseExpected(group, state) {
+  const latest = [...(state.verifiedReleaseHistoryByGroup.get(group) ?? [])].sort(compareEntityReleaseRows)[0];
+  if (!latest) {
+    return null;
+  }
+
+  return buildEntityReleaseCardSummary(
+    group,
+    latest.title,
+    latest.date,
+    latest.stream,
+    latest.release_kind ?? null,
+    latest.release_format ?? null,
+    state.releaseArtworkByKey,
+  );
+}
+
+function buildEntityDetailRecentAlbumsExpected(group, state) {
+  return [...(state.verifiedReleaseHistoryByGroup.get(group) ?? [])]
+    .filter((item) => item.stream === 'album')
+    .sort(compareEntityReleaseRows)
+    .slice(0, 12)
+    .map((item) =>
+      buildEntityReleaseCardSummary(
+        group,
+        item.title,
+        item.date,
+        item.stream,
+        item.release_kind ?? null,
+        item.release_format ?? null,
+        state.releaseArtworkByKey,
+      ),
+    )
+    .filter((item) => item !== null);
+}
+
+function inferEntityDetailTimelineEventType(item) {
+  const headline = (item.headline ?? '').toLowerCase();
+
+  if (headline.includes('tracklist')) {
+    return 'tracklist_reveal';
+  }
+  if (item.scheduled_date) {
+    return item.date_status === 'confirmed' ? 'official_announcement' : 'date_update';
+  }
+  if (item.scheduled_month) {
+    return 'date_update';
+  }
+  return 'first_signal';
+}
+
+function buildEntityDetailTimelineSummary(item) {
+  return [item.release_format ?? null, item.date_status ?? null, item.scheduled_date ?? item.scheduled_month ?? null]
+    .filter((part) => Boolean(part))
+    .join(' · ') || null;
+}
+
+function buildEntityDetailSourceTimelineExpected(group, state) {
+  return dedupeUpcomingCandidateGroupsForDisplay(state.rawUpcomingByGroup.get(group) ?? [])
+    .flatMap((rows) => {
+      const representative = pickUpcomingRepresentative(rows);
+      const scheduledDate = normalizeOptionalText(representative.scheduled_date);
+      const scheduledMonth =
+        normalizeOptionalText(representative.scheduled_month) || (scheduledDate ? scheduledDate.slice(0, 7) : null);
+
+      return rows.map((item) => ({
+        event_type: inferEntityDetailTimelineEventType(representative),
+        headline: representative.headline,
+        occurred_at: normalizeOptionalText(item.published_at) ?? '',
+        summary: buildEntityDetailTimelineSummary({
+          ...representative,
+          scheduled_date: scheduledDate,
+          scheduled_month: scheduledMonth,
+        }),
+        source_url: normalizeOptionalText(item.source_url),
+        source_type: normalizeOptionalText(item.source_type),
+        source_domain: normalizeOptionalText(item.source_domain) ?? (getSourceDomain(item.source_url) || null),
+        published_at: normalizeOptionalText(item.published_at) ?? '',
+        scheduled_date: scheduledDate,
+        scheduled_month: scheduledMonth,
+        date_precision: getUpcomingDatePrecisionValue(representative),
+        date_status: representative.date_status,
+        release_format: representative.release_format ?? null,
+        confidence_score: representative.confidence ?? null,
+        evidence_summary: normalizeOptionalText(item.evidence_summary),
+        source_count: rows.length,
+      }));
+    })
+    .sort((left, right) => {
+      const leftOccurredAt = getComparablePublishedAt(left.published_at);
+      const rightOccurredAt = getComparablePublishedAt(right.published_at);
+      if (leftOccurredAt !== rightOccurredAt) {
+        return rightOccurredAt - leftOccurredAt;
+      }
+      if ((left.headline ?? '') !== (right.headline ?? '')) {
+        return (left.headline ?? '').localeCompare(right.headline ?? '');
+      }
+      return (left.source_url ?? '').localeCompare(right.source_url ?? '');
+    })
+    .slice(0, 12)
+    .map((item) => item);
+}
+
 function buildSearchExpected(query, state, limit = 8) {
   const needle = createSearchNeedle(query);
   if (!needle) {
@@ -1915,6 +2164,10 @@ function buildEntityDetailExpected(slug, state) {
 
   const allowlist = state.youtubeChannelAllowlistByGroup.get(team.group);
   const artistProfile = state.artistProfileByGroup.get(team.group);
+  const artistSourceUrl =
+    team.artistSource ||
+    state.verifiedReleaseHistoryByGroup.get(team.group)?.find((item) => typeof item.artist_source === 'string' && item.artist_source.length > 0)?.artist_source ||
+    null;
 
   return {
     identity: {
@@ -1940,31 +2193,11 @@ function buildEntityDetailExpected(slug, state) {
       watch_reason: team.watchReason ?? null,
       tracking_status: team.trackingStatus ?? null,
     },
-    next_upcoming: buildEntityNextUpcomingSummary(team),
-    latest_release: team.latestRelease
-      ? {
-          release_title: team.latestRelease.title,
-          release_date: team.latestRelease.date || null,
-          stream: team.latestRelease.stream,
-          release_kind: team.latestRelease.releaseKind || null,
-        }
-      : null,
-    recent_albums: team.recentAlbums.map((item) => ({
-      release_title: item.title,
-      release_date: item.date,
-      stream: item.stream,
-      release_kind: item.release_kind ?? null,
-    })),
-    source_timeline: team.sourceTimeline.map((item) => ({
-      event_type: item.event_type,
-      source_type: item.source_type,
-      headline: item.headline,
-      source_url: item.source_url ?? null,
-      source_domain: item.source_domain ?? null,
-      occurred_at: item.occurred_at,
-      summary: item.summary,
-    })),
-    artist_source_url: team.artistSource || null,
+    next_upcoming: buildEntityDetailNextUpcomingExpected(team.group, state),
+    latest_release: buildEntityDetailLatestReleaseExpected(team.group, state),
+    recent_albums: buildEntityDetailRecentAlbumsExpected(team.group, state),
+    source_timeline: buildEntityDetailSourceTimelineExpected(team.group, state),
+    artist_source_url: artistSourceUrl,
   };
 }
 
@@ -2572,6 +2805,75 @@ function normalizeUpcomingSummary(item) {
   };
 }
 
+function normalizeEntityReleaseCard(item) {
+  if (!item) {
+    return null;
+  }
+
+  return {
+    release_title: item.release_title ?? null,
+    release_date: item.release_date ?? null,
+    stream: item.stream ?? null,
+    release_kind: item.release_kind ?? null,
+    release_format: item.release_format ?? null,
+    artwork: item.artwork
+      ? {
+          cover_image_url: item.artwork.cover_image_url ?? null,
+          thumbnail_image_url: item.artwork.thumbnail_image_url ?? null,
+          artwork_source_type: item.artwork.artwork_source_type ?? null,
+          artwork_source_url: item.artwork.artwork_source_url ?? null,
+          is_placeholder: item.artwork.is_placeholder === true,
+        }
+      : null,
+  };
+}
+
+function normalizeEntityUpcomingSummary(item) {
+  if (!item) {
+    return null;
+  }
+
+  return {
+    headline: item.headline ?? null,
+    scheduled_date: item.scheduled_date ?? null,
+    scheduled_month: item.scheduled_month ?? null,
+    date_precision: item.date_precision ?? null,
+    date_status: item.date_status ?? null,
+    release_format: item.release_format ?? null,
+    source_type: item.source_type ?? null,
+    source_url: item.source_url ?? null,
+    source_domain: item.source_domain ?? null,
+    evidence_summary: item.evidence_summary ?? null,
+    source_count: item.source_count ?? null,
+  };
+}
+
+function normalizeEntityTimelineItem(item) {
+  if (!item) {
+    return null;
+  }
+
+  const occurredAt = item.occurred_at ? new Date(item.occurred_at).toISOString() : null;
+
+  return {
+    event_type: item.event_type ?? null,
+    headline: item.headline ?? null,
+    occurred_at: Number.isNaN(new Date(item.occurred_at ?? '').getTime()) ? item.occurred_at ?? null : occurredAt,
+    summary: item.summary ?? null,
+    source_type: item.source_type ?? null,
+    source_url: item.source_url ?? null,
+    source_domain: item.source_domain ?? null,
+  };
+}
+
+function normalizeComparableUrl(value) {
+  if (typeof value !== 'string' || value.length === 0) {
+    return value ?? null;
+  }
+
+  return value.endsWith('/') ? value.slice(0, -1) : value;
+}
+
 function compareEntityDetailCase(expected, actual) {
   const result = {
     mismatch_categories: new Set(),
@@ -2587,13 +2889,13 @@ function compareEntityDetailCase(expected, actual) {
     ['data.identity.display_name', expected.identity.display_name, actual?.identity?.display_name],
     ['data.identity.canonical_name', expected.identity.canonical_name, actual?.identity?.canonical_name],
     ['data.identity.agency_name', expected.identity.agency_name, actual?.identity?.agency_name],
-    ['data.official_links.youtube', expected.official_links.youtube, actual?.official_links?.youtube],
-    ['data.official_links.x', expected.official_links.x, actual?.official_links?.x],
-    ['data.official_links.instagram', expected.official_links.instagram, actual?.official_links?.instagram],
+    ['data.official_links.youtube', normalizeComparableUrl(expected.official_links.youtube), normalizeComparableUrl(actual?.official_links?.youtube)],
+    ['data.official_links.x', normalizeComparableUrl(expected.official_links.x), normalizeComparableUrl(actual?.official_links?.x)],
+    ['data.official_links.instagram', normalizeComparableUrl(expected.official_links.instagram), normalizeComparableUrl(actual?.official_links?.instagram)],
     ['data.tracking_state.tier', expected.tracking_state.tier, actual?.tracking_state?.tier],
     ['data.tracking_state.watch_reason', expected.tracking_state.watch_reason, actual?.tracking_state?.watch_reason],
     ['data.tracking_state.tracking_status', expected.tracking_state.tracking_status, actual?.tracking_state?.tracking_status],
-    ['data.artist_source_url', expected.artist_source_url, actual?.artist_source_url],
+    ['data.artist_source_url', normalizeComparableUrl(expected.artist_source_url), normalizeComparableUrl(actual?.artist_source_url)],
   ]) {
     const [pathValue, left, right] = pathEntry;
     if (left !== right) {
@@ -2601,8 +2903,8 @@ function compareEntityDetailCase(expected, actual) {
     }
   }
 
-  const expectedLatest = normalizeReleaseSummary(expected.latest_release);
-  const actualLatest = normalizeReleaseSummary(actual?.latest_release);
+  const expectedLatest = normalizeEntityReleaseCard(expected.latest_release);
+  const actualLatest = normalizeEntityReleaseCard(actual?.latest_release);
   if (JSON.stringify(expectedLatest) !== JSON.stringify(actualLatest)) {
     addMismatch(result, 'latest-release or next-upcoming drift', {
       path: 'data.latest_release',
@@ -2611,8 +2913,8 @@ function compareEntityDetailCase(expected, actual) {
     });
   }
 
-  const expectedUpcoming = normalizeUpcomingSummary(expected.next_upcoming);
-  const actualUpcoming = normalizeUpcomingSummary(actual?.next_upcoming);
+  const expectedUpcoming = normalizeEntityUpcomingSummary(expected.next_upcoming);
+  const actualUpcoming = normalizeEntityUpcomingSummary(actual?.next_upcoming);
   if (JSON.stringify(expectedUpcoming) !== JSON.stringify(actualUpcoming)) {
     addMismatch(
       result,
@@ -2627,8 +2929,8 @@ function compareEntityDetailCase(expected, actual) {
     );
   }
 
-  const expectedAlbums = expected.recent_albums.map((item) => `${item.release_title}|${item.release_date}|${item.stream}`);
-  const actualAlbums = (actual?.recent_albums ?? []).map((item) => `${item.release_title}|${item.release_date}|${item.stream}`);
+  const expectedAlbums = expected.recent_albums.map(normalizeEntityReleaseCard);
+  const actualAlbums = (actual?.recent_albums ?? []).map(normalizeEntityReleaseCard);
   if (JSON.stringify(expectedAlbums) !== JSON.stringify(actualAlbums)) {
     addMismatch(result, 'missing rows or segments', {
       path: 'data.recent_albums',
@@ -2637,8 +2939,8 @@ function compareEntityDetailCase(expected, actual) {
     });
   }
 
-  const expectedTimeline = expected.source_timeline.map((item) => `${item.event_type}|${item.headline}|${item.source_type}|${item.source_url ?? ''}`);
-  const actualTimeline = (actual?.source_timeline ?? []).map((item) => `${item.headline}|${item.source_type}|${item.source_url ?? ''}`);
+  const expectedTimeline = expected.source_timeline.map(normalizeEntityTimelineItem);
+  const actualTimeline = (actual?.source_timeline ?? []).map(normalizeEntityTimelineItem);
   if (JSON.stringify(expectedTimeline) !== JSON.stringify(actualTimeline)) {
     addMismatch(result, 'missing rows or segments', {
       path: 'data.source_timeline',

--- a/backend/sql/migrations/0005_entity_detail_mobile_payload.sql
+++ b/backend/sql/migrations/0005_entity_detail_mobile_payload.sql
@@ -1,0 +1,327 @@
+drop materialized view if exists entity_detail_projection;
+
+create materialized view entity_detail_projection as
+with official_link_summary as (
+  select
+    eol.entity_id,
+    max(eol.url) filter (where eol.link_type = 'youtube') as youtube_url,
+    max(eol.url) filter (where eol.link_type = 'x') as x_url,
+    max(eol.url) filter (where eol.link_type = 'instagram') as instagram_url,
+    max(eol.url) filter (where eol.link_type = 'artist_source') as artist_source_url
+  from entity_official_links eol
+  group by eol.entity_id
+),
+youtube_channel_summary as (
+  select
+    eyc.entity_id,
+    min(yc.canonical_channel_url) filter (where eyc.channel_role in ('primary_team_channel', 'both')) as primary_team_channel_url,
+    coalesce(
+      array_agg(distinct yc.canonical_channel_url order by yc.canonical_channel_url)
+        filter (where eyc.channel_role in ('mv_allowlist', 'both')),
+      '{}'::text[]
+    ) as mv_allowlist_urls
+  from entity_youtube_channels eyc
+  join youtube_channels yc on yc.id = eyc.youtube_channel_id
+  group by eyc.entity_id
+),
+upcoming_source_choice as (
+  select distinct on (uss.upcoming_signal_id)
+    uss.upcoming_signal_id,
+    uss.source_type,
+    uss.source_url,
+    uss.source_domain,
+    uss.evidence_summary,
+    uss.published_at,
+    count(*) over (partition by uss.upcoming_signal_id) as source_count
+  from upcoming_signal_sources uss
+  order by
+    uss.upcoming_signal_id,
+    case uss.source_type
+      when 'agency_notice' then 0
+      when 'weverse_notice' then 1
+      when 'official_social' then 2
+      when 'news_rss' then 3
+      else 4
+    end,
+    uss.published_at desc nulls last,
+    uss.source_url asc
+),
+release_card_base as (
+  select
+    r.entity_id,
+    r.id as release_id,
+    r.release_title,
+    r.release_date,
+    r.stream,
+    r.release_kind,
+    r.release_format,
+    ra.cover_image_url,
+    ra.thumbnail_image_url,
+    ra.artwork_source_type,
+    ra.artwork_source_url
+  from releases r
+  left join release_artwork ra on ra.release_id = r.id
+),
+latest_release as (
+  select distinct on (rc.entity_id)
+    rc.entity_id,
+    rc.release_id,
+    rc.release_title,
+    rc.release_date,
+    rc.stream,
+    rc.release_kind,
+    rc.release_format,
+    rc.cover_image_url,
+    rc.thumbnail_image_url,
+    rc.artwork_source_type,
+    rc.artwork_source_url
+  from release_card_base rc
+  order by
+    rc.entity_id,
+    rc.release_date desc,
+    case when rc.stream = 'album' then 0 else 1 end,
+    rc.release_title asc
+),
+next_upcoming as (
+  select distinct on (u.entity_id)
+    u.entity_id,
+    u.id as upcoming_signal_id,
+    u.headline,
+    u.scheduled_date,
+    coalesce(
+      to_char(u.scheduled_month, 'YYYY-MM'),
+      to_char(date_trunc('month', u.scheduled_date::timestamp)::date, 'YYYY-MM')
+    ) as scheduled_month,
+    u.date_precision,
+    u.date_status,
+    u.release_format,
+    u.confidence_score,
+    u.latest_seen_at,
+    usc.source_type,
+    usc.source_url,
+    usc.source_domain,
+    usc.evidence_summary,
+    coalesce(usc.source_count, 0) as source_count
+  from upcoming_signals u
+  left join upcoming_source_choice usc on usc.upcoming_signal_id = u.id
+  where
+    u.is_active = true
+    and u.date_precision = 'exact'
+    and u.scheduled_date >= timezone('Asia/Seoul', now())::date
+  order by
+    u.entity_id,
+    u.scheduled_date asc,
+    u.confidence_score desc nulls last,
+    u.latest_seen_at desc nulls last,
+    u.id
+),
+recent_albums as (
+  select
+    ranked.entity_id,
+    jsonb_agg(
+      jsonb_build_object(
+        'release_id', ranked.release_id::text,
+        'release_title', ranked.release_title,
+        'release_date', ranked.release_date::text,
+        'stream', ranked.stream,
+        'release_kind', ranked.release_kind,
+        'release_format', ranked.release_format,
+        'artwork', case
+          when ranked.cover_image_url is null
+            and ranked.thumbnail_image_url is null
+            and ranked.artwork_source_type is null
+            and ranked.artwork_source_url is null
+            then null
+          else jsonb_build_object(
+            'cover_image_url', ranked.cover_image_url,
+            'thumbnail_image_url', ranked.thumbnail_image_url,
+            'artwork_source_type', ranked.artwork_source_type,
+            'artwork_source_url', ranked.artwork_source_url,
+            'is_placeholder', ranked.artwork_source_type = 'placeholder'
+          )
+        end
+      )
+      order by ranked.release_date desc, ranked.release_title asc
+    ) as recent_albums
+  from (
+    select
+      rc.entity_id,
+      rc.release_id,
+      rc.release_title,
+      rc.release_date,
+      rc.stream,
+      rc.release_kind,
+      rc.release_format,
+      rc.cover_image_url,
+      rc.thumbnail_image_url,
+      rc.artwork_source_type,
+      rc.artwork_source_url,
+      row_number() over (
+        partition by rc.entity_id
+        order by rc.release_date desc, rc.release_title asc
+      ) as release_rank
+    from release_card_base rc
+    where rc.stream = 'album'
+  ) ranked
+  where ranked.release_rank <= 12
+  group by ranked.entity_id
+),
+source_timeline as (
+  select
+    timeline.entity_id,
+    jsonb_agg(timeline.payload order by timeline.sort_at desc, timeline.sort_headline asc) as source_timeline
+  from (
+    select
+      us.entity_id,
+      coalesce(uss.published_at, us.latest_seen_at, us.first_seen_at, now()) as sort_at,
+      us.headline as sort_headline,
+      row_number() over (
+        partition by us.entity_id
+        order by coalesce(uss.published_at, us.latest_seen_at, us.first_seen_at, now()) desc, us.headline asc
+      ) as timeline_rank,
+      jsonb_build_object(
+        'event_type', case
+          when lower(us.headline) like '%tracklist%' then 'tracklist_reveal'
+          when us.scheduled_date is not null and us.date_status = 'confirmed' then 'official_announcement'
+          when us.scheduled_date is not null or us.scheduled_month is not null then 'date_update'
+          else 'first_signal'
+        end,
+        'headline', us.headline,
+        'occurred_at', coalesce(uss.published_at, us.latest_seen_at, us.first_seen_at),
+        'summary', nullif(
+          concat_ws(
+            ' · ',
+            nullif(us.release_format, ''),
+            nullif(us.date_status, ''),
+            coalesce(us.scheduled_date::text, to_char(us.scheduled_month, 'YYYY-MM'))
+          ),
+          ''
+        ),
+        'scheduled_date', us.scheduled_date::text,
+        'scheduled_month', coalesce(
+          to_char(us.scheduled_month, 'YYYY-MM'),
+          case
+            when us.scheduled_date is null then null
+            else to_char(date_trunc('month', us.scheduled_date::timestamp)::date, 'YYYY-MM')
+          end
+        ),
+        'date_precision', us.date_precision,
+        'date_status', us.date_status,
+        'release_format', us.release_format,
+        'confidence_score', us.confidence_score,
+        'source_type', uss.source_type,
+        'source_url', uss.source_url,
+        'source_domain', uss.source_domain,
+        'published_at', coalesce(uss.published_at, us.latest_seen_at, us.first_seen_at),
+        'evidence_summary', uss.evidence_summary,
+        'source_count', coalesce(
+          usc.source_count,
+          case when uss.upcoming_signal_id is null then 0 else 1 end
+        )
+      ) as payload
+    from upcoming_signals us
+    left join upcoming_signal_sources uss on uss.upcoming_signal_id = us.id
+    left join upcoming_source_choice usc on usc.upcoming_signal_id = us.id
+    where us.is_active = true
+  ) timeline
+  where timeline.timeline_rank <= 12
+  group by timeline.entity_id
+)
+select
+  e.id as entity_id,
+  e.slug as entity_slug,
+  jsonb_build_object(
+    'identity', jsonb_build_object(
+      'entity_slug', e.slug,
+      'display_name', e.display_name,
+      'canonical_name', e.canonical_name,
+      'entity_type', e.entity_type,
+      'agency_name', e.agency_name,
+      'debut_year', e.debut_year,
+      'badge_image_url', e.badge_image_url,
+      'badge_source_url', e.badge_source_url,
+      'badge_source_label', e.badge_source_label,
+      'badge_kind', e.badge_kind,
+      'representative_image_url', e.representative_image_url,
+      'representative_image_source', e.representative_image_source
+    ),
+    'official_links', jsonb_strip_nulls(
+      jsonb_build_object(
+        'youtube', ols.youtube_url,
+        'x', ols.x_url,
+        'instagram', ols.instagram_url
+      )
+    ),
+    'youtube_channels', jsonb_build_object(
+      'primary_team_channel_url', ycs.primary_team_channel_url,
+      'mv_allowlist_urls', to_jsonb(coalesce(ycs.mv_allowlist_urls, '{}'::text[]))
+    ),
+    'tracking_state', jsonb_build_object(
+      'tier', ets.tier,
+      'watch_reason', ets.watch_reason,
+      'tracking_status', ets.tracking_status
+    ),
+    'next_upcoming', case
+      when nu.entity_id is null then null
+      else jsonb_build_object(
+        'upcoming_signal_id', nu.upcoming_signal_id::text,
+        'headline', nu.headline,
+        'scheduled_date', nu.scheduled_date::text,
+        'scheduled_month', nu.scheduled_month,
+        'date_precision', nu.date_precision,
+        'date_status', nu.date_status,
+        'release_format', nu.release_format,
+        'confidence_score', nu.confidence_score,
+        'latest_seen_at', nu.latest_seen_at,
+        'source_type', nu.source_type,
+        'source_url', nu.source_url,
+        'source_domain', nu.source_domain,
+        'evidence_summary', nu.evidence_summary,
+        'source_count', nu.source_count
+      )
+    end,
+    'latest_release', case
+      when lr.entity_id is null then null
+      else jsonb_build_object(
+        'release_id', lr.release_id::text,
+        'release_title', lr.release_title,
+        'release_date', lr.release_date::text,
+        'stream', lr.stream,
+        'release_kind', lr.release_kind,
+        'release_format', lr.release_format,
+        'artwork', case
+          when lr.cover_image_url is null
+            and lr.thumbnail_image_url is null
+            and lr.artwork_source_type is null
+            and lr.artwork_source_url is null
+            then null
+          else jsonb_build_object(
+            'cover_image_url', lr.cover_image_url,
+            'thumbnail_image_url', lr.thumbnail_image_url,
+            'artwork_source_type', lr.artwork_source_type,
+            'artwork_source_url', lr.artwork_source_url,
+            'is_placeholder', lr.artwork_source_type = 'placeholder'
+          )
+        end
+      )
+    end,
+    'recent_albums', coalesce(ra.recent_albums, '[]'::jsonb),
+    'source_timeline', coalesce(st.source_timeline, '[]'::jsonb),
+    'artist_source_url', ols.artist_source_url
+  ) as payload,
+  now() as generated_at
+from entities e
+left join entity_tracking_state ets on ets.entity_id = e.id
+left join official_link_summary ols on ols.entity_id = e.id
+left join youtube_channel_summary ycs on ycs.entity_id = e.id
+left join latest_release lr on lr.entity_id = e.id
+left join next_upcoming nu on nu.entity_id = e.id
+left join recent_albums ra on ra.entity_id = e.id
+left join source_timeline st on st.entity_id = e.id
+with no data;
+
+create unique index if not exists idx_entity_detail_projection_entity_id
+  on entity_detail_projection (entity_id);
+
+create unique index if not exists idx_entity_detail_projection_slug
+  on entity_detail_projection (entity_slug);

--- a/backend/src/route-contract.test.ts
+++ b/backend/src/route-contract.test.ts
@@ -100,6 +100,11 @@ function buildEntityDetailPayload() {
       release_format: 'ep',
       confidence_score: 0.84,
       latest_seen_at: NOW,
+      source_type: 'news_rss',
+      source_url: 'https://starnews.example/yena-love-catcher',
+      source_domain: 'starnews.example',
+      evidence_summary: 'StarNews confirmed the March 11 comeback timing.',
+      source_count: 2,
     },
     latest_release: {
       release_id: YENA_RELEASE_ID,
@@ -107,6 +112,14 @@ function buildEntityDetailPayload() {
       release_date: '2025-06-29',
       stream: 'song',
       release_kind: 'single',
+      release_format: 'single',
+      artwork: {
+        cover_image_url: 'https://cdn.example.com/hate-rodrigo-cover.jpg',
+        thumbnail_image_url: 'https://cdn.example.com/hate-rodrigo-thumb.jpg',
+        artwork_source_type: 'releaseArtwork.cover_image_url',
+        artwork_source_url: 'https://artwork.example.com/hate-rodrigo',
+        is_placeholder: false,
+      },
     },
     recent_albums: [
       {
@@ -115,11 +128,22 @@ function buildEntityDetailPayload() {
         release_date: '2026-03-11',
         stream: 'album',
         release_kind: 'ep',
+        release_format: 'ep',
+        artwork: {
+          cover_image_url: 'https://cdn.example.com/love-catcher-cover.jpg',
+          thumbnail_image_url: 'https://cdn.example.com/love-catcher-thumb.jpg',
+          artwork_source_type: 'releaseArtwork.cover_image_url',
+          artwork_source_url: 'https://artwork.example.com/love-catcher',
+          is_placeholder: false,
+        },
       },
     ],
     source_timeline: [
       {
+        event_type: 'official_announcement',
         headline: '최예나, 3월 11일 컴백 확정',
+        occurred_at: NOW,
+        summary: 'ep · confirmed · 2026-03-11',
         source_url: 'https://starnews.example/yena-love-catcher',
         source_type: 'news_rss',
         source_domain: 'starnews.example',
@@ -130,6 +154,8 @@ function buildEntityDetailPayload() {
         date_status: 'confirmed',
         release_format: 'ep',
         confidence_score: 0.84,
+        evidence_summary: 'StarNews confirmed the March 11 comeback timing.',
+        source_count: 2,
       },
     ],
     artist_source_url: 'https://www.youtube.com/@YENA_OFFICIAL',
@@ -693,7 +719,15 @@ test('GET /v1/entities/:slug returns entity detail projection payload', async (t
   assert.equal(body.data.identity.entity_slug, 'yena');
   assert.equal(body.data.official_links.youtube, 'https://www.youtube.com/@YENA_OFFICIAL');
   assert.equal(body.data.next_upcoming.upcoming_signal_id, UPCOMING_SIGNAL_ID);
+  assert.equal(body.data.next_upcoming.source_url, 'https://starnews.example/yena-love-catcher');
+  assert.equal(body.data.next_upcoming.source_count, 2);
+  assert.equal(body.data.latest_release.release_format, 'single');
+  assert.equal(body.data.latest_release.artwork.cover_image_url, 'https://cdn.example.com/hate-rodrigo-cover.jpg');
   assert.equal(body.data.recent_albums.length, 1);
+  assert.equal(body.data.recent_albums[0].release_format, 'ep');
+  assert.equal(body.data.recent_albums[0].artwork.thumbnail_image_url, 'https://cdn.example.com/love-catcher-thumb.jpg');
+  assert.equal(body.data.source_timeline[0].event_type, 'official_announcement');
+  assert.equal(body.data.source_timeline[0].summary, 'ep · confirmed · 2026-03-11');
 });
 
 test('GET /v1/releases/lookup resolves legacy key to release id', async (t) => {

--- a/backend/src/routes/entities.ts
+++ b/backend/src/routes/entities.ts
@@ -55,6 +55,14 @@ type TrackingStateBlock = {
   tracking_status: string | null;
 };
 
+type ArtworkSummary = {
+  cover_image_url: string | null;
+  thumbnail_image_url: string | null;
+  artwork_source_type: string | null;
+  artwork_source_url: string | null;
+  is_placeholder: boolean;
+};
+
 type UpcomingSummary = {
   upcoming_signal_id: string;
   headline: string;
@@ -65,6 +73,11 @@ type UpcomingSummary = {
   release_format: string | null;
   confidence_score: number | null;
   latest_seen_at: string | null;
+  source_type: string | null;
+  source_url: string | null;
+  source_domain: string | null;
+  evidence_summary: string | null;
+  source_count: number | null;
 };
 
 type ReleaseSummary = {
@@ -73,10 +86,15 @@ type ReleaseSummary = {
   release_date: string;
   stream: string;
   release_kind: string | null;
+  release_format: string | null;
+  artwork: ArtworkSummary | null;
 };
 
 type SourceTimelineItem = {
+  event_type: string;
   headline: string;
+  occurred_at: string;
+  summary: string | null;
   source_url: string | null;
   source_type: string | null;
   source_domain: string | null;
@@ -87,6 +105,8 @@ type SourceTimelineItem = {
   date_status: string | null;
   release_format: string | null;
   confidence_score: number | null;
+  evidence_summary: string | null;
+  source_count: number | null;
 };
 
 type EntityDetailPayload = {
@@ -116,8 +136,24 @@ function asNullableNumber(value: unknown): number | null {
   return typeof value === 'number' && Number.isFinite(value) ? value : null;
 }
 
+function asNullableBoolean(value: unknown): boolean | null {
+  return typeof value === 'boolean' ? value : null;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function deriveScheduledMonth(scheduledDate: string | null, scheduledMonth: string | null): string | null {
+  if (scheduledMonth) {
+    return scheduledMonth;
+  }
+
+  if (scheduledDate && /^\d{4}-\d{2}-\d{2}$/.test(scheduledDate)) {
+    return scheduledDate.slice(0, 7);
+  }
+
+  return null;
 }
 
 function toIsoString(value: Date | string | undefined): string {
@@ -133,6 +169,30 @@ function toIsoString(value: Date | string | undefined): string {
   }
 
   return new Date().toISOString();
+}
+
+function normalizeArtworkSummary(value: unknown): ArtworkSummary | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const coverImageUrl = asNullableString(value.cover_image_url);
+  const thumbnailImageUrl = asNullableString(value.thumbnail_image_url);
+  const artworkSourceType = asNullableString(value.artwork_source_type);
+  const artworkSourceUrl = asNullableString(value.artwork_source_url);
+  const isPlaceholder = asNullableBoolean(value.is_placeholder) === true;
+
+  if (!coverImageUrl && !thumbnailImageUrl && !artworkSourceType && !artworkSourceUrl && !isPlaceholder) {
+    return null;
+  }
+
+  return {
+    cover_image_url: coverImageUrl,
+    thumbnail_image_url: thumbnailImageUrl,
+    artwork_source_type: artworkSourceType,
+    artwork_source_url: artworkSourceUrl,
+    is_placeholder: isPlaceholder,
+  };
 }
 
 function normalizeReleaseSummary(value: unknown): ReleaseSummary | null {
@@ -155,6 +215,8 @@ function normalizeReleaseSummary(value: unknown): ReleaseSummary | null {
     release_date: releaseDate,
     stream,
     release_kind: asNullableString(value.release_kind),
+    release_format: asNullableString(value.release_format),
+    artwork: normalizeArtworkSummary(value.artwork),
   };
 }
 
@@ -175,19 +237,49 @@ function normalizeSourceTimeline(value: unknown): SourceTimelineItem[] {
 
   return value
     .filter(isRecord)
-    .map((item) => ({
-      headline: asNullableString(item.headline) ?? '',
-      source_url: asNullableString(item.source_url),
-      source_type: asNullableString(item.source_type),
-      source_domain: asNullableString(item.source_domain),
-      published_at: asNullableString(item.published_at),
-      scheduled_date: asNullableString(item.scheduled_date),
-      scheduled_month: asNullableString(item.scheduled_month),
-      date_precision: asNullableString(item.date_precision),
-      date_status: asNullableString(item.date_status),
-      release_format: asNullableString(item.release_format),
-      confidence_score: asNullableNumber(item.confidence_score),
-    }))
+    .map((item) => {
+      const headline = asNullableString(item.headline) ?? '';
+      const scheduledDate = asNullableString(item.scheduled_date);
+      const scheduledMonth = deriveScheduledMonth(scheduledDate, asNullableString(item.scheduled_month));
+      const publishedAt = asNullableString(item.published_at);
+      const occurredAt = asNullableString(item.occurred_at) ?? publishedAt ?? scheduledDate ?? scheduledMonth ?? '';
+      const releaseFormat = asNullableString(item.release_format);
+      const dateStatus = asNullableString(item.date_status);
+      const eventType =
+        asNullableString(item.event_type) ??
+        (headline.toLowerCase().includes('tracklist')
+          ? 'tracklist_reveal'
+          : scheduledDate
+            ? dateStatus === 'confirmed'
+              ? 'official_announcement'
+              : 'date_update'
+            : scheduledMonth
+              ? 'date_update'
+              : 'first_signal');
+      const fallbackSummary = [releaseFormat, dateStatus, scheduledDate ?? scheduledMonth]
+        .filter((part): part is string => Boolean(part))
+        .join(' · ');
+      const summary = asNullableString(item.summary) ?? (fallbackSummary || null);
+
+      return {
+        event_type: eventType,
+        headline,
+        occurred_at: occurredAt,
+        summary,
+        source_url: asNullableString(item.source_url),
+        source_type: asNullableString(item.source_type),
+        source_domain: asNullableString(item.source_domain),
+        published_at: publishedAt ?? occurredAt,
+        scheduled_date: scheduledDate,
+        scheduled_month: scheduledMonth,
+        date_precision: asNullableString(item.date_precision),
+        date_status: dateStatus,
+        release_format: releaseFormat,
+        confidence_score: asNullableNumber(item.confidence_score),
+        evidence_summary: asNullableString(item.evidence_summary),
+        source_count: asNullableNumber(item.source_count),
+      };
+    })
     .filter((item) => item.headline.length > 0);
 }
 
@@ -209,12 +301,17 @@ function normalizeUpcomingSummary(value: unknown): UpcomingSummary | null {
     upcoming_signal_id: upcomingSignalId,
     headline,
     scheduled_date: asNullableString(value.scheduled_date),
-    scheduled_month: asNullableString(value.scheduled_month),
+    scheduled_month: deriveScheduledMonth(asNullableString(value.scheduled_date), asNullableString(value.scheduled_month)),
     date_precision: datePrecision,
     date_status: dateStatus,
     release_format: asNullableString(value.release_format),
     confidence_score: asNullableNumber(value.confidence_score),
     latest_seen_at: asNullableString(value.latest_seen_at),
+    source_type: asNullableString(value.source_type),
+    source_url: asNullableString(value.source_url),
+    source_domain: asNullableString(value.source_domain),
+    evidence_summary: asNullableString(value.evidence_summary),
+    source_count: asNullableNumber(value.source_count),
   };
 }
 

--- a/docs/specs/backend/mobile-adoption-readiness-review.md
+++ b/docs/specs/backend/mobile-adoption-readiness-review.md
@@ -58,7 +58,7 @@ mobile가 아래를 다시 계산하거나 조합해야 하면 readiness fail로
 |---|---|---|---|---|---|
 | Calendar | `GET /v1/calendar/month` | `calendar-screen.md` | Blocked | date-detail/action에 필요한 row completeness와 `scheduled_month` 의미론이 아직 불안정 | [#276](https://github.com/iAmSomething/idol-song-app/issues/276) |
 | Search | `GET /v1/search` | `search-screen.md` | Blocked | release-title/headline 기반 entity-result 규칙과 upcoming summary completeness가 아직 흔들림 | [#278](https://github.com/iAmSomething/idol-song-app/issues/278) |
-| Entity Detail | `GET /v1/entities/:slug` | `team-detail-screen.md` | Blocked | `next_upcoming` source/meta와 `recent_albums` card payload가 mobile-ready shape로 아직 고정되지 않음 | [#277](https://github.com/iAmSomething/idol-song-app/issues/277) |
+| Entity Detail | `GET /v1/entities/:slug` | `team-detail-screen.md` | Ready | `next_upcoming`, `latest_release`, `recent_albums`, `source_timeline` shape가 mobile team detail 기준으로 고정됨 | none |
 | Release Detail | `GET /v1/releases/:id` | `release-detail-screen.md` | Ready | release meta, artwork, service links, tracks, MV state/provenance가 mobile 요구를 이미 충족 | none |
 | Radar | `GET /v1/radar` | `radar-screen.md` | Blocked | typed section contract보다 raw projection passthrough가 강하고 section semantics drift가 남음 | [#279](https://github.com/iAmSomething/idol-song-app/issues/279) |
 
@@ -115,7 +115,7 @@ blocker issue:
 
 ### 6.3 Entity Detail
 
-판정: `Blocked`
+판정: `Ready`
 
 mobile team detail이 요구하는 것:
 
@@ -123,18 +123,14 @@ mobile team detail이 요구하는 것:
 - `최신 발매` 카드에 cover, release meta, action 진입점이 있어야 한다.
 - `최근 앨범 캐러셀`은 cover와 release summary만으로 바로 렌더돼야 한다.
 
-현재 확인된 문제:
+현재 상태:
 
-- current contract sample은 `recent_albums`를 빈 배열로만 보여주고, item shape를 명시하지 않는다.
-- runtime `recent_albums`는 release summary 중심이라 mobile carousel card에 필요한 cover/artwork contract가 없다.
-- `next_upcoming`는 headline/date/status는 있지만 source/meta action을 고정하는 shared shape가 아직 충분히 명시돼 있지 않다.
-- `source_timeline`를 shared contract에 계속 둘 거라면 item shape도 freeze가 필요하다.
+- `next_upcoming`가 source/meta action(`source_type`, `source_url`, `source_domain`, `evidence_summary`, `source_count`)을 포함한다.
+- `latest_release`와 `recent_albums`는 `release_format + artwork`를 가진 card payload로 고정됐다.
+- `source_timeline`도 `event_type`, `occurred_at`, `summary`를 포함한 shared item shape로 고정됐다.
+- representative shadow coverage도 `yena`, `blackpink`, `and-team`, `allday-project` 기준으로 clean까지 확인했다.
 
-즉, team detail 화면은 지금 붙이면 album card payload와 next-upcoming meta action을 client에서 다시 조합할 가능성이 높다.
-
-blocker issue:
-
-- [#277](https://github.com/iAmSomething/idol-song-app/issues/277)
+따라서 mobile team detail은 이제 client-side selector reconstruction 없이 backend contract를 직접 소비해도 된다.
 
 ### 6.4 Release Detail
 
@@ -205,13 +201,11 @@ blocker issue:
 
 - calendar screen implementation
 - search screen implementation
-- team detail screen implementation
 - radar screen implementation
 
 보류 해제 조건:
 
 - [#276](https://github.com/iAmSomething/idol-song-app/issues/276)
-- [#277](https://github.com/iAmSomething/idol-song-app/issues/277)
 - [#278](https://github.com/iAmSomething/idol-song-app/issues/278)
 - [#279](https://github.com/iAmSomething/idol-song-app/issues/279)
 

--- a/docs/specs/backend/shared-read-api-contracts.md
+++ b/docs/specs/backend/shared-read-api-contracts.md
@@ -335,15 +335,74 @@
       "watch_reason": "recent_release",
       "tracking_status": "recent_release"
     },
-    "next_upcoming": null,
+    "next_upcoming": {
+      "upcoming_signal_id": "upcoming_txt_example",
+      "headline": "TXT, 3월 12일 컴백 확정",
+      "scheduled_date": "2026-03-12",
+      "scheduled_month": "2026-03",
+      "date_precision": "exact",
+      "date_status": "confirmed",
+      "release_format": "mini",
+      "confidence_score": 0.91,
+      "latest_seen_at": "2026-03-06T03:00:00Z",
+      "source_type": "agency_notice",
+      "source_url": "https://ibighit.com/txt/example",
+      "source_domain": "ibighit.com",
+      "evidence_summary": "BIGHIT MUSIC confirmed the March 12 comeback date.",
+      "source_count": 2
+    },
     "latest_release": {
       "release_id": "rel_txt_example",
       "release_title": "Example",
       "release_date": "2026-02-27",
-      "stream": "album"
+      "stream": "album",
+      "release_kind": "mini",
+      "release_format": "mini",
+      "artwork": {
+        "cover_image_url": "https://cdn.example.com/txt-example-cover.jpg",
+        "thumbnail_image_url": "https://cdn.example.com/txt-example-thumb.jpg",
+        "artwork_source_type": "releaseArtwork.cover_image_url",
+        "artwork_source_url": "https://artwork.example.com/txt-example",
+        "is_placeholder": false
+      }
     },
-    "recent_albums": [],
-    "source_timeline": []
+    "recent_albums": [
+      {
+        "release_id": "rel_txt_example",
+        "release_title": "Example",
+        "release_date": "2026-02-27",
+        "stream": "album",
+        "release_kind": "mini",
+        "release_format": "mini",
+        "artwork": {
+          "cover_image_url": "https://cdn.example.com/txt-example-cover.jpg",
+          "thumbnail_image_url": "https://cdn.example.com/txt-example-thumb.jpg",
+          "artwork_source_type": "releaseArtwork.cover_image_url",
+          "artwork_source_url": "https://artwork.example.com/txt-example",
+          "is_placeholder": false
+        }
+      }
+    ],
+    "source_timeline": [
+      {
+        "event_type": "official_announcement",
+        "headline": "TXT, 3월 12일 컴백 확정",
+        "occurred_at": "2026-03-06T03:00:00Z",
+        "summary": "mini · confirmed · 2026-03-12",
+        "source_url": "https://ibighit.com/txt/example",
+        "source_type": "agency_notice",
+        "source_domain": "ibighit.com",
+        "published_at": "2026-03-06T03:00:00Z",
+        "scheduled_date": "2026-03-12",
+        "scheduled_month": "2026-03",
+        "date_precision": "exact",
+        "date_status": "confirmed",
+        "release_format": "mini",
+        "confidence_score": 0.91,
+        "evidence_summary": "BIGHIT MUSIC confirmed the March 12 comeback date.",
+        "source_count": 2
+      }
+    ]
   }
 }
 ```
@@ -351,8 +410,11 @@
 ### 7.5 Server-side Rules
 
 - `next_upcoming`은 exact future date 우선이며 없으면 `null`
+- `next_upcoming`은 mobile next-comeback card가 바로 렌더되도록 source/meta(`source_type`, `source_url`, `source_domain`, `evidence_summary`, `source_count`)를 포함한다
 - official links는 deduped canonical URL만 준다
-- recent album selection rule은 서버가 고정한다
+- latest release와 recent album card는 `release_format`과 nested `artwork` shape를 항상 포함한다
+- recent album selection rule은 서버가 고정하며 `album` stream 기준 최신순 최대 `12`개다
+- `source_timeline`를 shared contract로 유지하는 동안 item shape는 `event_type`, `occurred_at`, `summary`, source/date meta까지 포함한 구조로 고정한다
 
 ## 8. `GET /v1/releases/:id`
 


### PR DESCRIPTION
## Summary
- freeze entity detail payload for mobile next-upcoming, recent-albums, and source-timeline sections
- refresh entity detail projection and route contract to carry source/meta and artwork fields
- update shadow expectation and docs so representative entity detail coverage is clean

Closes #277