### PR TITLE
feat: wire mobile calendar tab to active dataset

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -2,7 +2,7 @@
 
 이 디렉터리는 `Expo + React Native + Expo Router` 기반 모바일 앱 워크스페이스다.
 
-현재 단계는 workspace bootstrap과 router shell까지만 포함한다.
+현재 단계는 workspace bootstrap과 router shell, 그리고 calendar tab의 data-backed container까지 포함한다.
 
 - route/layout expectations는 `docs/specs/mobile/expo-implementation-guide.md`를 따른다.
 - route/param 계약은 `docs/specs/mobile/route-param-contracts.md`를 따른다.
@@ -12,6 +12,7 @@
 
 - `app/`
   - Expo Router root layout / tab shell / detail placeholder route
+  - `calendar` tab은 active dataset + shared selector 기반 container까지 연결됨
   - hidden `debug/metadata` route for internal metadata inspection
 - `assets/`
   - placeholder / service icon / badge fallback asset inventory
@@ -33,6 +34,8 @@
   - gate registry / helper / off fallback definition
 - `src/services/datasetSource.ts`
   - bundled static data vs preview remote data selection layer
+- `src/services/activeDataset.ts`
+  - active dataset source resolution + dataset load entrypoint
 - `src/services/datasetFailurePolicy.ts`
   - runtime misconfiguration / remote dataset unavailable fallback policy
 - `src/services/storage.ts`
@@ -177,6 +180,9 @@ profile 차이는 아래 범위로만 제한한다.
   - `selectRecentReleaseSummariesBySlug`
   - `selectUpcomingEventsBySlug`
   - `selectReleaseDetailById`
+  - `selectMonthReleaseSummaries`
+  - `selectMonthUpcomingEvents`
+  - `selectCalendarMonthSnapshot`
 - 규칙
   - 화면은 raw JSON shape를 직접 읽지 않는다.
   - selector는 fallback을 포함한 최종 display model만 반환한다.

