### PR TITLE
feat: implement mobile radar tab

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -2,7 +2,7 @@
 
 이 디렉터리는 `Expo + React Native + Expo Router` 기반 모바일 앱 워크스페이스다.
 
-현재 단계는 workspace bootstrap과 router shell, 그리고 calendar / search tab의 data-backed container까지 포함한다.
+현재 단계는 workspace bootstrap과 router shell, 그리고 calendar / search / radar tab의 data-backed container까지 포함한다.
 
 - route/layout expectations는 `docs/specs/mobile/expo-implementation-guide.md`를 따른다.
 - route/param 계약은 `docs/specs/mobile/route-param-contracts.md`를 따른다.
@@ -13,6 +13,7 @@
 - `app/`
   - Expo Router root layout / tab shell / detail placeholder route
   - `calendar` tab은 active dataset + shared selector 기반 container까지 연결됨
+  - `radar` tab은 shared radar snapshot 기반 section stack까지 연결됨
   - `search` tab은 query state + recent query persistence + segmented result container까지 연결됨
   - hidden `debug/metadata` route for internal metadata inspection
 - `assets/`
@@ -184,6 +185,7 @@ profile 차이는 아래 범위로만 제한한다.
   - `selectMonthReleaseSummaries`
   - `selectMonthUpcomingEvents`
   - `selectCalendarMonthSnapshot`
+  - `selectRadarSnapshot`
   - `selectSearchResults`
 - 규칙
   - 화면은 raw JSON shape를 직접 읽지 않는다.

