### PR TITLE
[#314] Propagate request IDs end to end

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -53,6 +53,9 @@ PORT=3000 APP_TIMEZONE=Asia/Seoul npm run start
 - success `meta`에는 최소 `request_id`, `generated_at`, `timezone`, `route`, `source`가 포함된다.
 - error는 공통 `meta + error` shape로 내려가고 code는 `invalid_request`, `not_found`, `disallowed_origin`, `stale_projection`, `internal_error`를 기본으로 쓴다.
 - helper entrypoint는 `backend/src/lib/api.ts`다.
+- caller가 `X-Request-Id`를 보내면 backend는 같은 값을 `meta.request_id`와 `X-Request-Id` response header에 그대로 되돌린다.
+- caller가 보내지 않으면 backend가 `api-<uuid>` request id를 생성한다.
+- runtime 측정 / shadow report도 각 request의 sent/received request id를 artifact에 함께 남긴다.
 
 ## Normalization Helpers
 

--- a/backend/reports/backend_shadow_read_report.json
+++ b/backend/reports/backend_shadow_read_report.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-03-08T10:13:21.659Z",
+  "generated_at": "2026-03-08T10:32:32.484Z",
   "clean": false,
   "linked_parity_report": {
     "exists": true,
@@ -152,7 +152,9 @@
         ],
         "upcoming": []
       },
-      "actual_status_code": 200
+      "actual_status_code": 200,
+      "request_id_sent": "shadow--v1-search-q-ed-8a-b8-eb-a6-ac-ed-94-8c-ec-97-90-ec-8a-a4-f6902b2e-27d2-4483-b222-b46b382c617a",
+      "response_request_id": "shadow--v1-search-q-ed-8a-b8-eb-a6-ac-ed-94-8c-ec-97-90-ec-8a-a4-f6902b2e-27d2-4483-b222-b46b382c617a"
     },
     {
       "surface": "search",
@@ -283,7 +285,9 @@
           }
         ]
       },
-      "actual_status_code": 200
+      "actual_status_code": 200,
+      "request_id_sent": "shadow--v1-search-q-ed-88-ac-eb-b0-94-ed-88-ac-c84fcebd-a760-449b-bb9c-72b5dc4fc5f1",
+      "response_request_id": "shadow--v1-search-q-ed-88-ac-eb-b0-94-ed-88-ac-c84fcebd-a760-449b-bb9c-72b5dc4fc5f1"
     },
     {
       "surface": "search",
@@ -414,7 +418,9 @@
           }
         ]
       },
-      "actual_status_code": 200
+      "actual_status_code": 200,
+      "request_id_sent": "shadow--v1-search-q-ec-b5-9c-ec-98-88-eb-82-98-d47bcf9b-6f9f-4932-bc71-f998782c47cf",
+      "response_request_id": "shadow--v1-search-q-ec-b5-9c-ec-98-88-eb-82-98-d47bcf9b-6f9f-4932-bc71-f998782c47cf"
     },
     {
       "surface": "search",
@@ -494,7 +500,9 @@
         ],
         "upcoming": []
       },
-      "actual_status_code": 200
+      "actual_status_code": 200,
+      "request_id_sent": "shadow--v1-search-q-revive-2b-a37cc12e-23e0-4b3f-b480-39b304c350f9",
+      "response_request_id": "shadow--v1-search-q-revive-2b-a37cc12e-23e0-4b3f-b480-39b304c350f9"
     },
     {
       "surface": "search",
@@ -574,7 +582,9 @@
         ],
         "upcoming": []
       },
-      "actual_status_code": 200
+      "actual_status_code": 200,
+      "request_id_sent": "shadow--v1-search-q-ed-9d-b0-ec-88-98-ec-97-bc-ea-b3-a0-eb-9e-98-d76c6847-e3b6-4749-940e-11a77999981f",
+      "response_request_id": "shadow--v1-search-q-ed-9d-b0-ec-88-98-ec-97-bc-ea-b3-a0-eb-9e-98-d76c6847-e3b6-4749-940e-11a77999981f"
     },
     {
       "surface": "entity_detail",
@@ -807,7 +817,9 @@
         ],
         "artist_source_url": "https://musicbrainz.org/artist/745c5b92-325f-451d-bd52-e6b95229c776"
       },
-      "actual_status_code": 200
+      "actual_status_code": 200,
+      "request_id_sent": "shadow--v1-entities-yena-a3bdb501-4fbe-43c6-b3c7-8f72a4c0e2a8",
+      "response_request_id": "shadow--v1-entities-yena-a3bdb501-4fbe-43c6-b3c7-8f72a4c0e2a8"
     },
     {
       "surface": "entity_detail",
@@ -1334,7 +1346,9 @@
         ],
         "artist_source_url": "https://musicbrainz.org/artist/48646387-1664-4c9a-9139-9bfd091b823c"
       },
-      "actual_status_code": 200
+      "actual_status_code": 200,
+      "request_id_sent": "shadow--v1-entities-blackpink-848df699-5f19-47c0-b923-74cdd693c89c",
+      "response_request_id": "shadow--v1-entities-blackpink-848df699-5f19-47c0-b923-74cdd693c89c"
     },
     {
       "surface": "entity_detail",
@@ -1603,7 +1617,9 @@
         ],
         "artist_source_url": "https://musicbrainz.org/artist/bba737dc-7ec8-482d-b79f-68d949ef2c7f"
       },
-      "actual_status_code": 200
+      "actual_status_code": 200,
+      "request_id_sent": "shadow--v1-entities-and-team-3d636012-29b8-471c-85f7-962c32cac314",
+      "response_request_id": "shadow--v1-entities-and-team-3d636012-29b8-471c-85f7-962c32cac314"
     },
     {
       "surface": "entity_detail",
@@ -1714,7 +1730,9 @@
         "source_timeline": [],
         "artist_source_url": "https://musicbrainz.org/artist/ce5c564c-0fbe-429c-b93b-5d7e3109cf40"
       },
-      "actual_status_code": 200
+      "actual_status_code": 200,
+      "request_id_sent": "shadow--v1-entities-allday-project-3783a1d5-0393-4f41-ae2f-210579c0522b",
+      "response_request_id": "shadow--v1-entities-allday-project-3783a1d5-0393-4f41-ae2f-210579c0522b"
     },
     {
       "surface": "release_detail",
@@ -2063,7 +2081,11 @@
         }
       },
       "lookup_status_code": 200,
-      "detail_status_code": 200
+      "detail_status_code": 200,
+      "lookup_request_id_sent": "shadow--v1-releases-lookup-entity_slug-blackpink-title-deadline-date-2026-02-26-stream-album-12cde7d5-6bff-470c-a1cd-ac1066c5fc3e",
+      "lookup_response_request_id": "shadow--v1-releases-lookup-entity_slug-blackpink-title-deadline-date-2026-02-26-stream-album-12cde7d5-6bff-470c-a1cd-ac1066c5fc3e",
+      "detail_request_id_sent": "shadow--v1-releases-e3526174-e804-56f2-9d50-17f9f817a351-145602e4-10f8-441e-9eea-3c8b5f36fe62",
+      "detail_response_request_id": "shadow--v1-releases-e3526174-e804-56f2-9d50-17f9f817a351-145602e4-10f8-441e-9eea-3c8b5f36fe62"
     },
     {
       "surface": "release_detail",
@@ -2491,7 +2513,11 @@
         }
       },
       "lookup_status_code": 200,
-      "detail_status_code": 200
+      "detail_status_code": 200,
+      "lookup_request_id_sent": "shadow--v1-releases-lookup-entity_slug-ive-title-revive-2b-date-2026-02-23-stream-album-11cb3eb2-6151-4e67-b03b-5ed937c8f19d",
+      "lookup_response_request_id": "shadow--v1-releases-lookup-entity_slug-ive-title-revive-2b-date-2026-02-23-stream-album-11cb3eb2-6151-4e67-b03b-5ed937c8f19d",
+      "detail_request_id_sent": "shadow--v1-releases-c339f501-52fe-599d-8d2d-bf5694ae4de4-f36d86dc-19db-4714-84fb-e07f506ff284",
+      "detail_response_request_id": "shadow--v1-releases-c339f501-52fe-599d-8d2d-bf5694ae4de4-f36d86dc-19db-4714-84fb-e07f506ff284"
     },
     {
       "surface": "release_detail",
@@ -2708,7 +2734,11 @@
         }
       },
       "lookup_status_code": 200,
