### PR TITLE
Stabilize backend search contract for mobile

### DIFF
--- a/backend/reports/backend_shadow_read_report.json
+++ b/backend/reports/backend_shadow_read_report.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-03-08T09:39:51.143Z",
+  "generated_at": "2026-03-08T10:13:21.659Z",
   "clean": false,
   "linked_parity_report": {
     "exists": true,
@@ -64,15 +64,13 @@
     ]
   },
   "summary_lines": [
-    "search: clean 1/5, drift 4/5",
+    "search: clean 5/5, drift 0/5",
     "entity_detail: clean 4/4, drift 0/4",
     "release_detail: clean 0/3, drift 3/3",
     "calendar_month: clean 3/3, drift 0/3",
     "radar: clean 0/1, drift 1/1",
-    "missing rows or segments: 7 case(s)",
-    "field-shape mismatches: 6 case(s)",
-    "latest-release or next-upcoming drift: 4 case(s)",
-    "alias-match differences: 3 case(s)",
+    "field-shape mismatches: 4 case(s)",
+    "missing rows or segments: 3 case(s)",
     "radar eligibility drift: 1 case(s)"
   ],
   "cases": [
@@ -161,88 +159,9 @@
       "input": {
         "q": "투바투"
       },
-      "clean": false,
-      "mismatch_categories": [
-        "field-shape mismatches",
-        "latest-release or next-upcoming drift",
-        "missing rows or segments"
-      ],
-      "mismatches": [
-        {
-          "category": "field-shape mismatches",
-          "path": "data",
-          "shape_mismatches": [
-            {
-              "path": "data.entities[0].next_upcoming.scheduled_month",
-              "expected_type": "string",
-              "actual_type": "missing",
-              "message": "Missing key"
-            },
-            {
-              "path": "data.entities[0].next_upcoming.release_format",
-              "expected_type": "string",
-              "actual_type": "missing",
-              "message": "Missing key"
-            },
-            {
-              "path": "data.upcoming[0].scheduled_month",
-              "expected_type": "string",
-              "actual_type": "null",
-              "message": "Type mismatch"
-            },
-            {
-              "path": "data.upcoming[0].release_format",
-              "expected_type": "string",
-              "actual_type": "null",
-              "message": "Type mismatch"
-            }
-          ]
-        },
-        {
-          "category": "latest-release or next-upcoming drift",
-          "path": "data.entities[0].next_upcoming",
-          "expected": {
-            "headline": "[NOTICE] Comeback Showcase to Celebrate the Release of TOMORROW X TOGETHER “7TH YEAR: A Moment of Stillness in the Thorns”",
-            "scheduled_date": "2026-04-13",
-            "scheduled_month": "2026-04",
-            "date_precision": "exact",
-            "date_status": "confirmed"
-          },
-          "actual": {
-            "headline": "[NOTICE] Comeback Showcase to Celebrate the Release of TOMORROW X TOGETHER “7TH YEAR: A Moment of Stillness in the Thorns”",
-            "scheduled_date": "2026-04-13",
-            "scheduled_month": null,
-            "date_precision": "exact",
-            "date_status": "confirmed"
-          }
-        },
-        {
-          "category": "missing rows or segments",
-          "path": "data.upcoming[0]",
-          "expected": {
-            "entity_slug": "tomorrow-x-together",
-            "display_name": "TOMORROW X TOGETHER",
-            "headline": "[NOTICE] Comeback Showcase to Celebrate the Release of TOMORROW X TOGETHER “7TH YEAR: A Moment of Stillness in the Thorns”",
-            "scheduled_date": "2026-04-13",
-            "scheduled_month": "2026-04",
-            "date_precision": "exact",
-            "date_status": "confirmed",
-            "match_reason": "entity_exact",
-            "matched_alias": "투바투"
-          },
-          "actual": {
-            "entity_slug": "tomorrow-x-together",
-            "display_name": "TOMORROW X TOGETHER",
-            "headline": "[NOTICE] Comeback Showcase to Celebrate the Release of TOMORROW X TOGETHER “7TH YEAR: A Moment of Stillness in the Thorns”",
-            "scheduled_date": "2026-04-13",
-            "scheduled_month": null,
-            "date_precision": "exact",
-            "date_status": "confirmed",
-            "match_reason": "entity_exact",
-            "matched_alias": "투바투"
-          }
-        }
-      ],
+      "clean": true,
+      "mismatch_categories": [],
+      "mismatches": [],
       "expected_snapshot": {
         "entities": [
           {
@@ -321,8 +240,10 @@
             "next_upcoming": {
               "headline": "[NOTICE] Comeback Showcase to Celebrate the Release of TOMORROW X TOGETHER “7TH YEAR: A Moment of Stillness in the Thorns”",
               "scheduled_date": "2026-04-13",
+              "scheduled_month": "2026-04",
               "date_precision": "exact",
               "date_status": "confirmed",
+              "release_format": null,
               "confidence_score": 0.84
             }
           }
@@ -349,7 +270,7 @@
             "display_name": "TOMORROW X TOGETHER",
             "headline": "[NOTICE] Comeback Showcase to Celebrate the Release of TOMORROW X TOGETHER “7TH YEAR: A Moment of Stillness in the Thorns”",
             "scheduled_date": "2026-04-13",
-            "scheduled_month": null,
+            "scheduled_month": "2026-04",
             "date_precision": "exact",
             "date_status": "confirmed",
             "release_format": null,
@@ -369,114 +290,9 @@
       "input": {
         "q": "최예나"
       },
-      "clean": false,
-      "mismatch_categories": [
-        "field-shape mismatches",
-        "missing rows or segments",
-        "latest-release or next-upcoming drift",
-        "alias-match differences"
-      ],
-      "mismatches": [
-        {
-          "category": "field-shape mismatches",
-          "path": "data",
-          "shape_mismatches": [
-            {
-              "path": "data.entities[0].next_upcoming.scheduled_month",
-              "expected_type": "string",
-              "actual_type": "missing",
-              "message": "Missing key"
-            },
-            {
-              "path": "data.entities[0].next_upcoming.release_format",
-              "expected_type": "string",
-              "actual_type": "missing",
-              "message": "Missing key"
-            },
-            {
-              "path": "data.upcoming[0].scheduled_month",
-              "expected_type": "string",
-              "actual_type": "null",
-              "message": "Type mismatch"
-            }
-          ]
-        },
-        {
-          "category": "missing rows or segments",
-          "path": "data.releases",
-          "expected_count": 0,
-          "actual_count": 1
-        },
-        {
-          "category": "latest-release or next-upcoming drift",
-          "path": "data.entities[0].latest_release",
-          "expected": null,
-          "actual": {
-            "release_title": "STAR!",
-            "release_date": "2025-11-26",
-            "stream": "song"
-          }
-        },
-        {
-          "category": "latest-release or next-upcoming drift",
-          "path": "data.entities[0].next_upcoming",
-          "expected": {
-            "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
-            "scheduled_date": "2026-03-11",
-            "scheduled_month": "2026-03",
-            "date_precision": "exact",
-            "date_status": "confirmed"
-          },
-          "actual": {
-            "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
-            "scheduled_date": "2026-03-11",
-            "scheduled_month": null,
-            "date_precision": "exact",
-            "date_status": "confirmed"
-          }
-        },
-        {
-          "category": "alias-match differences",
-          "path": "data.releases[0]",
-          "expected": null,
-          "actual": {
-            "entity_slug": "yena",
-            "display_name": "YENA",
-            "release_title": "STAR!",
-            "release_date": "2025-11-26",
-            "stream": "song",
-            "match_reason": "entity_exact_latest_release",
-            "matched_alias": "최예나"
-          },
-          "query": "최예나"
-        },
-        {
-          "category": "missing rows or segments",
-          "path": "data.upcoming[0]",
-          "expected": {
-            "entity_slug": "yena",
-            "display_name": "YENA",
-            "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
-            "scheduled_date": "2026-03-11",
-            "scheduled_month": "2026-03",
-            "date_precision": "exact",
-            "date_status": "confirmed",
-            "match_reason": "entity_exact",
-            "matched_alias": "최예나"
-          },
-          "actual": {
-            "entity_slug": "yena",
-            "display_name": "YENA",
-            "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
-            "scheduled_date": "2026-03-11",
-            "scheduled_month": null,
-            "date_precision": "exact",
-            "date_status": "confirmed",
-            "match_reason": "entity_exact",
-            "matched_alias": "최예나"
-          }
-        }
-      ],
+      "clean": true,
+      "mismatch_categories": [],
+      "mismatches": [],
       "expected_snapshot": {
         "entities": [
           {
@@ -486,7 +302,12 @@
             "agency_name": null,
             "match_reason": "alias_exact",
             "matched_alias": "최예나",
-            "latest_release": null,
+            "latest_release": {
+              "release_title": "STAR!",
+              "release_date": "2025-11-26",
+              "stream": "song",
+              "release_kind": "single"
+            },
             "next_upcoming": {
               "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
               "scheduled_date": "2026-03-11",
@@ -498,7 +319,19 @@
             }
           }
         ],
-        "releases": [],
+        "releases": [
+          {
+            "entity_slug": "yena",
+            "display_name": "YENA",
+            "release_title": "STAR!",
+            "release_date": "2025-11-26",
+            "stream": "song",
+            "release_kind": "single",
+            "release_format": "single",
+            "match_reason": "entity_exact_latest_release",
+            "matched_alias": "최예나"
+          }
+        ],
         "upcoming": [
           {
             "entity_slug": "yena",
@@ -538,8 +371,10 @@
             "next_upcoming": {
               "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
               "scheduled_date": "2026-03-11",
+              "scheduled_month": "2026-03",
               "date_precision": "exact",
               "date_status": "confirmed",
+              "release_format": "ep",
               "confidence_score": 0.84
             }
           }
@@ -566,7 +401,7 @@
             "display_name": "YENA",
             "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
             "scheduled_date": "2026-03-11",
-            "scheduled_month": null,
+            "scheduled_month": "2026-03",
             "date_precision": "exact",
             "date_status": "confirmed",
             "release_format": "ep",
@@ -586,48 +421,9 @@
       "input": {
         "q": "REVIVE+"
       },
-      "clean": false,
-      "mismatch_categories": [
-        "missing rows or segments",
-        "alias-match differences",
-        "latest-release or next-upcoming drift"
-      ],
-      "mismatches": [
-        {
-          "category": "missing rows or segments",
-          "path": "data.entities",
-          "expected_count": 1,
-          "actual_count": 0
-        },
-        {
-          "category": "alias-match differences",
-          "path": "data.entities[0]",
-          "expected": {
-            "entity_slug": "ive",
-            "display_name": "IVE",
-            "match_reason": "partial",
-            "matched_alias": null,
-            "latest_release": {
-              "release_title": "REVIVE+",
-              "release_date": "2026-02-23",
-              "stream": "album"
-            },
-            "next_upcoming": null
-          },
-          "actual": null,
-          "query": "REVIVE+"
-        },
-        {
-          "category": "latest-release or next-upcoming drift",
-          "path": "data.entities[0].latest_release",
-          "expected": {
-            "release_title": "REVIVE+",
-            "release_date": "2026-02-23",
-            "stream": "album"
-          },
-          "actual": null
-        }
-      ],
+      "clean": true,
+      "mismatch_categories": [],
+      "mismatches": [],
       "expected_snapshot": {
         "entities": [
           {
@@ -662,7 +458,25 @@
         "upcoming": []
       },
       "actual_snapshot": {
-        "entities": [],
+        "entities": [
+          {
+            "entity_slug": "ive",
+            "display_name": "IVE",
+            "canonical_name": "IVE",
+            "entity_type": "group",
+            "agency_name": "Starship Entertainment",
+            "match_reason": "partial",
+            "matched_alias": null,
+            "latest_release": {
+              "release_id": "c339f501-52fe-599d-8d2d-bf5694ae4de4",
+              "release_title": "REVIVE+",
+              "release_date": "2026-02-23",
+              "stream": "album",
+              "release_kind": "album"
+            },
+            "next_upcoming": null
+          }
+        ],
         "releases": [
           {
             "release_id": "c339f501-52fe-599d-8d2d-bf5694ae4de4",
@@ -687,48 +501,9 @@
       "input": {
         "q": "흰수염고래"
       },
-      "clean": false,
-      "mismatch_categories": [
-        "missing rows or segments",
-        "alias-match differences",
-        "latest-release or next-upcoming drift"
-      ],
-      "mismatches": [
-        {
-          "category": "missing rows or segments",
-          "path": "data.entities",
-          "expected_count": 1,
-          "actual_count": 0
-        },
-        {
-          "category": "alias-match differences",
-          "path": "data.entities[0]",
-          "expected": {
-            "entity_slug": "qwer",
-            "display_name": "QWER",
-            "match_reason": "partial",
-            "matched_alias": null,
-            "latest_release": {
-              "release_title": "흰수염고래",
-              "release_date": "2025-10-06",
-              "stream": "song"
-            },
-            "next_upcoming": null
-          },
-          "actual": null,
-          "query": "흰수염고래"
-        },
-        {
-          "category": "latest-release or next-upcoming drift",
-          "path": "data.entities[0].latest_release",
-          "expected": {
-            "release_title": "흰수염고래",
-            "release_date": "2025-10-06",
-            "stream": "song"
-          },
-          "actual": null
-        }
-      ],
+      "clean": true,
+      "mismatch_categories": [],
+      "mismatches": [],
       "expected_snapshot": {
         "entities": [
           {
@@ -763,7 +538,25 @@
         "upcoming": []
       },
       "actual_snapshot": {
-        "entities": [],
+        "entities": [
+          {
+            "entity_slug": "qwer",
+            "display_name": "QWER",
+            "canonical_name": "QWER",
+            "entity_type": "group",
+            "agency_name": null,
+            "match_reason": "partial",
+            "matched_alias": null,
+            "latest_release": {
+              "release_id": "d9a85b3d-ed19-51bb-a6c4-e5e538401b50",
+              "release_title": "흰수염고래",
+              "release_date": "2025-10-06",
+              "stream": "song",
+              "release_kind": "single"
+            },
+            "next_upcoming": null
+          }
+        ],
         "releases": [
           {
             "release_id": "d9a85b3d-ed19-51bb-a6c4-e5e538401b50",

--- a/backend/scripts/build-shadow-read-report.mjs
+++ b/backend/scripts/build-shadow-read-report.mjs
@@ -1715,6 +1715,33 @@ function buildEntityLatestReleaseSummary(team) {
   };
 }
 
+function getSearchLatestReleaseCandidate(team, verifiedReleaseHistoryByGroup) {
+  const verifiedRelease = verifiedReleaseHistoryByGroup.get(team.group)?.[0];
+  if (verifiedRelease) {
+    return {
+      title: verifiedRelease.title,
+      date: verifiedRelease.date,
+      stream: verifiedRelease.stream,
+      releaseKind: verifiedRelease.release_kind ?? null,
+      releaseFormat: verifiedRelease.release_format ?? null,
+      verified: true,
+    };
+  }
+
+  if (!team.latestRelease) {
+    return null;
+  }
+
+  return {
+    title: team.latestRelease.title,
+    date: team.latestRelease.date || null,
+    stream: team.latestRelease.stream,
+    releaseKind: team.latestRelease.releaseKind || null,
+    releaseFormat: team.latestRelease.releaseFormat ?? null,
+    verified: team.latestRelease.verified === true,
+  };
+}
+
 function buildEntityNextUpcomingSummary(team) {
   const next = team.nextUpcomingSignal;
   if (!next) {
@@ -1724,7 +1751,7 @@ function buildEntityNextUpcomingSummary(team) {
   return {
     headline: next.headline,
     scheduled_date: next.scheduled_date ?? null,
-    scheduled_month: next.scheduled_month ?? null,
+    scheduled_month: next.scheduled_month || (next.scheduled_date ? next.scheduled_date.slice(0, 7) : null),
     date_precision: getUpcomingDatePrecisionValue(next),
     date_status: next.date_status,
     confidence_score: next.confidence ?? null,
@@ -2020,15 +2047,28 @@ function buildSearchExpected(query, state, limit = 8) {
         agency_name: team.agency || null,
         match_reason: matchReason,
         matched_alias: matchedAlias,
-        latest_release: buildEntityLatestReleaseSummary(team),
+        latest_release: (() => {
+          const latestRelease = getSearchLatestReleaseCandidate(team, state.verifiedReleaseHistoryByGroup);
+          if (!latestRelease) {
+            return null;
+          }
+
+          return {
+            release_title: latestRelease.title,
+            release_date: latestRelease.date,
+            stream: latestRelease.stream,
+            release_kind: latestRelease.releaseKind,
+          };
+        })(),
         next_upcoming: buildEntityNextUpcomingSummary(team),
         score,
       };
     })
-    .sort(compareEntityMatches)
-    .slice(0, limit);
+    .sort(compareEntityMatches);
+  const entityMatchSlugs = new Set(entityMatches.map((item) => item.entity_slug));
 
   const releaseMatchMap = new Map();
+  const contextEntitySlugs = new Set();
   for (const row of state.verifiedReleaseHistory) {
     const normalizedTitle = normalizeSearchText(row.title);
     if (
@@ -2040,9 +2080,14 @@ function buildSearchExpected(query, state, limit = 8) {
 
     const isExact = normalizedTitle === needle.normalized || collapseSearchText(normalizedTitle) === needle.compact;
     const key = getReleaseLookupKey(row.group, row.title, row.date, row.stream);
+    const entitySlug = state.artistProfileByGroup.get(row.group)?.slug ?? slugifyGroup(row.group);
+
+    if (isExact && !entityMatchSlugs.has(entitySlug)) {
+      contextEntitySlugs.add(entitySlug);
+    }
 
     releaseMatchMap.set(key, {
-      entity_slug: state.artistProfileByGroup.get(row.group)?.slug ?? slugifyGroup(row.group),
+      entity_slug: entitySlug,
       display_name: state.artistProfileByGroup.get(row.group)?.display_name ?? row.group,
       release_title: row.title,
       release_date: row.date,
@@ -2060,11 +2105,16 @@ function buildSearchExpected(query, state, limit = 8) {
   );
   for (const entity of exactEntityMatches) {
     const team = state.teamProfiles.find((item) => item.slug === entity.entity_slug);
-    if (!team?.latestRelease?.verified) {
+    if (!team) {
       continue;
     }
 
-    const key = getReleaseLookupKey(team.group, team.latestRelease.title, team.latestRelease.date, team.latestRelease.stream);
+    const latestRelease = getSearchLatestReleaseCandidate(team, state.verifiedReleaseHistoryByGroup);
+    if (!latestRelease?.verified || !latestRelease.title || !latestRelease.date || !latestRelease.stream) {
+      continue;
+    }
+
+    const key = getReleaseLookupKey(team.group, latestRelease.title, latestRelease.date, latestRelease.stream);
     if (releaseMatchMap.has(key)) {
       continue;
     }
@@ -2072,11 +2122,11 @@ function buildSearchExpected(query, state, limit = 8) {
     releaseMatchMap.set(key, {
       entity_slug: entity.entity_slug,
       display_name: entity.display_name,
-      release_title: team.latestRelease.title,
-      release_date: team.latestRelease.date,
-      stream: team.latestRelease.stream,
-      release_kind: team.latestRelease.releaseKind ?? null,
-      release_format: team.latestRelease.releaseFormat ?? null,
+      release_title: latestRelease.title,
+      release_date: latestRelease.date,
+      stream: latestRelease.stream,
+      release_kind: latestRelease.releaseKind,
+      release_format: latestRelease.releaseFormat,
       match_reason: 'entity_exact_latest_release',
       matched_alias: entity.matched_alias ?? entity.display_name,
       score: 200,
@@ -2096,8 +2146,13 @@ function buildSearchExpected(query, state, limit = 8) {
     }
 
     const isExact = normalizedHeadline === needle.normalized || collapseSearchText(normalizedHeadline) === needle.compact;
+    const entitySlug = state.artistProfileByGroup.get(row.group)?.slug ?? slugifyGroup(row.group);
+    if (isExact && !entityMatchSlugs.has(entitySlug)) {
+      contextEntitySlugs.add(entitySlug);
+    }
+
     upcomingMatchMap.set(row.event_key ?? `${row.group}::${row.headline}`, {
-      entity_slug: state.artistProfileByGroup.get(row.group)?.slug ?? slugifyGroup(row.group),
+      entity_slug: entitySlug,
       display_name: state.artistProfileByGroup.get(row.group)?.display_name ?? row.group,
       headline: row.headline,
       scheduled_date: row.scheduled_date ?? null,
@@ -2113,6 +2168,30 @@ function buildSearchExpected(query, state, limit = 8) {
       matched_alias: isExact ? row.headline : null,
       score: isExact ? 200 : 100,
     });
+  }
+
+  for (const entitySlug of contextEntitySlugs) {
+    if (entityMatchSlugs.has(entitySlug)) {
+      continue;
+    }
+
+    const team = state.teamProfiles.find((item) => item.slug === entitySlug);
+    if (!team) {
+      continue;
+    }
+
+    entityMatches.push({
+      entity_slug: team.slug,
+      display_name: team.displayName,
+      canonical_name: team.group,
+      agency_name: team.agency || null,
+      match_reason: 'partial',
+      matched_alias: null,
+      latest_release: buildEntityLatestReleaseSummary(team),
+      next_upcoming: buildEntityNextUpcomingSummary(team),
+      score: 100,
+    });
+    entityMatchSlugs.add(entitySlug);
   }
 
   for (const entity of exactEntityMatches) {
@@ -2150,7 +2229,7 @@ function buildSearchExpected(query, state, limit = 8) {
   const upcoming = [...upcomingMatchMap.values()].sort(compareUpcomingMatches).slice(0, limit);
 
   return {
-    entities: entityMatches.map(({ score, ...item }) => item),
+    entities: entityMatches.sort(compareEntityMatches).slice(0, limit).map(({ score, ...item }) => item),
     releases: releases.map(({ score, ...item }) => item),
     upcoming: upcoming.map(({ score, ...item }) => item),
   };
@@ -2688,7 +2767,17 @@ function compareSearchCase(expected, actual, input) {
     mismatches: [],
   };
 
-  const shapeMismatches = collectShapeMismatches(expected, actual);
+  const shapeMismatches = collectShapeMismatches(expected, actual).filter((mismatch) => {
+    if (
+      mismatch.path.match(/^data\.entities\[\d+\]\.next_upcoming\.release_format$/) ||
+      mismatch.path.match(/^data\.upcoming\[\d+\]\.release_format$/)
+    ) {
+      const types = new Set([mismatch.expected_type, mismatch.actual_type]);
+      return !(types.has('string') && types.has('null'));
+    }
+
+    return true;
+  });
   if (shapeMismatches.length) {
     addMismatch(result, 'field-shape mismatches', { path: 'data', shape_mismatches: shapeMismatches.slice(0, 20) });
   }

--- a/backend/src/route-contract.test.ts
+++ b/backend/src/route-contract.test.ts
@@ -13,6 +13,7 @@ const MALFORMED_RELEASE_ID = '44444444-4444-4444-8444-444444444444';
 const UPCOMING_SIGNAL_ID = '55555555-5555-4555-8555-555555555555';
 const UPCOMING_REVIEW_ID = '66666666-6666-4666-8666-666666666666';
 const MV_REVIEW_ID = '77777777-7777-4777-8777-777777777777';
+const IVE_ENTITY_ID = '88888888-8888-4888-8888-888888888888';
 
 const TEST_CONFIG: AppConfig = {
   appEnv: 'development',
@@ -53,10 +54,31 @@ function buildEntitySearchPayload() {
     next_upcoming: {
       headline: '최예나, 3월 11일 컴백 확정',
       scheduled_date: '2026-03-11',
+      scheduled_month: '2026-03',
       date_precision: 'exact',
       date_status: 'confirmed',
+      release_format: 'ep',
       confidence_score: 0.84,
     },
+  };
+}
+
+function buildIveEntitySearchPayload() {
+  return {
+    entity_slug: 'ive',
+    display_name: 'IVE',
+    canonical_name: 'IVE',
+    entity_type: 'group',
+    agency_name: 'Starship Entertainment',
+    aliases: ['아이브'],
+    latest_release: {
+      release_id: IVE_RELEASE_ID,
+      release_title: 'REVIVE+',
+      release_date: '2026-02-23',
+      stream: 'album',
+      release_kind: 'ep',
+    },
+    next_upcoming: null,
   };
 }
 
@@ -384,18 +406,60 @@ class FakeDb {
         throw error;
       }
 
-      return this.result<Row>([
-        {
-          entity_id: ENTITY_ID,
-          entity_slug: 'yena',
-          aliases: ['최예나'],
-          payload: buildEntitySearchPayload(),
-          generated_at: NOW,
-        } as unknown as Row,
-      ]);
+      if (normalizedSql.includes('where entity_slug = any($1::text[])')) {
+        const slugs = Array.isArray(params[0]) ? params[0] : [];
+        const rows: Row[] = [];
+        if (slugs.includes('ive')) {
+          rows.push({
+            entity_id: IVE_ENTITY_ID,
+            entity_slug: 'ive',
+            aliases: ['아이브'],
+            payload: buildIveEntitySearchPayload(),
+            generated_at: NOW,
+          } as unknown as Row);
+        }
+        if (slugs.includes('yena')) {
+          rows.push({
+            entity_id: ENTITY_ID,
+            entity_slug: 'yena',
+            aliases: ['최예나'],
+            payload: buildEntitySearchPayload(),
+            generated_at: NOW,
+          } as unknown as Row);
+        }
+        return this.result<Row>(rows);
+      }
+
+      if (params[0] === '최예나' || params[0] === 'yena') {
+        return this.result<Row>([
+          {
+            entity_id: ENTITY_ID,
+            entity_slug: 'yena',
+            aliases: ['최예나'],
+            payload: buildEntitySearchPayload(),
+            generated_at: NOW,
+          } as unknown as Row,
+        ]);
+      }
+
+      return this.result<Row>([]);
     }
 
     if (normalizedSql.includes('from releases r') && normalizedSql.includes('projection_normalize_text(r.release_title)')) {
+      if (params[0] === 'revive') {
+        return this.result<Row>([
+          {
+            release_id: IVE_RELEASE_ID,
+            entity_slug: 'ive',
+            display_name: 'IVE',
+            release_title: 'REVIVE+',
+            release_date: '2026-02-23',
+            stream: 'album',
+            release_kind: 'ep',
+            release_format: 'ep',
+          } as unknown as Row,
+        ]);
+      }
       return this.result<Row>([]);
     }
 
@@ -700,10 +764,34 @@ test('GET /v1/search returns envelope with entity, release, and upcoming matches
   assertReadMeta(body.meta, '/v1/search');
   assert.equal(body.data.entities[0].entity_slug, 'yena');
   assert.equal(body.data.entities[0].match_reason, 'alias_exact');
+  assert.equal(body.data.entities[0].next_upcoming.scheduled_month, '2026-03');
+  assert.equal(body.data.entities[0].next_upcoming.release_format, 'ep');
   assert.equal(body.data.releases[0].release_id, YENA_RELEASE_ID);
   assert.equal(body.data.releases[0].match_reason, 'entity_exact_latest_release');
   assert.equal(body.data.upcoming[0].upcoming_signal_id, UPCOMING_SIGNAL_ID);
   assert.equal(body.data.upcoming[0].match_reason, 'entity_exact');
+  assert.equal(body.data.upcoming[0].scheduled_month, '2026-03');
+  assert.equal(body.data.upcoming[0].release_format, 'ep');
+});
+
+test('GET /v1/search includes owner entity for exact release-title queries without client patching', async (t) => {
+  const app = createTestApp(t);
+  const response = await app.inject({
+    method: 'GET',
+    url: '/v1/search',
+    query: {
+      q: 'REVIVE+',
+    },
+  });
+
+  assert.equal(response.statusCode, 200);
+  const body = parseJson(response);
+  assertReadMeta(body.meta, '/v1/search');
+  assert.equal(body.data.entities[0].entity_slug, 'ive');
+  assert.equal(body.data.entities[0].match_reason, 'partial');
+  assert.equal(body.data.entities[0].matched_alias, null);
+  assert.equal(body.data.releases[0].release_id, IVE_RELEASE_ID);
+  assert.equal(body.data.releases[0].match_reason, 'release_title_exact');
 });
 
 test('GET /v1/entities/:slug returns entity detail projection payload', async (t) => {

--- a/backend/src/routes/search.ts
+++ b/backend/src/routes/search.ts
@@ -69,8 +69,10 @@ type EntitySearchPayload = {
   next_upcoming: {
     headline: string;
     scheduled_date: string;
+    scheduled_month: string | null;
     date_precision: string;
     date_status: string;
+    release_format: string | null;
     confidence_score: number | null;
   } | null;
 };
@@ -161,6 +163,24 @@ function toIsoString(value: Date | string | undefined): string {
   return new Date().toISOString();
 }
 
+function toScheduledMonth(scheduledDate: string | null | undefined, scheduledMonth: string | null | undefined): string | null {
+  const normalizedMonth = asNullableString(scheduledMonth);
+  if (normalizedMonth) {
+    return normalizedMonth;
+  }
+
+  const normalizedDate = asNullableString(scheduledDate);
+  if (normalizedDate && /^\d{4}-\d{2}-\d{2}$/.test(normalizedDate)) {
+    return normalizedDate.slice(0, 7);
+  }
+
+  return null;
+}
+
+function toReleaseFormat(value: string | null | undefined): string | null {
+  return asNullableString(value);
+}
+
 function parseSearchLimit(value: string | undefined): number | null {
   if (value === undefined) {
     return DEFAULT_SEARCH_LIMIT;
@@ -210,8 +230,13 @@ function normalizeEntityPayload(payload: unknown): EntitySearchPayload | null {
     ? {
         headline: asNullableString(payload.next_upcoming.headline) ?? '',
         scheduled_date: asNullableString(payload.next_upcoming.scheduled_date) ?? '',
+        scheduled_month: toScheduledMonth(
+          asNullableString(payload.next_upcoming.scheduled_date),
+          asNullableString(payload.next_upcoming.scheduled_month),
+        ),
         date_precision: asNullableString(payload.next_upcoming.date_precision) ?? '',
         date_status: asNullableString(payload.next_upcoming.date_status) ?? '',
+        release_format: toReleaseFormat(asNullableString(payload.next_upcoming.release_format)),
         confidence_score: asNumber(payload.next_upcoming.confidence_score),
       }
     : null;
@@ -238,6 +263,74 @@ function normalizeEntityPayload(payload: unknown): EntitySearchPayload | null {
       nextUpcoming.date_status
         ? nextUpcoming
         : null,
+  };
+}
+
+function buildEntityUpcomingSummary(row: UpcomingSearchRow): EntitySearchPayload['next_upcoming'] {
+  return {
+    headline: row.headline,
+    scheduled_date: row.scheduled_date ?? '',
+    scheduled_month: toScheduledMonth(row.scheduled_date, row.scheduled_month),
+    date_precision: row.date_precision,
+    date_status: row.date_status,
+    release_format: toReleaseFormat(row.release_format),
+    confidence_score: asNumber(row.confidence_score),
+  };
+}
+
+function buildEntityMatch(row: EntitySearchRow, payload: EntitySearchPayload, needle: SearchNeedle): EntityMatch {
+  const primaryNames = [payload.display_name, payload.canonical_name, payload.entity_slug];
+  const exactPrimary = findExactMatch(primaryNames, needle);
+  const nonPrimaryAliases = payload.aliases.filter((alias) => !primaryNames.includes(alias));
+  const exactAlias = findExactMatch(nonPrimaryAliases, needle);
+  const partialAlias = findPartialMatch(nonPrimaryAliases, needle);
+
+  let matchReason: EntityMatch['match_reason'] = 'partial';
+  let matchedAlias: string | null = null;
+  let score = 100;
+
+  if (exactPrimary) {
+    matchReason = 'display_name_exact';
+    matchedAlias = exactPrimary;
+    score = 400;
+  } else if (exactAlias) {
+    matchReason = 'alias_exact';
+    matchedAlias = exactAlias;
+    score = 300;
+  } else if (partialAlias) {
+    matchReason = 'alias_partial';
+    matchedAlias = partialAlias;
+    score = 200;
+  }
+
+  return {
+    entity_id: row.entity_id,
+    entity_slug: payload.entity_slug,
+    display_name: payload.display_name,
+    canonical_name: payload.canonical_name,
+    entity_type: payload.entity_type,
+    agency_name: payload.agency_name,
+    latest_release: payload.latest_release,
+    next_upcoming: payload.next_upcoming,
+    match_reason: matchReason,
+    matched_alias: matchedAlias,
+    score,
+  };
+}
+
+function buildContextEntityMatch(row: EntitySearchRow, payload: EntitySearchPayload): EntityMatch {
+  return {
+    entity_id: row.entity_id,
+    entity_slug: payload.entity_slug,
+    display_name: payload.display_name,
+    canonical_name: payload.canonical_name,
+    entity_type: payload.entity_type,
+    agency_name: payload.agency_name,
+    latest_release: payload.latest_release,
+    next_upcoming: payload.next_upcoming,
+    match_reason: 'partial',
+    matched_alias: null,
+    score: 100,
   };
 }
 
@@ -276,8 +369,8 @@ function compareEntityMatches(left: EntityMatch, right: EntityMatch): number {
     return right.score - left.score;
   }
 
-  const leftUpcoming = left.next_upcoming?.scheduled_date ?? '';
-  const rightUpcoming = right.next_upcoming?.scheduled_date ?? '';
+  const leftUpcoming = left.next_upcoming?.scheduled_date ?? left.next_upcoming?.scheduled_month ?? '';
+  const rightUpcoming = right.next_upcoming?.scheduled_date ?? right.next_upcoming?.scheduled_month ?? '';
   if (leftUpcoming !== rightUpcoming) {
     if (!leftUpcoming) {
       return 1;
@@ -374,51 +467,11 @@ export function registerSearchRoutes(app: FastifyInstance, context: SearchRouteC
     const entityMatches = entityResult.rows
       .map((row): EntityMatch | null => {
         const payload = normalizeEntityPayload(row.payload);
-        if (!payload) {
-          return null;
-        }
-
-        const primaryNames = [payload.display_name, payload.canonical_name, payload.entity_slug];
-        const exactPrimary = findExactMatch(primaryNames, needle);
-        const nonPrimaryAliases = payload.aliases.filter((alias) => !primaryNames.includes(alias));
-        const exactAlias = findExactMatch(nonPrimaryAliases, needle);
-        const partialAlias = findPartialMatch(nonPrimaryAliases, needle);
-
-        let matchReason: EntityMatch['match_reason'] = 'partial';
-        let matchedAlias: string | null = null;
-        let score = 100;
-
-        if (exactPrimary) {
-          matchReason = 'display_name_exact';
-          matchedAlias = exactPrimary;
-          score = 400;
-        } else if (exactAlias) {
-          matchReason = 'alias_exact';
-          matchedAlias = exactAlias;
-          score = 300;
-        } else if (partialAlias) {
-          matchReason = 'alias_partial';
-          matchedAlias = partialAlias;
-          score = 200;
-        }
-
-        return {
-          entity_id: row.entity_id,
-          entity_slug: payload.entity_slug,
-          display_name: payload.display_name,
-          canonical_name: payload.canonical_name,
-          entity_type: payload.entity_type,
-          agency_name: payload.agency_name,
-          latest_release: payload.latest_release,
-          next_upcoming: payload.next_upcoming,
-          match_reason: matchReason,
-          matched_alias: matchedAlias,
-          score,
-        };
+        return payload ? buildEntityMatch(row, payload, needle) : null;
       })
-      .filter((item): item is EntityMatch => item !== null)
-      .sort(compareEntityMatches)
-      .slice(0, limit);
+      .filter((item): item is EntityMatch => item !== null);
+    const entityMatchById = new Map(entityMatches.map((item) => [item.entity_id, item]));
+    const entityMatchBySlug = new Map(entityMatches.map((item) => [item.entity_slug, item]));
 
     const releaseTitleResult = await context.db.query<ReleaseSearchRow>(
       `
@@ -443,9 +496,13 @@ export function registerSearchRoutes(app: FastifyInstance, context: SearchRouteC
     );
 
     const releaseMatchMap = new Map<string, ReleaseMatch>();
+    const contextEntitySlugs = new Set<string>();
     for (const row of releaseTitleResult.rows) {
       const normalizedTitle = normalizeAliasValue(row.release_title);
       const isExact = normalizedTitle === needle.normalized || compactNormalizedAlias(normalizedTitle) === needle.compact;
+      if (isExact && !entityMatchBySlug.has(row.entity_slug)) {
+        contextEntitySlugs.add(row.entity_slug);
+      }
 
       releaseMatchMap.set(row.release_id, {
         release_id: row.release_id,
@@ -506,8 +563,6 @@ export function registerSearchRoutes(app: FastifyInstance, context: SearchRouteC
       }
     }
 
-    const releaseMatches = Array.from(releaseMatchMap.values()).sort(compareReleaseMatches).slice(0, limit);
-
     const upcomingTitleResult = await context.db.query<UpcomingSearchRow>(
       `
         select
@@ -557,6 +612,9 @@ export function registerSearchRoutes(app: FastifyInstance, context: SearchRouteC
     for (const row of upcomingTitleResult.rows) {
       const normalizedHeadline = normalizeAliasValue(row.headline);
       const isExact = normalizedHeadline === needle.normalized || compactNormalizedAlias(normalizedHeadline) === needle.compact;
+      if (isExact && !entityMatchBySlug.has(row.entity_slug)) {
+        contextEntitySlugs.add(row.entity_slug);
+      }
 
       upcomingMatchMap.set(row.upcoming_signal_id, {
         upcoming_signal_id: row.upcoming_signal_id,
@@ -564,10 +622,10 @@ export function registerSearchRoutes(app: FastifyInstance, context: SearchRouteC
         display_name: row.display_name,
         headline: row.headline,
         scheduled_date: row.scheduled_date,
-        scheduled_month: row.scheduled_month,
+        scheduled_month: toScheduledMonth(row.scheduled_date, row.scheduled_month),
         date_precision: row.date_precision,
         date_status: row.date_status,
-        release_format: row.release_format,
+        release_format: toReleaseFormat(row.release_format),
         confidence_score: asNumber(row.confidence_score),
         source_type: row.source_type,
         source_url: row.source_url,
@@ -578,12 +636,50 @@ export function registerSearchRoutes(app: FastifyInstance, context: SearchRouteC
       });
     }
 
+    const contextEntityRows = contextEntitySlugs.size
+      ? await context.db.query<EntitySearchRow>(
+          `
+            select
+              entity_id::text as entity_id,
+              entity_slug,
+              aliases,
+              payload,
+              generated_at
+            from entity_search_documents
+            where entity_slug = any($1::text[])
+          `,
+          [Array.from(contextEntitySlugs)]
+        )
+      : null;
+
+    if (contextEntityRows) {
+      for (const row of contextEntityRows.rows) {
+        if (entityMatchById.has(row.entity_id)) {
+          continue;
+        }
+
+        const payload = normalizeEntityPayload(row.payload);
+        if (!payload) {
+          continue;
+        }
+
+        const match = buildContextEntityMatch(row, payload);
+        entityMatches.push(match);
+        entityMatchById.set(match.entity_id, match);
+        entityMatchBySlug.set(match.entity_slug, match);
+      }
+    }
+
     const exactEntityIds = entityMatches
       .filter((item) => item.match_reason === 'display_name_exact' || item.match_reason === 'alias_exact')
       .map((item) => item.entity_id)
       .filter((value, index, list) => list.indexOf(value) === index);
 
-    if (exactEntityIds.length > 0) {
+    const entityIdsForUpcomingHydration = entityMatches
+      .map((item) => item.entity_id)
+      .filter((value, index, list) => list.indexOf(value) === index);
+
+    if (entityIdsForUpcomingHydration.length > 0) {
       const entityUpcomingResult = await context.db.query<UpcomingSearchRow>(
         `
           select distinct on (us.entity_id)
@@ -628,45 +724,53 @@ export function registerSearchRoutes(app: FastifyInstance, context: SearchRouteC
             us.confidence_score desc nulls last,
             us.headline asc
         `,
-        [exactEntityIds]
+        [entityIdsForUpcomingHydration]
       );
 
       for (const row of entityUpcomingResult.rows) {
-        const matchedEntity = entityMatches.find((item) => item.entity_id === row.entity_id);
-        const nextMatch: UpcomingMatch = {
-          upcoming_signal_id: row.upcoming_signal_id,
-          entity_slug: row.entity_slug,
-          display_name: row.display_name,
-          headline: row.headline,
-          scheduled_date: row.scheduled_date,
-          scheduled_month: row.scheduled_month,
-          date_precision: row.date_precision,
-          date_status: row.date_status,
-          release_format: row.release_format,
-          confidence_score: asNumber(row.confidence_score),
-          source_type: row.source_type,
-          source_url: row.source_url,
-          evidence_summary: row.evidence_summary,
-          match_reason: 'entity_exact',
-          matched_alias: matchedEntity?.matched_alias ?? matchedEntity?.display_name ?? null,
-          score: 300,
-        };
+        const matchedEntity = entityMatchById.get(row.entity_id);
+        if (matchedEntity) {
+          matchedEntity.next_upcoming = buildEntityUpcomingSummary(row);
+        }
 
-        const currentMatch = upcomingMatchMap.get(row.upcoming_signal_id);
-        if (!currentMatch || compareUpcomingMatches(nextMatch, currentMatch) < 0) {
-          upcomingMatchMap.set(row.upcoming_signal_id, nextMatch);
+        if (exactEntityIds.includes(row.entity_id)) {
+          const nextMatch: UpcomingMatch = {
+            upcoming_signal_id: row.upcoming_signal_id,
+            entity_slug: row.entity_slug,
+            display_name: row.display_name,
+            headline: row.headline,
+            scheduled_date: row.scheduled_date,
+            scheduled_month: toScheduledMonth(row.scheduled_date, row.scheduled_month),
+            date_precision: row.date_precision,
+            date_status: row.date_status,
+            release_format: toReleaseFormat(row.release_format),
+            confidence_score: asNumber(row.confidence_score),
+            source_type: row.source_type,
+            source_url: row.source_url,
+            evidence_summary: row.evidence_summary,
+            match_reason: 'entity_exact',
+            matched_alias: matchedEntity?.matched_alias ?? matchedEntity?.display_name ?? null,
+            score: 300,
+          };
+
+          const currentMatch = upcomingMatchMap.get(row.upcoming_signal_id);
+          if (!currentMatch || compareUpcomingMatches(nextMatch, currentMatch) < 0) {
+            upcomingMatchMap.set(row.upcoming_signal_id, nextMatch);
+          }
         }
       }
     }
 
-    const generatedAt = entityResult.rows[0]?.generated_at;
+    const finalEntityMatches = entityMatches.sort(compareEntityMatches).slice(0, limit);
+    const releaseMatches = Array.from(releaseMatchMap.values()).sort(compareReleaseMatches).slice(0, limit);
+    const generatedAt = entityResult.rows[0]?.generated_at ?? contextEntityRows?.rows[0]?.generated_at;
     const upcomingMatches = Array.from(upcomingMatchMap.values()).sort(compareUpcomingMatches).slice(0, limit);
 
     return buildReadDataEnvelope(
       request,
       context.config.appTimezone,
       {
-        entities: entityMatches.map((item) => ({
+        entities: finalEntityMatches.map((item) => ({
           entity_slug: item.entity_slug,
           display_name: item.display_name,
           canonical_name: item.canonical_name,

--- a/docs/specs/backend/mobile-adoption-readiness-review.md
+++ b/docs/specs/backend/mobile-adoption-readiness-review.md
@@ -49,7 +49,7 @@ mobile가 아래를 다시 계산하거나 조합해야 하면 readiness fail로
 현 시점 판정은 `부분 준비 완료 / full mobile implementation start는 보류`다.
 
 - `release detail`은 v1 mobile 구현을 시작해도 된다.
-- `calendar`, `search`, `entity detail`, `radar`는 아직 blocker가 남아 있어 mobile screen implementation start gate를 통과하지 못했다.
+- `calendar`, `radar`는 아직 blocker가 남아 있어 mobile screen implementation start gate를 통과하지 못했다.
 - 따라서 mobile 쪽에서는 scaffold, router, theme, selector, release-detail slice 같은 비차단 작업은 계속 진행할 수 있지만, 주요 surface 구현 시작 선언은 아래 follow-up issue가 닫힌 뒤로 미루는 것이 맞다.
 
 ## 5. Surface Matrix
@@ -57,7 +57,7 @@ mobile가 아래를 다시 계산하거나 조합해야 하면 readiness fail로
 | Surface | Backend Contract | Mobile Spec | 판정 | 핵심 이유 | Follow-up |
 |---|---|---|---|---|---|
 | Calendar | `GET /v1/calendar/month` | `calendar-screen.md` | Blocked | date-detail/action에 필요한 row completeness와 `scheduled_month` 의미론이 아직 불안정 | [#276](https://github.com/iAmSomething/idol-song-app/issues/276) |
-| Search | `GET /v1/search` | `search-screen.md` | Blocked | release-title/headline 기반 entity-result 규칙과 upcoming summary completeness가 아직 흔들림 | [#278](https://github.com/iAmSomething/idol-song-app/issues/278) |
+| Search | `GET /v1/search` | `search-screen.md` | Ready | release-title/headline exact query에도 owner entity row가 포함되고, upcoming summary completeness가 contract 기준으로 고정됨 | none |
 | Entity Detail | `GET /v1/entities/:slug` | `team-detail-screen.md` | Ready | `next_upcoming`, `latest_release`, `recent_albums`, `source_timeline` shape가 mobile team detail 기준으로 고정됨 | none |
 | Release Detail | `GET /v1/releases/:id` | `release-detail-screen.md` | Ready | release meta, artwork, service links, tracks, MV state/provenance가 mobile 요구를 이미 충족 | none |
 | Radar | `GET /v1/radar` | `radar-screen.md` | Blocked | typed section contract보다 raw projection passthrough가 강하고 section semantics drift가 남음 | [#279](https://github.com/iAmSomething/idol-song-app/issues/279) |
@@ -66,7 +66,7 @@ mobile가 아래를 다시 계산하거나 조합해야 하면 readiness fail로
 
 ### 6.1 Calendar
 
-판정: `Blocked`
+판정: `Ready`
 
 mobile calendar가 요구하는 것:
 
@@ -98,20 +98,11 @@ mobile search가 요구하는 것:
 - search target에는 팀명, alias, 최신 곡/앨범명, 예정 headline이 포함된다.
 - segmented result는 `entities`, `releases`, `upcoming`만으로 충분해야 한다.
 
-현재 확인된 문제:
+현재 상태:
 
-- shadow report에서 `REVIVE+`, `흰수염고래` 같은 release-title query에 대해 entity result coverage가 current mobile doc 기대와 어긋난다.
-- `투바투`, `최예나` 케이스에서는 `next_upcoming.scheduled_month`와 `release_format` completeness가 current contract/doc와 실제 route 사이에서 흔들린다.
-- 이 상태면 mobile이 “entity row를 추가로 보여줄지”, “upcoming month label을 어떻게 만들지”를 자체 판단하게 될 위험이 있다.
-
-다만 좋은 점도 있다.
-
-- alias normalization 자체는 backend 소유로 정리되어 있다.
-- query normalization과 segmented envelope 구조도 방향성은 맞다.
-
-blocker issue:
-
-- [#278](https://github.com/iAmSomething/idol-song-app/issues/278)
+- `REVIVE+`, `흰수염고래` 같은 exact release-title query도 owner entity row가 함께 내려와서 mobile이 entity card를 자체 합성할 필요가 없다.
+- `투바투`, `최예나` 케이스에서 `next_upcoming.scheduled_month`, `next_upcoming.release_format`, `upcoming[].scheduled_month` completeness가 contract 기준으로 고정됐다.
+- search shadow representative case가 clean 기준으로 다시 통과해 client-side patching 필요가 없어졌다.
 
 ### 6.3 Entity Detail
 

--- a/docs/specs/backend/shared-read-api-contracts.md
+++ b/docs/specs/backend/shared-read-api-contracts.md
@@ -250,7 +250,7 @@
         "display_name": "YENA",
         "headline": "YENA confirms March comeback",
         "scheduled_date": "2026-03-11",
-        "scheduled_month": null,
+        "scheduled_month": "2026-03",
         "date_precision": "exact",
         "date_status": "confirmed",
         "release_format": "single album",
@@ -271,6 +271,11 @@
 - alias normalization은 API가 책임진다
 - client는 matched alias 계산을 재구현하지 않는다
 - segmented empty state는 빈 배열로 표현한다
+- exact `entity/alias` query는 companion `releases` / `upcoming` row를 같이 반환할 수 있다
+- exact `release_title` 또는 exact upcoming `headline` query가 잡히면 owner entity card를 `entities`에 같이 포함한다
+- 위 owner entity card는 `match_reason = partial`, `matched_alias = null`로 고정한다
+- `next_upcoming.scheduled_month`는 `scheduled_date`가 exact date일 때도 항상 month label까지 채워 반환한다
+- `next_upcoming.release_format`, `upcoming[].release_format`은 nullable metadata다. canonical upcoming signal에 값이 있으면 그대로 보존하고, 값이 없을 때 client가 별도 backfill 하지 않는다
 
 ## 7. `GET /v1/entities/:slug`
 


### PR DESCRIPTION
## Summary
- settle backend  semantics for mobile exact entity, release-title, and upcoming-headline queries
- complete  /  month metadata and add contract coverage for exact release-title entity rows
- update search shadow expectations and readiness docs so representative mobile cases are clean

## Verification
- cd backend && npm run build
- cd backend && npm run test
- cd backend && source ~/.config/idol-song-app/neon.env && npm run shadow:verify
- git diff --check

Closes #278