--- a/mobile/app/(tabs)/calendar.tsx
+++ b/mobile/app/(tabs)/calendar.tsx
@@ -1,41 +1,377 @@
-import { StyleSheet, Text, View } from 'react-native';
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+
+import { useAppTheme } from '../../src/tokens/theme';
+import { loadActiveMobileDataset, type ActiveMobileDataset } from '../../src/services/activeDataset';
+import { selectCalendarMonthSnapshot } from '../../src/selectors';
+import type { CalendarMonthSnapshotModel, ReleaseSummaryModel, UpcomingEventModel } from '../../src/types';
+
+type CalendarScreenState =
+  | {
+      kind: 'loading';
+    }
+  | {
+      kind: 'error';
+      message: string;
+    }
+  | {
+      kind: 'ready' | 'empty';
+      source: ActiveMobileDataset;
+      snapshot: CalendarMonthSnapshotModel;
+    };
+
+function buildMonthKey(date: Date): string {
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, '0');
+  return `${year}-${month}`;
+}
+
+function formatMonthLabel(month: string): string {
+  const [year, monthValue] = month.split('-');
+  return `${year}년 ${Number(monthValue)}월`;
+}
+
+function formatUpcomingLabel(event: UpcomingEventModel): string {
+  if (event.datePrecision === 'exact' && event.scheduledDate) {
+    return event.scheduledDate;
+  }
+
+  if (event.scheduledMonth) {
+    return `${event.scheduledMonth} · 날짜 미정`;
+  }
+
+  return '날짜 미정';
+}
+
+function formatReleaseRowMeta(release: ReleaseSummaryModel): string {
+  const kind = release.releaseKind ?? 'release';
+  return `${release.releaseDate} · ${kind}`;
+}
 
 export default function CalendarTabScreen() {
+  const theme = useAppTheme();
+  const [reloadCount, setReloadCount] = useState(0);
+  const [state, setState] = useState<CalendarScreenState>({ kind: 'loading' });
+  const today = useMemo(() => new Date(), []);
+  const activeMonth = useMemo(() => buildMonthKey(today), [today]);
+  const todayIsoDate = useMemo(() => today.toISOString().slice(0, 10), [today]);
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setState({ kind: 'loading' });
+
+    void loadActiveMobileDataset()
+      .then((source) => {
+        if (cancelled) {
+          return;
+        }
+
+        const snapshot = selectCalendarMonthSnapshot(source.dataset, activeMonth, todayIsoDate);
+        const nextKind =
+          snapshot.releaseCount === 0 && snapshot.upcomingCount === 0 ? 'empty' : 'ready';
+
+        setState({
+          kind: nextKind,
+          source,
+          snapshot,
+        });
+      })
+      .catch((error: unknown) => {
+        if (cancelled) {
+          return;
+        }
+
+        setState({
+          kind: 'error',
+          message:
+            error instanceof Error
+              ? error.message
+              : 'Calendar dataset could not be loaded right now.',
+        });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activeMonth, reloadCount, todayIsoDate]);
+
+  if (state.kind === 'loading') {
+    return (
+      <View style={styles.stateContainer}>
+        <ActivityIndicator color={theme.colors.text.brand} />
+        <Text style={styles.eyebrow}>DATASET LOADING</Text>
+        <Text style={styles.title}>Calendar</Text>
+        <Text style={styles.body}>현재 월 데이터와 예정 신호를 불러오는 중입니다.</Text>
+      </View>
+    );
+  }
+
+  if (state.kind === 'error') {
+    return (
+      <View style={styles.stateContainer}>
+        <Text style={styles.eyebrow}>LOAD ERROR</Text>
+        <Text style={styles.title}>Calendar</Text>
+        <Text style={styles.body}>{state.message}</Text>
+        <Pressable style={styles.retryButton} onPress={() => setReloadCount((count) => count + 1)}>
+          <Text style={styles.retryButtonLabel}>다시 시도</Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  const { source, snapshot } = state;
+
   return (
-    <View style={styles.container}>
-      <Text style={styles.eyebrow}>TAB SHELL</Text>
-      <Text style={styles.title}>Calendar</Text>
-      <Text style={styles.body}>
-        Date detail and filter flows stay inside this screen as sheet state. Dedicated routes are not
-        added in v1.
-      </Text>
-    </View>
+    <ScrollView style={styles.screen} contentContainerStyle={styles.content}>
+      <View style={styles.header}>
+        <Text style={styles.eyebrow}>DATA-BACKED TAB</Text>
+        <Text style={styles.title}>{formatMonthLabel(snapshot.month)}</Text>
+        <Text style={styles.body}>
+          shared selector와 active dataset source를 통해 현재 월 요약을 먼저 여는 단계입니다.
+        </Text>
+      </View>
+
+      <View style={styles.sourceCard}>
+        <Text style={styles.sourceLabel}>Active source</Text>
+        <Text style={styles.sourceValue}>{source.sourceLabel}</Text>
+        {source.issues.length ? (
+          <Text style={styles.sourceIssue}>{source.issues.join(' / ')}</Text>
+        ) : null}
+      </View>
+
+      <View style={styles.summaryGrid}>
+        <View style={styles.summaryCard}>
+          <Text style={styles.summaryLabel}>이번 달 발매</Text>
+          <Text style={styles.summaryValue}>{snapshot.releaseCount}</Text>
+        </View>
+        <View style={styles.summaryCard}>
+          <Text style={styles.summaryLabel}>예정 컴백</Text>
+          <Text style={styles.summaryValue}>{snapshot.upcomingCount}</Text>
+        </View>
+        <View style={styles.summaryCard}>
+          <Text style={styles.summaryLabel}>가장 가까운 일정</Text>
+          <Text style={styles.summaryValueSmall}>
+            {snapshot.nearestUpcoming?.displayGroup ?? '없음'}
+          </Text>
+          <Text style={styles.summaryMeta}>
+            {snapshot.nearestUpcoming ? formatUpcomingLabel(snapshot.nearestUpcoming) : 'exact 일정 없음'}
+          </Text>
+        </View>
+      </View>
+
+      {state.kind === 'empty' ? (
+        <View style={styles.sectionCard}>
+          <Text style={styles.sectionTitle}>이번 달 일정 없음</Text>
+          <Text style={styles.body}>
+            현재 dataset source에는 {formatMonthLabel(snapshot.month)} 기준 발매나 예정 컴백이 없습니다.
+          </Text>
+        </View>
+      ) : (
+        <>
+          <View style={styles.sectionCard}>
+            <Text style={styles.sectionTitle}>Verified releases</Text>
+            {snapshot.releases.slice(0, 4).map((release) => (
+              <View key={release.id} style={styles.row}>
+                <Text style={styles.rowTitle}>{release.displayGroup}</Text>
+                <Text style={styles.rowBody}>{release.releaseTitle}</Text>
+                <Text style={styles.rowMeta}>{formatReleaseRowMeta(release)}</Text>
+              </View>
+            ))}
+          </View>
+
+          <View style={styles.sectionCard}>
+            <Text style={styles.sectionTitle}>Exact-date upcoming</Text>
+            {snapshot.exactUpcoming.length ? (
+              snapshot.exactUpcoming.slice(0, 4).map((event) => (
+                <View key={event.id} style={styles.row}>
+                  <Text style={styles.rowTitle}>{event.displayGroup}</Text>
+                  <Text style={styles.rowBody}>{event.releaseLabel ?? event.headline}</Text>
+                  <Text style={styles.rowMeta}>{formatUpcomingLabel(event)}</Text>
+                </View>
+              ))
+            ) : (
+              <Text style={styles.body}>현재 월에 exact-date 예정 신호가 없습니다.</Text>
+            )}
+          </View>
+
+          <View style={styles.sectionCard}>
+            <Text style={styles.sectionTitle}>Month-only signals</Text>
+            {snapshot.monthOnlyUpcoming.length ? (
+              snapshot.monthOnlyUpcoming.slice(0, 4).map((event) => (
+                <View key={event.id} style={styles.row}>
+                  <Text style={styles.rowTitle}>{event.displayGroup}</Text>
+                  <Text style={styles.rowBody}>{event.headline}</Text>
+                  <Text style={styles.rowMeta}>{formatUpcomingLabel(event)}</Text>
+                </View>
+              ))
+            ) : (
+              <Text style={styles.body}>현재 월에 month-only 예정 신호가 없습니다.</Text>
+            )}
+          </View>
+        </>
+      )}
+    </ScrollView>
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: 'center',
-    paddingHorizontal: 24,
-    backgroundColor: '#f7f6f2',
-  },
-  eyebrow: {
-    marginBottom: 8,
-    fontSize: 12,
-    fontWeight: '600',
-    letterSpacing: 1.2,
-    color: '#87634d',
-  },
-  title: {
-    marginBottom: 12,
-    fontSize: 28,
-    fontWeight: '700',
-    color: '#1f1b17',
-  },
-  body: {
-    fontSize: 16,
-    lineHeight: 24,
-    color: '#5e554d',
-  },
-});
+function createStyles(theme: ReturnType<typeof useAppTheme>) {
+  return StyleSheet.create({
+    screen: {
+      flex: 1,
+      backgroundColor: theme.colors.surface.base,
+    },
+    content: {
+      paddingHorizontal: theme.space[24],
+      paddingTop: theme.space[24],
+      paddingBottom: theme.space[32],
+      gap: theme.space[16],
+    },
+    stateContainer: {
+      flex: 1,
+      justifyContent: 'center',
+      paddingHorizontal: theme.space[24],
+      gap: theme.space[12],
+      backgroundColor: theme.colors.surface.base,
+    },
+    header: {
+      gap: theme.space[8],
+    },
+    eyebrow: {
+      color: theme.colors.text.brand,
+      fontSize: theme.typography.meta.fontSize,
+      fontWeight: theme.typography.meta.fontWeight,
+      letterSpacing: theme.typography.meta.letterSpacing,
+    },
+    title: {
+      color: theme.colors.text.primary,
+      fontSize: theme.typography.screenTitle.fontSize,
+      lineHeight: theme.typography.screenTitle.lineHeight,
+      fontWeight: theme.typography.screenTitle.fontWeight,
+      letterSpacing: theme.typography.screenTitle.letterSpacing,
+    },
+    body: {
+      color: theme.colors.text.secondary,
+      fontSize: theme.typography.body.fontSize,
+      lineHeight: theme.typography.body.lineHeight,
+      fontWeight: theme.typography.body.fontWeight,
+    },
+    sourceCard: {
+      gap: theme.space[4],
+      padding: theme.space[16],
+      borderRadius: theme.radius.card,
+      backgroundColor: theme.colors.surface.elevated,
+      borderWidth: 1,
+      borderColor: theme.colors.border.subtle,
+    },
+    sourceLabel: {
+      color: theme.colors.text.tertiary,
+      fontSize: theme.typography.meta.fontSize,
+      lineHeight: theme.typography.meta.lineHeight,
+      fontWeight: theme.typography.meta.fontWeight,
+    },
+    sourceValue: {
+      color: theme.colors.text.primary,
+      fontSize: theme.typography.cardTitle.fontSize,
+      lineHeight: theme.typography.cardTitle.lineHeight,
+      fontWeight: theme.typography.cardTitle.fontWeight,
+    },
+    sourceIssue: {
+      color: theme.colors.text.secondary,
+      fontSize: theme.typography.meta.fontSize,
+      lineHeight: theme.typography.meta.lineHeight,
+      fontWeight: theme.typography.meta.fontWeight,
+    },
+    summaryGrid: {
+      gap: theme.space[12],
+    },
+    summaryCard: {
+      gap: theme.space[4],
+      padding: theme.space[16],
+      borderRadius: theme.radius.card,
+      backgroundColor: theme.colors.surface.interactive,
+    },
+    summaryLabel: {
+      color: theme.colors.text.tertiary,
+      fontSize: theme.typography.meta.fontSize,
+      lineHeight: theme.typography.meta.lineHeight,
+      fontWeight: theme.typography.meta.fontWeight,
+    },
+    summaryValue: {
+      color: theme.colors.text.primary,
+      fontSize: 30,
+      lineHeight: 36,
+      fontWeight: '700',
+    },
+    summaryValueSmall: {
+      color: theme.colors.text.primary,
+      fontSize: theme.typography.sectionTitle.fontSize,
+      lineHeight: theme.typography.sectionTitle.lineHeight,
+      fontWeight: theme.typography.sectionTitle.fontWeight,
+    },
+    summaryMeta: {
+      color: theme.colors.text.secondary,
+      fontSize: theme.typography.meta.fontSize,
+      lineHeight: theme.typography.meta.lineHeight,
+      fontWeight: theme.typography.meta.fontWeight,
+    },
+    sectionCard: {
+      gap: theme.space[12],
+      padding: theme.space[16],
+      borderRadius: theme.radius.card,
+      backgroundColor: theme.colors.surface.elevated,
+      borderWidth: 1,
+      borderColor: theme.colors.border.subtle,
+    },
+    sectionTitle: {
+      color: theme.colors.text.primary,
+      fontSize: theme.typography.sectionTitle.fontSize,
+      lineHeight: theme.typography.sectionTitle.lineHeight,
+      fontWeight: theme.typography.sectionTitle.fontWeight,
+    },
+    row: {
+      gap: theme.space[4],
+      paddingTop: theme.space[12],
+      borderTopWidth: 1,
+      borderTopColor: theme.colors.border.subtle,
+    },
+    rowTitle: {
+      color: theme.colors.text.primary,
+      fontSize: theme.typography.cardTitle.fontSize,
+      lineHeight: theme.typography.cardTitle.lineHeight,
+      fontWeight: theme.typography.cardTitle.fontWeight,
+    },
+    rowBody: {
+      color: theme.colors.text.secondary,
+      fontSize: theme.typography.body.fontSize,
+      lineHeight: theme.typography.body.lineHeight,
+      fontWeight: theme.typography.body.fontWeight,
+    },
+    rowMeta: {
+      color: theme.colors.text.tertiary,
+      fontSize: theme.typography.meta.fontSize,
+      lineHeight: theme.typography.meta.lineHeight,
+      fontWeight: theme.typography.meta.fontWeight,
+    },
+    retryButton: {
+      alignSelf: 'flex-start',
+      paddingHorizontal: theme.space[16],
+      paddingVertical: theme.space[12],
+      borderRadius: theme.radius.button,
+      backgroundColor: theme.colors.text.brand,
+    },
+    retryButtonLabel: {
+      color: theme.colors.text.inverse,
+      fontSize: theme.typography.buttonPrimary.fontSize,
+      lineHeight: theme.typography.buttonPrimary.lineHeight,
+      fontWeight: theme.typography.buttonPrimary.fontWeight,
+    },
+  });
+}

--- a/mobile/app/README.md
+++ b/mobile/app/README.md
@@ -11,6 +11,7 @@
 - `(tabs)/_layout.tsx`
   - `calendar`, `radar`, `search` 탭 shell
 - `(tabs)/calendar.tsx`
+  - active dataset source + shared selector 기반 current-month container
 - `(tabs)/radar.tsx`
 - `(tabs)/search.tsx`
   - 탭 placeholder screen

--- a/mobile/src/README.md
+++ b/mobile/src/README.md
@@ -12,8 +12,10 @@
   - `context.ts`: dataset -> indexed selector context
   - `adapters.ts`: raw JSON -> display model 변환 규칙
   - `index.ts`: shared selectors entrypoint
+    - team / release detail selector 외에 calendar month snapshot selector 포함
 - `services/`: data source / external handoff / helper
   - `datasetSource.ts`: bundled-static vs preview-remote source selector
+  - `activeDataset.ts`: runtime selection을 실제 dataset payload로 로드하는 entrypoint
   - `datasetFailurePolicy.ts`: remote unavailable / misconfig degraded-mode fallback policy
   - `storage.ts`: `AsyncStorage` adapter + namespaced key/value helper
   - `datasetCache.ts`: static dataset artifact cache entry helper

--- a/mobile/src/features/route-shell.smoke.test.tsx
+++ b/mobile/src/features/route-shell.smoke.test.tsx
@@ -60,6 +60,17 @@ function renderTree(element: React.ReactElement) {
   return tree!;
 }
 
+async function renderTreeAsync(element: React.ReactElement) {
+  let tree: renderer.ReactTestRenderer;
+
+  await act(async () => {
+    tree = renderer.create(element);
+    await Promise.resolve();
+  });
+
+  return tree!;
+}
+
 describe('mobile route shell smoke', () => {
   test('root index redirects to calendar tab', () => {
     const tree = renderTree(<IndexRoute />).toJSON() as renderer.ReactTestRendererJSON;
@@ -71,8 +82,8 @@ describe('mobile route shell smoke', () => {
     expect(() => renderTree(<TabsLayout />)).not.toThrow();
   });
 
-  test('tab placeholder screens render without crashing', () => {
-    expect(() => renderTree(<CalendarTabScreen />)).not.toThrow();
+  test('tab placeholder screens render without crashing', async () => {
+    await expect(renderTreeAsync(<CalendarTabScreen />)).resolves.toBeDefined();
     expect(() => renderTree(<RadarTabScreen />)).not.toThrow();
     expect(() => renderTree(<SearchTabScreen />)).not.toThrow();
   });

--- a/mobile/src/selectors/index.test.ts
+++ b/mobile/src/selectors/index.test.ts
@@ -1,8 +1,11 @@
 import type { MobileRawDataset } from '../types';
 
 import {
+  selectCalendarMonthSnapshot,
   createSelectorContext,
   selectLatestReleaseSummaryBySlug,
+  selectMonthReleaseSummaries,
+  selectMonthUpcomingEvents,
   selectRecentReleaseSummariesBySlug,
   selectReleaseDetailById,
   selectTeamSummaryBySlug,
@@ -70,7 +73,7 @@ const dataset: MobileRawDataset = {
     },
     {
       group: 'YENA',
-      scheduled_month: '2026-04',
+      scheduled_month: '2026-03',
       date_precision: 'month_only',
       date_status: 'scheduled',
       headline: 'YENA spring follow-up rumored',
@@ -185,6 +188,32 @@ describe('mobile selector/adapters scaffold', () => {
     expect(upcoming[0]?.confidence).toBe('high');
     expect(upcoming[1]?.datePrecision).toBe('month_only');
     expect(upcoming[1]?.confidence).toBe('low');
+  });
+
+  test('builds month release summaries from release history rows', () => {
+    const releases = selectMonthReleaseSummaries(dataset, '2026-03');
+
+    expect(releases).toHaveLength(1);
+    expect(releases[0]?.releaseTitle).toBe('LOVE CATCHER');
+    expect(releases[0]?.coverImageUrl).toBe('https://example.com/love-catcher.jpg');
+  });
+
+  test('builds month upcoming rows with exact before month-only ordering', () => {
+    const upcoming = selectMonthUpcomingEvents(dataset, '2026-03');
+
+    expect(upcoming).toHaveLength(2);
+    expect(upcoming[0]?.datePrecision).toBe('exact');
+    expect(upcoming[1]?.datePrecision).toBe('month_only');
+  });
+
+  test('builds a calendar month snapshot with nearest exact upcoming', () => {
+    const snapshot = selectCalendarMonthSnapshot(dataset, '2026-03', '2026-03-08');
+
+    expect(snapshot.releaseCount).toBe(1);
+    expect(snapshot.upcomingCount).toBe(2);
+    expect(snapshot.nearestUpcoming?.headline).toContain('3월 11일');
+    expect(snapshot.exactUpcoming).toHaveLength(1);
+    expect(snapshot.monthOnlyUpcoming).toHaveLength(1);
   });
 
   test('resolves a release detail model by normalized release id', () => {

--- a/mobile/src/selectors/index.ts
+++ b/mobile/src/selectors/index.ts
@@ -1,4 +1,5 @@
 import type {
+  CalendarMonthSnapshotModel,
   MobileRawDataset,
   ReleaseDetailModel,
   ReleaseSummaryModel,
@@ -97,6 +98,51 @@ export function selectRecentReleaseSummariesBySlug(
     });
 }
 
+function isIsoDateInMonth(value: string | undefined, month: string): boolean {
+  return Boolean(value && value.slice(0, 7) === month);
+}
+
+function resolveUpcomingMonth(
+  upcoming: MobileRawDataset['upcomingCandidates'][number],
+): string | undefined {
+  return upcoming.scheduled_month ?? upcoming.scheduled_date?.slice(0, 7);
+}
+
+export function selectMonthReleaseSummaries(
+  input: MobileSelectorContext | MobileRawDataset,
+  month: string,
+  limit = Number.POSITIVE_INFINITY,
+): ReleaseSummaryModel[] {
+  const context = resolveContext(input);
+  const summaries: ReleaseSummaryModel[] = [];
+
+  for (const [group, history] of context.releaseHistoryByGroup.entries()) {
+    const profile = context.profilesByGroup.get(group);
+    const displayGroup = profile?.display_name?.trim() || group;
+
+    for (const release of history.releases) {
+      if (!isIsoDateInMonth(release.date, month)) {
+        continue;
+      }
+
+      const releaseId = buildReleaseId(group, release.title, release.date, release.stream ?? 'album');
+      summaries.push(
+        adaptReleaseHistoryEntry(
+          group,
+          displayGroup,
+          release,
+          context.artworkByReleaseId.get(releaseId),
+          context.detailByReleaseId.get(releaseId),
+        ),
+      );
+    }
+  }
+
+  return summaries
+    .sort((left, right) => compareIsoDateDescending(left.releaseDate, right.releaseDate))
+    .slice(0, limit);
+}
+
 export function selectUpcomingEventsBySlug(
   input: MobileSelectorContext | MobileRawDataset,
   slug: string,
@@ -111,6 +157,48 @@ export function selectUpcomingEventsBySlug(
   return (context.upcomingByGroup.get(team.group) ?? [])
     .map((upcoming) => adaptUpcomingEvent(team.group, team.displayName, upcoming))
     .sort(compareUpcomingDate);
+}
+
+export function selectMonthUpcomingEvents(
+  input: MobileSelectorContext | MobileRawDataset,
+  month: string,
+): UpcomingEventModel[] {
+  const context = resolveContext(input);
+  const events: UpcomingEventModel[] = [];
+
+  for (const upcoming of context.dataset.upcomingCandidates) {
+    if (resolveUpcomingMonth(upcoming) !== month) {
+      continue;
+    }
+
+    const displayGroup = context.profilesByGroup.get(upcoming.group)?.display_name?.trim() || upcoming.group;
+    events.push(adaptUpcomingEvent(upcoming.group, displayGroup, upcoming));
+  }
+
+  return events.sort(compareUpcomingDate);
+}
+
+export function selectCalendarMonthSnapshot(
+  input: MobileSelectorContext | MobileRawDataset,
+  month: string,
+  todayIsoDate: string,
+): CalendarMonthSnapshotModel {
+  const releases = selectMonthReleaseSummaries(input, month);
+  const upcoming = selectMonthUpcomingEvents(input, month);
+  const exactUpcoming = upcoming.filter((event) => event.datePrecision === 'exact');
+  const monthOnlyUpcoming = upcoming.filter((event) => event.datePrecision === 'month_only');
+  const nearestUpcoming =
+    exactUpcoming.find((event) => event.scheduledDate && event.scheduledDate >= todayIsoDate) ?? null;
+
+  return {
+    month,
+    releaseCount: releases.length,
+    upcomingCount: upcoming.length,
+    nearestUpcoming,
+    releases,
+    exactUpcoming,
+    monthOnlyUpcoming,
+  };
 }
 
 export function selectReleaseDetailById(

--- a/mobile/src/services/activeDataset.test.ts
+++ b/mobile/src/services/activeDataset.test.ts
@@ -1,0 +1,113 @@
+import type { RuntimeConfigState } from '../config/runtime';
+
+import { loadActiveMobileDataset } from './activeDataset';
+
+function buildRuntimeState(overrides: Partial<RuntimeConfigState> = {}): RuntimeConfigState {
+  return {
+    mode: 'normal',
+    config: {
+      profile: 'development',
+      dataSource: {
+        mode: 'bundled-static',
+        remoteDatasetUrl: null,
+        datasetVersion: 'fixture-v1',
+      },
+      services: {
+        apiBaseUrl: null,
+        analyticsWriteKey: null,
+      },
+      logging: {
+        level: 'verbose',
+      },
+      featureGates: {
+        radar: true,
+        analytics: false,
+        remoteRefresh: false,
+        mvEmbed: true,
+        shareActions: true,
+      },
+      build: {
+        version: '0.1.0',
+        commitSha: null,
+      },
+    },
+    issues: [],
+    ...overrides,
+  };
+}
+
+describe('loadActiveMobileDataset', () => {
+  test('returns bundled fixture for bundled-static runtime selection', async () => {
+    const result = await loadActiveMobileDataset({
+      runtimeState: buildRuntimeState(),
+    });
+
+    expect(result.selection.kind).toBe('bundled-static');
+    expect(result.sourceLabel).toBe('Bundled static dataset');
+    expect(result.dataset.artistProfiles.length).toBeGreaterThan(0);
+  });
+
+  test('loads a remote dataset when preview-remote is active', async () => {
+    const result = await loadActiveMobileDataset({
+      runtimeState: buildRuntimeState({
+        config: {
+          ...buildRuntimeState().config,
+          profile: 'preview',
+          dataSource: {
+            mode: 'preview-static',
+            remoteDatasetUrl: 'https://example.com/mobile-dataset.json',
+            datasetVersion: 'preview-v1',
+          },
+          featureGates: {
+            ...buildRuntimeState().config.featureGates,
+            remoteRefresh: true,
+          },
+        },
+      }),
+      fetchImpl: jest.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          artistProfiles: [],
+          releases: [],
+          upcomingCandidates: [],
+          releaseArtwork: [],
+          releaseDetails: [],
+          releaseHistory: [],
+          youtubeChannelAllowlists: [],
+        }),
+      })) as unknown as typeof fetch,
+    });
+
+    expect(result.selection.kind).toBe('preview-remote');
+    expect(result.sourceLabel).toBe('Preview remote dataset');
+    expect(result.dataset.artistProfiles).toEqual([]);
+  });
+
+  test('throws a typed error when the remote dataset payload is invalid', async () => {
+    await expect(
+      loadActiveMobileDataset({
+        runtimeState: buildRuntimeState({
+          config: {
+            ...buildRuntimeState().config,
+            profile: 'preview',
+            dataSource: {
+              mode: 'preview-static',
+              remoteDatasetUrl: 'https://example.com/mobile-dataset.json',
+              datasetVersion: 'preview-v1',
+            },
+            featureGates: {
+              ...buildRuntimeState().config.featureGates,
+              remoteRefresh: true,
+            },
+          },
+        }),
+        fetchImpl: jest.fn(async () => ({
+          ok: true,
+          json: async () => ({ nope: true }),
+        })) as unknown as typeof fetch,
+      }),
+    ).rejects.toMatchObject({
+      code: 'invalid_dataset',
+    });
+  });
+});

--- a/mobile/src/services/activeDataset.ts
+++ b/mobile/src/services/activeDataset.ts
@@ -1,0 +1,96 @@
+import { getRuntimeConfigState, type RuntimeConfigState } from '../config/runtime';
+import type { MobileRawDataset } from '../types';
+
+import {
+  isRemoteDatasetSelection,
+  selectDatasetSource,
+  type DatasetSelection,
+} from './datasetSource';
+import { cloneBundledDatasetFixture } from './bundledDatasetFixture';
+
+export type ActiveMobileDataset = {
+  dataset: MobileRawDataset;
+  selection: DatasetSelection;
+  runtimeState: RuntimeConfigState;
+  sourceLabel: string;
+  issues: string[];
+};
+
+export class ActiveDatasetLoadError extends Error {
+  constructor(
+    public readonly code: 'remote_unavailable' | 'invalid_dataset',
+    message: string,
+  ) {
+    super(message);
+    this.name = 'ActiveDatasetLoadError';
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isMobileRawDataset(value: unknown): value is MobileRawDataset {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  return (
+    Array.isArray(value.artistProfiles) &&
+    Array.isArray(value.releases) &&
+    Array.isArray(value.upcomingCandidates) &&
+    Array.isArray(value.releaseArtwork) &&
+    Array.isArray(value.releaseDetails) &&
+    Array.isArray(value.releaseHistory) &&
+    Array.isArray(value.youtubeChannelAllowlists)
+  );
+}
+
+function getDatasetSourceLabel(selection: DatasetSelection): string {
+  return selection.kind === 'preview-remote' ? 'Preview remote dataset' : 'Bundled static dataset';
+}
+
+export async function loadActiveMobileDataset(options: {
+  runtimeState?: RuntimeConfigState;
+  fetchImpl?: typeof fetch;
+} = {}): Promise<ActiveMobileDataset> {
+  const runtimeState = options.runtimeState ?? getRuntimeConfigState();
+  const selection = selectDatasetSource(runtimeState.config);
+  const issues = runtimeState.issues.map((issue) => issue.message);
+
+  if (!isRemoteDatasetSelection(selection)) {
+    return {
+      dataset: cloneBundledDatasetFixture(),
+      selection,
+      runtimeState,
+      sourceLabel: getDatasetSourceLabel(selection),
+      issues,
+    };
+  }
+
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const response = await fetchImpl(selection.remoteDatasetUrl);
+
+  if (!response.ok) {
+    throw new ActiveDatasetLoadError(
+      'remote_unavailable',
+      `Remote dataset request failed with status ${response.status}.`,
+    );
+  }
+
+  const payload = await response.json();
+  if (!isMobileRawDataset(payload)) {
+    throw new ActiveDatasetLoadError(
+      'invalid_dataset',
+      'Remote dataset payload does not match the expected contract.',
+    );
+  }
+
+  return {
+    dataset: payload,
+    selection,
+    runtimeState,
+    sourceLabel: getDatasetSourceLabel(selection),
+    issues,
+  };
+}

--- a/mobile/src/services/bundledDatasetFixture.ts
+++ b/mobile/src/services/bundledDatasetFixture.ts
@@ -1,0 +1,244 @@
+import type { MobileRawDataset } from '../types';
+
+const bundledDatasetFixture: MobileRawDataset = {
+  artistProfiles: [
+    {
+      slug: 'yena',
+      group: 'YENA',
+      display_name: 'YENA',
+      aliases: ['최예나'],
+      search_aliases: ['예나'],
+      agency: 'YUE HUA Entertainment',
+      official_youtube_url: 'https://www.youtube.com/@YENA_OFFICIAL',
+      official_x_url: 'https://x.com/YENA_OFFICIAL',
+      official_instagram_url: 'https://www.instagram.com/yena.official/',
+      artist_source_url: 'https://musicbrainz.org/artist/example-yena',
+    },
+    {
+      slug: 'p1harmony',
+      group: 'P1Harmony',
+      display_name: 'P1Harmony',
+      aliases: ['피원하모니'],
+      search_aliases: ['피원하'],
+      agency: 'FNC Entertainment',
+      official_youtube_url: 'https://www.youtube.com/@P1Harmony',
+      official_x_url: 'https://x.com/P1H_official',
+      official_instagram_url: 'https://www.instagram.com/p1h_official/',
+      artist_source_url: 'https://musicbrainz.org/artist/example-p1harmony',
+    },
+    {
+      slug: 'bts',
+      group: 'BTS',
+      display_name: 'BTS',
+      aliases: ['방탄소년단'],
+      search_aliases: ['방탄'],
+      agency: 'BIGHIT MUSIC',
+      official_youtube_url: 'https://www.youtube.com/@BTS',
+      official_x_url: 'https://x.com/bts_bighit',
+      official_instagram_url: 'https://www.instagram.com/bts.bighitofficial/',
+      artist_source_url: 'https://musicbrainz.org/artist/example-bts',
+    },
+    {
+      slug: 'le-sserafim',
+      group: 'LE SSERAFIM',
+      display_name: 'LE SSERAFIM',
+      aliases: ['르세라핌'],
+      search_aliases: ['르세라핌'],
+      agency: 'SOURCE MUSIC',
+      official_youtube_url: 'https://www.youtube.com/@LESSERAFIM_OFFICIAL',
+      official_x_url: 'https://x.com/le_sserafim',
+      official_instagram_url: 'https://www.instagram.com/le_sserafim/',
+      artist_source_url: 'https://musicbrainz.org/artist/example-le-sserafim',
+    },
+  ],
+  releases: [
+    {
+      group: 'YENA',
+      latest_song: {
+        title: 'Drama Queen',
+        date: '2026-03-11',
+        source: 'https://musicbrainz.org/release-group/example-drama-queen',
+        release_kind: 'single',
+        context_tags: ['title_track'],
+      },
+      latest_album: {
+        title: 'LOVE CATCHER',
+        date: '2026-03-11',
+        source: 'https://musicbrainz.org/release-group/example-love-catcher',
+        release_kind: 'ep',
+        context_tags: [],
+      },
+    },
+    {
+      group: 'BTS',
+      latest_song: {
+        title: 'Signal Fire',
+        date: '2026-03-21',
+        source: 'https://musicbrainz.org/release-group/example-signal-fire',
+        release_kind: 'single',
+        context_tags: ['title_track'],
+      },
+      latest_album: null,
+    },
+  ],
+  upcomingCandidates: [
+    {
+      group: 'YENA',
+      scheduled_date: '2026-03-11',
+      scheduled_month: '2026-03',
+      date_precision: 'exact',
+      date_status: 'confirmed',
+      headline: 'YENA confirms a March 11 comeback',
+      release_label: 'LOVE CATCHER',
+      source_type: 'news_rss',
+      source_url: 'https://example.com/yena-comeback',
+      confidence: 0.84,
+    },
+    {
+      group: 'P1Harmony',
+      scheduled_date: '2026-03-12',
+      scheduled_month: '2026-03',
+      date_precision: 'exact',
+      date_status: 'scheduled',
+      headline: 'P1Harmony schedules a March 12 return',
+      release_label: 'DUH!',
+      source_type: 'official_social',
+      source_url: 'https://example.com/p1harmony-return',
+      confidence: 0.72,
+    },
+    {
+      group: 'LE SSERAFIM',
+      scheduled_month: '2026-03',
+      date_precision: 'month_only',
+      date_status: 'rumor',
+      headline: 'LE SSERAFIM is rumored to return later this month',
+      release_label: 'Rumored follow-up',
+      source_type: 'news_rss',
+      source_url: 'https://example.com/lesserafim-rumor',
+      confidence: 0.44,
+    },
+  ],
+  releaseArtwork: [
+    {
+      group: 'YENA',
+      release_title: 'LOVE CATCHER',
+      release_date: '2026-03-11',
+      stream: 'album',
+      cover_image_url: 'https://example.com/love-catcher.jpg',
+    },
+    {
+      group: 'BTS',
+      release_title: 'Signal Fire',
+      release_date: '2026-03-21',
+      stream: 'song',
+      cover_image_url: 'https://example.com/signal-fire.jpg',
+    },
+  ],
+  releaseDetails: [
+    {
+      group: 'YENA',
+      release_title: 'LOVE CATCHER',
+      release_date: '2026-03-11',
+      stream: 'album',
+      release_kind: 'ep',
+      spotify_url: 'https://open.spotify.com/album/example-love-catcher',
+      youtube_music_url: 'https://music.youtube.com/playlist?list=example-love-catcher',
+      youtube_video_status: 'manual_override',
+      notes: 'Representative EP detail.',
+      tracks: [
+        {
+          order: 1,
+          title: 'Drama Queen',
+          is_title_track: true,
+        },
+        {
+          order: 2,
+          title: 'Love Catcher',
+          is_title_track: false,
+        },
+      ],
+    },
+    {
+      group: 'BTS',
+      release_title: 'Signal Fire',
+      release_date: '2026-03-21',
+      stream: 'song',
+      release_kind: 'single',
+      spotify_url: 'https://open.spotify.com/track/example-signal-fire',
+      youtube_music_url: 'https://music.youtube.com/watch?v=example-signal-fire',
+      youtube_video_status: 'manual_override',
+      notes: 'Representative single detail.',
+      tracks: [
+        {
+          order: 1,
+          title: 'Signal Fire',
+          is_title_track: true,
+        },
+      ],
+    },
+  ],
+  releaseHistory: [
+    {
+      group: 'YENA',
+      releases: [
+        {
+          title: 'LOVE CATCHER',
+          date: '2026-03-11',
+          source: 'https://musicbrainz.org/release-group/example-love-catcher',
+          release_kind: 'ep',
+          stream: 'album',
+          context_tags: [],
+        },
+        {
+          title: 'NEMONEMO',
+          date: '2025-09-01',
+          source: 'https://musicbrainz.org/release-group/example-nemonemo',
+          release_kind: 'single',
+          stream: 'song',
+          context_tags: [],
+        },
+      ],
+    },
+    {
+      group: 'BTS',
+      releases: [
+        {
+          title: 'Signal Fire',
+          date: '2026-03-21',
+          source: 'https://musicbrainz.org/release-group/example-signal-fire',
+          release_kind: 'single',
+          stream: 'song',
+          context_tags: ['title_track'],
+        },
+      ],
+    },
+  ],
+  youtubeChannelAllowlists: [
+    {
+      group: 'YENA',
+      primary_team_channel_url: 'https://www.youtube.com/@YENA_OFFICIAL',
+      channels: [
+        {
+          channel_url: 'https://www.youtube.com/@YENA_OFFICIAL',
+          display_in_team_links: true,
+        },
+      ],
+    },
+    {
+      group: 'BTS',
+      primary_team_channel_url: 'https://www.youtube.com/@BTS',
+      channels: [
+        {
+          channel_url: 'https://www.youtube.com/@BTS',
+          display_in_team_links: true,
+        },
+      ],
+    },
+  ],
+};
+
+export const BUNDLED_DATASET_FIXTURE = bundledDatasetFixture;
+
+export function cloneBundledDatasetFixture(): MobileRawDataset {
+  return JSON.parse(JSON.stringify(bundledDatasetFixture)) as MobileRawDataset;
+}

--- a/mobile/src/types/displayModels.ts
+++ b/mobile/src/types/displayModels.ts
@@ -85,3 +85,13 @@ export interface ReleaseDetailModel {
   notes?: string;
   tracks: TrackModel[];
 }
+
+export interface CalendarMonthSnapshotModel {
+  month: string;
+  releaseCount: number;
+  upcomingCount: number;
+  nearestUpcoming: UpcomingEventModel | null;
+  releases: ReleaseSummaryModel[];
+  exactUpcoming: UpcomingEventModel[];
+  monthOnlyUpcoming: UpcomingEventModel[];
+}


### PR DESCRIPTION
## Summary\n- wire the mobile calendar tab to the active dataset loader and shared month selectors\n- add safe loading, empty, and error states for the current-month container\n- cover the new selectors and route behavior with tests and refresh the mobile docs\n\nCloses #331