### PR TITLE
Add backend public read rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ npm run build
 - 두 경로 모두 backend `npm ci`, `npm run build`, `npm run test`를 선행한 뒤 Railway CLI deploy를 실행
 - GitHub Environment `preview`, `production`에 `RAILWAY_TOKEN`, `RAILWAY_PROJECT_ID`, `RAILWAY_ENVIRONMENT_ID`, `RAILWAY_SERVICE_ID`, `BACKEND_PUBLIC_URL`를 설정해야 함
 
-backend deploy topology와 rehearsal 규칙은 `docs/specs/backend/preview-staging-backend-path.md`, 운영 entrypoint는 `backend/README.md`에 정리돼 있습니다.
+backend deploy topology와 rehearsal 규칙은 `docs/specs/backend/preview-staging-backend-path.md`, public read rate-limit 정책은 `docs/specs/backend/public-read-rate-limit-policy.md`, 운영 entrypoint는 `backend/README.md`에 정리돼 있습니다.
 
 ## 현재 방향
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -51,11 +51,42 @@ PORT=3000 APP_TIMEZONE=Asia/Seoul npm run start
 
 - `/v1/*` read endpoint는 공통 success envelope `meta + data`를 사용한다.
 - success `meta`에는 최소 `request_id`, `generated_at`, `timezone`, `route`, `source`가 포함된다.
-- error는 공통 `meta + error` shape로 내려가고 code는 `invalid_request`, `not_found`, `disallowed_origin`, `stale_projection`, `internal_error`를 기본으로 쓴다.
+- error는 공통 `meta + error` shape로 내려가고 code는 `invalid_request`, `not_found`, `disallowed_origin`, `rate_limited`, `stale_projection`, `internal_error`를 기본으로 쓴다.
 - helper entrypoint는 `backend/src/lib/api.ts`다.
 - caller가 `X-Request-Id`를 보내면 backend는 같은 값을 `meta.request_id`와 `X-Request-Id` response header에 그대로 되돌린다.
 - caller가 보내지 않으면 backend가 `api-<uuid>` request id를 생성한다.
 - runtime 측정 / shadow report도 각 request의 sent/received request id를 artifact에 함께 남긴다.
+
+## Public Read Rate Limits
+
+정책 문서는 아래를 기준으로 본다.
+
+- `docs/specs/backend/public-read-rate-limit-policy.md`
+
+현재 runtime은 public read endpoint에 in-memory fixed-window limiter를 붙인다.
+
+- `search`
+- `calendarMonth`
+- `entityDetail`
+- `releaseDetail`
+- `radar`
+
+기본 window는 `60초`다.
+
+- development
+  - `search 600`, `calendarMonth 300`, `entityDetail 300`, `releaseDetail 300`, `radar 120`
+- preview
+  - `search 240`, `calendarMonth 180`, `entityDetail 240`, `releaseDetail 240`, `radar 90`
+- production
+  - `search 180`, `calendarMonth 120`, `entityDetail 180`, `releaseDetail 180`, `radar 60`
+
+over-limit response는 `429 rate_limited`이며 아래 header를 같이 반환한다.
+
+- `RateLimit-Limit`
+- `RateLimit-Remaining`
+- `RateLimit-Reset`
+- `Retry-After`
+- `X-RateLimit-Bucket`
 
 ## Normalization Helpers
 

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -5,6 +5,13 @@ import Fastify, { type FastifyInstance, type FastifyReply } from 'fastify';
 import { loadConfig, type AppConfig } from './config.js';
 import { ReadApiError, buildReadErrorEnvelope } from './lib/api.js';
 import { closeDbPool, createDbPool, type DbPool, withFailFastReadTimeouts } from './lib/db.js';
+import {
+  InMemoryFixedWindowRateLimiter,
+  applyRateLimitHeaders,
+  buildRateLimitMeta,
+  resolveRateLimitIdentifier,
+  resolveReadRateLimitBucket,
+} from './lib/rateLimit.js';
 import { registerCalendarRoutes } from './routes/calendar.js';
 import { registerEntityRoutes } from './routes/entities.js';
 import { registerHealthRoute } from './routes/health.js';
