### PR TITLE
Implement mobile calendar month grid

### DIFF
--- a/mobile/app/(tabs)/calendar.tsx
+++ b/mobile/app/(tabs)/calendar.tsx
@@ -8,10 +8,24 @@ import {
   View,
 } from 'react-native';
 
-import { useAppTheme } from '../../src/tokens/theme';
-import { loadActiveMobileDataset, type ActiveMobileDataset } from '../../src/services/activeDataset';
+import {
+  buildCalendarMonthGrid,
+  resolveInitialCalendarSelection,
+  resolveNextCalendarSelection,
+} from '../../src/features/calendarGrid';
 import { selectCalendarMonthSnapshot } from '../../src/selectors';
-import type { CalendarMonthSnapshotModel, ReleaseSummaryModel, UpcomingEventModel } from '../../src/types';
+import {
+  loadActiveMobileDataset,
+  type ActiveMobileDataset,
+} from '../../src/services/activeDataset';
+import { useAppTheme } from '../../src/tokens/theme';
+import type {
+  CalendarDayBadgeKind,
+  CalendarMonthSnapshotModel,
+  CalendarSelectedDayModel,
+  ReleaseSummaryModel,
+  UpcomingEventModel,
+} from '../../src/types';
 
 type CalendarScreenState =
   | {
@@ -55,9 +69,32 @@ function formatReleaseRowMeta(release: ReleaseSummaryModel): string {
   return `${release.releaseDate} · ${kind}`;
 }
 
+function formatSelectedDaySummary(selectedDay: CalendarSelectedDayModel): string {
+  return `발매 ${selectedDay.releases.length} · 예정 ${selectedDay.exactUpcoming.length}`;
+}
+
+function getBadgePalette(
+  theme: ReturnType<typeof useAppTheme>,
+  kind: CalendarDayBadgeKind,
+): { backgroundColor: string; color: string } {
+  if (kind === 'release') {
+    return {
+      backgroundColor: theme.colors.status.title.bg,
+      color: theme.colors.status.title.text,
+    };
+  }
+
+  const token = theme.colors.status[kind];
+  return {
+    backgroundColor: token.bg,
+    color: token.text,
+  };
+}
+
 export default function CalendarTabScreen() {
   const theme = useAppTheme();
   const [reloadCount, setReloadCount] = useState(0);
+  const [selectedDayIso, setSelectedDayIso] = useState<string | null>(null);
   const [state, setState] = useState<CalendarScreenState>({ kind: 'loading' });
   const today = useMemo(() => new Date(), []);
   const activeMonth = useMemo(() => buildMonthKey(today), [today]);
@@ -103,6 +140,31 @@ export default function CalendarTabScreen() {
     };
   }, [activeMonth, reloadCount, todayIsoDate]);
 
