### PR TITLE
Implement mobile search tab query experience

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -2,7 +2,7 @@
 
 이 디렉터리는 `Expo + React Native + Expo Router` 기반 모바일 앱 워크스페이스다.
 
-현재 단계는 workspace bootstrap과 router shell, 그리고 calendar tab의 data-backed container까지 포함한다.
+현재 단계는 workspace bootstrap과 router shell, 그리고 calendar / search tab의 data-backed container까지 포함한다.
 
 - route/layout expectations는 `docs/specs/mobile/expo-implementation-guide.md`를 따른다.
 - route/param 계약은 `docs/specs/mobile/route-param-contracts.md`를 따른다.
@@ -13,6 +13,7 @@
 - `app/`
   - Expo Router root layout / tab shell / detail placeholder route
   - `calendar` tab은 active dataset + shared selector 기반 container까지 연결됨
+  - `search` tab은 query state + recent query persistence + segmented result container까지 연결됨
   - hidden `debug/metadata` route for internal metadata inspection
 - `assets/`
   - placeholder / service icon / badge fallback asset inventory
@@ -183,6 +184,7 @@ profile 차이는 아래 범위로만 제한한다.
   - `selectMonthReleaseSummaries`
   - `selectMonthUpcomingEvents`
   - `selectCalendarMonthSnapshot`
+  - `selectSearchResults`
 - 규칙
   - 화면은 raw JSON shape를 직접 읽지 않는다.
   - selector는 fallback을 포함한 최종 display model만 반환한다.