@@ -21,7 +28,8 @@ export type BuildAppOptions = {
 
 const ACCESS_CONTROL_ALLOW_METHODS = 'GET,OPTIONS';
 const DEFAULT_ACCESS_CONTROL_ALLOW_HEADERS = 'Content-Type, X-Request-Id';
-const ACCESS_CONTROL_EXPOSE_HEADERS = 'X-Request-Id';
+const ACCESS_CONTROL_EXPOSE_HEADERS =
+  'X-Request-Id, RateLimit-Limit, RateLimit-Remaining, RateLimit-Reset, Retry-After, X-RateLimit-Bucket';
 const REQUEST_ID_HEADER = 'x-request-id';
 
 function createRequestId(): string {
@@ -84,6 +92,7 @@ function applyCorsHeaders(reply: FastifyReply, origin: string, requestedHeaders:
 export function buildApp(options: BuildAppOptions = {}): FastifyInstance {
   const config = options.config ?? loadConfig();
   const db = withFailFastReadTimeouts(options.db ?? createDbPool(config));
+  const rateLimiter = new InMemoryFixedWindowRateLimiter();
   const app = Fastify({
     genReqId: createRequestId,
     logger: true,
@@ -93,27 +102,58 @@ export function buildApp(options: BuildAppOptions = {}): FastifyInstance {
   app.addHook('onRequest', async (request, reply) => {
     const origin = getRequestOrigin(request);
 
-    if (!origin) {
+    if (origin) {
+      appendVaryHeader(reply, 'Origin');
+
+      if (!config.allowedWebOrigins.includes(origin)) {
+        return reply
+          .code(403)
+          .send(
+            buildReadErrorEnvelope(request, config.appTimezone, 'disallowed_origin', 'Origin is not allowed.', {
+              app_env: config.appEnv,
+              origin,
+            }),
+          );
+      }
+
+      applyCorsHeaders(reply, origin, getRequestedAccessControlHeaders(request));
+
+      if (request.method === 'OPTIONS') {
+        return reply.code(204).send();
+      }
+    }
+
+    if (request.method !== 'GET') {
       return;
     }
 
-    appendVaryHeader(reply, 'Origin');
+    const bucketName = resolveReadRateLimitBucket(request.raw.url ?? request.url);
 
-    if (!config.allowedWebOrigins.includes(origin)) {
-      return reply
-        .code(403)
-        .send(
-          buildReadErrorEnvelope(request, config.appTimezone, 'disallowed_origin', 'Origin is not allowed.', {
-            app_env: config.appEnv,
-            origin,
-          }),
-        );
+    if (!bucketName) {
+      return;
     }
 
-    applyCorsHeaders(reply, origin, getRequestedAccessControlHeaders(request));
+    const identifier = resolveRateLimitIdentifier(request);
+    const decision = rateLimiter.consume(bucketName, identifier.identifier, config.readRateLimits[bucketName]);
 
-    if (request.method === 'OPTIONS') {
-      return reply.code(204).send();
+    applyRateLimitHeaders(reply, decision);
+
+    if (!decision.allowed) {
+      request.log.warn(
+        {
+          request_id: request.id,
+          rate_limit_bucket: decision.bucketName,
+          rate_limit_identifier_kind: decision.identifierKind,
+          rate_limit_limit: decision.limit,
+          rate_limit_retry_after_seconds: decision.retryAfterSeconds,
+        },
+        'Public read endpoint rate limit exceeded',
+      );
+      return reply
+        .code(429)
+        .send(
+          buildReadErrorEnvelope(request, config.appTimezone, 'rate_limited', 'Rate limit exceeded.', buildRateLimitMeta(decision)),
+        );
     }
   });
 

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -1,5 +1,13 @@
 export type DatabaseMode = 'pooled' | 'direct';
 export type AppEnv = 'development' | 'preview' | 'production';
+export type RateLimitBucketName = 'search' | 'calendarMonth' | 'entityDetail' | 'releaseDetail' | 'radar';
+
+export type RateLimitPolicy = {
+  max: number;
+  windowMs: number;
+};
+
+export type ReadRateLimitConfig = Record<RateLimitBucketName, RateLimitPolicy>;
 
 export type AppConfig = {
   appEnv: AppEnv;
@@ -10,9 +18,11 @@ export type AppConfig = {
   databaseConnectionTimeoutMs: number;
   databaseReadTimeoutMs: number;
   allowedWebOrigins: string[];
+  readRateLimits: ReadRateLimitConfig;
 };
 
 const PRODUCTION_WEB_ORIGIN = 'https://iamsomething.github.io';
+const ONE_MINUTE_MS = 60_000;
 const DEVELOPMENT_WEB_ORIGINS = [
   'http://localhost:4173',
   'http://127.0.0.1:4173',
@@ -102,6 +112,36 @@ function dedupeOrigins(origins: string[]): string[] {
   return [...new Set(origins)];
 }
 
+function buildDefaultReadRateLimits(appEnv: AppEnv): ReadRateLimitConfig {
+  if (appEnv === 'production') {
+    return {
+      search: { max: 180, windowMs: ONE_MINUTE_MS },
+      calendarMonth: { max: 120, windowMs: ONE_MINUTE_MS },
+      entityDetail: { max: 180, windowMs: ONE_MINUTE_MS },
+      releaseDetail: { max: 180, windowMs: ONE_MINUTE_MS },
+      radar: { max: 60, windowMs: ONE_MINUTE_MS },
+    };
+  }
+
+  if (appEnv === 'preview') {
+    return {
+      search: { max: 240, windowMs: ONE_MINUTE_MS },
+      calendarMonth: { max: 180, windowMs: ONE_MINUTE_MS },
+      entityDetail: { max: 240, windowMs: ONE_MINUTE_MS },
+      releaseDetail: { max: 240, windowMs: ONE_MINUTE_MS },
+      radar: { max: 90, windowMs: ONE_MINUTE_MS },
+    };
+  }
+
+  return {
+    search: { max: 600, windowMs: ONE_MINUTE_MS },
+    calendarMonth: { max: 300, windowMs: ONE_MINUTE_MS },
+    entityDetail: { max: 300, windowMs: ONE_MINUTE_MS },
+    releaseDetail: { max: 300, windowMs: ONE_MINUTE_MS },
+    radar: { max: 120, windowMs: ONE_MINUTE_MS },
+  };
+}
+
 export function loadConfig(env: NodeJS.ProcessEnv = process.env): AppConfig {
   const appEnv = parseAppEnv(env.APP_ENV);
   const pooledUrl = env.DATABASE_URL_POOLED?.trim();
@@ -124,5 +164,6 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): AppConfig {
       ...buildDefaultAllowedWebOrigins(appEnv),
       ...parseAllowedWebOrigins(env.WEB_ALLOWED_ORIGINS),
     ]),
+    readRateLimits: buildDefaultReadRateLimits(appEnv),
   };
 }

--- a/backend/src/lib/api.ts
+++ b/backend/src/lib/api.ts
@@ -4,6 +4,7 @@ export type ReadApiErrorCode =
   | 'invalid_request'
   | 'not_found'
   | 'disallowed_origin'
+  | 'rate_limited'
   | 'timeout'
   | 'stale_projection'
   | 'internal_error'

--- a/backend/src/lib/rateLimit.ts
+++ b/backend/src/lib/rateLimit.ts
@@ -1,0 +1,174 @@
+import type { FastifyReply, FastifyRequest } from 'fastify';
+
+import type { RateLimitBucketName, RateLimitPolicy } from '../config.js';
+
+const RATE_LIMIT_PRUNE_INTERVAL = 200;
+
+type RateLimitStoreEntry = {
+  count: number;
+  resetAtMs: number;
+};
+
+export type RateLimitDecision = {
+  allowed: boolean;
+  bucketName: RateLimitBucketName;
+  limit: number;
+  remaining: number;
+  resetAt: string;
+  resetInSeconds: number;
+  retryAfterSeconds: number;
+  windowSeconds: number;
+  identifierKind: 'ip';
+};
+
+function parsePathname(rawUrl: string): string {
+  try {
+    return new URL(rawUrl, 'http://backend.local').pathname;
+  } catch {
+    return rawUrl.split('?')[0] || rawUrl;
+  }
+}
+
+function getHeaderValue(raw: string | string[] | undefined): string | null {
+  if (Array.isArray(raw)) {
+    const first = raw.find((value) => value.trim().length > 0);
+    return first ? first.trim() : null;
+  }
+
+  if (typeof raw === 'string' && raw.trim().length > 0) {
+    return raw.trim();
+  }
+
+  return null;
+}
+
+function getForwardedIp(raw: string | null): string | null {
+  if (!raw) {
+    return null;
+  }
+
+  const first = raw
+    .split(',')
+    .map((token) => token.trim())
+    .find((token) => token.length > 0);
+
+  return first || null;
+}
+
+function normalizeIdentifier(value: string | null | undefined): string {
+  if (!value) {
+    return 'unknown';
+  }
+
+  return value.trim().toLowerCase() || 'unknown';
+}
+
+export function resolveReadRateLimitBucket(rawUrl: string): RateLimitBucketName | null {
+  const pathname = parsePathname(rawUrl);
+
+  if (pathname === '/v1/search') {
+    return 'search';
+  }
+
+  if (pathname === '/v1/calendar/month') {
+    return 'calendarMonth';
+  }
+
+  if (pathname === '/v1/radar') {
+    return 'radar';
+  }
+
+  if (pathname === '/v1/releases/lookup' || pathname.startsWith('/v1/releases/')) {
+    return 'releaseDetail';
+  }
+
+  if (pathname.startsWith('/v1/entities/')) {
+    return 'entityDetail';
+  }
+
+  return null;
+}
+
+export function resolveRateLimitIdentifier(request: FastifyRequest): { identifier: string; identifierKind: 'ip' } {
+  const cfConnectingIp = getHeaderValue(request.headers['cf-connecting-ip']);
+  const forwardedFor = getForwardedIp(getHeaderValue(request.headers['x-forwarded-for']));
+  const realIp = getHeaderValue(request.headers['x-real-ip']);
+  const identifier = normalizeIdentifier(cfConnectingIp || forwardedFor || realIp || request.ip);
+
+  return {
+    identifier,
+    identifierKind: 'ip',
+  };
+}
+
+export function applyRateLimitHeaders(reply: FastifyReply, decision: RateLimitDecision): void {
+  reply.header('RateLimit-Limit', String(decision.limit));
+  reply.header('RateLimit-Remaining', String(decision.remaining));
+  reply.header('RateLimit-Reset', String(decision.resetInSeconds));
+  reply.header('X-RateLimit-Bucket', decision.bucketName);
+
+  if (!decision.allowed) {
+    reply.header('Retry-After', String(decision.retryAfterSeconds));
+  }
+}
+
+export function buildRateLimitMeta(decision: RateLimitDecision): Record<string, unknown> {
+  return {
+    rate_limit_bucket: decision.bucketName,
+    rate_limit_limit: decision.limit,
+    rate_limit_remaining: decision.remaining,
+    rate_limit_reset_at: decision.resetAt,
+    rate_limit_retry_after_seconds: decision.retryAfterSeconds,
+    rate_limit_window_seconds: decision.windowSeconds,
+    rate_limit_identifier_kind: decision.identifierKind,
+  };
+}
+
+export class InMemoryFixedWindowRateLimiter {
+  private readonly entries = new Map<string, RateLimitStoreEntry>();
+  private operationCount = 0;
+
+  consume(bucketName: RateLimitBucketName, identifier: string, policy: RateLimitPolicy, now = Date.now()): RateLimitDecision {
+    this.prune(now);
+
+    const key = `${bucketName}:${identifier}`;
+    const existing = this.entries.get(key);
+    const resetAtMs = !existing || now >= existing.resetAtMs ? now + policy.windowMs : existing.resetAtMs;
+    const count = !existing || now >= existing.resetAtMs ? 1 : existing.count + 1;
+
+    this.entries.set(key, {
+      count,
+      resetAtMs,
+    });
+
+    const allowed = count <= policy.max;
+    const remaining = Math.max(0, policy.max - count);
+    const resetInSeconds = Math.max(1, Math.ceil((resetAtMs - now) / 1000));
+
+    return {
+      allowed,
+      bucketName,
+      limit: policy.max,
+      remaining,
+      resetAt: new Date(resetAtMs).toISOString(),
+      resetInSeconds,
+      retryAfterSeconds: resetInSeconds,
+      windowSeconds: Math.ceil(policy.windowMs / 1000),
+      identifierKind: 'ip',
+    };
+  }
+
+  private prune(now: number): void {
+    this.operationCount += 1;
+
+    if (this.operationCount % RATE_LIMIT_PRUNE_INTERVAL !== 0) {
+      return;
+    }
+
+    for (const [key, value] of this.entries.entries()) {
+      if (value.resetAtMs <= now) {
+        this.entries.delete(key);
+      }
+    }
+  }
+}

--- a/backend/src/route-contract.test.ts
+++ b/backend/src/route-contract.test.ts
@@ -25,6 +25,13 @@ const TEST_CONFIG: AppConfig = {
   databaseConnectionTimeoutMs: 3_000,
   databaseReadTimeoutMs: 5_000,
   allowedWebOrigins: ['https://iamsomething.github.io'],
+  readRateLimits: {
+    search: { max: 600, windowMs: 60_000 },
+    calendarMonth: { max: 300, windowMs: 60_000 },
+    entityDetail: { max: 300, windowMs: 60_000 },
+    releaseDetail: { max: 300, windowMs: 60_000 },
+    radar: { max: 120, windowMs: 60_000 },
+  },
 };
 
 type QueryResult<Row> = {
@@ -812,6 +819,91 @@ test('GET /v1/search includes owner entity for exact release-title queries witho
   assert.equal(body.data.entities[0].matched_alias, null);
   assert.equal(body.data.releases[0].release_id, IVE_RELEASE_ID);
   assert.equal(body.data.releases[0].match_reason, 'release_title_exact');
+});
+
+test('public read endpoints return deterministic 429 envelopes when rate limited', async (t) => {
+  const app = buildApp({
+    config: {
+      ...TEST_CONFIG,
+      readRateLimits: {
+        ...TEST_CONFIG.readRateLimits,
+        search: {
+          max: 2,
+          windowMs: 60_000,
+        },
+      },
+    },
+    db: new FakeDb() as unknown as DbPool,
+  });
+
+  t.after(async () => {
+    await app.close();
+  });
+
+  const first = await app.inject({
+    method: 'GET',
+    url: '/v1/search',
+    query: {
+      q: '최예나',
+    },
+    headers: {
+      'x-forwarded-for': '203.0.113.42',
+    },
+  });
+  const second = await app.inject({
+    method: 'GET',
+    url: '/v1/search',
+    query: {
+      q: '최예나',
+    },
+    headers: {
+      'x-forwarded-for': '203.0.113.42',
+    },
+  });
+  const third = await app.inject({
+    method: 'GET',
+    url: '/v1/search',
+    query: {
+      q: '최예나',
+    },
+    headers: {
+      'x-forwarded-for': '203.0.113.42',
+    },
+  });
+  const otherClient = await app.inject({
+    method: 'GET',
+    url: '/v1/search',
+    query: {
+      q: '최예나',
+    },
+    headers: {
+      'x-forwarded-for': '203.0.113.99',
+    },
+  });
+
+  assert.equal(first.statusCode, 200);
+  assert.equal(first.headers['ratelimit-limit'], '2');
+  assert.equal(first.headers['ratelimit-remaining'], '1');
+  assert.equal(first.headers['x-ratelimit-bucket'], 'search');
+
+  assert.equal(second.statusCode, 200);
+  assert.equal(second.headers['ratelimit-remaining'], '0');
+
+  assert.equal(third.statusCode, 429);
+  assert.equal(third.headers['ratelimit-limit'], '2');
+  assert.equal(third.headers['ratelimit-remaining'], '0');
+  assert.equal(third.headers['x-ratelimit-bucket'], 'search');
+  assert.ok(Number(third.headers['retry-after']) >= 1);
+
+  const thirdBody = parseJson(third);
+  assert.equal(thirdBody.error.code, 'rate_limited');
+  assert.equal(thirdBody.meta.rate_limit_bucket, 'search');
+  assert.equal(thirdBody.meta.rate_limit_limit, 2);
+  assert.equal(thirdBody.meta.rate_limit_identifier_kind, 'ip');
+  assert.ok(typeof thirdBody.meta.rate_limit_reset_at === 'string');
+
+  assert.equal(otherClient.statusCode, 200);
+  assert.equal(otherClient.headers['ratelimit-remaining'], '1');
 });
 
 test('GET /v1/entities/:slug returns entity detail projection payload', async (t) => {

--- a/docs/specs/backend/README.md
+++ b/docs/specs/backend/README.md
@@ -42,6 +42,9 @@
 12. `mobile-adoption-readiness-review.md`
    - backend contract가 mobile screen 구현을 바로 받을 수 있는지 surface별 readiness 검토
    - blocker / non-blocker / follow-up issue 기준의 gate decision
+13. `public-read-rate-limit-policy.md`
+   - public read endpoint의 bucket별 rate-limit 기준
+   - preview / production 기대치와 `429 rate_limited` contract
 
 ## 읽는 순서
 
@@ -57,6 +60,7 @@
 10. `mobile-adoption-readiness-review.md`
 11. `phased-rollout-plan.md`
 12. `backend-migration-epic.md`
+13. `public-read-rate-limit-policy.md`
 
 ## 원칙
 

--- a/docs/specs/backend/preview-staging-backend-path.md
+++ b/docs/specs/backend/preview-staging-backend-path.md
@@ -98,6 +98,7 @@ preview에서 달라져도 되는 것:
 - 실험용 entity / release seed 일부
 - worker cadence
 - log verbosity
+- rate-limit threshold
 - alert threshold
 - deploy frequency
 
@@ -111,6 +112,7 @@ preview에서 달라지면 안 되는 것:
 - date precision semantics
 - title-track / MV / service-link meaning
 - request-id propagation policy (`X-Request-Id` echo)
+- `429 rate_limited` envelope / header contract
 - fallback / error contract
 
 즉 preview는 데이터 품질이나 시점은 production보다 느슨할 수 있지만, payload shape와 제품 의미론은 production과 동일해야 한다.

--- a/docs/specs/backend/public-read-rate-limit-policy.md
+++ b/docs/specs/backend/public-read-rate-limit-policy.md
@@ -1,0 +1,171 @@
+# Public Read Rate-Limit Policy
+
+## 1. 목적
+
+이 문서는 public read API가 익명 무제한 트래픽을 전제로 동작하지 않도록
+endpoint별 rate-limit 정책과 over-limit 응답 계약을 고정한다.
+
+목표는 두 가지다.
+
+- 정상적인 web/mobile 사용은 막지 않는다.
+- 실수성 burst나 hostile high-volume traffic에는 deterministic하게 감속한다.
+
+## 2. 적용 범위
+
+현재 policy는 아래 public read surface에 적용한다.
+
+| bucket | routes |
+| --- | --- |
+| `search` | `GET /v1/search` |
+| `calendarMonth` | `GET /v1/calendar/month` |
+| `entityDetail` | `GET /v1/entities/:slug`, `GET /v1/entities/:slug/channels` |
+| `releaseDetail` | `GET /v1/releases/:id`, `GET /v1/releases/lookup` |
+| `radar` | `GET /v1/radar` |
+
+비적용 범위:
+
+- `GET /health`
+- `GET /ready`
+- `GET /v1/review/*`
+
+review endpoint는 operator surface라 별도 인증/운영 정책 이슈에서 다룬다.
+
+## 3. Current Runtime Model
+
+현재 구현은 single-process Fastify runtime 기준의 in-memory fixed-window limiter다.
+
+의미:
+
+- 한 instance 안에서는 deterministic하다.
+- same-client burst에 즉시 반응한다.
+- multi-instance global quota는 아니다.
+
+즉 이 계층은 edge firewall 대체재가 아니라 application-level abuse brake다.
+
+## 4. Client Identity Rule
+
+limiter key는 client IP 기반이다.
+
+우선순위:
+
+1. `CF-Connecting-IP`
+2. `X-Forwarded-For` 첫 번째 값
+3. `X-Real-IP`
+4. Fastify `request.ip`
+
+원칙:
+
+- raw IP 값 자체를 응답 payload에 다시 싣지 않는다.
+- 응답에는 `rate_limit_identifier_kind = ip`만 남긴다.
+
+## 5. Default Policy
+
+window는 모든 bucket에서 `60초` fixed window를 사용한다.
+
+### 5.1 Development
+
+| bucket | limit / 60s |
+| --- | --- |
+| `search` | `600` |
+| `calendarMonth` | `300` |
+| `entityDetail` | `300` |
+| `releaseDetail` | `300` |
+| `radar` | `120` |
+
+개발 환경은 local QA와 반복 테스트를 막지 않도록 가장 느슨하다.
+
+### 5.2 Preview
+
+| bucket | limit / 60s |
+| --- | --- |
+| `search` | `240` |
+| `calendarMonth` | `180` |
+| `entityDetail` | `240` |
+| `releaseDetail` | `240` |
+| `radar` | `90` |
+
+preview는 production보다 여유 있지만, over-limit contract 자체는 production과 동일해야 한다.
+
+### 5.3 Production
+
+| bucket | limit / 60s |
+| --- | --- |
+| `search` | `180` |
+| `calendarMonth` | `120` |
+| `entityDetail` | `180` |
+| `releaseDetail` | `180` |
+| `radar` | `60` |
+
+의도:
+
+- search의 live typing / retry는 흡수한다.
+- detail/calendar/radar의 반복 refresh는 허용하되 scraper-style burst는 감속한다.
+
+## 6. Deterministic Over-limit Contract
+
+limit를 초과하면 backend는 internal error가 아니라 explicit `429 rate_limited`를 반환한다.
+
+```json
+{
+  "meta": {
+    "request_id": "uuid-or-trace-id",
+    "timezone": "Asia/Seoul",
+    "rate_limit_bucket": "search",
+    "rate_limit_limit": 180,
+    "rate_limit_remaining": 0,
+    "rate_limit_reset_at": "2026-03-08T12:01:00.000Z",
+    "rate_limit_retry_after_seconds": 17,
+    "rate_limit_window_seconds": 60,
+    "rate_limit_identifier_kind": "ip"
+  },
+  "error": {
+    "code": "rate_limited",
+    "message": "Rate limit exceeded."
+  }
+}
+```
+
+header contract:
+
+- `RateLimit-Limit`
+- `RateLimit-Remaining`
+- `RateLimit-Reset`
+- `Retry-After` (`429`일 때만)
+- `X-RateLimit-Bucket`
+
+## 7. Noise / Logging Rule
+
+rate-limit hit는 warn level 한 줄만 남긴다.
+
+남기는 필드:
+
+- `request_id`
+- `rate_limit_bucket`
+- `rate_limit_identifier_kind`
+- `rate_limit_limit`
+- `rate_limit_retry_after_seconds`
+
+남기지 않는 것:
+
+- raw IP
+- full request header dump
+- query/body 전체 payload
+
+## 8. QA Rule
+
+rate-limit verification은 아래 두 축으로 본다.
+
+1. targeted burst test
+   - 같은 client identifier로 limit 초과 시 `429 rate_limited`
+2. manual smoke
+   - 다른 client identifier는 같은 window에서도 정상 `200`
+   - response header와 envelope meta가 QA-visible
+
+## 9. Follow-up Considerations
+
+later production traffic가 multi-instance 또는 CDN edge 기준으로 커지면 아래를 재검토한다.
+
+- shared store 기반 limiter
+- authenticated client tier 분리
+- operator endpoint 전용 policy
+- edge/CDN-level coarse rate limiting

--- a/docs/specs/backend/shared-read-api-contracts.md
+++ b/docs/specs/backend/shared-read-api-contracts.md
@@ -776,8 +776,26 @@ v1 read endpoint는 아래 error shape를 따른다.
 
 - `invalid_request`
 - `not_found`
+- `rate_limited`
 - `stale_projection`
 - `internal_error`
+
+`rate_limited`일 때는 아래 meta/header를 같이 쓴다.
+
+- meta
+  - `rate_limit_bucket`
+  - `rate_limit_limit`
+  - `rate_limit_remaining`
+  - `rate_limit_reset_at`
+  - `rate_limit_retry_after_seconds`
+  - `rate_limit_window_seconds`
+  - `rate_limit_identifier_kind`
+- headers
+  - `RateLimit-Limit`
+  - `RateLimit-Remaining`
+  - `RateLimit-Reset`
+  - `Retry-After`
+  - `X-RateLimit-Bucket`
 
 ## 14. Acceptance Checklist
 


### PR DESCRIPTION
## Summary\n- add in-memory fixed-window rate limiting for public read endpoints with deterministic 429 envelopes\n- document environment-specific rate-limit policy and response headers\n- add route-contract coverage for over-limit behavior\n\nCloses #316