+  const snapshot = state.kind === 'ready' || state.kind === 'empty' ? state.snapshot : null;
+  const source = state.kind === 'ready' || state.kind === 'empty' ? state.source : null;
+
+  useEffect(() => {
+    if (!snapshot) {
+      return;
+    }
+
+    setSelectedDayIso((current) => {
+      if (current && current.slice(0, 7) === snapshot.month) {
+        return current;
+      }
+
+      return resolveInitialCalendarSelection(snapshot.month, todayIsoDate);
+    });
+  }, [snapshot, todayIsoDate]);
+
+  const monthGrid = useMemo(() => {
+    if (!snapshot || !selectedDayIso) {
+      return null;
+    }
+
+    return buildCalendarMonthGrid(snapshot, selectedDayIso, todayIsoDate);
+  }, [selectedDayIso, snapshot, todayIsoDate]);
+
   if (state.kind === 'loading') {
     return (
       <View style={styles.stateContainer}>
@@ -127,7 +189,9 @@ export default function CalendarTabScreen() {
     );
   }
 
-  const { source, snapshot } = state;
+  if (!snapshot || !source) {
+    return null;
+  }
 
   return (
     <ScrollView style={styles.screen} contentContainerStyle={styles.content}>
@@ -135,7 +199,7 @@ export default function CalendarTabScreen() {
         <Text style={styles.eyebrow}>DATA-BACKED TAB</Text>
         <Text style={styles.title}>{formatMonthLabel(snapshot.month)}</Text>
         <Text style={styles.body}>
-          shared selector와 active dataset source를 통해 현재 월 요약을 먼저 여는 단계입니다.
+          현재 월 grid, day badge, selected-day state를 shared selector와 dataset source 위에서 렌더링합니다.
         </Text>
       </View>
 
@@ -162,62 +226,165 @@ export default function CalendarTabScreen() {
             {snapshot.nearestUpcoming?.displayGroup ?? '없음'}
           </Text>
           <Text style={styles.summaryMeta}>
-            {snapshot.nearestUpcoming ? formatUpcomingLabel(snapshot.nearestUpcoming) : 'exact 일정 없음'}
+            {snapshot.nearestUpcoming
+              ? formatUpcomingLabel(snapshot.nearestUpcoming)
+              : 'exact 일정 없음'}
           </Text>
         </View>
       </View>
 
-      {state.kind === 'empty' ? (
+      {monthGrid ? (
         <View style={styles.sectionCard}>
-          <Text style={styles.sectionTitle}>이번 달 일정 없음</Text>
-          <Text style={styles.body}>
-            현재 dataset source에는 {formatMonthLabel(snapshot.month)} 기준 발매나 예정 컴백이 없습니다.
-          </Text>
-        </View>
-      ) : (
-        <>
-          <View style={styles.sectionCard}>
-            <Text style={styles.sectionTitle}>Verified releases</Text>
-            {snapshot.releases.slice(0, 4).map((release) => (
-              <View key={release.id} style={styles.row}>
-                <Text style={styles.rowTitle}>{release.displayGroup}</Text>
-                <Text style={styles.rowBody}>{release.releaseTitle}</Text>
-                <Text style={styles.rowMeta}>{formatReleaseRowMeta(release)}</Text>
+          <View style={styles.calendarHeader}>
+            <Text style={styles.sectionTitle}>Calendar grid</Text>
+            <Text style={styles.sectionMeta}>
+              {monthGrid.selectedDay ? monthGrid.selectedDay.label : formatMonthLabel(snapshot.month)}
+            </Text>
+          </View>
+
+          <View style={styles.weekdayRow}>
+            {monthGrid.weekdayLabels.map((label) => (
+              <Text key={label} style={styles.weekdayLabel}>
+                {label}
+              </Text>
+            ))}
+          </View>
+
+          <View style={styles.calendarGrid}>
+            {monthGrid.weeks.map((week, weekIndex) => (
+              <View key={`${monthGrid.month}-week-${weekIndex}`} style={styles.weekRow}>
+                {week.map((cell, cellIndex) => {
+                  if (!cell) {
+                    return <View key={`${monthGrid.month}-empty-${weekIndex}-${cellIndex}`} style={styles.emptyCell} />;
+                  }
+
+                  return (
+                    <Pressable
+                      key={cell.isoDate}
+                      accessibilityRole="button"
+                      accessibilityState={{ selected: cell.isSelected }}
+                      onPress={() =>
+                        setSelectedDayIso((current) =>
+                          resolveNextCalendarSelection(current ?? cell.isoDate, cell.isoDate, snapshot.month),
+                        )
+                      }
+                      style={({ pressed }) => [
+                        styles.dayCell,
+                        cell.isToday ? styles.dayCellToday : null,
+                        cell.isSelected ? styles.dayCellSelected : null,
+                        pressed ? styles.dayCellPressed : null,
+                      ]}
+                    >
+                      <View style={styles.dayCellHeader}>
+                        <Text
+                          style={[
+                            styles.dayNumber,
+                            cell.isSelected ? styles.dayNumberSelected : null,
+                          ]}
+                        >
+                          {cell.dayNumber}
+                        </Text>
+                        {cell.releaseCount > 0 || cell.upcomingCount > 0 ? (
+                          <Text style={styles.dayCounts}>
+                            {cell.releaseCount}/{cell.upcomingCount}
+                          </Text>
+                        ) : null}
+                      </View>
+
+                      <View style={styles.badgeStack}>
+                        {cell.badges.map((badge) => {
+                          const palette = getBadgePalette(theme, badge.kind);
+                          return (
+                            <View
+                              key={badge.id}
+                              style={[
+                                styles.badgePill,
+                                {
+                                  backgroundColor: palette.backgroundColor,
+                                },
+                              ]}
+                            >
+                              <Text style={[styles.badgeText, { color: palette.color }]}>
+                                {badge.monogram}
+                              </Text>
+                            </View>
+                          );
+                        })}
+                        {cell.overflowCount > 0 ? (
+                          <Text style={styles.overflowLabel}>+{cell.overflowCount}</Text>
+                        ) : null}
+                      </View>
+                    </Pressable>
+                  );
+                })}
               </View>
             ))}
           </View>
 
-          <View style={styles.sectionCard}>
-            <Text style={styles.sectionTitle}>Exact-date upcoming</Text>
-            {snapshot.exactUpcoming.length ? (
-              snapshot.exactUpcoming.slice(0, 4).map((event) => (
-                <View key={event.id} style={styles.row}>
-                  <Text style={styles.rowTitle}>{event.displayGroup}</Text>
-                  <Text style={styles.rowBody}>{event.releaseLabel ?? event.headline}</Text>
-                  <Text style={styles.rowMeta}>{formatUpcomingLabel(event)}</Text>
-                </View>
-              ))
-            ) : (
-              <Text style={styles.body}>현재 월에 exact-date 예정 신호가 없습니다.</Text>
-            )}
-          </View>
+          {state.kind === 'empty' ? (
+            <Text style={styles.body}>
+              현재 dataset source에는 {formatMonthLabel(snapshot.month)} 기준 발매나 예정 컴백이 없습니다.
+            </Text>
+          ) : null}
+        </View>
+      ) : null}
 
-          <View style={styles.sectionCard}>
-            <Text style={styles.sectionTitle}>Month-only signals</Text>
-            {snapshot.monthOnlyUpcoming.length ? (
-              snapshot.monthOnlyUpcoming.slice(0, 4).map((event) => (
-                <View key={event.id} style={styles.row}>
-                  <Text style={styles.rowTitle}>{event.displayGroup}</Text>
-                  <Text style={styles.rowBody}>{event.headline}</Text>
-                  <Text style={styles.rowMeta}>{formatUpcomingLabel(event)}</Text>
+      {monthGrid?.selectedDay ? (
+        <View style={styles.sectionCard}>
+          <Text style={styles.sectionTitle}>{monthGrid.selectedDay.label}</Text>
+          <Text style={styles.sectionMeta}>{formatSelectedDaySummary(monthGrid.selectedDay)}</Text>
+
+          {monthGrid.selectedDay.isEmpty ? (
+            <Text style={styles.body}>이 날짜에는 등록된 일정이 없습니다.</Text>
+          ) : (
+            <>
+              {monthGrid.selectedDay.releases.length ? (
+                <View style={styles.subsection}>
+                  <Text style={styles.subsectionTitle}>Verified releases</Text>
+                  {monthGrid.selectedDay.releases.map((release) => (
+                    <View key={release.id} style={styles.row}>
+                      <Text style={styles.rowTitle}>{release.displayGroup}</Text>
+                      <Text style={styles.rowBody}>{release.releaseTitle}</Text>
+                      <Text style={styles.rowMeta}>{formatReleaseRowMeta(release)}</Text>
+                    </View>
+                  ))}
                 </View>
-              ))
-            ) : (
-              <Text style={styles.body}>현재 월에 month-only 예정 신호가 없습니다.</Text>
-            )}
-          </View>
-        </>
-      )}
+              ) : null}
+
+              {monthGrid.selectedDay.exactUpcoming.length ? (
+                <View style={styles.subsection}>
+                  <Text style={styles.subsectionTitle}>Scheduled comebacks</Text>
+                  {monthGrid.selectedDay.exactUpcoming.map((event) => (
+                    <View key={event.id} style={styles.row}>
+                      <Text style={styles.rowTitle}>{event.displayGroup}</Text>
+                      <Text style={styles.rowBody}>{event.releaseLabel ?? event.headline}</Text>
+                      <Text style={styles.rowMeta}>{formatUpcomingLabel(event)}</Text>
+                    </View>
+                  ))}
+                </View>
+              ) : null}
+            </>
+          )}
+        </View>
+      ) : null}
+
+      <View style={styles.sectionCard}>
+        <Text style={styles.sectionTitle}>Month-only signals</Text>
+        <Text style={styles.body}>
+          month-only 예정 신호는 날짜 셀에 넣지 않고 월 컨텍스트 버킷으로 유지합니다.
+        </Text>
+        {snapshot.monthOnlyUpcoming.length ? (
+          snapshot.monthOnlyUpcoming.map((event) => (
+            <View key={event.id} style={styles.row}>
+              <Text style={styles.rowTitle}>{event.displayGroup}</Text>
+              <Text style={styles.rowBody}>{event.headline}</Text>
+              <Text style={styles.rowMeta}>{formatUpcomingLabel(event)}</Text>
+            </View>
+          ))
+        ) : (
+          <Text style={styles.body}>현재 월에 month-only 예정 신호가 없습니다.</Text>
+        )}
+      </View>
     </ScrollView>
   );
 }
@@ -264,18 +431,19 @@ function createStyles(theme: ReturnType<typeof useAppTheme>) {
       fontWeight: theme.typography.body.fontWeight,
     },
     sourceCard: {
-      gap: theme.space[4],
-      padding: theme.space[16],
       borderRadius: theme.radius.card,
-      backgroundColor: theme.colors.surface.elevated,
       borderWidth: 1,
-      borderColor: theme.colors.border.subtle,
+      borderColor: theme.colors.border.default,
+      backgroundColor: theme.colors.surface.elevated,
+      padding: theme.space[16],
+      gap: theme.space[8],
     },
     sourceLabel: {
       color: theme.colors.text.tertiary,
       fontSize: theme.typography.meta.fontSize,
-      lineHeight: theme.typography.meta.lineHeight,
       fontWeight: theme.typography.meta.fontWeight,
+      letterSpacing: theme.typography.meta.letterSpacing,
+      textTransform: 'uppercase',
     },
     sourceValue: {
       color: theme.colors.text.primary,
@@ -293,22 +461,26 @@ function createStyles(theme: ReturnType<typeof useAppTheme>) {
       gap: theme.space[12],
     },
     summaryCard: {
-      gap: theme.space[4],
-      padding: theme.space[16],
       borderRadius: theme.radius.card,
-      backgroundColor: theme.colors.surface.interactive,
+      borderWidth: 1,
+      borderColor: theme.colors.border.subtle,
+      backgroundColor: theme.colors.surface.elevated,
+      padding: theme.space[16],
+      gap: theme.space[8],
     },
     summaryLabel: {
       color: theme.colors.text.tertiary,
       fontSize: theme.typography.meta.fontSize,
       lineHeight: theme.typography.meta.lineHeight,
       fontWeight: theme.typography.meta.fontWeight,
+      letterSpacing: theme.typography.meta.letterSpacing,
+      textTransform: 'uppercase',
     },
     summaryValue: {
       color: theme.colors.text.primary,
-      fontSize: 30,
-      lineHeight: 36,
-      fontWeight: '700',
+      fontSize: theme.typography.screenTitle.fontSize,
+      lineHeight: theme.typography.screenTitle.lineHeight,
+      fontWeight: theme.typography.screenTitle.fontWeight,
     },
     summaryValueSmall: {
       color: theme.colors.text.primary,
@@ -318,17 +490,20 @@ function createStyles(theme: ReturnType<typeof useAppTheme>) {
     },
     summaryMeta: {
       color: theme.colors.text.secondary,
-      fontSize: theme.typography.meta.fontSize,
-      lineHeight: theme.typography.meta.lineHeight,
-      fontWeight: theme.typography.meta.fontWeight,
+      fontSize: theme.typography.body.fontSize,
+      lineHeight: theme.typography.body.lineHeight,
+      fontWeight: theme.typography.body.fontWeight,
     },
     sectionCard: {
-      gap: theme.space[12],
-      padding: theme.space[16],
       borderRadius: theme.radius.card,
-      backgroundColor: theme.colors.surface.elevated,
       borderWidth: 1,
-      borderColor: theme.colors.border.subtle,
+      borderColor: theme.colors.border.default,
+      backgroundColor: theme.colors.surface.elevated,
+      padding: theme.space[16],
+      gap: theme.space[12],
+    },
+    calendarHeader: {
+      gap: theme.space[4],
     },
     sectionTitle: {
       color: theme.colors.text.primary,
@@ -336,9 +511,112 @@ function createStyles(theme: ReturnType<typeof useAppTheme>) {
       lineHeight: theme.typography.sectionTitle.lineHeight,
       fontWeight: theme.typography.sectionTitle.fontWeight,
     },
+    sectionMeta: {
+      color: theme.colors.text.secondary,
+      fontSize: theme.typography.body.fontSize,
+      lineHeight: theme.typography.body.lineHeight,
+      fontWeight: theme.typography.body.fontWeight,
+    },
+    weekdayRow: {
+      flexDirection: 'row',
+      gap: theme.space[8],
+    },
+    weekdayLabel: {
+      flex: 1,
+      color: theme.colors.text.tertiary,
+      fontSize: theme.typography.meta.fontSize,
+      lineHeight: theme.typography.meta.lineHeight,
+      fontWeight: theme.typography.meta.fontWeight,
+      textAlign: 'center',
+    },
+    calendarGrid: {
+      gap: theme.space[8],
+    },
+    weekRow: {
+      flexDirection: 'row',
+      gap: theme.space[8],
+    },
+    emptyCell: {
+      flex: 1,
+      minHeight: 88,
+    },
+    dayCell: {
+      flex: 1,
+      minHeight: 88,
+      borderRadius: theme.radius.button,
+      borderWidth: 1,
+      borderColor: theme.colors.border.subtle,
+      backgroundColor: theme.colors.surface.base,
+      padding: theme.space[8],
+      gap: theme.space[8],
+    },
+    dayCellPressed: {
+      backgroundColor: theme.colors.surface.interactive,
+    },
+    dayCellToday: {
+      borderColor: theme.colors.border.strong,
+    },
+    dayCellSelected: {
+      borderColor: theme.colors.border.focus,
+      backgroundColor: theme.colors.surface.interactive,
+    },
+    dayCellHeader: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'flex-start',
+    },
+    dayNumber: {
+      color: theme.colors.text.primary,
+      fontSize: theme.typography.cardTitle.fontSize,
+      lineHeight: theme.typography.cardTitle.lineHeight,
+      fontWeight: theme.typography.cardTitle.fontWeight,
+    },
+    dayNumberSelected: {
+      color: theme.colors.text.brand,
+    },
+    dayCounts: {
+      color: theme.colors.text.tertiary,
+      fontSize: theme.typography.meta.fontSize,
+      lineHeight: theme.typography.meta.lineHeight,
+      fontWeight: theme.typography.meta.fontWeight,
+    },
+    badgeStack: {
+      gap: theme.space[4],
+      alignItems: 'flex-start',
+    },
+    badgePill: {
+      minWidth: 32,
+      borderRadius: theme.radius.chip,
+      paddingHorizontal: theme.space[8],
+      paddingVertical: theme.space[4],
+    },
+    badgeText: {
+      fontSize: theme.typography.chip.fontSize,
+      lineHeight: theme.typography.chip.lineHeight,
+      fontWeight: theme.typography.chip.fontWeight,
+      letterSpacing: theme.typography.chip.letterSpacing,
+      textAlign: 'center',
+    },
+    overflowLabel: {
+      color: theme.colors.text.tertiary,
+      fontSize: theme.typography.meta.fontSize,
+      lineHeight: theme.typography.meta.lineHeight,
+      fontWeight: theme.typography.meta.fontWeight,
+    },
+    subsection: {
+      gap: theme.space[8],
+    },
+    subsectionTitle: {
+      color: theme.colors.text.tertiary,
+      fontSize: theme.typography.meta.fontSize,
+      lineHeight: theme.typography.meta.lineHeight,
+      fontWeight: theme.typography.meta.fontWeight,
+      letterSpacing: theme.typography.meta.letterSpacing,
+      textTransform: 'uppercase',
+    },
     row: {
       gap: theme.space[4],
-      paddingTop: theme.space[12],
+      paddingTop: theme.space[8],
       borderTopWidth: 1,
       borderTopColor: theme.colors.border.subtle,
     },
@@ -364,7 +642,7 @@ function createStyles(theme: ReturnType<typeof useAppTheme>) {
       alignSelf: 'flex-start',
       paddingHorizontal: theme.space[16],
       paddingVertical: theme.space[12],
-      borderRadius: theme.radius.button,
+      borderRadius: theme.radius.chip,
       backgroundColor: theme.colors.text.brand,
     },
     retryButtonLabel: {

--- a/mobile/src/features/calendarGrid.test.ts
+++ b/mobile/src/features/calendarGrid.test.ts
@@ -1,0 +1,127 @@
+import { buildCalendarMonthGrid, resolveInitialCalendarSelection, resolveNextCalendarSelection } from './calendarGrid';
+import { cloneBundledDatasetFixture } from '../services/bundledDatasetFixture';
+import { selectCalendarMonthSnapshot } from '../selectors';
+import type { CalendarMonthSnapshotModel, ReleaseSummaryModel } from '../types';
+
+function createRelease(
+  group: string,
+  displayGroup: string,
+  releaseDate: string,
+): ReleaseSummaryModel {
+  return {
+    id: `${group}-${releaseDate}`,
+    group,
+    displayGroup,
+    releaseTitle: `${displayGroup} release`,
+    releaseDate,
+    releaseKind: 'single',
+    stream: 'song',
+    contextTags: [],
+  };
+}
+
+describe('calendar month grid', () => {
+  test('builds a March 2026 grid with exact badges and month-only excluded from day cells', () => {
+    const snapshot = selectCalendarMonthSnapshot(
+      cloneBundledDatasetFixture(),
+      '2026-03',
+      '2026-03-07',
+    );
+
+    const grid = buildCalendarMonthGrid(snapshot, '2026-03-11', '2026-03-07');
+    const march11 = grid.weeks.flat().find((cell) => cell?.isoDate === '2026-03-11');
+    const march12 = grid.weeks.flat().find((cell) => cell?.isoDate === '2026-03-12');
+    const march7 = grid.weeks.flat().find((cell) => cell?.isoDate === '2026-03-07');
+
+    expect(grid.weekdayLabels).toEqual(['일', '월', '화', '수', '목', '금', '토']);
+    expect(grid.weeks).toHaveLength(5);
+    expect(march11).toEqual(
+      expect.objectContaining({
+        isSelected: true,
+        releaseCount: 1,
+        upcomingCount: 1,
+      }),
+    );
+    expect(march11?.badges).toEqual([
+      expect.objectContaining({
+        group: 'YENA',
+        kind: 'release',
+      }),
+    ]);
+    expect(march12?.badges).toEqual([
+      expect.objectContaining({
+        group: 'P1Harmony',
+        kind: 'scheduled',
+      }),
+    ]);
+    expect(march7).toEqual(
+      expect.objectContaining({
+        isToday: true,
+        badges: [],
+      }),
+    );
+    expect(grid.selectedDay).toEqual(
+      expect.objectContaining({
+        isoDate: '2026-03-11',
+        isEmpty: false,
+      }),
+    );
+    expect(snapshot.monthOnlyUpcoming).toHaveLength(1);
+    expect(grid.weeks.flat().some((cell) => cell?.badges.some((badge) => badge.group === 'LE SSERAFIM'))).toBe(
+      false,
+    );
+  });
+
+  test('caps visible badges at two and exposes overflow count', () => {
+    const snapshot: CalendarMonthSnapshotModel = {
+      month: '2026-03',
+      releaseCount: 3,
+      upcomingCount: 0,
+      nearestUpcoming: null,
+      releases: [
+        createRelease('ALPHA', 'Alpha', '2026-03-08'),
+        createRelease('BETA', 'Beta', '2026-03-08'),
+        createRelease('GAMMA', 'Gamma', '2026-03-08'),
+      ],
+      exactUpcoming: [],
+      monthOnlyUpcoming: [],
+    };
+
+    const grid = buildCalendarMonthGrid(snapshot, '2026-03-08', '2026-03-07');
+    const march8 = grid.weeks.flat().find((cell) => cell?.isoDate === '2026-03-08');
+
+    expect(march8?.badges).toHaveLength(2);
+    expect(march8?.overflowCount).toBe(1);
+  });
+
+  test('supports empty-day selection and month-safe fallback selection', () => {
+    const snapshot = selectCalendarMonthSnapshot(
+      cloneBundledDatasetFixture(),
+      '2026-03',
+      '2026-03-07',
+    );
+
+    const emptyDayGrid = buildCalendarMonthGrid(snapshot, '2026-03-13', '2026-03-07');
+    expect(emptyDayGrid.selectedDay).toEqual(
+      expect.objectContaining({
+        isoDate: '2026-03-13',
+        isEmpty: true,
+      }),
+    );
+
+    const fallbackGrid = buildCalendarMonthGrid(snapshot, '2026-04-02', '2026-03-07');
+    expect(fallbackGrid.selectedDay?.isoDate).toBe('2026-03-07');
+  });
+});
+
+describe('calendar selection helpers', () => {
+  test('uses today when the active month matches today', () => {
+    expect(resolveInitialCalendarSelection('2026-03', '2026-03-07')).toBe('2026-03-07');
+    expect(resolveInitialCalendarSelection('2026-04', '2026-03-07')).toBe('2026-04-01');
+  });
+
+  test('keeps selection safe when tapping out-of-month content', () => {
+    expect(resolveNextCalendarSelection('2026-03-11', '2026-04-01', '2026-03')).toBe('2026-03-11');
+    expect(resolveNextCalendarSelection('2026-03-11', '2026-03-12', '2026-03')).toBe('2026-03-12');
+  });
+});

--- a/mobile/src/features/calendarGrid.ts
+++ b/mobile/src/features/calendarGrid.ts
@@ -1,0 +1,214 @@
+import type {
+  CalendarDayBadgeKind,
+  CalendarDayBadgeModel,
+  CalendarDayCellModel,
+  CalendarMonthGridModel,
+  CalendarMonthSnapshotModel,
+  CalendarSelectedDayModel,
+  ReleaseSummaryModel,
+  UpcomingEventModel,
+} from '../types';
+
+const WEEKDAY_LABELS = ['일', '월', '화', '수', '목', '금', '토'] as const;
+
+function buildMonthDate(month: string, day = 1): Date {
+  return new Date(`${month}-${`${day}`.padStart(2, '0')}T00:00:00`);
+}
+
+function formatIsoDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, '0');
+  const day = `${date.getDate()}`.padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function formatSelectedDayLabel(isoDate: string): string {
+  const [year, month, day] = isoDate.split('-');
+  return `${year}년 ${Number(month)}월 ${Number(day)}일`;
+}
+
+function isIsoDateInMonth(isoDate: string, month: string): boolean {
+  return isoDate.slice(0, 7) === month;
+}
+
+function buildTeamMonogram(label: string): string {
+  const compact = label.replace(/\s+/g, '');
+  if (!compact) {
+    return '??';
+  }
+
+  const hasHangul = /[가-힣]/.test(compact);
+  if (hasHangul) {
+    return compact.slice(0, 2);
+  }
+
+  return compact.replace(/[^A-Za-z0-9]/g, '').slice(0, 2).toUpperCase() || compact.slice(0, 2).toUpperCase();
+}
+
+function getBadgeKind(
+  group: string,
+  releaseRows: ReleaseSummaryModel[],
+  upcomingRows: UpcomingEventModel[],
+): CalendarDayBadgeKind {
+  if (releaseRows.some((item) => item.group === group)) {
+    return 'release';
+  }
+
+  return upcomingRows.find((item) => item.group === group)?.status ?? 'scheduled';
+}
+
+function getBadgeLabel(
+  group: string,
+  releaseRows: ReleaseSummaryModel[],
+  upcomingRows: UpcomingEventModel[],
+): string {
+  return (
+    releaseRows.find((item) => item.group === group)?.displayGroup ??
+    upcomingRows.find((item) => item.group === group)?.displayGroup ??
+    group
+  );
+}
+
+function buildBadges(
+  releaseRows: ReleaseSummaryModel[],
+  upcomingRows: UpcomingEventModel[],
+): CalendarDayBadgeModel[] {
+  const seenGroups = new Set<string>();
+  const groups = [...releaseRows.map((item) => item.group), ...upcomingRows.map((item) => item.group)].filter((group) => {
+    if (seenGroups.has(group)) {
+      return false;
+    }
+
+    seenGroups.add(group);
+    return true;
+  });
+
+  return groups.slice(0, 2).map((group) => {
+    const label = getBadgeLabel(group, releaseRows, upcomingRows);
+    return {
+      id: `${group}-${getBadgeKind(group, releaseRows, upcomingRows)}`,
+      group,
+      label,
+      monogram: buildTeamMonogram(label),
+      kind: getBadgeKind(group, releaseRows, upcomingRows),
+    };
+  });
+}
+
+function buildSelectedDayModel(
+  snapshot: CalendarMonthSnapshotModel,
+  selectedDayIso: string,
+): CalendarSelectedDayModel {
+  const releases = snapshot.releases.filter((item) => item.releaseDate === selectedDayIso);
+  const exactUpcoming = snapshot.exactUpcoming.filter((item) => item.scheduledDate === selectedDayIso);
+
+  return {
+    isoDate: selectedDayIso,
+    label: formatSelectedDayLabel(selectedDayIso),
+    releases,
+    exactUpcoming,
+    isEmpty: releases.length === 0 && exactUpcoming.length === 0,
+  };
+}
+
+export function shiftMonthKey(month: string, offset: number): string {
+  const base = buildMonthDate(month);
+  return formatIsoDate(new Date(base.getFullYear(), base.getMonth() + offset, 1)).slice(0, 7);
+}
+
+export function resolveInitialCalendarSelection(month: string, todayIsoDate: string): string {
+  if (todayIsoDate.slice(0, 7) === month) {
+    return todayIsoDate;
+  }
+
+  return `${month}-01`;
+}
+
+export function resolveNextCalendarSelection(currentIsoDate: string, nextIsoDate: string, month: string): string {
+  if (nextIsoDate.slice(0, 7) !== month) {
+    return currentIsoDate;
+  }
+
+  return nextIsoDate;
+}
+
+function resolveSafeSelection(
+  month: string,
+  selectedDayIso: string,
+  todayIsoDate: string,
+): string {
+  if (isIsoDateInMonth(selectedDayIso, month)) {
+    return selectedDayIso;
+  }
+
+  return resolveInitialCalendarSelection(month, todayIsoDate);
+}
+
+export function buildCalendarMonthGrid(
+  snapshot: CalendarMonthSnapshotModel,
+  selectedDayIso: string,
+  todayIsoDate: string,
+): CalendarMonthGridModel {
+  const safeSelectedDayIso = resolveSafeSelection(snapshot.month, selectedDayIso, todayIsoDate);
+  const monthStart = buildMonthDate(snapshot.month);
+  const daysInMonth = new Date(monthStart.getFullYear(), monthStart.getMonth() + 1, 0).getDate();
+  const leadingEmptyCells = monthStart.getDay();
+  const releaseMap = new Map<string, ReleaseSummaryModel[]>();
+  const upcomingMap = new Map<string, UpcomingEventModel[]>();
+
+  for (const release of snapshot.releases) {
+    const rows = releaseMap.get(release.releaseDate) ?? [];
+    rows.push(release);
+    releaseMap.set(release.releaseDate, rows);
+  }
+
+  for (const upcoming of snapshot.exactUpcoming) {
+    if (!upcoming.scheduledDate) {
+      continue;
+    }
+
+    const rows = upcomingMap.get(upcoming.scheduledDate) ?? [];
+    rows.push(upcoming);
+    upcomingMap.set(upcoming.scheduledDate, rows);
+  }
+
+  const cells: (CalendarDayCellModel | null)[] = [];
+  for (let index = 0; index < leadingEmptyCells; index += 1) {
+    cells.push(null);
+  }
+
+  for (let day = 1; day <= daysInMonth; day += 1) {
+    const isoDate = `${snapshot.month}-${`${day}`.padStart(2, '0')}`;
+    const releaseRows = releaseMap.get(isoDate) ?? [];
+    const upcomingRows = upcomingMap.get(isoDate) ?? [];
+    const uniqueGroupCount = new Set([...releaseRows.map((item) => item.group), ...upcomingRows.map((item) => item.group)]).size;
+
+    cells.push({
+      isoDate,
+      dayNumber: day,
+      isCurrentMonth: true,
+      isToday: isoDate === todayIsoDate,
+      isSelected: isoDate === safeSelectedDayIso,
+      badges: buildBadges(releaseRows, upcomingRows),
+      overflowCount: Math.max(0, uniqueGroupCount - 2),
+      releaseCount: releaseRows.length,
+      upcomingCount: upcomingRows.length,
+    });
+  }
+
+  while (cells.length % 7 !== 0) {
+    cells.push(null);
+  }
+
+  const weeks: (CalendarDayCellModel | null)[][] = [];
+  for (let index = 0; index < cells.length; index += 7) {
+    weeks.push(cells.slice(index, index + 7));
+  }
+
+  return {
+    month: snapshot.month,
+    weekdayLabels: [...WEEKDAY_LABELS],
+    weeks,
+    selectedDay: buildSelectedDayModel(snapshot, safeSelectedDayIso),
+  };
+}

--- a/mobile/src/types/displayModels.ts
+++ b/mobile/src/types/displayModels.ts
@@ -95,3 +95,40 @@ export interface CalendarMonthSnapshotModel {
   exactUpcoming: UpcomingEventModel[];
   monthOnlyUpcoming: UpcomingEventModel[];
 }
+
+export type CalendarDayBadgeKind = 'release' | UpcomingStatus;
+
+export interface CalendarDayBadgeModel {
+  id: string;
+  group: string;
+  label: string;
+  monogram: string;
+  kind: CalendarDayBadgeKind;
+}
+
+export interface CalendarDayCellModel {
+  isoDate: string;
+  dayNumber: number;
+  isCurrentMonth: boolean;
+  isToday: boolean;
+  isSelected: boolean;
+  badges: CalendarDayBadgeModel[];
+  overflowCount: number;
+  releaseCount: number;
+  upcomingCount: number;
+}
+
+export interface CalendarSelectedDayModel {
+  isoDate: string;
+  label: string;
+  releases: ReleaseSummaryModel[];
+  exactUpcoming: UpcomingEventModel[];
+  isEmpty: boolean;
+}
+
+export interface CalendarMonthGridModel {
+  month: string;
+  weekdayLabels: string[];
+  weeks: (CalendarDayCellModel | null)[][];
+  selectedDay: CalendarSelectedDayModel | null;
+}


### PR DESCRIPTION
## Summary
- add a pure month-grid helper and tests for exact-day badges, overflow, and empty-day selection
- replace the calendar tab summary-only shell with a real month grid and selected-day detail panel
- keep month-only upcoming signals out of day cells and in a separate month context bucket

Closes #332