--- a/mobile/app/(tabs)/search.tsx
+++ b/mobile/app/(tabs)/search.tsx
@@ -1,41 +1,699 @@
-import { StyleSheet, Text, View } from 'react-native';
+import { useRouter } from 'expo-router';
+import React, { useDeferredValue, useEffect, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+
+import {
+  createSelectorContext,
+  selectSearchResults,
+  selectTeamSummaryBySlug,
+} from '../../src/selectors';
+import { loadActiveMobileDataset, type ActiveMobileDataset } from '../../src/services/activeDataset';
+import { clearRecentQueries, persistRecentQuery, readRecentQueries } from '../../src/services/recentQueries';
+import { useAppTheme } from '../../src/tokens/theme';
+import type {
+  ReleaseSummaryModel,
+  SearchTeamResultModel,
+  SearchUpcomingResultModel,
+  TeamSummaryModel,
+} from '../../src/types';
+
+type SearchScreenState =
+  | { kind: 'loading' }
+  | { kind: 'error'; message: string }
+  | { kind: 'ready'; source: ActiveMobileDataset };
+
+type SearchSegment = 'entities' | 'releases' | 'upcoming';
+
+function formatReleaseMeta(release: ReleaseSummaryModel): string {
+  const releaseKind = release.releaseKind ?? 'release';
+  return `${release.releaseDate} · ${releaseKind}`;
+}
+
+function formatUpcomingMeta(result: SearchUpcomingResultModel): string {
+  const event = result.upcoming;
+  const dateLabel = event.scheduledDate
+    ? event.scheduledDate
+    : event.scheduledMonth
+      ? `${event.scheduledMonth} · 날짜 미정`
+      : '날짜 미정';
+
+  return [dateLabel, event.status ?? '예정', event.sourceType].join(' · ');
+}
+
+function formatTeamMeta(result: SearchTeamResultModel): string {
+  if (result.latestRelease) {
+    return `최근 발매 · ${result.latestRelease.releaseTitle}`;
+  }
+
+  return result.team.agency ?? '최근 발매 정보 없음';
+}
+
+function formatSuggestedLabel(team: TeamSummaryModel): string {
+  return team.badge?.monogram ?? team.displayName.slice(0, 2).toUpperCase();
+}
 
 export default function SearchTabScreen() {
+  const router = useRouter();
+  const theme = useAppTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  const [reloadCount, setReloadCount] = useState(0);
+  const [state, setState] = useState<SearchScreenState>({ kind: 'loading' });
+  const [query, setQuery] = useState('');
+  const [activeSegment, setActiveSegment] = useState<SearchSegment>('entities');
+  const [recentQueries, setRecentQueries] = useState<string[]>([]);
+  const deferredQuery = useDeferredValue(query);
+
+  useEffect(() => {
+    let cancelled = false;
+    setState({ kind: 'loading' });
+
+    void Promise.all([loadActiveMobileDataset(), readRecentQueries()])
+      .then(([source, history]) => {
+        if (cancelled) {
+          return;
+        }
+
+        setRecentQueries(history);
+        setState({
+          kind: 'ready',
+          source,
+        });
+      })
+      .catch((error: unknown) => {
+        if (cancelled) {
+          return;
+        }
+
+        setState({
+          kind: 'error',
+          message:
+            error instanceof Error
+              ? error.message
+              : 'Search dataset could not be loaded right now.',
+        });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [reloadCount]);
+
+  const selectorContext = useMemo(() => {
+    if (state.kind !== 'ready') {
+      return null;
+    }
+
+    return createSelectorContext(state.source.dataset);
+  }, [state]);
+
+  const results = useMemo(() => {
+    if (!selectorContext) {
+      return null;
+    }
+
+    return selectSearchResults(selectorContext, deferredQuery);
+  }, [deferredQuery, selectorContext]);
+
+  const suggestedTeams = useMemo(() => {
+    if (!selectorContext) {
+      return [];
+    }
+
+    return selectorContext.dataset.artistProfiles
+      .map((profile) => selectTeamSummaryBySlug(selectorContext, profile.slug))
+      .filter((team): team is TeamSummaryModel => team !== null)
+      .sort((left, right) => left.displayName.localeCompare(right.displayName))
+      .slice(0, 4);
+  }, [selectorContext]);
+
+  const teamSlugByGroup = useMemo(() => {
+    const entries = new Map<string, string>();
+
+    if (!selectorContext) {
+      return entries;
+    }
+
+    for (const profile of selectorContext.dataset.artistProfiles) {
+      entries.set(profile.group, profile.slug);
+    }
+
+    return entries;
+  }, [selectorContext]);
+
+  async function rememberQuery(nextQuery: string) {
+    const history = await persistRecentQuery(nextQuery);
+    setRecentQueries(history);
+  }
+
+  async function handleSubmitQuery(nextQuery = query) {
+    const normalized = nextQuery.trim();
+    if (!normalized) {
+      return;
+    }
+
+    await rememberQuery(normalized);
+  }
+
+  async function handleRecentQueryPress(nextQuery: string) {
+    setQuery(nextQuery);
+    await rememberQuery(nextQuery);
+  }
+
+  async function handleClearHistory() {
+    await clearRecentQueries();
+    setRecentQueries([]);
+  }
+
+  function openTeamDetail(slug: string) {
+    router.push({
+      pathname: '/artists/[slug]',
+      params: { slug },
+    });
+  }
+
+  function openReleaseDetail(releaseId: string) {
+    router.push({
+      pathname: '/releases/[id]',
+      params: { id: releaseId },
+    });
+  }
+
+  if (state.kind === 'loading') {
+    return (
+      <View style={styles.stateContainer}>
+        <ActivityIndicator color={theme.colors.text.brand} />
+        <Text style={styles.eyebrow}>DATASET LOADING</Text>
+        <Text style={styles.title}>Search</Text>
+        <Text style={styles.body}>검색 대상 팀, 발매, 예정 데이터를 불러오는 중입니다.</Text>
+      </View>
+    );
+  }
+
+  if (state.kind === 'error') {
+    return (
+      <View style={styles.stateContainer}>
+        <Text style={styles.eyebrow}>LOAD ERROR</Text>
+        <Text style={styles.title}>Search</Text>
+        <Text style={styles.body}>{state.message}</Text>
+        <Pressable style={styles.retryButton} onPress={() => setReloadCount((count) => count + 1)}>
+          <Text style={styles.retryButtonLabel}>다시 시도</Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  if (!results) {
+    return null;
+  }
+
+  const segmentCounts: Record<SearchSegment, number> = {
+    entities: results.entities.length,
+    releases: results.releases.length,
+    upcoming: results.upcoming.length,
+  };
+
+  const activeRows =
+    activeSegment === 'entities'
+      ? results.entities
+      : activeSegment === 'releases'
+        ? results.releases
+        : results.upcoming;
+
   return (
-    <View style={styles.container}>
-      <Text style={styles.eyebrow}>TAB SHELL</Text>
-      <Text style={styles.title}>Search</Text>
-      <Text style={styles.body}>
-        Search query state stays local to this screen in v1. Permanent query route params are not
-        introduced yet.
-      </Text>
-    </View>
+    <ScrollView style={styles.screen} contentContainerStyle={styles.content}>
+      <View style={styles.header}>
+        <Text style={styles.eyebrow}>SEARCH TAB</Text>
+        <Text style={styles.title}>Search</Text>
+        <Text style={styles.body}>한글 별칭, 영문 그룹명, 릴리즈명, 예정 headline까지 같은 selector semantics로 찾습니다.</Text>
+      </View>
+
+      <View style={styles.searchCard}>
+        <TextInput
+          testID="search-input"
+          value={query}
+          onChangeText={setQuery}
+          onSubmitEditing={() => void handleSubmitQuery()}
+          placeholder="팀, 앨범, 곡, 별칭 검색"
+          placeholderTextColor={theme.colors.text.tertiary}
+          autoCapitalize="none"
+          autoCorrect={false}
+          returnKeyType="search"
+          style={styles.searchInput}
+        />
+        {query.trim() ? (
+          <Pressable
+            testID="search-clear-button"
+            accessibilityRole="button"
+            onPress={() => setQuery('')}
+            style={styles.inlineButton}
+          >
+            <Text style={styles.inlineButtonLabel}>지우기</Text>
+          </Pressable>
+        ) : null}
+      </View>
+
+      <View style={styles.segmentRow}>
+        {([
+          ['entities', '팀'],
+          ['releases', '발매'],
+          ['upcoming', '예정'],
+        ] as const).map(([segment, label]) => (
+          <Pressable
+            key={segment}
+            testID={`search-segment-${segment}`}
+            accessibilityRole="button"
+            accessibilityState={{ selected: activeSegment === segment }}
+            onPress={() => setActiveSegment(segment)}
+            style={({ pressed }) => [
+              styles.segmentButton,
+              activeSegment === segment ? styles.segmentButtonActive : null,
+              pressed ? styles.segmentButtonPressed : null,
+            ]}
+          >
+            <Text style={activeSegment === segment ? styles.segmentLabelActive : styles.segmentLabel}>
+              {label}
+            </Text>
+            <Text style={activeSegment === segment ? styles.segmentCountActive : styles.segmentCount}>
+              {segmentCounts[segment]}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
+
+      {!query.trim() ? (
+        <>
+          <View style={styles.sectionCard}>
+            <View style={styles.sectionHeader}>
+              <Text style={styles.sectionTitle}>최근 검색</Text>
+              {recentQueries.length ? (
+                <Pressable
+                  testID="search-clear-history"
+                  accessibilityRole="button"
+                  onPress={() => void handleClearHistory()}
+                  style={styles.inlineButton}
+                >
+                  <Text style={styles.inlineButtonLabel}>전체 삭제</Text>
+                </Pressable>
+              ) : null}
+            </View>
+
+            {recentQueries.length ? (
+              <View style={styles.chipRow}>
+                {recentQueries.map((recentQuery) => (
+                  <Pressable
+                    key={recentQuery}
+                    testID={`recent-query-${recentQuery}`}
+                    accessibilityRole="button"
+                    onPress={() => void handleRecentQueryPress(recentQuery)}
+                    style={({ pressed }) => [styles.historyChip, pressed ? styles.segmentButtonPressed : null]}
+                  >
+                    <Text style={styles.historyChipLabel}>{recentQuery}</Text>
+                  </Pressable>
+                ))}
+              </View>
+            ) : (
+              <Text style={styles.body}>최근 검색이 없습니다.</Text>
+            )}
+          </View>
+
+          <View style={styles.sectionCard}>
+            <Text style={styles.sectionTitle}>추천 팀</Text>
+            <View style={styles.suggestedGrid}>
+              {suggestedTeams.map((team) => (
+                <Pressable
+                  key={team.slug}
+                  testID={`suggested-team-${team.slug}`}
+                  accessibilityRole="button"
+                  onPress={() => openTeamDetail(team.slug)}
+                  style={({ pressed }) => [styles.suggestedCard, pressed ? styles.segmentButtonPressed : null]}
+                >
+                  <View style={styles.suggestedBadge}>
+                    <Text style={styles.suggestedBadgeLabel}>{formatSuggestedLabel(team)}</Text>
+                  </View>
+                  <Text style={styles.suggestedTitle}>{team.displayName}</Text>
+                  <Text style={styles.suggestedMeta}>{team.agency ?? 'Tracked team'}</Text>
+                </Pressable>
+              ))}
+            </View>
+          </View>
+        </>
+      ) : (
+        <View style={styles.sectionCard}>
+          <View style={styles.sectionHeader}>
+            <Text style={styles.sectionTitle}>검색 결과</Text>
+            <Text style={styles.sectionMeta}>{segmentCounts[activeSegment]}건</Text>
+          </View>
+
+          {activeRows.length === 0 ? (
+            <Text style={styles.body}>검색 결과가 없습니다.</Text>
+          ) : null}
+
+          {activeSegment === 'entities'
+            ? results.entities.map((result) => (
+                <Pressable
+                  key={result.team.slug}
+                  accessibilityRole="button"
+                  onPress={() => openTeamDetail(result.team.slug)}
+                  style={({ pressed }) => [styles.resultRow, pressed ? styles.segmentButtonPressed : null]}
+                >
+                  <View style={styles.resultLeadingBadge}>
+                    <Text style={styles.resultLeadingBadgeLabel}>
+                      {result.team.badge?.monogram ?? result.team.displayName.slice(0, 2).toUpperCase()}
+                    </Text>
+                  </View>
+                  <View testID={`search-team-result-${result.team.slug}`} style={styles.resultCopy}>
+                    <Text style={styles.resultTitle}>{result.team.displayName}</Text>
+                    <Text style={styles.resultBody}>{formatTeamMeta(result)}</Text>
+                    <Text style={styles.resultMeta}>{result.matchKind}</Text>
+                  </View>
+                </Pressable>
+              ))
+            : null}
+
+          {activeSegment === 'releases'
+            ? results.releases.map((result) => (
+                <Pressable
+                  key={result.release.id}
+                  accessibilityRole="button"
+                  onPress={() => openReleaseDetail(result.release.id)}
+                  style={({ pressed }) => [styles.resultRow, pressed ? styles.segmentButtonPressed : null]}
+                >
+                  <View style={styles.resultLeadingBadge}>
+                    <Text style={styles.resultLeadingBadgeLabel}>{result.release.displayGroup.slice(0, 2)}</Text>
+                  </View>
+                  <View testID={`search-release-result-${result.release.id}`} style={styles.resultCopy}>
+                    <Text style={styles.resultTitle}>{result.release.releaseTitle}</Text>
+                    <Text style={styles.resultBody}>{result.release.displayGroup}</Text>
+                    <Text style={styles.resultMeta}>
+                      {formatReleaseMeta(result.release)} · {result.matchKind}
+                    </Text>
+                  </View>
+                </Pressable>
+              ))
+            : null}
+
+          {activeSegment === 'upcoming'
+            ? results.upcoming.map((result) => (
+                <Pressable
+                  key={result.upcoming.id}
+                  accessibilityRole="button"
+                  onPress={() => {
+                    const slug = teamSlugByGroup.get(result.upcoming.group);
+                    if (slug) {
+                      openTeamDetail(slug);
+                    }
+                  }}
+                  style={({ pressed }) => [styles.resultRow, pressed ? styles.segmentButtonPressed : null]}
+                >
+                  <View style={styles.resultLeadingBadge}>
+                    <Text style={styles.resultLeadingBadgeLabel}>
+                      {result.upcoming.displayGroup.slice(0, 2)}
+                    </Text>
+                  </View>
+                  <View testID={`search-upcoming-result-${result.upcoming.id}`} style={styles.resultCopy}>
+                    <Text style={styles.resultTitle}>{result.upcoming.displayGroup}</Text>
+                    <Text style={styles.resultBody}>
+                      {result.upcoming.releaseLabel ?? result.upcoming.headline}
+                    </Text>
+                    <Text style={styles.resultMeta}>
+                      {formatUpcomingMeta(result)} · {result.matchKind}
+                    </Text>
+                  </View>
+                </Pressable>
+              ))
+            : null}
+        </View>
+      )}
+    </ScrollView>
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: 'center',
-    paddingHorizontal: 24,
-    backgroundColor: '#f7f6f2',
-  },
-  eyebrow: {
-    marginBottom: 8,
-    fontSize: 12,
-    fontWeight: '600',
-    letterSpacing: 1.2,
-    color: '#87634d',
-  },
-  title: {
-    marginBottom: 12,
-    fontSize: 28,
-    fontWeight: '700',
-    color: '#1f1b17',
-  },
-  body: {
-    fontSize: 16,
-    lineHeight: 24,
-    color: '#5e554d',
-  },
-});
+function createStyles(theme: ReturnType<typeof useAppTheme>) {
+  return StyleSheet.create({
+    screen: {
+      flex: 1,
+      backgroundColor: theme.colors.surface.base,
+    },
+    content: {
+      paddingHorizontal: theme.space[24],
+      paddingTop: theme.space[24],
+      paddingBottom: theme.space[32],
+      gap: theme.space[16],
+    },
+    stateContainer: {
+      flex: 1,
+      justifyContent: 'center',
+      paddingHorizontal: theme.space[24],
+      gap: theme.space[12],
+      backgroundColor: theme.colors.surface.base,
+    },
+    header: {
+      gap: theme.space[8],
+    },
+    eyebrow: {
+      color: theme.colors.text.brand,
+      fontSize: theme.typography.meta.fontSize,
+      fontWeight: theme.typography.meta.fontWeight,
+      letterSpacing: theme.typography.meta.letterSpacing,
+    },
+    title: {
+      color: theme.colors.text.primary,
+      fontSize: theme.typography.screenTitle.fontSize,
+      lineHeight: theme.typography.screenTitle.lineHeight,
+      fontWeight: theme.typography.screenTitle.fontWeight,
+      letterSpacing: theme.typography.screenTitle.letterSpacing,
+    },
+    body: {
+      color: theme.colors.text.secondary,
+      fontSize: theme.typography.body.fontSize,
+      lineHeight: theme.typography.body.lineHeight,
+      fontWeight: theme.typography.body.fontWeight,
+    },
+    searchCard: {
+      borderRadius: theme.radius.card,
+      borderWidth: 1,
+      borderColor: theme.colors.border.default,
+      backgroundColor: theme.colors.surface.elevated,
+      padding: theme.space[12],
+      gap: theme.space[8],
+    },
+    searchInput: {
+      color: theme.colors.text.primary,
+      fontSize: theme.typography.sectionTitle.fontSize,
+      lineHeight: theme.typography.sectionTitle.lineHeight,
+      fontWeight: theme.typography.body.fontWeight,
+      minHeight: 48,
+    },
+    inlineButton: {
+      alignSelf: 'flex-start',
+      paddingHorizontal: theme.space[12],
+      paddingVertical: theme.space[8],
+      borderRadius: theme.radius.button,
+      borderWidth: 1,
+      borderColor: theme.colors.border.subtle,
+      backgroundColor: theme.colors.surface.base,
+    },
+    inlineButtonLabel: {
+      color: theme.colors.text.primary,
+      fontSize: theme.typography.buttonService.fontSize,
+      lineHeight: theme.typography.buttonService.lineHeight,
+      fontWeight: theme.typography.buttonService.fontWeight,
+    },
+    segmentRow: {
+      flexDirection: 'row',
+      gap: theme.space[8],
+    },
+    segmentButton: {
+      flex: 1,
+      borderRadius: theme.radius.button,
+      borderWidth: 1,
+      borderColor: theme.colors.border.subtle,
+      backgroundColor: theme.colors.surface.elevated,
+      paddingHorizontal: theme.space[12],
+      paddingVertical: theme.space[12],
+      gap: theme.space[4],
+      alignItems: 'center',
+    },
+    segmentButtonActive: {
+      borderColor: theme.colors.border.focus,
+      backgroundColor: theme.colors.surface.interactive,
+    },
+    segmentButtonPressed: {
+      backgroundColor: theme.colors.surface.interactive,
+    },
+    segmentLabel: {
+      color: theme.colors.text.primary,
+      fontSize: theme.typography.buttonService.fontSize,
+      lineHeight: theme.typography.buttonService.lineHeight,
+      fontWeight: theme.typography.buttonService.fontWeight,
+    },
+    segmentLabelActive: {
+      color: theme.colors.text.brand,
+      fontSize: theme.typography.buttonService.fontSize,
+      lineHeight: theme.typography.buttonService.lineHeight,
+      fontWeight: theme.typography.buttonService.fontWeight,
+    },
+    segmentCount: {
+      color: theme.colors.text.tertiary,
+      fontSize: theme.typography.meta.fontSize,
+      lineHeight: theme.typography.meta.lineHeight,
+      fontWeight: theme.typography.meta.fontWeight,
+    },
+    segmentCountActive: {
+      color: theme.colors.text.brand,
+      fontSize: theme.typography.meta.fontSize,
+      lineHeight: theme.typography.meta.lineHeight,
+      fontWeight: theme.typography.meta.fontWeight,
+    },
+    sectionCard: {
+      borderRadius: theme.radius.card,
+      borderWidth: 1,
+      borderColor: theme.colors.border.default,
+      backgroundColor: theme.colors.surface.elevated,
+      padding: theme.space[16],
+      gap: theme.space[12],
+    },
+    sectionHeader: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      gap: theme.space[8],
+    },
+    sectionTitle: {
+      color: theme.colors.text.primary,
+      fontSize: theme.typography.sectionTitle.fontSize,
+      lineHeight: theme.typography.sectionTitle.lineHeight,
+      fontWeight: theme.typography.sectionTitle.fontWeight,
+    },
+    sectionMeta: {
+      color: theme.colors.text.secondary,
+      fontSize: theme.typography.meta.fontSize,
+      lineHeight: theme.typography.meta.lineHeight,
+      fontWeight: theme.typography.meta.fontWeight,
+    },
+    chipRow: {
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+      gap: theme.space[8],
+    },
+    historyChip: {
+      borderRadius: theme.radius.chip,
+      borderWidth: 1,
+      borderColor: theme.colors.border.subtle,
+      backgroundColor: theme.colors.surface.base,
+      paddingHorizontal: theme.space[12],
+      paddingVertical: theme.space[8],
+    },
+    historyChipLabel: {
+      color: theme.colors.text.primary,
+      fontSize: theme.typography.buttonService.fontSize,
+      lineHeight: theme.typography.buttonService.lineHeight,
+      fontWeight: theme.typography.buttonService.fontWeight,
+    },
+    suggestedGrid: {
+      gap: theme.space[8],
+    },
+    suggestedCard: {
+      borderRadius: theme.radius.button,
+      borderWidth: 1,
+      borderColor: theme.colors.border.subtle,
+      backgroundColor: theme.colors.surface.base,
+      padding: theme.space[12],
+      gap: theme.space[8],
+    },
+    suggestedBadge: {
+      alignSelf: 'flex-start',
+      minWidth: 40,
+      borderRadius: theme.radius.chip,
+      backgroundColor: theme.colors.status.title.bg,
+      paddingHorizontal: theme.space[12],
+      paddingVertical: theme.space[4],
+    },
+    suggestedBadgeLabel: {
+      color: theme.colors.status.title.text,
+      fontSize: theme.typography.buttonService.fontSize,
+      lineHeight: theme.typography.buttonService.lineHeight,
+      fontWeight: theme.typography.buttonService.fontWeight,
+      textAlign: 'center',
+    },
+    suggestedTitle: {
+      color: theme.colors.text.primary,
+      fontSize: theme.typography.cardTitle.fontSize,
+      lineHeight: theme.typography.cardTitle.lineHeight,
+      fontWeight: theme.typography.cardTitle.fontWeight,
+    },
+    suggestedMeta: {
+      color: theme.colors.text.secondary,
+      fontSize: theme.typography.body.fontSize,
+      lineHeight: theme.typography.body.lineHeight,
+      fontWeight: theme.typography.body.fontWeight,
+    },
+    resultRow: {
+      flexDirection: 'row',
+      gap: theme.space[12],
+      paddingTop: theme.space[12],
+      borderTopWidth: 1,
+      borderTopColor: theme.colors.border.subtle,
+    },
+    resultLeadingBadge: {
+      width: 44,
+      height: 44,
+      borderRadius: theme.radius.button,
+      backgroundColor: theme.colors.surface.base,
+      borderWidth: 1,
+      borderColor: theme.colors.border.subtle,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    resultLeadingBadgeLabel: {
+      color: theme.colors.text.primary,
+      fontSize: theme.typography.buttonService.fontSize,
+      lineHeight: theme.typography.buttonService.lineHeight,
+      fontWeight: theme.typography.buttonService.fontWeight,
+    },
+    resultCopy: {
+      flex: 1,
+      gap: theme.space[4],
+    },
+    resultTitle: {
+      color: theme.colors.text.primary,
+      fontSize: theme.typography.cardTitle.fontSize,
+      lineHeight: theme.typography.cardTitle.lineHeight,
+      fontWeight: theme.typography.cardTitle.fontWeight,
+    },
+    resultBody: {
+      color: theme.colors.text.secondary,
+      fontSize: theme.typography.body.fontSize,
+      lineHeight: theme.typography.body.lineHeight,
+      fontWeight: theme.typography.body.fontWeight,
+    },
+    resultMeta: {
+      color: theme.colors.text.tertiary,
+      fontSize: theme.typography.meta.fontSize,
+      lineHeight: theme.typography.meta.lineHeight,
+      fontWeight: theme.typography.meta.fontWeight,
+    },
+    retryButton: {
+      alignSelf: 'flex-start',
+      borderRadius: theme.radius.button,
+      backgroundColor: theme.colors.text.brand,
+      paddingHorizontal: theme.space[16],
+      paddingVertical: theme.space[12],
+    },
+    retryButtonLabel: {
+      color: theme.colors.surface.base,
+      fontSize: theme.typography.buttonService.fontSize,
+      lineHeight: theme.typography.buttonService.lineHeight,
+      fontWeight: theme.typography.buttonService.fontWeight,
+    },
+  });
+}

--- a/mobile/src/README.md
+++ b/mobile/src/README.md
@@ -12,7 +12,7 @@
   - `context.ts`: dataset -> indexed selector context
   - `adapters.ts`: raw JSON -> display model 변환 규칙
   - `index.ts`: shared selectors entrypoint
-    - team / release detail selector 외에 calendar month snapshot selector 포함
+    - team / release detail selector 외에 calendar month snapshot / search result selector 포함
 - `services/`: data source / external handoff / helper
   - `datasetSource.ts`: bundled-static vs preview-remote source selector
   - `activeDataset.ts`: runtime selection을 실제 dataset payload로 로드하는 entrypoint

--- a/mobile/src/features/route-shell.smoke.test.tsx
+++ b/mobile/src/features/route-shell.smoke.test.tsx
@@ -12,6 +12,9 @@ import ReleaseDetailPlaceholderScreen from '../../app/releases/[id]';
 jest.mock('expo-router', () => {
   const React = jest.requireActual<typeof import('react')>('react');
   const useLocalSearchParams = jest.fn(() => ({}));
+  const useRouter = jest.fn(() => ({
+    push: jest.fn(),
+  }));
 
   function Redirect({ href }: { href: string }) {
     return React.createElement('redirect', { href });
@@ -35,8 +38,10 @@ jest.mock('expo-router', () => {
     Redirect,
     Stack,
     Tabs,
+    useRouter,
     useLocalSearchParams,
     __mock: {
+      useRouter,
       useLocalSearchParams,
     },
   };
@@ -44,10 +49,12 @@ jest.mock('expo-router', () => {
 
 const { __mock } = jest.requireMock('expo-router') as {
   __mock: {
+    useRouter: jest.Mock;
     useLocalSearchParams: jest.Mock;
   };
 };
 
+const mockUseRouter = __mock.useRouter;
 const mockUseLocalSearchParams = __mock.useLocalSearchParams;
 
 function renderTree(element: React.ReactElement) {
@@ -66,12 +73,19 @@ async function renderTreeAsync(element: React.ReactElement) {
   await act(async () => {
     tree = renderer.create(element);
     await Promise.resolve();
+    await Promise.resolve();
   });
 
   return tree!;
 }
 
 describe('mobile route shell smoke', () => {
+  beforeEach(() => {
+    mockUseRouter.mockReturnValue({
+      push: jest.fn(),
+    });
+  });
+
   test('root index redirects to calendar tab', () => {
     const tree = renderTree(<IndexRoute />).toJSON() as renderer.ReactTestRendererJSON;
     expect(tree.props.href).toBe('/(tabs)/calendar');
@@ -85,7 +99,7 @@ describe('mobile route shell smoke', () => {
   test('tab placeholder screens render without crashing', async () => {
     await expect(renderTreeAsync(<CalendarTabScreen />)).resolves.toBeDefined();
     expect(() => renderTree(<RadarTabScreen />)).not.toThrow();
-    expect(() => renderTree(<SearchTabScreen />)).not.toThrow();
+    await expect(renderTreeAsync(<SearchTabScreen />)).resolves.toBeDefined();
   });
 
   test('artist detail placeholder handles valid and missing slug safely', () => {

--- a/mobile/src/features/searchTab.test.tsx
+++ b/mobile/src/features/searchTab.test.tsx
@@ -1,0 +1,104 @@
+import renderer, { act } from 'react-test-renderer';
+import { Text } from 'react-native';
+
+import SearchTabScreen from '../../app/(tabs)/search';
+import { persistRecentQuery, readRecentQueries } from '../services/recentQueries';
+import { resetStorageAdapter, setStorageAdapter, type KeyValueStorageAdapter } from '../services/storage';
+
+function createMemoryStorage(): KeyValueStorageAdapter {
+  const values = new Map<string, string>();
+
+  return {
+    async getItem(key) {
+      return values.has(key) ? values.get(key) ?? null : null;
+    },
+    async setItem(key, value) {
+      values.set(key, value);
+    },
+    async removeItem(key) {
+      values.delete(key);
+    },
+  };
+}
+
+jest.mock('expo-router', () => {
+  const push = jest.fn();
+
+  return {
+    useRouter: () => ({ push }),
+    __mock: { push },
+  };
+});
+
+async function renderSearchScreen() {
+  let tree: renderer.ReactTestRenderer;
+
+  await act(async () => {
+    tree = renderer.create(<SearchTabScreen />);
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+
+  return tree!;
+}
+
+function hasText(tree: renderer.ReactTestRenderer, value: string): boolean {
+  return tree.root.findAllByType(Text).some((node) => node.props.children === value);
+}
+
+describe('mobile search tab', () => {
+  beforeEach(() => {
+    setStorageAdapter(createMemoryStorage());
+  });
+
+  afterEach(() => {
+    resetStorageAdapter();
+  });
+
+  test('renders sectioned results for alias queries and persists recent searches on submit', async () => {
+    const tree = await renderSearchScreen();
+
+    await act(async () => {
+      tree.root.findByProps({ testID: 'search-input' }).props.onChangeText('최예나');
+    });
+
+    expect(tree.root.findByProps({ testID: 'search-team-result-yena' })).toBeDefined();
+
+    await act(async () => {
+      tree.root.findByProps({ testID: 'search-segment-releases' }).props.onPress();
+    });
+
+    expect(tree.root.findByProps({ testID: 'search-release-result-yena--love-catcher--2026-03-11--album' })).toBeDefined();
+
+    await act(async () => {
+      tree.root.findByProps({ testID: 'search-segment-upcoming' }).props.onPress();
+    });
+
+    expect(
+      tree.root.findByProps({
+        testID: 'search-upcoming-result-yena--yena-confirms-a-march-11-comeback--2026-03-11--album',
+      }),
+    ).toBeDefined();
+
+    await act(async () => {
+      await tree.root.findByProps({ testID: 'search-input' }).props.onSubmitEditing();
+    });
+
+    await expect(readRecentQueries()).resolves.toEqual(['최예나']);
+  });
+
+  test('shows recent queries when idle and allows clearing history', async () => {
+    await persistRecentQuery('피원하');
+
+    const tree = await renderSearchScreen();
+
+    expect(tree.root.findByProps({ testID: 'recent-query-피원하' })).toBeDefined();
+
+    await act(async () => {
+      tree.root.findByProps({ testID: 'search-clear-history' }).props.onPress();
+    });
+
+    expect(await readRecentQueries()).toEqual([]);
+    expect(hasText(tree, '최근 검색이 없습니다.')).toBe(true);
+  });
+});

--- a/mobile/src/selectors/index.test.ts
+++ b/mobile/src/selectors/index.test.ts
@@ -5,6 +5,7 @@ import {
   createSelectorContext,
   selectLatestReleaseSummaryBySlug,
   selectMonthReleaseSummaries,
+  selectSearchResults,
   selectMonthUpcomingEvents,
   selectRecentReleaseSummariesBySlug,
   selectReleaseDetailById,
@@ -168,8 +169,8 @@ describe('mobile selector/adapters scaffold', () => {
     const release = selectLatestReleaseSummaryBySlug(dataset, 'yena');
 
     expect(release).not.toBeNull();
-    expect(release?.releaseTitle).toBe('Drama Queen');
-    expect(release?.stream).toBe('song');
+    expect(release?.releaseTitle).toBe('LOVE CATCHER');
+    expect(release?.stream).toBe('album');
   });
 
   test('returns recent release history rows as normalized summary models', () => {
@@ -214,6 +215,24 @@ describe('mobile selector/adapters scaffold', () => {
     expect(snapshot.nearestUpcoming?.headline).toContain('3월 11일');
     expect(snapshot.exactUpcoming).toHaveLength(1);
     expect(snapshot.monthOnlyUpcoming).toHaveLength(1);
+  });
+
+  test('returns sectioned search results for Korean alias and exact upcoming coverage', () => {
+    const results = selectSearchResults(dataset, '최예나');
+
+    expect(results.entities[0]?.team.slug).toBe('yena');
+    expect(results.entities[0]?.matchKind).toBe('alias_exact');
+    expect(results.releases[0]?.release.releaseTitle).toBe('LOVE CATCHER');
+    expect(results.releases[0]?.matchKind).toBe('entity_exact_latest_release');
+    expect(results.upcoming[0]?.upcoming.group).toBe('YENA');
+    expect(results.upcoming[0]?.matchKind).toBe('entity_exact');
+  });
+
+  test('returns release-title exact search matches ahead of partial matches', () => {
+    const results = selectSearchResults(dataset, 'LOVE CATCHER');
+
+    expect(results.releases[0]?.release.releaseTitle).toBe('LOVE CATCHER');
+    expect(results.releases[0]?.matchKind).toBe('release_title_exact');
   });
 
   test('resolves a release detail model by normalized release id', () => {

--- a/mobile/src/selectors/index.ts
+++ b/mobile/src/selectors/index.ts
@@ -3,6 +3,10 @@ import type {
   MobileRawDataset,
   ReleaseDetailModel,
   ReleaseSummaryModel,
+  SearchReleaseResultModel,
+  SearchResultsModel,
+  SearchTeamResultModel,
+  SearchUpcomingResultModel,
   TeamSummaryModel,
   UpcomingEventModel,
 } from '../types';
@@ -15,7 +19,7 @@ import {
   adaptUpcomingEvent,
 } from './adapters';
 import { createSelectorContext, type MobileSelectorContext } from './context';
-import { buildReleaseId, compareIsoDateDescending, compareUpcomingDate } from './normalize';
+import { buildReleaseId, compareIsoDateDescending, compareUpcomingDate, normalizeSearchToken } from './normalize';
 
 export { createSelectorContext } from './context';
 export * from './adapters';
@@ -61,7 +65,18 @@ export function selectLatestReleaseSummaryBySlug(
     releaseCollection,
     context.artworkByReleaseId,
     context.detailByReleaseId,
-  ).sort((left, right) => compareIsoDateDescending(left.releaseDate, right.releaseDate));
+  ).sort((left, right) => {
+    const dateDelta = compareIsoDateDescending(left.releaseDate, right.releaseDate);
+    if (dateDelta !== 0) {
+      return dateDelta;
+    }
+
+    if (left.stream !== right.stream) {
+      return left.stream === 'album' ? -1 : 1;
+    }
+
+    return left.releaseTitle.localeCompare(right.releaseTitle);
+  });
 
   return candidates[0] ?? null;
 }
@@ -224,6 +239,224 @@ export function selectNearestExactUpcomingEvent(
   }
 
   return events.sort(compareUpcomingDate)[0] ?? null;
+}
+
+function includesPartialMatch(tokens: string[], query: string): boolean {
+  return tokens.some((token) => token.includes(query));
+}
+
+function findSearchTeamResults(
+  context: MobileSelectorContext,
+  normalizedQuery: string,
+): SearchTeamResultModel[] {
+  const results: SearchTeamResultModel[] = [];
+
+  for (const profile of context.dataset.artistProfiles) {
+    const team = adaptTeamSummary(profile, context.allowlistsByGroup.get(profile.group));
+    const displayTokens = [profile.group, profile.display_name]
+      .filter((value): value is string => Boolean(value?.trim()))
+      .map(normalizeSearchToken);
+    const searchAliasTokens = (profile.search_aliases ?? []).map(normalizeSearchToken);
+    const aliasTokens = (profile.aliases ?? []).map(normalizeSearchToken);
+    const allTokens = Array.from(new Set([...displayTokens, ...searchAliasTokens, ...aliasTokens]));
+
+    let matchKind: SearchTeamResultModel['matchKind'] | null = null;
+
+    if (displayTokens.includes(normalizedQuery)) {
+      matchKind = 'display_name_exact';
+    } else if (searchAliasTokens.includes(normalizedQuery)) {
+      matchKind = 'search_alias_exact';
+    } else if (aliasTokens.includes(normalizedQuery)) {
+      matchKind = 'alias_exact';
+    } else if (includesPartialMatch([...searchAliasTokens, ...aliasTokens], normalizedQuery)) {
+      matchKind = 'alias_partial';
+    } else if (includesPartialMatch(allTokens, normalizedQuery)) {
+      matchKind = 'partial';
+    }
+
+    if (!matchKind) {
+      continue;
+    }
+
+    results.push({
+      team,
+      latestRelease: selectLatestReleaseSummaryBySlug(context, team.slug),
+      matchKind,
+    });
+  }
+
+  const rank: Record<SearchTeamResultModel['matchKind'], number> = {
+    display_name_exact: 0,
+    search_alias_exact: 1,
+    alias_exact: 2,
+    alias_partial: 3,
+    partial: 4,
+  };
+
+  return results.sort((left, right) => {
+    const rankDelta = rank[left.matchKind] - rank[right.matchKind];
+    if (rankDelta !== 0) {
+      return rankDelta;
+    }
+
+    return left.team.displayName.localeCompare(right.team.displayName);
+  });
+}
+
+function findSearchReleaseResults(
+  context: MobileSelectorContext,
+  normalizedQuery: string,
+): SearchReleaseResultModel[] {
+  const latestReleaseIdsByGroup = new Map<string, string>();
+
+  for (const profile of context.dataset.artistProfiles) {
+    const latestRelease = selectLatestReleaseSummaryBySlug(context, profile.slug);
+    if (latestRelease) {
+      latestReleaseIdsByGroup.set(profile.group, latestRelease.id);
+    }
+  }
+
+  const results: SearchReleaseResultModel[] = [];
+
+  for (const [group, history] of context.releaseHistoryByGroup.entries()) {
+    const profile = context.profilesByGroup.get(group);
+    const displayGroup = profile?.display_name?.trim() || group;
+    const teamTokens = [group, profile?.display_name, ...(profile?.aliases ?? []), ...(profile?.search_aliases ?? [])]
+      .filter((value): value is string => Boolean(value?.trim()))
+      .map(normalizeSearchToken);
+
+    for (const release of history.releases) {
+      const releaseId = buildReleaseId(group, release.title, release.date, release.stream ?? 'album');
+      const releaseTitleToken = normalizeSearchToken(release.title);
+
+      let matchKind: SearchReleaseResultModel['matchKind'] | null = null;
+
+      if (releaseTitleToken === normalizedQuery) {
+        matchKind = 'release_title_exact';
+      } else if (
+        teamTokens.includes(normalizedQuery) &&
+        latestReleaseIdsByGroup.get(group) === releaseId
+      ) {
+        matchKind = 'entity_exact_latest_release';
+      } else if (releaseTitleToken.includes(normalizedQuery) || teamTokens.some((token) => token.includes(normalizedQuery))) {
+        matchKind = 'partial';
+      }
+
+      if (!matchKind) {
+        continue;
+      }
+
+      results.push({
+        release: adaptReleaseHistoryEntry(
+          group,
+          displayGroup,
+          release,
+          context.artworkByReleaseId.get(releaseId),
+          context.detailByReleaseId.get(releaseId),
+        ),
+        matchKind,
+      });
+    }
+  }
+
+  const rank: Record<SearchReleaseResultModel['matchKind'], number> = {
+    release_title_exact: 0,
+    entity_exact_latest_release: 1,
+    partial: 2,
+  };
+
+  return results
+    .sort((left, right) => {
+      const rankDelta = rank[left.matchKind] - rank[right.matchKind];
+      if (rankDelta !== 0) {
+        return rankDelta;
+      }
+
+      return compareIsoDateDescending(left.release.releaseDate, right.release.releaseDate);
+    })
+    .slice(0, 20);
+}
+
+function findSearchUpcomingResults(
+  context: MobileSelectorContext,
+  normalizedQuery: string,
+): SearchUpcomingResultModel[] {
+  const results: SearchUpcomingResultModel[] = [];
+
+  for (const upcoming of context.dataset.upcomingCandidates) {
+    const displayGroup = context.profilesByGroup.get(upcoming.group)?.display_name?.trim() || upcoming.group;
+    const teamProfile = context.profilesByGroup.get(upcoming.group);
+    const teamTokens = [upcoming.group, teamProfile?.display_name, ...(teamProfile?.aliases ?? []), ...(teamProfile?.search_aliases ?? [])]
+      .filter((value): value is string => Boolean(value?.trim()))
+      .map(normalizeSearchToken);
+    const headlineToken = normalizeSearchToken(upcoming.headline);
+    const releaseLabelToken = normalizeSearchToken(upcoming.release_label ?? '');
+    const headlineWords = headlineToken.split(' ').filter(Boolean);
+
+    let matchKind: SearchUpcomingResultModel['matchKind'] | null = null;
+
+    if (teamTokens.includes(normalizedQuery)) {
+      matchKind = 'entity_exact';
+    } else if (headlineWords.includes(normalizedQuery) || releaseLabelToken === normalizedQuery) {
+      matchKind = 'headline_exact';
+    } else if (
+      headlineToken.includes(normalizedQuery) ||
+      releaseLabelToken.includes(normalizedQuery) ||
+      teamTokens.some((token) => token.includes(normalizedQuery))
+    ) {
+      matchKind = 'partial';
+    }
+
+    if (!matchKind) {
+      continue;
+    }
+
+    results.push({
+      upcoming: adaptUpcomingEvent(upcoming.group, displayGroup, upcoming),
+      matchKind,
+    });
+  }
+
+  const rank: Record<SearchUpcomingResultModel['matchKind'], number> = {
+    entity_exact: 0,
+    headline_exact: 1,
+    partial: 2,
+  };
+
+  return results
+    .sort((left, right) => {
+      const rankDelta = rank[left.matchKind] - rank[right.matchKind];
+      if (rankDelta !== 0) {
+        return rankDelta;
+      }
+
+      return compareUpcomingDate(left.upcoming, right.upcoming);
+    })
+    .slice(0, 20);
+}
+
+export function selectSearchResults(
+  input: MobileSelectorContext | MobileRawDataset,
+  query: string,
+): SearchResultsModel {
+  const context = resolveContext(input);
+  const normalizedQuery = normalizeSearchToken(query);
+
+  if (!normalizedQuery) {
+    return {
+      query,
+      entities: [],
+      releases: [],
+      upcoming: [],
+    };
+  }
+
+  return {
+    query,
+    entities: findSearchTeamResults(context, normalizedQuery),
+    releases: findSearchReleaseResults(context, normalizedQuery),
+    upcoming: findSearchUpcomingResults(context, normalizedQuery),
+  };
 }
 
 export function selectCalendarMonthSnapshot(

--- a/mobile/src/types/displayModels.ts
+++ b/mobile/src/types/displayModels.ts
@@ -86,6 +86,46 @@ export interface ReleaseDetailModel {
   tracks: TrackModel[];
 }
 
+export type SearchTeamMatchKind =
+  | 'display_name_exact'
+  | 'search_alias_exact'
+  | 'alias_exact'
+  | 'alias_partial'
+  | 'partial';
+
+export type SearchReleaseMatchKind =
+  | 'release_title_exact'
+  | 'entity_exact_latest_release'
+  | 'partial';
+
+export type SearchUpcomingMatchKind =
+  | 'entity_exact'
+  | 'headline_exact'
+  | 'partial';
+
+export interface SearchTeamResultModel {
+  team: TeamSummaryModel;
+  latestRelease: ReleaseSummaryModel | null;
+  matchKind: SearchTeamMatchKind;
+}
+
+export interface SearchReleaseResultModel {
+  release: ReleaseSummaryModel;
+  matchKind: SearchReleaseMatchKind;
+}
+
+export interface SearchUpcomingResultModel {
+  upcoming: UpcomingEventModel;
+  matchKind: SearchUpcomingMatchKind;
+}
+
+export interface SearchResultsModel {
+  query: string;
+  entities: SearchTeamResultModel[];
+  releases: SearchReleaseResultModel[];
+  upcoming: SearchUpcomingResultModel[];
+}
+
 export interface CalendarMonthSnapshotModel {
   month: string;
   releaseCount: number;


### PR DESCRIPTION
## Summary
- implement a real mobile search tab with query state, recent queries, and segmented results
- add shared search selector models and ranking logic for entities, releases, and upcoming rows
- cover the new search flow with selector, screen, and route smoke tests

## Verification
- cd mobile && npm run lint
- cd mobile && npm run typecheck
- cd mobile && npm run test
- cd mobile && CI=1 npx expo export --platform web --output-dir /tmp/idol-song-app-mobile-search-export
- git diff --check

Closes #335