-      "detail_status_code": 200
+      "detail_status_code": 200,
+      "lookup_request_id_sent": "shadow--v1-releases-lookup-entity_slug-qwer-title-ed-9d-b0-ec-88-98-ec-97-bc-ea-b3-a0-eb-9e-98-date-2025-10-06-stream-song-352df4d3-976f-4dc7-9675-7dc70640808e",
+      "lookup_response_request_id": "shadow--v1-releases-lookup-entity_slug-qwer-title-ed-9d-b0-ec-88-98-ec-97-bc-ea-b3-a0-eb-9e-98-date-2025-10-06-stream-song-352df4d3-976f-4dc7-9675-7dc70640808e",
+      "detail_request_id_sent": "shadow--v1-releases-d9a85b3d-ed19-51bb-a6c4-e5e538401b50-fbbc5ddd-bc51-4b0d-81fb-c6baabb8e43c",
+      "detail_response_request_id": "shadow--v1-releases-d9a85b3d-ed19-51bb-a6c4-e5e538401b50-fbbc5ddd-bc51-4b0d-81fb-c6baabb8e43c"
     },
     {
       "surface": "calendar_month",
@@ -3466,7 +3496,9 @@
           }
         ]
       },
-      "actual_status_code": 200
+      "actual_status_code": 200,
+      "request_id_sent": "shadow--v1-calendar-month-month-2026-03-a2f49a66-9728-4380-93f5-d1010d145503",
+      "response_request_id": "shadow--v1-calendar-month-month-2026-03-a2f49a66-9728-4380-93f5-d1010d145503"
     },
     {
       "surface": "calendar_month",
@@ -4368,7 +4400,9 @@
           }
         ]
       },
-      "actual_status_code": 200
+      "actual_status_code": 200,
+      "request_id_sent": "shadow--v1-calendar-month-month-2026-04-4842632d-6298-4da8-be8f-043135f893d6",
+      "response_request_id": "shadow--v1-calendar-month-month-2026-04-4842632d-6298-4da8-be8f-043135f893d6"
     },
     {
       "surface": "calendar_month",
@@ -5122,7 +5156,9 @@
         ],
         "scheduled_list": []
       },
-      "actual_status_code": 200
+      "actual_status_code": 200,
+      "request_id_sent": "shadow--v1-calendar-month-month-2025-10-ec53e558-7f52-4851-8c77-3810215ea8fd",
+      "response_request_id": "shadow--v1-calendar-month-month-2025-10-ec53e558-7f52-4851-8c77-3810215ea8fd"
     },
     {
       "surface": "radar",
@@ -6001,7 +6037,9 @@
           }
         ]
       },
-      "actual_status_code": 200
+      "actual_status_code": 200,
+      "request_id_sent": "shadow--v1-radar-08a9af03-99da-4ff7-bf74-03a238fef524",
+      "response_request_id": "shadow--v1-radar-08a9af03-99da-4ff7-bf74-03a238fef524"
     }
   ]
 }

--- a/backend/reports/read_api_runtime_measurements.json
+++ b/backend/reports/read_api_runtime_measurements.json
@@ -1,161 +1,233 @@
 {
-  "generated_at": "2026-03-07T10:28:30.558Z",
-  "base_url": "http://127.0.0.1:3216",
-  "iterations_per_case": 5,
+  "generated_at": "2026-03-08T10:32:27.583Z",
+  "base_url": "http://127.0.0.1:3217",
+  "iterations_per_case": 1,
   "timeout_ms": 3000,
   "cases": [
     {
       "surface": "health",
       "label": "health",
-      "request_count": 5,
-      "success_count": 5,
+      "request_count": 1,
+      "success_count": 1,
       "error_count": 0,
       "error_rate": 0,
       "status_counts": {
-        "200": 5
+        "200": 1
       },
       "latency_ms": {
-        "avg": 10.26,
-        "p50": 0.65,
-        "p95": 48.03,
-        "max": 48.03
+        "avg": 68.7,
+        "p50": 68.7,
+        "p95": 68.7,
+        "max": 68.7
       },
-      "sample_errors": []
+      "sample_errors": [],
+      "measurements": [
+        {
+          "status": 200,
+          "duration_ms": 68.7,
+          "request_id_sent": "runtime-health-health-1-72f44221-6cd1-4250-a9b6-36e5fd24e3d2",
+          "response_request_id": "runtime-health-health-1-72f44221-6cd1-4250-a9b6-36e5fd24e3d2",
+          "error": null
+        }
+      ]
     },
     {
       "surface": "ready",
       "label": "ready",
-      "request_count": 5,
-      "success_count": 5,
+      "request_count": 1,
+      "success_count": 1,
       "error_count": 0,
       "error_rate": 0,
       "status_counts": {
-        "200": 5
+        "200": 1
       },
       "latency_ms": {
-        "avg": 166.04,
-        "p50": 72.77,
-        "p95": 538.77,
-        "max": 538.77
+        "avg": 1148.96,
+        "p50": 1148.96,
+        "p95": 1148.96,
+        "max": 1148.96
       },
-      "sample_errors": []
+      "sample_errors": [],
+      "measurements": [
+        {
+          "status": 200,
+          "duration_ms": 1148.96,
+          "request_id_sent": "runtime-ready-ready-1-363dafca-8f5b-4012-84b4-15347c41480f",
+          "response_request_id": "runtime-ready-ready-1-363dafca-8f5b-4012-84b4-15347c41480f",
+          "error": null
+        }
+      ]
     },
     {
       "surface": "search",
       "label": "search-yena",
-      "request_count": 5,
-      "success_count": 5,
+      "request_count": 1,
+      "success_count": 1,
       "error_count": 0,
       "error_rate": 0,
       "status_counts": {
-        "200": 5
+        "200": 1
       },
       "latency_ms": {
-        "avg": 366.51,
-        "p50": 365.89,
-        "p95": 368.66,
-        "max": 368.66
+        "avg": 780.07,
+        "p50": 780.07,
+        "p95": 780.07,
+        "max": 780.07
       },
-      "sample_errors": []
+      "sample_errors": [],
+      "measurements": [
+        {
+          "status": 200,
+          "duration_ms": 780.07,
+          "request_id_sent": "runtime-search-search-yena-1-71086e2e-b1f2-4a15-9de9-6b0588c70b26",
+          "response_request_id": "runtime-search-search-yena-1-71086e2e-b1f2-4a15-9de9-6b0588c70b26",
+          "error": null
+        }
+      ]
     },
     {
       "surface": "entity_detail",
       "label": "entity-yena",
-      "request_count": 5,
-      "success_count": 5,
+      "request_count": 1,
+      "success_count": 1,
       "error_count": 0,
       "error_rate": 0,
       "status_counts": {
-        "200": 5
+        "200": 1
       },
       "latency_ms": {
-        "avg": 72.47,
-        "p50": 72.88,
-        "p95": 74.11,
-        "max": 74.11
+        "avg": 110.38,
+        "p50": 110.38,
+        "p95": 110.38,
+        "max": 110.38
       },
-      "sample_errors": []
+      "sample_errors": [],
+      "measurements": [
+        {
+          "status": 200,
+          "duration_ms": 110.38,
+          "request_id_sent": "runtime-entity_detail-entity-yena-1-c6d48211-0947-4a78-b2ff-65ef1acbb583",
+          "response_request_id": "runtime-entity_detail-entity-yena-1-c6d48211-0947-4a78-b2ff-65ef1acbb583",
+          "error": null
+        }
+      ]
     },
     {
       "surface": "release_lookup",
       "label": "release-lookup-blackpink-deadline",
-      "request_count": 5,
-      "success_count": 5,
+      "request_count": 1,
+      "success_count": 1,
       "error_count": 0,
       "error_rate": 0,
       "status_counts": {
-        "200": 5
+        "200": 1
       },
       "latency_ms": {
-        "avg": 73.28,
-        "p50": 73.18,
-        "p95": 74.7,
-        "max": 74.7
+        "avg": 106.95,
+        "p50": 106.95,
+        "p95": 106.95,
+        "max": 106.95
       },
-      "sample_errors": []
+      "sample_errors": [],
+      "measurements": [
+        {
+          "status": 200,
+          "duration_ms": 106.95,
+          "request_id_sent": "runtime-release_lookup-release-lookup-blackpink-deadline-1-764efa7e-34bc-4515-90e9-7b4334bedb95",
+          "response_request_id": "runtime-release_lookup-release-lookup-blackpink-deadline-1-764efa7e-34bc-4515-90e9-7b4334bedb95",
+          "error": null
+        }
+      ]
     },
     {
       "surface": "release_detail",
       "label": "release-detail-blackpink-deadline",
-      "request_count": 5,
-      "success_count": 5,
+      "request_count": 1,
+      "success_count": 1,
       "error_count": 0,
       "error_rate": 0,
       "status_counts": {
-        "200": 5
+        "200": 1
       },
       "latency_ms": {
-        "avg": 72.41,
-        "p50": 72.14,
-        "p95": 74.11,
-        "max": 74.11
+        "avg": 86.08,
+        "p50": 86.08,
+        "p95": 86.08,
+        "max": 86.08
       },
-      "sample_errors": []
+      "sample_errors": [],
+      "measurements": [
+        {
+          "status": 200,
+          "duration_ms": 86.08,
+          "request_id_sent": "runtime-release_detail-release-detail-blackpink-deadline-1-b461d019-05e6-4f9a-b3b4-9dd618f6e347",
+          "response_request_id": "runtime-release_detail-release-detail-blackpink-deadline-1-b461d019-05e6-4f9a-b3b4-9dd618f6e347",
+          "error": null
+        }
+      ]
     },
     {
       "surface": "calendar_month",
       "label": "calendar-2026-03",
-      "request_count": 5,
-      "success_count": 5,
+      "request_count": 1,
+      "success_count": 1,
       "error_count": 0,
       "error_rate": 0,
       "status_counts": {
-        "200": 5
+        "200": 1
       },
       "latency_ms": {
-        "avg": 73,
-        "p50": 72.21,
-        "p95": 75.94,
-        "max": 75.94
+        "avg": 180.08,
+        "p50": 180.08,
+        "p95": 180.08,
+        "max": 180.08
       },
-      "sample_errors": []
+      "sample_errors": [],
+      "measurements": [
+        {
+          "status": 200,
+          "duration_ms": 180.08,
+          "request_id_sent": "runtime-calendar_month-calendar-2026-03-1-17bf0529-97c1-4973-b8e5-9d9dc34f84fb",
+          "response_request_id": "runtime-calendar_month-calendar-2026-03-1-17bf0529-97c1-4973-b8e5-9d9dc34f84fb",
+          "error": null
+        }
+      ]
     },
     {
       "surface": "radar",
       "label": "radar-default",
-      "request_count": 5,
-      "success_count": 5,
+      "request_count": 1,
+      "success_count": 1,
       "error_count": 0,
       "error_rate": 0,
       "status_counts": {
-        "200": 5
+        "200": 1
       },
       "latency_ms": {
-        "avg": 72.18,
-        "p50": 71.68,
-        "p95": 73.58,
-        "max": 73.58
+        "avg": 109.12,
+        "p50": 109.12,
+        "p95": 109.12,
+        "max": 109.12
       },
-      "sample_errors": []
+      "sample_errors": [],
+      "measurements": [
+        {
+          "status": 200,
+          "duration_ms": 109.12,
+          "request_id_sent": "runtime-radar-radar-default-1-aa413002-96e1-4b44-8b2e-ab5cc739d806",
+          "response_request_id": "runtime-radar-radar-default-1-aa413002-96e1-4b44-8b2e-ab5cc739d806",
+          "error": null
+        }
+      ]
     }
   ],
   "overall": {
-    "request_count": 40,
-    "success_count": 40,
+    "request_count": 8,
+    "success_count": 8,
     "error_count": 0,
     "error_rate": 0,
     "status_counts": {
-      "200": 40
+      "200": 8
     }
   }
 }