--- a/mobile/app/(tabs)/radar.tsx
+++ b/mobile/app/(tabs)/radar.tsx
@@ -1,41 +1,567 @@
-import { StyleSheet, Text, View } from 'react-native';
+import { useRouter } from 'expo-router';
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+
+import { selectRadarSnapshot } from '../../src/selectors';
+import {
+  loadActiveMobileDataset,
+  type ActiveMobileDataset,
+} from '../../src/services/activeDataset';
+import { useAppTheme } from '../../src/tokens/theme';
+import type {
+  RadarLongGapItemModel,
+  RadarRookieItemModel,
+  RadarSnapshotModel,
+  RadarUpcomingCardModel,
+  TeamSummaryModel,
+} from '../../src/types';
+
+type RadarScreenState =
+  | { kind: 'loading' }
+  | { kind: 'error'; message: string }
+  | { kind: 'ready'; source: ActiveMobileDataset; snapshot: RadarSnapshotModel };
+
+function formatUpcomingMeta(card: RadarUpcomingCardModel): string {
+  const status = card.upcoming.status ?? '예정';
+  const confidence = card.upcoming.confidence ? ` · ${card.upcoming.confidence}` : '';
+  const scheduledLabel = card.upcoming.scheduledDate ?? card.upcoming.scheduledMonth ?? '날짜 미정';
+  return `${scheduledLabel} · ${status}${confidence}`;
+}
+
+function formatLongGapMeta(item: RadarLongGapItemModel): string {
+  const releaseLabel = item.latestRelease
+    ? `${item.latestRelease.releaseTitle} · ${item.latestRelease.releaseDate}`
+    : '마지막 발매 정보 없음';
+  const upcomingLabel = item.hasUpcomingSignal ? '예정 신호 있음' : '예정 신호 없음';
+  return `${releaseLabel} · ${item.gapLabel} · ${upcomingLabel}`;
+}
+
+function formatRookieMeta(item: RadarRookieItemModel): string {
+  const releaseLabel = item.latestRelease
+    ? `${item.latestRelease.releaseTitle} · ${item.latestRelease.releaseDate}`
+    : '최근 발매 정보 없음';
+  const upcomingLabel = item.hasUpcomingSignal ? '예정 신호 있음' : '예정 신호 없음';
+  return `데뷔 ${item.debutYear} · ${releaseLabel} · ${upcomingLabel}`;
+}
+
+function resolveBadgeLabel(team: TeamSummaryModel): string {
+  return team.badge?.monogram ?? team.displayName.slice(0, 2).toUpperCase();
+}
 
 export default function RadarTabScreen() {
+  const router = useRouter();
+  const theme = useAppTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+  const [reloadCount, setReloadCount] = useState(0);
+  const [hideEmptySections, setHideEmptySections] = useState(false);
+  const [state, setState] = useState<RadarScreenState>({ kind: 'loading' });
+  const today = useMemo(() => new Date(), []);
+  const todayIsoDate = useMemo(() => today.toISOString().slice(0, 10), [today]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setState({ kind: 'loading' });
+
+    void loadActiveMobileDataset()
+      .then((source) => {
+        if (cancelled) {
+          return;
+        }
+
+        setState({
+          kind: 'ready',
+          source,
+          snapshot: selectRadarSnapshot(source.dataset, todayIsoDate),
+        });
+      })
+      .catch((error: unknown) => {
+        if (cancelled) {
+          return;
+        }
+
+        setState({
+          kind: 'error',
+          message:
+            error instanceof Error
+              ? error.message
+              : 'Radar dataset could not be loaded right now.',
+        });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [reloadCount, todayIsoDate]);
+
+  function openSearchTab() {
+    router.push('/(tabs)/search');
+  }
+
+  function openTeamDetail(slug: string) {
+    router.push({
+      pathname: '/artists/[slug]',
+      params: { slug },
+    });
+  }
+
+  if (state.kind === 'loading') {
+    return (
+      <View style={styles.stateContainer}>
+        <ActivityIndicator color={theme.colors.text.brand} />
+        <Text style={styles.eyebrow}>DATA-BACKED TAB</Text>
+        <Text style={styles.title}>레이더</Text>
+        <Text style={styles.body}>가장 가까운 컴백과 레이더 요약을 불러오는 중입니다.</Text>
+      </View>
+    );
+  }
+
+  if (state.kind === 'error') {
+    return (
+      <View style={styles.stateContainer}>
+        <Text style={styles.eyebrow}>LOAD ERROR</Text>
+        <Text style={styles.title}>레이더</Text>
+        <Text style={styles.body}>{state.message}</Text>
+        <Pressable style={styles.retryButton} onPress={() => setReloadCount((count) => count + 1)}>
+          <Text style={styles.retryButtonLabel}>다시 시도</Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  const { snapshot, source } = state;
+
   return (
-    <View style={styles.container}>
-      <Text style={styles.eyebrow}>TAB SHELL</Text>
-      <Text style={styles.title}>Radar</Text>
-      <Text style={styles.body}>
-        Featured upcoming, weekly picks, long-gap, rookie, and change-feed sections will land inside
-        this tab without changing the top-level route structure.
-      </Text>
+    <ScrollView style={styles.screen} contentContainerStyle={styles.content}>
+      <View style={styles.appBar}>
+        <View style={styles.appBarCopy}>
+          <Text style={styles.eyebrow}>DATA-BACKED TAB</Text>
+          <Text style={styles.title}>레이더</Text>
+          <Text style={styles.body}>{source.sourceLabel}</Text>
+        </View>
+        <View style={styles.appBarActions}>
+          <Pressable
+            testID="radar-search-button"
+            accessibilityRole="button"
+            onPress={openSearchTab}
+            style={({ pressed }) => [styles.appBarButton, pressed ? styles.buttonPressed : null]}
+          >
+            <Text style={styles.appBarButtonLabel}>검색</Text>
+          </Pressable>
+          <Pressable
+            testID="radar-filter-button"
+            accessibilityRole="button"
+            onPress={() => setHideEmptySections((value) => !value)}
+            style={({ pressed }) => [
+              styles.appBarButton,
+              hideEmptySections ? styles.appBarButtonActive : null,
+              pressed ? styles.buttonPressed : null,
+            ]}
+          >
+            <Text style={hideEmptySections ? styles.appBarButtonLabelActive : styles.appBarButtonLabel}>
+              빈 섹션 숨김
+            </Text>
+          </Pressable>
+        </View>
+      </View>
+
+      <View style={styles.summaryStrip}>
+        <View style={styles.summaryCard}>
+          <Text style={styles.summaryValue}>{snapshot.weeklyUpcoming.length}</Text>
+          <Text style={styles.summaryLabel}>이번 주 예정</Text>
+        </View>
+        <View style={styles.summaryCard}>
+          <Text style={styles.summaryValue}>{snapshot.changeFeed.length}</Text>
+          <Text style={styles.summaryLabel}>일정 변경</Text>
+        </View>
+        <View style={styles.summaryCard}>
+          <Text style={styles.summaryValue}>{snapshot.longGap.length + snapshot.rookie.length}</Text>
+          <Text style={styles.summaryLabel}>장기 공백 · 루키</Text>
+        </View>
+      </View>
+
+      <RadarFeaturedSection
+        styles={styles}
+        item={snapshot.featuredUpcoming}
+        onPressTeam={openTeamDetail}
+      />
+
+      <RadarSection
+        title="이번 주 예정"
+        emptyCopy="이번 주 예정이 없습니다."
+        styles={styles}
+        hideWhenEmpty={hideEmptySections}
+        items={snapshot.weeklyUpcoming}
+        renderItem={(item) => (
+          <Pressable
+            key={item.id}
+            testID={`radar-weekly-card-${item.team.slug}`}
+            accessibilityRole="button"
+            onPress={() => openTeamDetail(item.team.slug)}
+            style={({ pressed }) => [styles.card, pressed ? styles.buttonPressed : null]}
+          >
+            <View style={styles.cardBadge}>
+              <Text style={styles.cardBadgeLabel}>{resolveBadgeLabel(item.team)}</Text>
+            </View>
+            <View style={styles.cardCopy}>
+              <Text style={styles.cardTitle}>{item.team.displayName}</Text>
+              <Text style={styles.cardBody}>{item.upcoming.releaseLabel ?? item.upcoming.headline}</Text>
+              <Text style={styles.cardMeta}>
+                {item.dayLabel} · {formatUpcomingMeta(item)}
+              </Text>
+            </View>
+          </Pressable>
+        )}
+      />
+
+      <RadarSection
+        title="일정 변경"
+        emptyCopy="감지된 일정 변경이 없습니다."
+        styles={styles}
+        hideWhenEmpty={hideEmptySections}
+        items={snapshot.changeFeed}
+        renderItem={(item) => (
+          <View key={item.id} style={styles.card}>
+            <Text style={styles.cardTitle}>{item.label}</Text>
+          </View>
+        )}
+      />
+
+      <RadarSection
+        title="장기 공백 레이더"
+        emptyCopy="현재 장기 공백 대상이 없습니다."
+        styles={styles}
+        hideWhenEmpty={hideEmptySections}
+        items={snapshot.longGap}
+        renderItem={(item) => (
+          <Pressable
+            key={item.id}
+            testID={`radar-long-gap-card-${item.team.slug}`}
+            accessibilityRole="button"
+            onPress={() => openTeamDetail(item.team.slug)}
+            style={({ pressed }) => [styles.card, pressed ? styles.buttonPressed : null]}
+          >
+            <View style={styles.cardBadge}>
+              <Text style={styles.cardBadgeLabel}>{resolveBadgeLabel(item.team)}</Text>
+            </View>
+            <View style={styles.cardCopy}>
+              <Text style={styles.cardTitle}>{item.team.displayName}</Text>
+              <Text style={styles.cardMeta}>{formatLongGapMeta(item)}</Text>
+            </View>
+          </Pressable>
+        )}
+      />
+
+      <RadarSection
+        title="루키 레이더"
+        emptyCopy="현재 루키 대상이 없습니다."
+        styles={styles}
+        hideWhenEmpty={hideEmptySections}
+        items={snapshot.rookie}
+        renderItem={(item) => (
+          <Pressable
+            key={item.id}
+            testID={`radar-rookie-card-${item.team.slug}`}
+            accessibilityRole="button"
+            onPress={() => openTeamDetail(item.team.slug)}
+            style={({ pressed }) => [styles.card, pressed ? styles.buttonPressed : null]}
+          >
+            <View style={styles.cardBadge}>
+              <Text style={styles.cardBadgeLabel}>{resolveBadgeLabel(item.team)}</Text>
+            </View>
+            <View style={styles.cardCopy}>
+              <Text style={styles.cardTitle}>{item.team.displayName}</Text>
+              <Text style={styles.cardMeta}>{formatRookieMeta(item)}</Text>
+            </View>
+          </Pressable>
+        )}
+      />
+    </ScrollView>
+  );
+}
+
+function RadarFeaturedSection({
+  item,
+  onPressTeam,
+  styles,
+}: {
+  item: RadarUpcomingCardModel | null;
+  onPressTeam: (slug: string) => void;
+  styles: ReturnType<typeof createStyles>;
+}) {
+  return (
+    <View style={styles.sectionCard}>
+      <View style={styles.sectionHeader}>
+        <Text style={styles.sectionTitle}>가장 가까운 컴백</Text>
+      </View>
+      {item ? (
+        <Pressable
+          testID="radar-featured-card"
+          accessibilityRole="button"
+          onPress={() => onPressTeam(item.team.slug)}
+          style={({ pressed }) => [styles.featuredCard, pressed ? styles.buttonPressed : null]}
+        >
+          <Text style={styles.featuredEyebrow}>{item.dayLabel}</Text>
+          <Text style={styles.featuredTitle}>{item.team.displayName}</Text>
+          <Text style={styles.featuredBody}>{item.upcoming.releaseLabel ?? item.upcoming.headline}</Text>
+          <Text style={styles.featuredMeta}>{formatUpcomingMeta(item)}</Text>
+        </Pressable>
+      ) : (
+        <Text style={styles.emptyCopy}>가까운 컴백 일정이 없습니다.</Text>
+      )}
     </View>
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: 'center',
-    paddingHorizontal: 24,
-    backgroundColor: '#f7f6f2',
-  },
-  eyebrow: {
-    marginBottom: 8,
-    fontSize: 12,
-    fontWeight: '600',
-    letterSpacing: 1.2,
-    color: '#87634d',
-  },
-  title: {
-    marginBottom: 12,
-    fontSize: 28,
-    fontWeight: '700',
-    color: '#1f1b17',
-  },
-  body: {
-    fontSize: 16,
-    lineHeight: 24,
-    color: '#5e554d',
-  },
-});
+function RadarSection<T>({
+  emptyCopy,
+  hideWhenEmpty,
+  items,
+  renderItem,
+  styles,
+  title,
+}: {
+  emptyCopy: string;
+  hideWhenEmpty: boolean;
+  items: T[];
+  renderItem: (item: T) => React.ReactNode;
+  styles: ReturnType<typeof createStyles>;
+  title: string;
+}) {
+  if (hideWhenEmpty && items.length === 0) {
+    return null;
+  }
+
+  return (
+    <View style={styles.sectionCard}>
+      <View style={styles.sectionHeader}>
+        <Text style={styles.sectionTitle}>{title}</Text>
+      </View>
+      {items.length === 0 ? <Text style={styles.emptyCopy}>{emptyCopy}</Text> : null}
+      {items.map(renderItem)}
+    </View>
+  );
+}
+
+function createStyles(theme: ReturnType<typeof useAppTheme>) {
+  return StyleSheet.create({
+    screen: {
+      flex: 1,
+      backgroundColor: theme.colors.surface.base,
+    },
+    content: {
+      paddingHorizontal: theme.space[24],
+      paddingTop: theme.space[24],
+      paddingBottom: theme.space[32],
+      gap: theme.space[16],
+    },
+    stateContainer: {
+      flex: 1,
+      justifyContent: 'center',
+      paddingHorizontal: theme.space[24],
+      gap: theme.space[12],
+      backgroundColor: theme.colors.surface.base,
+    },
+    appBar: {
+      gap: theme.space[12],
+    },
+    appBarCopy: {
+      gap: theme.space[8],
+    },
+    appBarActions: {
+      flexDirection: 'row',
+      gap: theme.space[8],
+    },
+    appBarButton: {
+      borderRadius: theme.radius.button,
+      borderWidth: 1,
+      borderColor: theme.colors.border.subtle,
+      backgroundColor: theme.colors.surface.elevated,
+      paddingHorizontal: theme.space[12],
+      paddingVertical: theme.space[8],
+    },
+    appBarButtonActive: {
+      backgroundColor: theme.colors.text.brand,
+      borderColor: theme.colors.text.brand,
+    },
+    appBarButtonLabel: {
+      color: theme.colors.text.primary,
+      fontSize: theme.typography.buttonService.fontSize,
+      lineHeight: theme.typography.buttonService.lineHeight,
+      fontWeight: theme.typography.buttonService.fontWeight,
+    },
+    appBarButtonLabelActive: {
+      color: theme.colors.surface.base,
+      fontSize: theme.typography.buttonService.fontSize,
+      lineHeight: theme.typography.buttonService.lineHeight,
+      fontWeight: theme.typography.buttonService.fontWeight,
+    },
+    eyebrow: {
+      color: theme.colors.text.brand,
+      fontSize: theme.typography.meta.fontSize,
+      fontWeight: theme.typography.meta.fontWeight,
+      letterSpacing: theme.typography.meta.letterSpacing,
+    },
+    title: {
+      color: theme.colors.text.primary,
+      fontSize: theme.typography.screenTitle.fontSize,
+      lineHeight: theme.typography.screenTitle.lineHeight,
+      fontWeight: theme.typography.screenTitle.fontWeight,
+      letterSpacing: theme.typography.screenTitle.letterSpacing,
+    },
+    body: {
+      color: theme.colors.text.secondary,
+      fontSize: theme.typography.body.fontSize,
+      lineHeight: theme.typography.body.lineHeight,
+      fontWeight: theme.typography.body.fontWeight,
+    },
+    summaryStrip: {
+      flexDirection: 'row',
+      gap: theme.space[8],
+    },
+    summaryCard: {
+      flex: 1,
+      borderRadius: theme.radius.button,
+      borderWidth: 1,
+      borderColor: theme.colors.border.subtle,
+      backgroundColor: theme.colors.surface.elevated,
+      padding: theme.space[12],
+      gap: theme.space[4],
+    },
+    summaryValue: {
+      color: theme.colors.text.primary,
+      fontSize: theme.typography.cardTitle.fontSize,
+      lineHeight: theme.typography.cardTitle.lineHeight,
+      fontWeight: theme.typography.cardTitle.fontWeight,
+    },
+    summaryLabel: {
+      color: theme.colors.text.secondary,
+      fontSize: theme.typography.meta.fontSize,
+      lineHeight: theme.typography.meta.lineHeight,
+      fontWeight: theme.typography.meta.fontWeight,
+    },
+    sectionCard: {
+      borderRadius: theme.radius.card,
+      borderWidth: 1,
+      borderColor: theme.colors.border.default,
+      backgroundColor: theme.colors.surface.elevated,
+      padding: theme.space[16],
+      gap: theme.space[12],
+    },
+    sectionHeader: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      gap: theme.space[8],
+    },
+    sectionTitle: {
+      color: theme.colors.text.primary,
+      fontSize: theme.typography.sectionTitle.fontSize,
+      lineHeight: theme.typography.sectionTitle.lineHeight,
+      fontWeight: theme.typography.sectionTitle.fontWeight,
+    },
+    featuredCard: {
+      borderRadius: theme.radius.card,
+      backgroundColor: theme.colors.status.title.bg,
+      padding: theme.space[16],
+      gap: theme.space[8],
+    },
+    featuredEyebrow: {
+      color: theme.colors.status.title.text,
+      fontSize: theme.typography.meta.fontSize,
+      lineHeight: theme.typography.meta.lineHeight,
+      fontWeight: theme.typography.meta.fontWeight,
+    },
+    featuredTitle: {
+      color: theme.colors.text.primary,
+      fontSize: theme.typography.screenTitle.fontSize,
+      lineHeight: theme.typography.screenTitle.lineHeight,
+      fontWeight: theme.typography.screenTitle.fontWeight,
+    },
+    featuredBody: {
+      color: theme.colors.text.primary,
+      fontSize: theme.typography.cardTitle.fontSize,
+      lineHeight: theme.typography.cardTitle.lineHeight,
+      fontWeight: theme.typography.cardTitle.fontWeight,
+    },
+    featuredMeta: {
+      color: theme.colors.text.secondary,
+      fontSize: theme.typography.body.fontSize,
+      lineHeight: theme.typography.body.lineHeight,
+      fontWeight: theme.typography.body.fontWeight,
+    },
+    card: {
+      flexDirection: 'row',
+      gap: theme.space[12],
+      borderTopWidth: 1,
+      borderTopColor: theme.colors.border.subtle,
+      paddingTop: theme.space[12],
+    },
+    cardBadge: {
+      width: 44,
+      height: 44,
+      borderRadius: theme.radius.button,
+      borderWidth: 1,
+      borderColor: theme.colors.border.subtle,
+      backgroundColor: theme.colors.surface.base,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    cardBadgeLabel: {
+      color: theme.colors.text.primary,
+      fontSize: theme.typography.buttonService.fontSize,
+      lineHeight: theme.typography.buttonService.lineHeight,
+      fontWeight: theme.typography.buttonService.fontWeight,
+    },
+    cardCopy: {
+      flex: 1,
+      gap: theme.space[4],
+    },
+    cardTitle: {
+      color: theme.colors.text.primary,
+      fontSize: theme.typography.cardTitle.fontSize,
+      lineHeight: theme.typography.cardTitle.lineHeight,
+      fontWeight: theme.typography.cardTitle.fontWeight,
+    },
+    cardBody: {
+      color: theme.colors.text.secondary,
+      fontSize: theme.typography.body.fontSize,
+      lineHeight: theme.typography.body.lineHeight,
+      fontWeight: theme.typography.body.fontWeight,
+    },
+    cardMeta: {
+      color: theme.colors.text.tertiary,
+      fontSize: theme.typography.meta.fontSize,
+      lineHeight: theme.typography.meta.lineHeight,
+      fontWeight: theme.typography.meta.fontWeight,
+    },
+    emptyCopy: {
+      color: theme.colors.text.secondary,
+      fontSize: theme.typography.body.fontSize,
+      lineHeight: theme.typography.body.lineHeight,
+      fontWeight: theme.typography.body.fontWeight,
+    },
+    retryButton: {
+      alignSelf: 'flex-start',
+      borderRadius: theme.radius.button,
+      backgroundColor: theme.colors.text.brand,
+      paddingHorizontal: theme.space[16],
+      paddingVertical: theme.space[12],
+    },
+    retryButtonLabel: {
+      color: theme.colors.surface.base,
+      fontSize: theme.typography.buttonService.fontSize,
+      lineHeight: theme.typography.buttonService.lineHeight,
+      fontWeight: theme.typography.buttonService.fontWeight,
+    },
+    buttonPressed: {
+      opacity: 0.84,
+    },
+  });
+}

--- a/mobile/src/README.md
+++ b/mobile/src/README.md
@@ -12,7 +12,7 @@
   - `context.ts`: dataset -> indexed selector context
   - `adapters.ts`: raw JSON -> display model 변환 규칙
   - `index.ts`: shared selectors entrypoint
-    - team / release detail selector 외에 calendar month snapshot / search result selector 포함
+    - team / release detail selector 외에 calendar month snapshot / radar snapshot / search result selector 포함
 - `services/`: data source / external handoff / helper
   - `datasetSource.ts`: bundled-static vs preview-remote source selector
   - `activeDataset.ts`: runtime selection을 실제 dataset payload로 로드하는 entrypoint

--- a/mobile/src/features/radarTab.test.tsx
+++ b/mobile/src/features/radarTab.test.tsx
@@ -1,0 +1,44 @@
+import renderer, { act } from 'react-test-renderer';
+
+import RadarTabScreen from '../../app/(tabs)/radar';
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+  }),
+}));
+
+async function renderRadarScreen() {
+  let tree: renderer.ReactTestRenderer;
+
+  await act(async () => {
+    tree = renderer.create(<RadarTabScreen />);
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+
+  return tree!;
+}
+
+describe('mobile radar tab', () => {
+  test('renders radar sections from shared selector data', async () => {
+    const tree = await renderRadarScreen();
+
+    expect(tree.root.findByProps({ testID: 'radar-featured-card' })).toBeDefined();
+    expect(tree.root.findByProps({ testID: 'radar-weekly-card-yena' })).toBeDefined();
+    expect(tree.root.findByProps({ testID: 'radar-long-gap-card-weeekly' })).toBeDefined();
+    expect(tree.root.findByProps({ testID: 'radar-rookie-card-atheart' })).toBeDefined();
+  });
+
+  test('hides empty sections when the filter toggle is active', async () => {
+    const tree = await renderRadarScreen();
+
+    await act(async () => {
+      tree.root.findByProps({ testID: 'radar-filter-button' }).props.onPress();
+    });
+
+    expect(tree.root.findByProps({ testID: 'radar-featured-card' })).toBeDefined();
+    expect(tree.root.findByProps({ testID: 'radar-long-gap-card-weeekly' })).toBeDefined();
+    expect(tree.root.findByProps({ testID: 'radar-rookie-card-atheart' })).toBeDefined();
+  });
+});

--- a/mobile/src/features/route-shell.smoke.test.tsx
+++ b/mobile/src/features/route-shell.smoke.test.tsx
@@ -98,7 +98,7 @@ describe('mobile route shell smoke', () => {
 
   test('tab placeholder screens render without crashing', async () => {
     await expect(renderTreeAsync(<CalendarTabScreen />)).resolves.toBeDefined();
-    expect(() => renderTree(<RadarTabScreen />)).not.toThrow();
+    await expect(renderTreeAsync(<RadarTabScreen />)).resolves.toBeDefined();
     await expect(renderTreeAsync(<SearchTabScreen />)).resolves.toBeDefined();
   });
 

--- a/mobile/src/selectors/index.test.ts
+++ b/mobile/src/selectors/index.test.ts
@@ -5,6 +5,7 @@ import {
   createSelectorContext,
   selectLatestReleaseSummaryBySlug,
   selectMonthReleaseSummaries,
+  selectRadarSnapshot,
   selectSearchResults,
   selectMonthUpcomingEvents,
   selectRecentReleaseSummariesBySlug,
@@ -39,6 +40,26 @@ const dataset: MobileRawDataset = {
       official_youtube_url: 'https://www.youtube.com/@BLACKPINK',
       representative_image_url: 'https://example.com/blackpink.jpg',
     },
+    {
+      slug: 'weeekly',
+      group: 'Weeekly',
+      display_name: 'Weeekly',
+      aliases: ['위클리'],
+      search_aliases: ['위클리'],
+      agency: 'IST Entertainment',
+      official_youtube_url: 'https://www.youtube.com/@Weeekly',
+      artist_source_url: 'https://musicbrainz.org/artist/example-weeekly',
+    },
+    {
+      slug: 'atheart',
+      group: 'AtHeart',
+      display_name: 'AtHeart',
+      aliases: ['앳하트'],
+      search_aliases: ['앳하트'],
+      agency: 'Titan Content',
+      official_youtube_url: 'https://www.youtube.com/@AtHeartOfficial',
+      artist_source_url: 'https://musicbrainz.org/artist/example-atheart',
+    },
   ],
   releases: [
     {
@@ -56,6 +77,26 @@ const dataset: MobileRawDataset = {
         source: 'https://musicbrainz.org/release-group/love-catcher',
         release_kind: 'ep',
         context_tags: [],
+      },
+    },
+    {
+      group: 'Weeekly',
+      latest_song: {
+        title: 'Lights On',
+        date: '2024-01-15',
+        source: 'https://musicbrainz.org/release-group/lights-on',
+        release_kind: 'single',
+        context_tags: ['title_track'],
+      },
+    },
+    {
+      group: 'AtHeart',
+      latest_song: {
+        title: 'Glow Up',
+        date: '2025-11-18',
+        source: 'https://musicbrainz.org/release-group/glow-up',
+        release_kind: 'single',
+        context_tags: ['title_track'],
       },
     },
   ],
@@ -82,6 +123,17 @@ const dataset: MobileRawDataset = {
       source_url: 'https://example.com/yena-social',
       confidence: 0.41,
     },
+    {
+      group: 'AtHeart',
+      scheduled_month: '2026-04',
+      date_precision: 'month_only',
+      date_status: 'scheduled',
+      headline: 'AtHeart schedules an April follow-up',
+      release_label: 'Spring chapter',
+      source_type: 'official_social',
+      source_url: 'https://example.com/atheart-social',
+      confidence: 0.62,
+    },
   ],
   releaseArtwork: [
     {
@@ -90,6 +142,20 @@ const dataset: MobileRawDataset = {
       release_date: '2026-03-11',
       stream: 'album',
       cover_image_url: 'https://example.com/love-catcher.jpg',
+    },
+    {
+      group: 'Weeekly',
+      release_title: 'Lights On',
+      release_date: '2024-01-15',
+      stream: 'song',
+      cover_image_url: 'https://example.com/lights-on.jpg',
+    },
+    {
+      group: 'AtHeart',
+      release_title: 'Glow Up',
+      release_date: '2025-11-18',
+      stream: 'song',
+      cover_image_url: 'https://example.com/glow-up.jpg',
     },
   ],
   releaseDetails: [
@@ -116,6 +182,34 @@ const dataset: MobileRawDataset = {
         },
       ],
     },
+    {
+      group: 'Weeekly',
+      release_title: 'Lights On',
+      release_date: '2024-01-15',
+      stream: 'song',
+      release_kind: 'single',
+      tracks: [
+        {
+          order: 1,
+          title: 'Lights On',
+          is_title_track: true,
+        },
+      ],
+    },
+    {
+      group: 'AtHeart',
+      release_title: 'Glow Up',
+      release_date: '2025-11-18',
+      stream: 'song',
+      release_kind: 'single',
+      tracks: [
+        {
+          order: 1,
+          title: 'Glow Up',
+          is_title_track: true,
+        },
+      ],
+    },
   ],
   releaseHistory: [
     {
@@ -131,11 +225,37 @@ const dataset: MobileRawDataset = {
         },
         {
           title: 'NEMONEMO',
-          date: '2025-09-01',
+          date: '2024-09-01',
           source: 'https://musicbrainz.org/release-group/nemonemo',
           release_kind: 'single',
           stream: 'song',
           context_tags: [],
+        },
+      ],
+    },
+    {
+      group: 'Weeekly',
+      releases: [
+        {
+          title: 'Lights On',
+          date: '2024-01-15',
+          source: 'https://musicbrainz.org/release-group/lights-on',
+          release_kind: 'single',
+          stream: 'song',
+          context_tags: ['title_track'],
+        },
+      ],
+    },
+    {
+      group: 'AtHeart',
+      releases: [
+        {
+          title: 'Glow Up',
+          date: '2025-11-18',
+          source: 'https://musicbrainz.org/release-group/glow-up',
+          release_kind: 'single',
+          stream: 'song',
+          context_tags: ['title_track'],
         },
       ],
     },
@@ -233,6 +353,17 @@ describe('mobile selector/adapters scaffold', () => {
 
     expect(results.releases[0]?.release.releaseTitle).toBe('LOVE CATCHER');
     expect(results.releases[0]?.matchKind).toBe('release_title_exact');
+  });
+
+  test('builds a radar snapshot with featured, weekly, long-gap, and rookie sections', () => {
+    const snapshot = selectRadarSnapshot(dataset, '2026-03-08');
+
+    expect(snapshot.featuredUpcoming?.team.slug).toBe('yena');
+    expect(snapshot.featuredUpcoming?.dayLabel).toBe('D-3');
+    expect(snapshot.weeklyUpcoming).toHaveLength(1);
+    expect(snapshot.changeFeed).toHaveLength(0);
+    expect(snapshot.longGap[0]?.team.slug).toBe('weeekly');
+    expect(snapshot.rookie[0]?.team.slug).toBe('atheart');
   });
 
   test('resolves a release detail model by normalized release id', () => {

--- a/mobile/src/selectors/index.ts
+++ b/mobile/src/selectors/index.ts
@@ -1,6 +1,10 @@
 import type {
   CalendarMonthSnapshotModel,
   MobileRawDataset,
+  RadarLongGapItemModel,
+  RadarRookieItemModel,
+  RadarSnapshotModel,
+  RadarUpcomingCardModel,
   ReleaseDetailModel,
   ReleaseSummaryModel,
   SearchReleaseResultModel,
@@ -497,4 +501,222 @@ export function selectReleaseDetailById(
   const displayGroup = team?.display_name?.trim() || detail.group;
 
   return adaptReleaseDetail(detail.group, displayGroup, detail, context.artworkByReleaseId.get(releaseId));
+}
+
+function parseIsoDate(value: string | undefined): number | null {
+  if (!value) {
+    return null;
+  }
+
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+function resolveDayLabel(todayIsoDate: string, scheduledDate?: string): string {
+  if (!scheduledDate) {
+    return '날짜 미정';
+  }
+
+  const todayTime = parseIsoDate(todayIsoDate);
+  const scheduledTime = parseIsoDate(scheduledDate);
+
+  if (todayTime == null || scheduledTime == null) {
+    return scheduledDate;
+  }
+
+  const dayDelta = Math.round((scheduledTime - todayTime) / 86_400_000);
+
+  if (dayDelta === 0) {
+    return '오늘';
+  }
+
+  if (dayDelta === 1) {
+    return '내일';
+  }
+
+  if (dayDelta > 1) {
+    return `D-${dayDelta}`;
+  }
+
+  return `D+${Math.abs(dayDelta)}`;
+}
+
+function buildRadarUpcomingCard(
+  context: MobileSelectorContext,
+  upcoming: UpcomingEventModel,
+  todayIsoDate: string,
+): RadarUpcomingCardModel | null {
+  const team = selectTeamSummaryBySlug(context, context.profilesByGroup.get(upcoming.group)?.slug ?? '');
+  if (!team) {
+    return null;
+  }
+
+  return {
+    id: upcoming.id,
+    team,
+    upcoming,
+    dayLabel: resolveDayLabel(todayIsoDate, upcoming.scheduledDate),
+  };
+}
+
+function isWithinWeeklyWindow(todayIsoDate: string, scheduledDate?: string): boolean {
+  const todayTime = parseIsoDate(todayIsoDate);
+  const scheduledTime = parseIsoDate(scheduledDate);
+
+  if (todayTime == null || scheduledTime == null) {
+    return false;
+  }
+
+  const dayDelta = Math.round((scheduledTime - todayTime) / 86_400_000);
+  return dayDelta >= 0 && dayDelta <= 6;
+}
+
+function resolveLatestReleaseSummaryByGroup(
+  context: MobileSelectorContext,
+  group: string,
+): ReleaseSummaryModel | null {
+  const slug = context.profilesByGroup.get(group)?.slug;
+  if (!slug) {
+    return null;
+  }
+
+  return selectLatestReleaseSummaryBySlug(context, slug);
+}
+
+function resolveEarliestReleaseYear(context: MobileSelectorContext, group: string): number | null {
+  const history = context.releaseHistoryByGroup.get(group);
+  if (!history || history.releases.length === 0) {
+    return null;
+  }
+
+  const years = history.releases
+    .map((release) => Number(release.date.slice(0, 4)))
+    .filter((value) => Number.isFinite(value));
+
+  if (years.length === 0) {
+    return null;
+  }
+
+  return Math.min(...years);
+}
+
+function buildLongGapItems(
+  context: MobileSelectorContext,
+  todayIsoDate: string,
+): RadarLongGapItemModel[] {
+  const todayTime = parseIsoDate(todayIsoDate);
+  if (todayTime == null) {
+    return [];
+  }
+
+  const thresholdDays = 365;
+  const items: RadarLongGapItemModel[] = [];
+
+  for (const profile of context.dataset.artistProfiles) {
+    const team = adaptTeamSummary(profile, context.allowlistsByGroup.get(profile.group));
+    const latestRelease = resolveLatestReleaseSummaryByGroup(context, profile.group);
+
+    if (!latestRelease) {
+      continue;
+    }
+
+    const latestReleaseTime = parseIsoDate(latestRelease.releaseDate);
+    if (latestReleaseTime == null) {
+      continue;
+    }
+
+    const gapDays = Math.floor((todayTime - latestReleaseTime) / 86_400_000);
+    if (gapDays < thresholdDays) {
+      continue;
+    }
+
+    const debutYear = resolveEarliestReleaseYear(context, profile.group);
+    if (debutYear != null && debutYear >= Number(todayIsoDate.slice(0, 4)) - 1) {
+      continue;
+    }
+
+    items.push({
+      id: team.slug,
+      team,
+      latestRelease,
+      gapDays,
+      gapLabel: `${gapDays}일 공백`,
+      hasUpcomingSignal: (context.upcomingByGroup.get(profile.group) ?? []).length > 0,
+    });
+  }
+
+  return items.sort((left, right) => right.gapDays - left.gapDays);
+}
+
+function buildRookieItems(
+  context: MobileSelectorContext,
+  todayIsoDate: string,
+): RadarRookieItemModel[] {
+  const currentYear = Number(todayIsoDate.slice(0, 4));
+  const items: RadarRookieItemModel[] = [];
+
+  for (const profile of context.dataset.artistProfiles) {
+    const debutYear = resolveEarliestReleaseYear(context, profile.group);
+    if (debutYear == null || debutYear < currentYear - 1) {
+      continue;
+    }
+
+    const team = adaptTeamSummary(profile, context.allowlistsByGroup.get(profile.group));
+    items.push({
+      id: team.slug,
+      team,
+      debutYear,
+      latestRelease: resolveLatestReleaseSummaryByGroup(context, profile.group),
+      hasUpcomingSignal: (context.upcomingByGroup.get(profile.group) ?? []).length > 0,
+    });
+  }
+
+  return items.sort((left, right) => {
+    if (left.debutYear !== right.debutYear) {
+      return right.debutYear - left.debutYear;
+    }
+
+    const latestReleaseDelta = compareIsoDateDescending(
+      left.latestRelease?.releaseDate,
+      right.latestRelease?.releaseDate,
+    );
+    if (latestReleaseDelta !== 0) {
+      return latestReleaseDelta;
+    }
+
+    return left.team.displayName.localeCompare(right.team.displayName);
+  });
+}
+
+export function selectRadarSnapshot(
+  input: MobileSelectorContext | MobileRawDataset,
+  todayIsoDate: string,
+): RadarSnapshotModel {
+  const context = resolveContext(input);
+  const upcomingEvents = context.dataset.upcomingCandidates
+    .map((upcoming) => {
+      const displayGroup = context.profilesByGroup.get(upcoming.group)?.display_name?.trim() || upcoming.group;
+      return adaptUpcomingEvent(upcoming.group, displayGroup, upcoming);
+    })
+    .filter((event) => event.datePrecision === 'exact')
+    .sort(compareUpcomingDate);
+
+  const featuredUpcoming =
+    upcomingEvents
+      .filter((event) => event.scheduledDate && event.scheduledDate >= todayIsoDate)
+      .map((event) => buildRadarUpcomingCard(context, event, todayIsoDate))
+      .find((value): value is RadarUpcomingCardModel => value !== null) ?? null;
+
+  const weeklyUpcoming = upcomingEvents
+    .filter((event) => isWithinWeeklyWindow(todayIsoDate, event.scheduledDate))
+    .map((event) => buildRadarUpcomingCard(context, event, todayIsoDate))
+    .filter((value): value is RadarUpcomingCardModel => value !== null);
+
+  return {
+    featuredUpcoming,
+    weeklyUpcoming,
+    changeFeed: [],
+    longGap: buildLongGapItems(context, todayIsoDate),
+    rookie: buildRookieItems(context, todayIsoDate),
+  };
 }

--- a/mobile/src/services/bundledDatasetFixture.ts
+++ b/mobile/src/services/bundledDatasetFixture.ts
@@ -50,6 +50,30 @@ const bundledDatasetFixture: MobileRawDataset = {
       official_instagram_url: 'https://www.instagram.com/le_sserafim/',
       artist_source_url: 'https://musicbrainz.org/artist/example-le-sserafim',
     },
+    {
+      slug: 'weeekly',
+      group: 'Weeekly',
+      display_name: 'Weeekly',
+      aliases: ['위클리'],
+      search_aliases: ['위클리'],
+      agency: 'IST Entertainment',
+      official_youtube_url: 'https://www.youtube.com/@Weeekly',
+      official_x_url: 'https://x.com/_Weeekly',
+      official_instagram_url: 'https://www.instagram.com/_weeekly/',
+      artist_source_url: 'https://musicbrainz.org/artist/example-weeekly',
+    },
+    {
+      slug: 'atheart',
+      group: 'AtHeart',
+      display_name: 'AtHeart',
+      aliases: ['앳하트'],
+      search_aliases: ['앳하트'],
+      agency: 'Titan Content',
+      official_youtube_url: 'https://www.youtube.com/@AtHeartOfficial',
+      official_x_url: 'https://x.com/AtHeartOfficial',
+      official_instagram_url: 'https://www.instagram.com/atheart_official/',
+      artist_source_url: 'https://musicbrainz.org/artist/example-atheart',
+    },
   ],
   releases: [
     {
@@ -75,6 +99,28 @@ const bundledDatasetFixture: MobileRawDataset = {
         title: 'Signal Fire',
         date: '2026-03-21',
         source: 'https://musicbrainz.org/release-group/example-signal-fire',
+        release_kind: 'single',
+        context_tags: ['title_track'],
+      },
+      latest_album: null,
+    },
+    {
+      group: 'Weeekly',
+      latest_song: {
+        title: 'Lights On',
+        date: '2024-01-15',
+        source: 'https://musicbrainz.org/release-group/example-lights-on',
+        release_kind: 'single',
+        context_tags: ['title_track'],
+      },
+      latest_album: null,
+    },
+    {
+      group: 'AtHeart',
+      latest_song: {
+        title: 'Glow Up',
+        date: '2025-11-18',
+        source: 'https://musicbrainz.org/release-group/example-glow-up',
         release_kind: 'single',
         context_tags: ['title_track'],
       },
@@ -117,6 +163,17 @@ const bundledDatasetFixture: MobileRawDataset = {
       source_url: 'https://example.com/lesserafim-rumor',
       confidence: 0.44,
     },
+    {
+      group: 'AtHeart',
+      scheduled_month: '2026-04',
+      date_precision: 'month_only',
+      date_status: 'scheduled',
+      headline: 'AtHeart plans an April follow-up release',
+      release_label: 'Spring chapter',
+      source_type: 'official_social',
+      source_url: 'https://example.com/atheart-april',
+      confidence: 0.68,
+    },
   ],
   releaseArtwork: [
     {
@@ -132,6 +189,20 @@ const bundledDatasetFixture: MobileRawDataset = {
       release_date: '2026-03-21',
       stream: 'song',
       cover_image_url: 'https://example.com/signal-fire.jpg',
+    },
+    {
+      group: 'Weeekly',
+      release_title: 'Lights On',
+      release_date: '2024-01-15',
+      stream: 'song',
+      cover_image_url: 'https://example.com/lights-on.jpg',
+    },
+    {
+      group: 'AtHeart',
+      release_title: 'Glow Up',
+      release_date: '2025-11-18',
+      stream: 'song',
+      cover_image_url: 'https://example.com/glow-up.jpg',
     },
   ],
   releaseDetails: [
@@ -176,6 +247,42 @@ const bundledDatasetFixture: MobileRawDataset = {
         },
       ],
     },
+    {
+      group: 'Weeekly',
+      release_title: 'Lights On',
+      release_date: '2024-01-15',
+      stream: 'song',
+      release_kind: 'single',
+      spotify_url: 'https://open.spotify.com/track/example-lights-on',
+      youtube_music_url: 'https://music.youtube.com/watch?v=example-lights-on',
+      youtube_video_status: 'manual_override',
+      notes: 'Representative dormant-group detail.',
+      tracks: [
+        {
+          order: 1,
+          title: 'Lights On',
+          is_title_track: true,
+        },
+      ],
+    },
+    {
+      group: 'AtHeart',
+      release_title: 'Glow Up',
+      release_date: '2025-11-18',
+      stream: 'song',
+      release_kind: 'single',
+      spotify_url: 'https://open.spotify.com/track/example-glow-up',
+      youtube_music_url: 'https://music.youtube.com/watch?v=example-glow-up',
+      youtube_video_status: 'manual_override',
+      notes: 'Representative rookie detail.',
+      tracks: [
+        {
+          order: 1,
+          title: 'Glow Up',
+          is_title_track: true,
+        },
+      ],
+    },
   ],
   releaseHistory: [
     {
@@ -191,7 +298,7 @@ const bundledDatasetFixture: MobileRawDataset = {
         },
         {
           title: 'NEMONEMO',
-          date: '2025-09-01',
+          date: '2024-09-01',
           source: 'https://musicbrainz.org/release-group/example-nemonemo',
           release_kind: 'single',
           stream: 'song',
@@ -206,6 +313,32 @@ const bundledDatasetFixture: MobileRawDataset = {
           title: 'Signal Fire',
           date: '2026-03-21',
           source: 'https://musicbrainz.org/release-group/example-signal-fire',
+          release_kind: 'single',
+          stream: 'song',
+          context_tags: ['title_track'],
+        },
+      ],
+    },
+    {
+      group: 'Weeekly',
+      releases: [
+        {
+          title: 'Lights On',
+          date: '2024-01-15',
+          source: 'https://musicbrainz.org/release-group/example-lights-on',
+          release_kind: 'single',
+          stream: 'song',
+          context_tags: ['title_track'],
+        },
+      ],
+    },
+    {
+      group: 'AtHeart',
+      releases: [
+        {
+          title: 'Glow Up',
+          date: '2025-11-18',
+          source: 'https://musicbrainz.org/release-group/example-glow-up',
           release_kind: 'single',
           stream: 'song',
           context_tags: ['title_track'],
@@ -230,6 +363,26 @@ const bundledDatasetFixture: MobileRawDataset = {
       channels: [
         {
           channel_url: 'https://www.youtube.com/@BTS',
+          display_in_team_links: true,
+        },
+      ],
+    },
+    {
+      group: 'Weeekly',
+      primary_team_channel_url: 'https://www.youtube.com/@Weeekly',
+      channels: [
+        {
+          channel_url: 'https://www.youtube.com/@Weeekly',
+          display_in_team_links: true,
+        },
+      ],
+    },
+    {
+      group: 'AtHeart',
+      primary_team_channel_url: 'https://www.youtube.com/@AtHeartOfficial',
+      channels: [
+        {
+          channel_url: 'https://www.youtube.com/@AtHeartOfficial',
           display_in_team_links: true,
         },
       ],

--- a/mobile/src/types/displayModels.ts
+++ b/mobile/src/types/displayModels.ts
@@ -172,3 +172,41 @@ export interface CalendarMonthGridModel {
   weeks: (CalendarDayCellModel | null)[][];
   selectedDay: CalendarSelectedDayModel | null;
 }
+
+export interface RadarUpcomingCardModel {
+  id: string;
+  team: TeamSummaryModel;
+  upcoming: UpcomingEventModel;
+  dayLabel: string;
+}
+
+export interface RadarChangeFeedItemModel {
+  id: string;
+  label: string;
+  sourceUrl?: string;
+}
+
+export interface RadarLongGapItemModel {
+  id: string;
+  team: TeamSummaryModel;
+  latestRelease: ReleaseSummaryModel | null;
+  gapDays: number;
+  gapLabel: string;
+  hasUpcomingSignal: boolean;
+}
+
+export interface RadarRookieItemModel {
+  id: string;
+  team: TeamSummaryModel;
+  debutYear: number;
+  latestRelease: ReleaseSummaryModel | null;
+  hasUpcomingSignal: boolean;
+}
+
+export interface RadarSnapshotModel {
+  featuredUpcoming: RadarUpcomingCardModel | null;
+  weeklyUpcoming: RadarUpcomingCardModel[];
+  changeFeed: RadarChangeFeedItemModel[];
+  longGap: RadarLongGapItemModel[];
+  rookie: RadarRookieItemModel[];
+}


### PR DESCRIPTION
## Summary
- implement the mobile radar tab on top of shared selectors and dataset-backed display models
- render featured upcoming, weekly upcoming, long-gap, and rookie sections with safe empty states
- add radar tab tests and fixture coverage for long-gap and rookie edge cases

## Verification
- cd mobile && npm run lint
- cd mobile && npm run typecheck
- cd mobile && npm run test
- cd mobile && CI=1 npx expo export --platform web --output-dir /tmp/idol-song-app-mobile-radar-export
- git diff --check

Closes #336