--- a/backend/scripts/build-shadow-read-report.mjs
+++ b/backend/scripts/build-shadow-read-report.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -3380,8 +3381,29 @@ function limitSnapshot(value, depth = 0) {
   return value;
 }
 
+function createShadowRequestId(url) {
+  const normalizedUrl = String(url).replace(/[^a-z0-9_-]+/gi, '-').toLowerCase();
+  return `shadow-${normalizedUrl}-${randomUUID()}`;
+}
+
+function readInjectedResponseRequestId(body, response) {
+  if (body && typeof body === 'object' && body.meta && typeof body.meta.request_id === 'string') {
+    return body.meta.request_id;
+  }
+
+  const headerValue = response.headers['x-request-id'];
+  return typeof headerValue === 'string' && headerValue.trim().length > 0 ? headerValue.trim() : null;
+}
+
 async function injectJson(app, url) {
-  const response = await app.inject({ method: 'GET', url });
+  const requestId = createShadowRequestId(url);
+  const response = await app.inject({
+    method: 'GET',
+    url,
+    headers: {
+      'x-request-id': requestId,
+    },
+  });
   let body = null;
   try {
     body = response.json();
@@ -3392,6 +3414,8 @@ async function injectJson(app, url) {
   return {
     statusCode: response.statusCode,
     body,
+    requestIdSent: requestId,
+    responseRequestId: readInjectedResponseRequestId(body, response),
   };
 }
 
@@ -3617,6 +3641,8 @@ async function buildSearchCaseReport(app, state, query) {
 
   return buildCaseReport('search', { q: query }, expected, actualData, comparison, {
     actual_status_code: actualResponse.statusCode,
+    request_id_sent: actualResponse.requestIdSent,
+    response_request_id: actualResponse.responseRequestId,
   });
 }
 
@@ -3634,6 +3660,8 @@ async function buildEntityCaseReport(app, state, slug) {
 
   return buildCaseReport('entity_detail', { slug }, expected, actualData, comparison, {
     actual_status_code: actualResponse.statusCode,
+    request_id_sent: actualResponse.requestIdSent,
+    response_request_id: actualResponse.responseRequestId,
   });
 }
 
@@ -3645,7 +3673,7 @@ async function buildReleaseCaseReport(app, state, definition) {
   const lookupResponse = await injectJson(app, lookupUrl);
   const lookupData = lookupResponse.body?.data ?? null;
 
-  let detailResponse = { statusCode: 0, body: null };
+  let detailResponse = { statusCode: 0, body: null, requestIdSent: null, responseRequestId: null };
   if (lookupResponse.statusCode === 200 && lookupData?.canonical_path) {
     detailResponse = await injectJson(app, lookupData.canonical_path);
   }
@@ -3679,6 +3707,10 @@ async function buildReleaseCaseReport(app, state, definition) {
   return buildCaseReport('release_detail', definition, expected, actual, comparison, {
     lookup_status_code: lookupResponse.statusCode,
     detail_status_code: detailResponse.statusCode,
+    lookup_request_id_sent: lookupResponse.requestIdSent,
+    lookup_response_request_id: lookupResponse.responseRequestId,
+    detail_request_id_sent: detailResponse.requestIdSent,
+    detail_response_request_id: detailResponse.responseRequestId,
   });
 }
 
@@ -3696,6 +3728,8 @@ async function buildCalendarCaseReport(app, state, month) {
 
   return buildCaseReport('calendar_month', { month }, expected, actualData, comparison, {
     actual_status_code: actualResponse.statusCode,
+    request_id_sent: actualResponse.requestIdSent,
+    response_request_id: actualResponse.responseRequestId,
   });
 }
 
@@ -3713,6 +3747,8 @@ async function buildRadarCaseReport(app, state) {
 
   return buildCaseReport('radar', { surface: 'default' }, expected, actualData, comparison, {
     actual_status_code: actualResponse.statusCode,
+    request_id_sent: actualResponse.requestIdSent,
+    response_request_id: actualResponse.responseRequestId,
   });
 }
 

--- a/backend/scripts/measure-read-api-runtime.mjs
+++ b/backend/scripts/measure-read-api-runtime.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { randomUUID } from 'node:crypto';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { performance } from 'node:perf_hooks';
@@ -23,6 +24,21 @@ function average(values) {
     return null;
   }
   return Number((values.reduce((sum, value) => sum + value, 0) / values.length).toFixed(2));
+}
+
+function createRequestId(surface, label, iteration) {
+  const normalizedSurface = String(surface).replace(/[^a-z0-9_-]+/gi, '-').toLowerCase();
+  const normalizedLabel = String(label).replace(/[^a-z0-9_-]+/gi, '-').toLowerCase();
+  return `runtime-${normalizedSurface}-${normalizedLabel}-${iteration}-${randomUUID()}`;
+}
+
+function readResponseRequestId(body, response) {
+  if (body && typeof body === 'object' && body.meta && typeof body.meta.request_id === 'string') {
+    return body.meta.request_id;
+  }
+
+  const headerValue = response.headers.get('x-request-id');
+  return typeof headerValue === 'string' && headerValue.trim().length > 0 ? headerValue.trim() : null;
 }
 
 function parseArgs(argv) {
@@ -148,7 +164,7 @@ function createRuntimeCases(baseUrl) {
   ];
 }
 
-async function measureRequest({ url, expectedStatus, timeoutMs }) {
+async function measureRequest({ url, expectedStatus, timeoutMs, requestId }) {
   const startedAt = performance.now();
 
   try {
@@ -156,14 +172,23 @@ async function measureRequest({ url, expectedStatus, timeoutMs }) {
       signal: AbortSignal.timeout(timeoutMs),
       headers: {
         accept: 'application/json',
+        'x-request-id': requestId,
       },
     });
+    let body = null;
+    try {
+      body = await response.json();
+    } catch {
+      body = null;
+    }
     const durationMs = Number((performance.now() - startedAt).toFixed(2));
     return {
       ok: response.status === expectedStatus,
       status: response.status,
       durationMs,
       error: null,
+      request_id_sent: requestId,
+      response_request_id: readResponseRequestId(body, response),
     };
   } catch (error) {
     const durationMs = Number((performance.now() - startedAt).toFixed(2));
@@ -172,6 +197,8 @@ async function measureRequest({ url, expectedStatus, timeoutMs }) {
       status: null,
       durationMs,
       error: error instanceof Error ? error.message : String(error),
+      request_id_sent: requestId,
+      response_request_id: null,
     };
   }
 }
@@ -211,6 +238,13 @@ function summarizeMeasurements(caseConfig, measurements) {
       max: durations.length ? Number(Math.max(...durations).toFixed(2)) : null,
     },
     sample_errors: sampleErrors,
+    measurements: measurements.map((measurement) => ({
+      status: measurement.status,
+      duration_ms: measurement.durationMs,
+      request_id_sent: measurement.request_id_sent,
+      response_request_id: measurement.response_request_id,
+      error: measurement.error,
+    })),
   };
 }
 
@@ -249,11 +283,13 @@ async function main() {
     const measurements = [];
     for (let index = 0; index < iterations; index += 1) {
       const request = await runtimeCase.createRequest();
+      const requestId = createRequestId(runtimeCase.surface, runtimeCase.label, index + 1);
       measurements.push(
         await measureRequest({
           url: request.url,
           expectedStatus: request.expectedStatus,
           timeoutMs,
+          requestId,
         }),
       );
     }

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'node:crypto';
+
 import Fastify, { type FastifyInstance, type FastifyReply } from 'fastify';
 
 import { loadConfig, type AppConfig } from './config.js';
@@ -18,7 +20,13 @@ export type BuildAppOptions = {
 };
 
 const ACCESS_CONTROL_ALLOW_METHODS = 'GET,OPTIONS';
-const DEFAULT_ACCESS_CONTROL_ALLOW_HEADERS = 'Content-Type';
+const DEFAULT_ACCESS_CONTROL_ALLOW_HEADERS = 'Content-Type, X-Request-Id';
+const ACCESS_CONTROL_EXPOSE_HEADERS = 'X-Request-Id';
+const REQUEST_ID_HEADER = 'x-request-id';
+
+function createRequestId(): string {
+  return `api-${randomUUID()}`;
+}
 
 function appendVaryHeader(reply: FastifyReply, value: string): void {
   const current = reply.getHeader('Vary');
@@ -67,6 +75,7 @@ function applyCorsHeaders(reply: FastifyReply, origin: string, requestedHeaders:
   reply.header('Access-Control-Allow-Origin', origin);
   reply.header('Access-Control-Allow-Methods', ACCESS_CONTROL_ALLOW_METHODS);
   reply.header('Access-Control-Allow-Headers', requestedHeaders);
+  reply.header('Access-Control-Expose-Headers', ACCESS_CONTROL_EXPOSE_HEADERS);
   reply.header('Access-Control-Max-Age', '600');
   appendVaryHeader(reply, 'Origin');
   appendVaryHeader(reply, 'Access-Control-Request-Headers');
@@ -76,7 +85,9 @@ export function buildApp(options: BuildAppOptions = {}): FastifyInstance {
   const config = options.config ?? loadConfig();
   const db = withFailFastReadTimeouts(options.db ?? createDbPool(config));
   const app = Fastify({
+    genReqId: createRequestId,
     logger: true,
+    requestIdHeader: REQUEST_ID_HEADER,
   });
 
   app.addHook('onRequest', async (request, reply) => {
@@ -113,7 +124,7 @@ export function buildApp(options: BuildAppOptions = {}): FastifyInstance {
         .send(buildReadErrorEnvelope(request, config.appTimezone, error.code, error.message, error.meta));
     }
 
-    request.log.error({ err: error }, 'Unhandled request error');
+    request.log.error({ err: error, request_id: request.id }, 'Unhandled request error');
     return reply
       .code(500)
       .send(buildReadErrorEnvelope(request, config.appTimezone, 'internal_error', 'Unexpected server error.'));
@@ -133,6 +144,11 @@ export function buildApp(options: BuildAppOptions = {}): FastifyInstance {
 
   app.addHook('onClose', async () => {
     await closeDbPool(db);
+  });
+
+  app.addHook('onSend', async (request, reply, payload) => {
+    reply.header('X-Request-Id', request.id);
+    return payload;
   });
 
   registerHealthRoute(app);

--- a/backend/src/route-contract.test.ts
+++ b/backend/src/route-contract.test.ts
@@ -14,6 +14,7 @@ const UPCOMING_SIGNAL_ID = '55555555-5555-4555-8555-555555555555';
 const UPCOMING_REVIEW_ID = '66666666-6666-4666-8666-666666666666';
 const MV_REVIEW_ID = '77777777-7777-4777-8777-777777777777';
 const IVE_ENTITY_ID = '88888888-8888-4888-8888-888888888888';
+const CALLER_REQUEST_ID = 'web-search-trace-yena-001';
 
 const TEST_CONFIG: AppConfig = {
   appEnv: 'development',
@@ -721,6 +722,25 @@ function assertErrorEnvelope(body: Record<string, any>, code: string, route: str
   assert.equal(typeof body.meta.request_id, 'string');
 }
 
+test('caller-provided x-request-id is echoed in success envelope and response headers', async (t) => {
+  const app = createTestApp(t);
+  const response = await app.inject({
+    method: 'GET',
+    url: '/v1/search',
+    query: {
+      q: '최예나',
+    },
+    headers: {
+      'x-request-id': CALLER_REQUEST_ID,
+    },
+  });
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.headers['x-request-id'], CALLER_REQUEST_ID);
+  const body = parseJson(response);
+  assert.equal(body.meta.request_id, CALLER_REQUEST_ID);
+});
+
 test('GET /health returns plain health status', async (t) => {
   const app = createTestApp(t);
   const response = await app.inject({
@@ -936,9 +956,15 @@ test('error envelopes cover invalid request, not found, and stale projection cas
   const invalidReleaseId = await standardApp.inject({
     method: 'GET',
     url: '/v1/releases/not-a-uuid',
+    headers: {
+      'x-request-id': CALLER_REQUEST_ID,
+    },
   });
   assert.equal(invalidReleaseId.statusCode, 400);
-  assertErrorEnvelope(parseJson(invalidReleaseId), 'invalid_request', '/v1/releases/:id');
+  assert.equal(invalidReleaseId.headers['x-request-id'], CALLER_REQUEST_ID);
+  const invalidReleaseIdBody = parseJson(invalidReleaseId);
+  assertErrorEnvelope(invalidReleaseIdBody, 'invalid_request', '/v1/releases/:id');
+  assert.equal(invalidReleaseIdBody.meta.request_id, CALLER_REQUEST_ID);
 
   const invalidCalendarMonth = await standardApp.inject({
     method: 'GET',

--- a/docs/specs/backend/preview-staging-backend-path.md
+++ b/docs/specs/backend/preview-staging-backend-path.md
@@ -110,6 +110,7 @@ preview에서 달라지면 안 되는 것:
 - enum domain
 - date precision semantics
 - title-track / MV / service-link meaning
+- request-id propagation policy (`X-Request-Id` echo)
 - fallback / error contract
 
 즉 preview는 데이터 품질이나 시점은 production보다 느슨할 수 있지만, payload shape와 제품 의미론은 production과 동일해야 한다.

--- a/docs/specs/backend/shared-read-api-contracts.md
+++ b/docs/specs/backend/shared-read-api-contracts.md
@@ -58,6 +58,9 @@
 - `generated_at`은 projection freshness 판단용이다
 - `timezone`은 제품 의미론 기준을 명시한다
 - payload business data는 `data` 아래에 둔다
+- caller가 `X-Request-Id`를 보내면 backend는 같은 값을 `meta.request_id`와 `X-Request-Id` response header에 그대로 반영한다
+- caller가 보내지 않으면 backend가 `api-<uuid>` 형태 request id를 생성한다
+- preview와 production은 같은 request-id policy를 사용한다
 
 ## 4. Endpoint Summary
 

--- a/web/scripts/verify-backend-timeout.ts
+++ b/web/scripts/verify-backend-timeout.ts
@@ -1,8 +1,10 @@
 import assert from 'node:assert/strict'
 
 import {
+  BackendFetchNetworkError,
   BackendFetchTimeoutError,
   classifyBackendFetchError,
+  extractBackendFetchRequestId,
   fetchJsonWithTimeout,
 } from '../src/lib/backendFetch'
 
@@ -58,6 +60,8 @@ async function run() {
     (error: unknown) => {
       assert.ok(error instanceof BackendFetchTimeoutError)
       assert.equal(classifyBackendFetchError(error), 'timeout')
+      assert.equal(typeof error.requestId, 'string')
+      assert.equal(extractBackendFetchRequestId(error), error.requestId)
       return true
     },
   )
@@ -79,6 +83,9 @@ async function run() {
   })
 
   assert.equal(classifyBackendFetchError(new Error('socket hang up')), 'network_error')
+  const networkError = new BackendFetchNetworkError('web-search-123', new Error('socket hang up'))
+  assert.equal(classifyBackendFetchError(networkError), 'network_error')
+  assert.equal(extractBackendFetchRequestId(networkError), 'web-search-123')
 
   const success = await fetchJsonWithTimeout<{ ok: true }>('https://success.example/test', {
     signal: new AbortController().signal,
@@ -89,6 +96,8 @@ async function run() {
   assert.equal(success.ok, true)
   assert.equal(success.status, 200)
   assert.deepEqual(success.body, { ok: true })
+  assert.equal(typeof success.requestId, 'string')
+  assert.equal(success.responseRequestId, null)
 
   console.log('backend timeout verification passed')
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8,7 +8,11 @@ import {
   type RefObject,
 } from 'react'
 import './App.css'
-import { classifyBackendFetchError, fetchJsonWithTimeout } from './lib/backendFetch'
+import {
+  classifyBackendFetchError,
+  extractBackendFetchRequestId,
+  fetchJsonWithTimeout,
+} from './lib/backendFetch'
 import {
   buildServiceActionLinks,
   openMusicHandoff,
@@ -242,6 +246,7 @@ type ReleaseDetailApiResource = ReleaseDetailApiSnapshot & {
   source: ReleaseDetailSourceState
   loading: boolean
   errorCode: string | null
+  traceId: string | null
 }
 
 type ReleaseDetailApiRequest = {
@@ -309,6 +314,7 @@ type SearchSurfaceResource = SearchSurfaceSnapshot & {
   source: SearchSourceState
   loading: boolean
   errorCode: string | null
+  traceId: string | null
 }
 
 type EntityDetailApiResponse = {
@@ -382,6 +388,7 @@ type EntityDetailSurfaceResource = {
   source: EntityDetailSourceState
   loading: boolean
   errorCode: string | null
+  traceId: string | null
 }
 
 type EntityDetailTimelineEntry = NonNullable<NonNullable<EntityDetailApiResponse['data']>['source_timeline']>[number]
@@ -442,6 +449,7 @@ type CalendarMonthSurfaceResource = {
   source: CalendarMonthSourceState
   loading: boolean
   errorCode: string | null
+  traceId: string | null
 }
 
 type RadarApiReleaseSummary = {
@@ -503,6 +511,7 @@ type RadarSurfaceResource = {
   source: RadarSourceState
   loading: boolean
   errorCode: string | null
+  traceId: string | null
 }
 
 type ActType = 'group' | 'solo' | 'unit'
@@ -879,6 +888,7 @@ const TRANSLATIONS = {
     radarJsonPrimary: '현재 레이더 섹션은 transitional JSON 기본 경로를 사용 중입니다.',
     surfaceSourceLabel: '소스',
     surfaceReasonLabel: '이유',
+    surfaceTraceLabel: '요청 ID',
     surfaceSourceModeLabels: {
       api: 'backend API',
       json: 'transitional JSON',
@@ -1160,6 +1170,7 @@ const TRANSLATIONS = {
     radarJsonPrimary: 'The radar sections are currently using the transitional JSON primary path.',
     surfaceSourceLabel: 'Source',
     surfaceReasonLabel: 'Reason',
+    surfaceTraceLabel: 'Request ID',
     surfaceSourceModeLabels: {
       api: 'backend API',
       json: 'transitional JSON',
@@ -1637,6 +1648,7 @@ function getSurfaceStatusLabels(language: Language) {
   return {
     sourceLabel: copy.surfaceSourceLabel,
     reasonLabel: copy.surfaceReasonLabel,
+    traceLabel: copy.surfaceTraceLabel,
     sourceStateLabels: copy.surfaceSourceModeLabels,
     fallbackReasonLabels: copy.surfaceFallbackReasonLabels,
   }
@@ -1646,16 +1658,19 @@ function buildSurfaceStatusMessage({
   language,
   source,
   errorCode,
+  traceId,
   baseMessage,
 }: {
   language: Language
   source: SurfaceStatusSource
   errorCode: string | null
+  traceId?: string | null
   baseMessage: string
 }) {
   const metadata = buildSurfaceStatusMeta({
     source,
     errorCode,
+    traceId,
     labels: getSurfaceStatusLabels(language),
   })
   return `${baseMessage} ${metadata}`
@@ -1983,6 +1998,7 @@ function App() {
               language,
               source: 'api',
               errorCode: null,
+              traceId: searchSurfaceResource.traceId,
               baseMessage: copy.searchBackendActive,
             })
           : searchSurfaceResource.loading
@@ -1997,6 +2013,7 @@ function App() {
                   language,
                   source: 'json_fallback',
                   errorCode: searchSurfaceResource.errorCode,
+                  traceId: searchSurfaceResource.traceId,
                   baseMessage:
                     searchSurfaceResource.errorCode === 'timeout'
                       ? copy.searchBackendTimeout
@@ -2183,6 +2200,7 @@ function App() {
             language,
             source: 'api',
             errorCode: null,
+            traceId: calendarMonthResource.traceId,
             baseMessage: copy.calendarBackendActive,
           })
         : calendarMonthResource.loading
@@ -2197,6 +2215,7 @@ function App() {
                 language,
                 source: 'json_fallback',
                 errorCode: calendarMonthResource.errorCode,
+                traceId: calendarMonthResource.traceId,
                 baseMessage:
                   calendarMonthResource.errorCode === 'timeout'
                     ? copy.calendarBackendTimeout
@@ -2221,6 +2240,7 @@ function App() {
             language,
             source: 'api',
             errorCode: null,
+            traceId: radarResource.traceId,
             baseMessage: copy.radarBackendActive,
           })
         : radarResource.loading
@@ -2235,6 +2255,7 @@ function App() {
                 language,
                 source: 'json_fallback',
                 errorCode: radarResource.errorCode,
+                traceId: radarResource.traceId,
                 baseMessage:
                   radarResource.errorCode === 'timeout'
                     ? copy.radarBackendTimeout
@@ -2720,12 +2741,14 @@ function App() {
                         language,
                         source: 'api',
                         errorCode: null,
+                        traceId: selectedTeamResource.traceId,
                         baseMessage: teamCopy.backendActive,
                       })
                     : buildSurfaceStatusMessage({
                         language,
                         source: 'json_fallback',
                         errorCode: selectedTeamResource.errorCode,
+                        traceId: selectedTeamResource.traceId,
                         baseMessage:
                           selectedTeamResource.errorCode === 'timeout'
                             ? teamCopy.backendTimeout
@@ -3606,6 +3629,7 @@ function ReleaseDetailPage({
             language,
             source: 'api',
             errorCode: null,
+            traceId: releaseDetailResource.traceId,
             baseMessage: teamCopy.releaseDetailBackendActive,
           })
         : releaseDetailResource.loading
@@ -3619,6 +3643,7 @@ function ReleaseDetailPage({
               language,
               source: 'json_fallback',
               errorCode: releaseDetailResource.errorCode,
+              traceId: releaseDetailResource.traceId,
               baseMessage:
                 releaseDetailResource.errorCode === 'timeout'
                   ? teamCopy.releaseDetailBackendTimeout
@@ -6916,14 +6941,32 @@ async function fetchApiJson<T>(
   path: string,
   signal: AbortSignal,
   timeoutMs: number,
-): Promise<{ ok: boolean; status: number; body: T | null }> {
-  return fetchJsonWithTimeout<T>(buildBackendApiUrl(path), {
+  requestIdPrefix: string,
+): Promise<{ ok: boolean; status: number; body: T | null; traceId: string | null }> {
+  const result = await fetchJsonWithTimeout<T>(buildBackendApiUrl(path), {
     headers: {
       Accept: 'application/json',
     },
+    requestIdPrefix,
     signal,
     timeoutMs,
   })
+
+  return {
+    ...result,
+    traceId: result.responseRequestId ?? result.requestId,
+  }
+}
+
+function getBackendTraceIdFromError(error: unknown): string | null {
+  return extractBackendFetchRequestId(error)
+}
+
+function buildFetchFailureState(error: unknown) {
+  return {
+    errorCode: classifyBackendFetchError(error),
+    traceId: getBackendTraceIdFromError(error),
+  }
 }
 
 function normalizeApiReleaseDetailSnapshot(
@@ -7019,29 +7062,34 @@ async function fetchReleaseDetailApiSnapshot(
   group: string,
   fallbackSnapshot: ReleaseDetailApiSnapshot,
   signal: AbortSignal,
-): Promise<{ snapshot: ReleaseDetailApiSnapshot | null; errorCode: string | null }> {
+): Promise<{ snapshot: ReleaseDetailApiSnapshot | null; errorCode: string | null; traceId: string | null }> {
   const cacheKey = getReleaseLookupKey(group, album.title, album.date, normalizeReleaseStream(album.stream, album.release_kind))
   const cachedSnapshot = releaseDetailApiSnapshotCache.get(cacheKey)
   if (cachedSnapshot) {
     return {
       snapshot: cachedSnapshot,
       errorCode: null,
+      traceId: null,
     }
   }
 
   let releaseId = releaseDetailApiIdCache.get(cacheKey) ?? null
   let canonicalPath: string | null = null
+  let traceId: string | null = null
 
   if (!releaseId) {
     const lookupResult = await fetchApiJson<ReleaseDetailLookupApiResponse>(
       buildReleaseDetailLookupUrl(album, group),
       signal,
       RELEASE_DETAIL_LOOKUP_TIMEOUT_MS,
+      `web-release-lookup-${group}`,
     )
+    traceId = lookupResult.traceId
     if (!lookupResult.ok || !lookupResult.body?.data?.release_id) {
       return {
         snapshot: null,
         errorCode: lookupResult.body?.error?.code ?? `lookup_${lookupResult.status}`,
+        traceId,
       }
     }
 
@@ -7054,11 +7102,14 @@ async function fetchReleaseDetailApiSnapshot(
     `/v1/releases/${releaseId}`,
     signal,
     RELEASE_DETAIL_FETCH_TIMEOUT_MS,
+    `web-release-detail-${group}`,
   )
+  traceId = detailResult.traceId ?? traceId
   if (!detailResult.ok || !detailResult.body?.data) {
     return {
       snapshot: null,
       errorCode: detailResult.body?.error?.code ?? `detail_${detailResult.status}`,
+      traceId,
     }
   }
 
@@ -7075,6 +7126,7 @@ async function fetchReleaseDetailApiSnapshot(
     return {
       snapshot: null,
       errorCode: 'invalid_projection_payload',
+      traceId,
     }
   }
 
@@ -7082,6 +7134,7 @@ async function fetchReleaseDetailApiSnapshot(
   return {
     snapshot,
     errorCode: null,
+    traceId,
   }
 }
 
@@ -7108,12 +7161,14 @@ function useReleaseDetailResource({
     snapshot: ReleaseDetailApiSnapshot | null
     loading: boolean
     errorCode: string | null
+    traceId: string | null
   }>(() => {
     return {
       cacheKey,
       snapshot: cachedSnapshot,
       loading: false,
       errorCode: null,
+      traceId: null,
     }
   })
 
@@ -7139,6 +7194,7 @@ function useReleaseDetailResource({
           snapshot: cachedSnapshot,
           loading: false,
           errorCode: null,
+          traceId: null,
         })
       })
       return
@@ -7163,11 +7219,12 @@ function useReleaseDetailResource({
         snapshot: null,
         loading: true,
         errorCode: null,
+        traceId: null,
       })
     })
 
     void fetchReleaseDetailApiSnapshot(effectRequestAlbum, group, effectFallbackSnapshot, controller.signal)
-      .then(({ snapshot, errorCode }) => {
+      .then(({ snapshot, errorCode, traceId }) => {
         if (cancelled) {
           return
         }
@@ -7178,6 +7235,7 @@ function useReleaseDetailResource({
             snapshot,
             loading: false,
             errorCode: null,
+            traceId,
           })
           return
         }
@@ -7187,6 +7245,7 @@ function useReleaseDetailResource({
           snapshot: null,
           loading: false,
           errorCode,
+          traceId,
         })
       })
       .catch((error: unknown) => {
@@ -7194,8 +7253,8 @@ function useReleaseDetailResource({
           return
         }
 
-        const classifiedError = classifyBackendFetchError(error)
-        if (classifiedError === null) {
+        const failureState = buildFetchFailureState(error)
+        if (failureState.errorCode === null) {
           return
         }
 
@@ -7203,7 +7262,8 @@ function useReleaseDetailResource({
           cacheKey,
           snapshot: null,
           loading: false,
-          errorCode: classifiedError,
+          errorCode: failureState.errorCode,
+          traceId: failureState.traceId,
         })
       })
 
@@ -7230,6 +7290,7 @@ function useReleaseDetailResource({
     source,
     loading,
     errorCode,
+    traceId: sourceMode === 'api' && remoteState.cacheKey === cacheKey ? remoteState.traceId : null,
   }
 }
 
@@ -7361,13 +7422,14 @@ function buildSearchSurfaceApiSnapshot(data: SearchApiResponse['data']): SearchS
 async function fetchSearchSurfaceApiSnapshot(
   search: string,
   signal: AbortSignal,
-): Promise<{ snapshot: SearchSurfaceSnapshot | null; errorCode: string | null }> {
+): Promise<{ snapshot: SearchSurfaceSnapshot | null; errorCode: string | null; traceId: string | null }> {
   const cacheKey = search.trim()
   const cachedSnapshot = searchSurfaceApiSnapshotCache.get(cacheKey)
   if (cachedSnapshot) {
     return {
       snapshot: cachedSnapshot,
       errorCode: null,
+      traceId: null,
     }
   }
 
@@ -7379,11 +7441,13 @@ async function fetchSearchSurfaceApiSnapshot(
     `/v1/search?${params.toString()}`,
     signal,
     SEARCH_SURFACE_TIMEOUT_MS,
+    'web-search',
   )
   if (!result.ok || !result.body?.data) {
     return {
       snapshot: null,
       errorCode: result.body?.error?.code ?? `search_${result.status}`,
+      traceId: result.traceId,
     }
   }
 
@@ -7392,6 +7456,7 @@ async function fetchSearchSurfaceApiSnapshot(
   return {
     snapshot,
     errorCode: null,
+    traceId: result.traceId,
   }
 }
 
@@ -7411,12 +7476,14 @@ function useSearchSurfaceResource({
     snapshot: SearchSurfaceSnapshot | null
     loading: boolean
     errorCode: string | null
+    traceId: string | null
   }>(() => {
     return {
       cacheKey,
       snapshot: cachedSnapshot,
       loading: false,
       errorCode: null,
+      traceId: null,
     }
   })
 
@@ -7432,6 +7499,7 @@ function useSearchSurfaceResource({
           snapshot: cachedSnapshot,
           loading: false,
           errorCode: null,
+          traceId: null,
         })
       })
       return
@@ -7450,11 +7518,12 @@ function useSearchSurfaceResource({
         snapshot: null,
         loading: true,
         errorCode: null,
+        traceId: null,
       })
     })
 
     void fetchSearchSurfaceApiSnapshot(search, controller.signal)
-      .then(({ snapshot, errorCode }) => {
+      .then(({ snapshot, errorCode, traceId }) => {
         if (cancelled) {
           return
         }
@@ -7464,6 +7533,7 @@ function useSearchSurfaceResource({
           snapshot,
           loading: false,
           errorCode,
+          traceId,
         })
       })
       .catch((error: unknown) => {
@@ -7471,8 +7541,8 @@ function useSearchSurfaceResource({
           return
         }
 
-        const classifiedError = classifyBackendFetchError(error)
-        if (classifiedError === null) {
+        const failureState = buildFetchFailureState(error)
+        if (failureState.errorCode === null) {
           return
         }
 
@@ -7480,7 +7550,8 @@ function useSearchSurfaceResource({
           cacheKey,
           snapshot: null,
           loading: false,
-          errorCode: classifiedError,
+          errorCode: failureState.errorCode,
+          traceId: failureState.traceId,
         })
       })
 
@@ -7513,6 +7584,7 @@ function useSearchSurfaceResource({
     source,
     loading,
     errorCode,
+    traceId: sourceMode === 'api' && remoteState.cacheKey === cacheKey ? remoteState.traceId : null,
   }
 }
 
@@ -7713,12 +7785,13 @@ function buildCalendarMonthApiSnapshot(data: CalendarMonthApiResponse['data']): 
 async function fetchCalendarMonthApiSnapshot(
   monthKey: string,
   signal: AbortSignal,
-): Promise<{ snapshot: CalendarMonthApiSnapshot | null; errorCode: string | null }> {
+): Promise<{ snapshot: CalendarMonthApiSnapshot | null; errorCode: string | null; traceId: string | null }> {
   const cachedSnapshot = calendarMonthApiSnapshotCache.get(monthKey)
   if (cachedSnapshot) {
     return {
       snapshot: cachedSnapshot,
       errorCode: null,
+      traceId: null,
     }
   }
 
@@ -7726,11 +7799,13 @@ async function fetchCalendarMonthApiSnapshot(
     `/v1/calendar/month?month=${encodeURIComponent(monthKey)}`,
     signal,
     CALENDAR_MONTH_FETCH_TIMEOUT_MS,
+    `web-calendar-${monthKey}`,
   )
   if (!result.ok || !result.body?.data) {
     return {
       snapshot: null,
       errorCode: result.body?.error?.code ?? `calendar_month_${result.status}`,
+      traceId: result.traceId,
     }
   }
 
@@ -7739,6 +7814,7 @@ async function fetchCalendarMonthApiSnapshot(
   return {
     snapshot,
     errorCode: null,
+    traceId: result.traceId,
   }
 }
 
@@ -7755,11 +7831,13 @@ function useCalendarMonthResource({
     snapshot: CalendarMonthApiSnapshot | null
     loading: boolean
     errorCode: string | null
+    traceId: string | null
   }>(() => ({
     monthKey,
     snapshot: cachedSnapshot,
     loading: false,
     errorCode: null,
+    traceId: null,
   }))
 
   useEffect(() => {
@@ -7774,6 +7852,7 @@ function useCalendarMonthResource({
           snapshot: cachedSnapshot,
           loading: false,
           errorCode: null,
+          traceId: null,
         })
       })
       return
@@ -7792,11 +7871,12 @@ function useCalendarMonthResource({
         snapshot: null,
         loading: true,
         errorCode: null,
+        traceId: null,
       })
     })
 
     void fetchCalendarMonthApiSnapshot(monthKey, controller.signal)
-      .then(({ snapshot, errorCode }) => {
+      .then(({ snapshot, errorCode, traceId }) => {
         if (cancelled) {
           return
         }
@@ -7806,6 +7886,7 @@ function useCalendarMonthResource({
           snapshot,
           loading: false,
           errorCode,
+          traceId,
         })
       })
       .catch((error: unknown) => {
@@ -7813,8 +7894,8 @@ function useCalendarMonthResource({
           return
         }
 
-        const classifiedError = classifyBackendFetchError(error)
-        if (classifiedError === null) {
+        const failureState = buildFetchFailureState(error)
+        if (failureState.errorCode === null) {
           return
         }
 
@@ -7822,7 +7903,8 @@ function useCalendarMonthResource({
           monthKey,
           snapshot: null,
           loading: false,
-          errorCode: classifiedError,
+          errorCode: failureState.errorCode,
+          traceId: failureState.traceId,
         })
       })
 
@@ -7855,6 +7937,7 @@ function useCalendarMonthResource({
     source,
     loading,
     errorCode,
+    traceId: sourceMode === 'api' && remoteState.monthKey === monthKey ? remoteState.traceId : null,
   }
 }
 
@@ -8056,21 +8139,23 @@ function buildRadarApiSnapshot(data: RadarApiResponse['data']): RadarApiSnapshot
 
 async function fetchRadarApiSnapshot(
   signal: AbortSignal,
-): Promise<{ snapshot: RadarApiSnapshot | null; errorCode: string | null }> {
+): Promise<{ snapshot: RadarApiSnapshot | null; errorCode: string | null; traceId: string | null }> {
   const cacheKey = 'default'
   const cachedSnapshot = radarApiSnapshotCache.get(cacheKey)
   if (cachedSnapshot) {
     return {
       snapshot: cachedSnapshot,
       errorCode: null,
+      traceId: null,
     }
   }
 
-  const result = await fetchApiJson<RadarApiResponse>('/v1/radar', signal, RADAR_FETCH_TIMEOUT_MS)
+  const result = await fetchApiJson<RadarApiResponse>('/v1/radar', signal, RADAR_FETCH_TIMEOUT_MS, 'web-radar')
   if (!result.ok || !result.body?.data) {
     return {
       snapshot: null,
       errorCode: result.body?.error?.code ?? `radar_${result.status}`,
+      traceId: result.traceId,
     }
   }
 
@@ -8079,6 +8164,7 @@ async function fetchRadarApiSnapshot(
   return {
     snapshot,
     errorCode: null,
+    traceId: result.traceId,
   }
 }
 
@@ -8093,10 +8179,12 @@ function useRadarSurfaceResource({
     snapshot: RadarApiSnapshot | null
     loading: boolean
     errorCode: string | null
+    traceId: string | null
   }>(() => ({
     snapshot: cachedSnapshot,
     loading: false,
     errorCode: null,
+    traceId: null,
   }))
 
   useEffect(() => {
@@ -8110,6 +8198,7 @@ function useRadarSurfaceResource({
           snapshot: cachedSnapshot,
           loading: false,
           errorCode: null,
+          traceId: null,
         })
       })
       return
@@ -8127,11 +8216,12 @@ function useRadarSurfaceResource({
         snapshot: null,
         loading: true,
         errorCode: null,
+        traceId: null,
       })
     })
 
     void fetchRadarApiSnapshot(controller.signal)
-      .then(({ snapshot, errorCode }) => {
+      .then(({ snapshot, errorCode, traceId }) => {
         if (cancelled) {
           return
         }
@@ -8140,6 +8230,7 @@ function useRadarSurfaceResource({
           snapshot,
           loading: false,
           errorCode,
+          traceId,
         })
       })
       .catch((error: unknown) => {
@@ -8147,15 +8238,16 @@ function useRadarSurfaceResource({
           return
         }
 
-        const classifiedError = classifyBackendFetchError(error)
-        if (classifiedError === null) {
+        const failureState = buildFetchFailureState(error)
+        if (failureState.errorCode === null) {
           return
         }
 
         setRemoteState({
           snapshot: null,
           loading: false,
-          errorCode: classifiedError,
+          errorCode: failureState.errorCode,
+          traceId: failureState.traceId,
         })
       })
 
@@ -8179,6 +8271,7 @@ function useRadarSurfaceResource({
     source,
     loading: sourceMode === 'api' && remoteState.snapshot === null && remoteState.loading,
     errorCode: sourceMode === 'api' ? remoteState.errorCode : null,
+    traceId: sourceMode === 'api' ? remoteState.traceId : null,
   }
 }
 
@@ -8402,13 +8495,14 @@ function buildEntityDetailTeamProfile(
 async function fetchEntityDetailApiSnapshot(
   fallbackTeam: TeamProfile,
   signal: AbortSignal,
-): Promise<{ team: TeamProfile | null; errorCode: string | null }> {
+): Promise<{ team: TeamProfile | null; errorCode: string | null; traceId: string | null }> {
   const cacheKey = fallbackTeam.group
   const cachedSnapshot = entityDetailApiSnapshotCache.get(cacheKey)
   if (cachedSnapshot) {
     return {
       team: cachedSnapshot,
       errorCode: null,
+      traceId: null,
     }
   }
 
@@ -8416,11 +8510,13 @@ async function fetchEntityDetailApiSnapshot(
     `/v1/entities/${encodeURIComponent(fallbackTeam.slug)}`,
     signal,
     ENTITY_DETAIL_FETCH_TIMEOUT_MS,
+    `web-entity-${fallbackTeam.slug}`,
   )
   if (!result.ok || !result.body?.data) {
     return {
       team: null,
       errorCode: result.body?.error?.code ?? `entity_${result.status}`,
+      traceId: result.traceId,
     }
   }
 
@@ -8429,6 +8525,7 @@ async function fetchEntityDetailApiSnapshot(
   return {
     team,
     errorCode: null,
+    traceId: result.traceId,
   }
 }
 
@@ -8448,11 +8545,13 @@ function useEntityDetailResource({
     team: TeamProfile | null
     loading: boolean
     errorCode: string | null
+    traceId: string | null
   }>(() => ({
     cacheKey,
     team: cachedSnapshot,
     loading: false,
     errorCode: null,
+    traceId: null,
   }))
 
   useEffect(() => {
@@ -8467,6 +8566,7 @@ function useEntityDetailResource({
           team: cachedSnapshot,
           loading: false,
           errorCode: null,
+          traceId: null,
         })
       })
       return
@@ -8485,11 +8585,12 @@ function useEntityDetailResource({
         team: null,
         loading: true,
         errorCode: null,
+        traceId: null,
       })
     })
 
     void fetchEntityDetailApiSnapshot(fallbackTeam, controller.signal)
-      .then(({ team, errorCode }) => {
+      .then(({ team, errorCode, traceId }) => {
         if (cancelled) {
           return
         }
@@ -8499,6 +8600,7 @@ function useEntityDetailResource({
           team,
           loading: false,
           errorCode,
+          traceId,
         })
       })
       .catch((error: unknown) => {
@@ -8506,8 +8608,8 @@ function useEntityDetailResource({
           return
         }
 
-        const classifiedError = classifyBackendFetchError(error)
-        if (classifiedError === null) {
+        const failureState = buildFetchFailureState(error)
+        if (failureState.errorCode === null) {
           return
         }
 
@@ -8515,7 +8617,8 @@ function useEntityDetailResource({
           cacheKey,
           team: null,
           loading: false,
-          errorCode: classifiedError,
+          errorCode: failureState.errorCode,
+          traceId: failureState.traceId,
         })
       })
 
@@ -8552,6 +8655,7 @@ function useEntityDetailResource({
     source,
     loading,
     errorCode,
+    traceId: sourceMode === 'api' && remoteState.cacheKey === cacheKey ? remoteState.traceId : null,
   }
 }
 

--- a/web/src/lib/backendFetch.ts
+++ b/web/src/lib/backendFetch.ts
@@ -1,7 +1,24 @@
-export class BackendFetchTimeoutError extends Error {
-  constructor(message = 'Backend request timed out.') {
-    super(message)
+export class BackendFetchTransportError extends Error {
+  requestId: string
+
+  constructor(requestId: string, message: string, options?: ErrorOptions) {
+    super(message, options)
+    this.name = 'BackendFetchTransportError'
+    this.requestId = requestId
+  }
+}
+
+export class BackendFetchTimeoutError extends BackendFetchTransportError {
+  constructor(requestId: string, message = 'Backend request timed out.') {
+    super(requestId, message)
     this.name = 'BackendFetchTimeoutError'
+  }
+}
+
+export class BackendFetchNetworkError extends BackendFetchTransportError {
+  constructor(requestId: string, cause: unknown, message = 'Backend request failed before a response was received.') {
+    super(requestId, message, { cause })
+    this.name = 'BackendFetchNetworkError'
   }
 }
 
@@ -10,15 +27,55 @@ type FetchJsonWithTimeoutOptions = {
   timeoutMs: number
   headers?: HeadersInit
   fetchImpl?: typeof fetch
+  requestIdPrefix?: string
 }
 
 function isAbortError(error: unknown): boolean {
   return error instanceof DOMException && error.name === 'AbortError'
 }
 
+function normalizeRequestIdPrefix(value: string | undefined): string {
+  const normalized = String(value ?? 'web')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+
+  return normalized || 'web'
+}
+
+function createRequestId(prefix: string | undefined): string {
+  const normalizedPrefix = normalizeRequestIdPrefix(prefix)
+
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return `${normalizedPrefix}-${crypto.randomUUID()}`
+  }
+
+  return `${normalizedPrefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`
+}
+
+function readResponseRequestId(body: unknown, response: Response): string | null {
+  if (body && typeof body === 'object' && 'meta' in body) {
+    const meta = (body as { meta?: { request_id?: unknown } }).meta
+    if (meta && typeof meta.request_id === 'string' && meta.request_id.trim().length > 0) {
+      return meta.request_id.trim()
+    }
+  }
+
+  const responseHeaders =
+    'headers' in response && response.headers && typeof response.headers.get === 'function' ? response.headers : null
+  const headerValue = responseHeaders?.get('x-request-id') ?? responseHeaders?.get('X-Request-Id') ?? null
+  return typeof headerValue === 'string' && headerValue.trim().length > 0 ? headerValue.trim() : null
+}
+
 export function classifyBackendFetchError(error: unknown): 'timeout' | 'network_error' | null {
   if (error instanceof BackendFetchTimeoutError) {
     return 'timeout'
+  }
+
+  if (error instanceof BackendFetchNetworkError) {
+    return 'network_error'
   }
 
   if (isAbortError(error)) {
@@ -28,12 +85,19 @@ export function classifyBackendFetchError(error: unknown): 'timeout' | 'network_
   return 'network_error'
 }
 
+export function extractBackendFetchRequestId(error: unknown): string | null {
+  return error instanceof BackendFetchTransportError ? error.requestId : null
+}
+
 export async function fetchJsonWithTimeout<T>(
   url: string,
-  { signal, timeoutMs, headers, fetchImpl = fetch }: FetchJsonWithTimeoutOptions,
-): Promise<{ ok: boolean; status: number; body: T | null }> {
+  { signal, timeoutMs, headers, fetchImpl = fetch, requestIdPrefix }: FetchJsonWithTimeoutOptions,
+): Promise<{ ok: boolean; status: number; body: T | null; requestId: string; responseRequestId: string | null }> {
   const controller = new AbortController()
   let didTimeout = false
+  const requestId = createRequestId(requestIdPrefix)
+  const requestHeaders = new Headers(headers)
+  requestHeaders.set('x-request-id', requestId)
 
   const onAbort = () => {
     controller.abort()
@@ -52,7 +116,7 @@ export async function fetchJsonWithTimeout<T>(
 
   try {
     const response = await fetchImpl(url, {
-      headers,
+      headers: requestHeaders,
       signal: controller.signal,
     })
 
@@ -67,10 +131,16 @@ export async function fetchJsonWithTimeout<T>(
       ok: response.ok,
       status: response.status,
       body,
+      requestId,
+      responseRequestId: readResponseRequestId(body, response),
     }
   } catch (error) {
     if (didTimeout && isAbortError(error)) {
-      throw new BackendFetchTimeoutError()
+      throw new BackendFetchTimeoutError(requestId)
+    }
+
+    if (!isAbortError(error)) {
+      throw new BackendFetchNetworkError(requestId, error)
     }
 
     throw error

--- a/web/src/lib/surfaceStatus.ts
+++ b/web/src/lib/surfaceStatus.ts
@@ -11,6 +11,7 @@ export type SurfaceFallbackReasonKey =
 type SurfaceStatusLabels = {
   sourceLabel: string
   reasonLabel: string
+  traceLabel: string
   sourceStateLabels: Record<SurfaceStatusSource, string>
   fallbackReasonLabels: Record<SurfaceFallbackReasonKey, string>
 }
@@ -54,10 +55,12 @@ export function getSurfaceFallbackReasonKey(errorCode: string | null): SurfaceFa
 export function buildSurfaceStatusMeta({
   source,
   errorCode,
+  traceId,
   labels,
 }: {
   source: SurfaceStatusSource
   errorCode: string | null
+  traceId?: string | null
   labels: SurfaceStatusLabels
 }) {
   const parts = [`${labels.sourceLabel}: ${labels.sourceStateLabels[source]}`]
@@ -65,6 +68,10 @@ export function buildSurfaceStatusMeta({
 
   if (reason) {
     parts.push(`${labels.reasonLabel}: ${labels.fallbackReasonLabels[reason]}`)
+  }
+
+  if (traceId) {
+    parts.push(`${labels.traceLabel}: ${traceId}`)
   }
 
   return parts.join(' · ')


### PR DESCRIPTION
## Summary
- accept and echo caller-provided `X-Request-Id` in backend responses and logs
- propagate request IDs through web backend fetch helpers and surface status fallback metadata
- persist sent/received request IDs in runtime measurement and shadow-read diagnostic reports

## Verification
- `cd backend && npm run test`
- `cd web && npm run build`
- `cd web && npm run lint`
- `cd web && npm run verify:timeout`
- `cd backend && source ~/.config/idol-song-app/neon.env && npm run shadow:verify`
- `cd backend && node ./scripts/measure-read-api-runtime.mjs --base-url http://127.0.0.1:3217 --iterations 1 --report-path ./reports/read_api_runtime_measurements.json`
- `git diff --check`

Closes #314