### PR TITLE
feat: implement mobile entity detail screen

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -2,7 +2,7 @@
 
 이 디렉터리는 `Expo + React Native + Expo Router` 기반 모바일 앱 워크스페이스다.
 
-현재 단계는 workspace bootstrap과 router shell, 그리고 calendar / search / radar tab의 data-backed container까지 포함한다.
+현재 단계는 workspace bootstrap과 router shell, 그리고 calendar / search / radar tab, entity detail route의 data-backed container까지 포함한다.
 
 - route/layout expectations는 `docs/specs/mobile/expo-implementation-guide.md`를 따른다.
 - route/param 계약은 `docs/specs/mobile/route-param-contracts.md`를 따른다.
@@ -11,10 +11,11 @@
 ## 현재 포함 범위
 
 - `app/`
-  - Expo Router root layout / tab shell / detail placeholder route
+  - Expo Router root layout / tab shell / detail route scaffold
   - `calendar` tab은 active dataset + shared selector 기반 container까지 연결됨
   - `radar` tab은 shared radar snapshot 기반 section stack까지 연결됨
   - `search` tab은 query state + recent query persistence + segmented result container까지 연결됨
+  - `artists/[slug]` route는 shared entity detail snapshot 기반 detail screen까지 연결됨
   - hidden `debug/metadata` route for internal metadata inspection
 - `assets/`
   - placeholder / service icon / badge fallback asset inventory
@@ -186,6 +187,7 @@ profile 차이는 아래 범위로만 제한한다.
   - `selectMonthUpcomingEvents`
   - `selectCalendarMonthSnapshot`
   - `selectRadarSnapshot`
+  - `selectEntityDetailSnapshot`
   - `selectSearchResults`
 - 규칙
   - 화면은 raw JSON shape를 직접 읽지 않는다.

--- a/mobile/app/artists/[slug].tsx
+++ b/mobile/app/artists/[slug].tsx
@@ -1,5 +1,40 @@
-import { Stack, useLocalSearchParams } from 'expo-router';
-import { StyleSheet, Text, View } from 'react-native';
+import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  Image,
+  Linking,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+
+import { selectEntityDetailSnapshot } from '../../src/selectors';
+import {
+  loadActiveMobileDataset,
+  type ActiveMobileDataset,
+} from '../../src/services/activeDataset';
+import { useAppTheme } from '../../src/tokens/theme';
+import type {
+  EntityDetailSnapshotModel,
+  ReleaseSummaryModel,
+  TeamSummaryModel,
+  UpcomingEventModel,
+} from '../../src/types';
+
+type EntityDetailScreenState =
+  | { kind: 'loading' }
+  | { kind: 'error'; message: string }
+  | { kind: 'missing'; reason: string }
+  | { kind: 'ready'; source: ActiveMobileDataset; snapshot: EntityDetailSnapshotModel };
+
+type OfficialLinkItem = {
+  key: string;
+  label: string;
+  url: string;
+};
 
 function getSingleParam(value: string | string[] | undefined): string | null {
   if (Array.isArray(value)) {
@@ -9,54 +44,677 @@ function getSingleParam(value: string | string[] | undefined): string | null {
   return value ?? null;
 }
 
-export default function ArtistDetailPlaceholderScreen() {
-  const params = useLocalSearchParams<{ slug?: string | string[] }>();
-  const slug = getSingleParam(params.slug);
-  const isValid = typeof slug === 'string' && slug.trim().length > 0;
+function formatUpcomingMeta(event: UpcomingEventModel): string {
+  if (event.datePrecision === 'exact' && event.scheduledDate) {
+    return `${event.scheduledDate} · ${event.status ?? '예정'}`;
+  }
+
+  if (event.scheduledMonth) {
+    return `${event.scheduledMonth} · 날짜 미정 · ${event.status ?? '예정'}`;
+  }
+
+  return event.status ?? '예정';
+}
+
+function formatReleaseMeta(release: ReleaseSummaryModel): string {
+  return `${release.releaseDate} · ${release.releaseKind ?? 'release'}`;
+}
+
+function buildOfficialLinks(team: TeamSummaryModel): OfficialLinkItem[] {
+  return [
+    team.officialYoutubeUrl
+      ? {
+          key: 'youtube',
+          label: 'YouTube',
+          url: team.officialYoutubeUrl,
+        }
+      : null,
+    team.officialInstagramUrl
+      ? {
+          key: 'instagram',
+          label: 'Instagram',
+          url: team.officialInstagramUrl,
+        }
+      : null,
+    team.officialXUrl
+      ? {
+          key: 'x',
+          label: 'X',
+          url: team.officialXUrl,
+        }
+      : null,
+    team.artistSourceUrl
+      ? {
+          key: 'source',
+          label: 'Source',
+          url: team.artistSourceUrl,
+        }
+      : null,
+  ].filter((item): item is OfficialLinkItem => item !== null);
+}
+
+async function openExternalUrl(url: string) {
+  try {
+    await Linking.openURL(url);
+  } catch {
+    // Keep the current route stack stable when external handoff fails.
+  }
+}
+
+function EntityBadge({
+  team,
+  styles,
+}: {
+  team: TeamSummaryModel;
+  styles: ReturnType<typeof createStyles>;
+}) {
+  if (team.badge?.imageUrl) {
+    return <Image source={{ uri: team.badge.imageUrl }} style={styles.heroImage} />;
+  }
 
   return (
-    <View style={styles.container}>
-      <Stack.Screen options={{ title: isValid ? slug : 'Artist Detail' }} />
-      <Text style={styles.eyebrow}>PUSH DETAIL</Text>
-      <Text style={styles.title}>Artist Detail</Text>
-      <Text style={styles.body}>
-        {isValid
-          ? `slug param is wired: ${slug}`
-          : 'Missing or invalid slug. The final screen should show a safe empty or recovery state instead of crashing.'}
-      </Text>
-      <Text style={styles.meta}>Path contract: /artists/[slug]</Text>
+    <View style={styles.heroMonogramWrap}>
+      <Text style={styles.heroMonogram}>{team.badge?.monogram ?? team.displayName.slice(0, 2).toUpperCase()}</Text>
     </View>
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: 'center',
-    paddingHorizontal: 24,
-    backgroundColor: '#fcfbf8',
-  },
-  eyebrow: {
-    marginBottom: 8,
-    fontSize: 12,
-    fontWeight: '600',
-    letterSpacing: 1.2,
-    color: '#87634d',
-  },
-  title: {
-    marginBottom: 12,
-    fontSize: 28,
-    fontWeight: '700',
-    color: '#1f1b17',
-  },
-  body: {
-    marginBottom: 12,
-    fontSize: 16,
-    lineHeight: 24,
-    color: '#5e554d',
-  },
-  meta: {
-    fontSize: 13,
-    color: '#8a7e72',
-  },
-});
+export default function ArtistDetailScreen() {
+  const router = useRouter();
+  const params = useLocalSearchParams<{ slug?: string | string[] }>();
+  const theme = useAppTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+  const slug = getSingleParam(params.slug)?.trim() ?? '';
+  const [reloadCount, setReloadCount] = useState(0);
+  const [state, setState] = useState<EntityDetailScreenState>({ kind: 'loading' });
+
+  useEffect(() => {
+    let cancelled = false;
+
+    if (!slug) {
+      setState({
+        kind: 'missing',
+        reason: '팀 slug가 없거나 잘못되어 화면을 열 수 없습니다.',
+      });
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    setState({ kind: 'loading' });
+
+    void loadActiveMobileDataset()
+      .then((source) => {
+        if (cancelled) {
+          return;
+        }
+
+        const snapshot = selectEntityDetailSnapshot(source.dataset, slug);
+        if (!snapshot) {
+          setState({
+            kind: 'missing',
+            reason: '해당 팀 데이터를 찾지 못했습니다.',
+          });
+          return;
+        }
+
+        setState({
+          kind: 'ready',
+          source,
+          snapshot,
+        });
+      })
+      .catch((error: unknown) => {
+        if (cancelled) {
+          return;
+        }
+
+        setState({
+          kind: 'error',
+          message:
+            error instanceof Error
+              ? error.message
+              : '팀 상세 데이터를 불러오지 못했습니다.',
+        });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [reloadCount, slug]);
+
+  const screenTitle =
+    state.kind === 'ready'
+      ? state.snapshot.team.displayName
+      : slug || 'Team Detail';
+
+  if (state.kind === 'loading') {
+    return (
+      <View style={styles.stateContainer}>
+        <Stack.Screen options={{ title: screenTitle }} />
+        <ActivityIndicator color={theme.colors.text.brand} />
+        <Text style={styles.eyebrow}>DETAIL LOADING</Text>
+        <Text style={styles.title}>팀 상세</Text>
+        <Text style={styles.body}>팀 요약, 다음 컴백, 최근 앨범을 불러오는 중입니다.</Text>
+      </View>
+    );
+  }
+
+  if (state.kind === 'error') {
+    return (
+      <View style={styles.stateContainer}>
+        <Stack.Screen options={{ title: screenTitle }} />
+        <Text style={styles.eyebrow}>LOAD ERROR</Text>
+        <Text style={styles.title}>팀 상세</Text>
+        <Text style={styles.body}>{state.message}</Text>
+        <Pressable style={styles.retryButton} onPress={() => setReloadCount((count) => count + 1)}>
+          <Text style={styles.retryButtonLabel}>다시 시도</Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  if (state.kind === 'missing') {
+    return (
+      <View style={styles.stateContainer}>
+        <Stack.Screen options={{ title: screenTitle }} />
+        <Text testID="entity-missing-state" style={styles.eyebrow}>
+          SAFE RECOVERY
+        </Text>
+        <Text style={styles.title}>팀 상세</Text>
+        <Text style={styles.body}>{state.reason}</Text>
+        <Pressable style={styles.retryButton} onPress={() => router.push('/(tabs)/search')}>
+          <Text style={styles.retryButtonLabel}>검색으로 이동</Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  const { snapshot, source } = state;
+  const officialLinks = buildOfficialLinks(snapshot.team);
+
+  return (
+    <ScrollView style={styles.screen} contentContainerStyle={styles.content}>
+      <Stack.Screen options={{ title: snapshot.team.displayName }} />
+
+      <View style={styles.appBar}>
+        <Pressable
+          accessibilityRole="button"
+          onPress={() => router.back()}
+          style={({ pressed }) => [styles.backButton, pressed ? styles.buttonPressed : null]}
+        >
+          <Text style={styles.backButtonLabel}>뒤로</Text>
+        </Pressable>
+        <Text style={styles.appBarMeta}>{source.sourceLabel}</Text>
+      </View>
+
+      <View style={styles.heroCard}>
+        <EntityBadge team={snapshot.team} styles={styles} />
+        <View style={styles.heroCopy}>
+          <Text testID="entity-detail-title" style={styles.heroTitle}>
+            {snapshot.team.displayName}
+          </Text>
+          <Text style={styles.heroMeta}>{snapshot.team.agency ?? '소속사 정보 없음'}</Text>
+          <Text style={styles.heroBody}>
+            다음 컴백과 최신 발매를 한 화면에서 확인하는 팀 허브입니다.
+          </Text>
+        </View>
+      </View>
+
+      {officialLinks.length > 0 ? (
+        <View style={styles.linkRow}>
+          {officialLinks.map((link) => (
+            <Pressable
+              key={link.key}
+              testID={`entity-official-link-${link.key}`}
+              accessibilityRole="button"
+              onPress={() => void openExternalUrl(link.url)}
+              style={({ pressed }) => [styles.linkChip, pressed ? styles.buttonPressed : null]}
+            >
+              <Text style={styles.linkChipLabel}>{link.label}</Text>
+            </Pressable>
+          ))}
+        </View>
+      ) : null}
+
+      <SectionCard title="다음 컴백" styles={styles}>
+        {snapshot.nextUpcoming ? (
+          <View testID="entity-next-upcoming-card" style={styles.primaryCard}>
+            <Text style={styles.primaryCardTitle}>
+              {snapshot.nextUpcoming.releaseLabel ?? snapshot.nextUpcoming.headline}
+            </Text>
+            <Text style={styles.primaryCardMeta}>{formatUpcomingMeta(snapshot.nextUpcoming)}</Text>
+            <Text style={styles.primaryCardBody}>{snapshot.nextUpcoming.headline}</Text>
+            {snapshot.nextUpcoming.sourceUrl ? (
+              <Pressable
+                accessibilityRole="button"
+                onPress={() => void openExternalUrl(snapshot.nextUpcoming!.sourceUrl!)}
+                style={({ pressed }) => [styles.metaButton, pressed ? styles.buttonPressed : null]}
+              >
+                <Text style={styles.metaButtonLabel}>출처 보기</Text>
+              </Pressable>
+            ) : null}
+          </View>
+        ) : (
+          <Text style={styles.emptyCopy}>등록된 예정 컴백이 없습니다.</Text>
+        )}
+      </SectionCard>
+
+      <SectionCard title="최신 발매" styles={styles}>
+        {snapshot.latestRelease ? (
+          <Pressable
+            testID="entity-latest-release-card"
+            accessibilityRole="button"
+            onPress={() =>
+              router.push({
+                pathname: '/releases/[id]',
+                params: { id: snapshot.latestRelease!.id },
+              })
+            }
+            style={({ pressed }) => [styles.releaseCard, pressed ? styles.buttonPressed : null]}
+          >
+            <View style={styles.releaseArtwork}>
+              {snapshot.latestRelease.coverImageUrl ? (
+                <Image source={{ uri: snapshot.latestRelease.coverImageUrl }} style={styles.releaseArtworkImage} />
+              ) : (
+                <Text style={styles.releaseArtworkFallback}>
+                  {snapshot.team.badge?.monogram ?? snapshot.team.displayName.slice(0, 2).toUpperCase()}
+                </Text>
+              )}
+            </View>
+            <View style={styles.releaseCopy}>
+              <Text style={styles.primaryCardTitle}>{snapshot.latestRelease.releaseTitle}</Text>
+              <Text style={styles.primaryCardMeta}>{formatReleaseMeta(snapshot.latestRelease)}</Text>
+              <Text style={styles.primaryCardBody}>
+                {snapshot.latestRelease.representativeSongTitle ?? '상세 화면으로 이동'}
+              </Text>
+            </View>
+          </Pressable>
+        ) : (
+          <Text style={styles.emptyCopy}>최신 발매 정보가 없습니다.</Text>
+        )}
+      </SectionCard>
+
+      <SectionCard title="최근 앨범들" styles={styles}>
+        {snapshot.recentAlbums.length > 0 ? (
+          <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.albumRow}>
+            {snapshot.recentAlbums.map((release) => (
+              <Pressable
+                key={release.id}
+                testID={`entity-recent-album-card-${release.id}`}
+                accessibilityRole="button"
+                onPress={() =>
+                  router.push({
+                    pathname: '/releases/[id]',
+                    params: { id: release.id },
+                  })
+                }
+                style={({ pressed }) => [styles.albumCard, pressed ? styles.buttonPressed : null]}
+              >
+                <View style={styles.albumArtwork}>
+                  {release.coverImageUrl ? (
+                    <Image source={{ uri: release.coverImageUrl }} style={styles.albumArtworkImage} />
+                  ) : (
+                    <Text style={styles.albumArtworkFallback}>
+                      {snapshot.team.badge?.monogram ?? snapshot.team.displayName.slice(0, 2).toUpperCase()}
+                    </Text>
+                  )}
+                </View>
+                <Text style={styles.albumTitle}>{release.releaseTitle}</Text>
+                <Text style={styles.albumMeta}>{formatReleaseMeta(release)}</Text>
+              </Pressable>
+            ))}
+          </ScrollView>
+        ) : (
+          <Text style={styles.emptyCopy}>등록된 최근 앨범이 없습니다.</Text>
+        )}
+      </SectionCard>
+
+      <SectionCard title="소스 타임라인" styles={styles}>
+        {snapshot.sourceTimeline.length > 0 ? (
+          <View testID="entity-source-timeline" style={styles.timelineList}>
+            {snapshot.sourceTimeline.map((item) => (
+              <View key={item.id} style={styles.timelineRow}>
+                <View style={styles.timelineDot} />
+                <View style={styles.timelineCopy}>
+                  <Text style={styles.timelineTitle}>{item.title}</Text>
+                  <Text style={styles.timelineMeta}>{item.meta}</Text>
+                </View>
+                {item.sourceUrl ? (
+                  <Pressable
+                    accessibilityRole="button"
+                    onPress={() => void openExternalUrl(item.sourceUrl!)}
+                    style={({ pressed }) => [styles.metaButton, pressed ? styles.buttonPressed : null]}
+                  >
+                    <Text style={styles.metaButtonLabel}>열기</Text>
+                  </Pressable>
+                ) : null}
+              </View>
+            ))}
+          </View>
+        ) : (
+          <Text style={styles.emptyCopy}>표시할 소스 타임라인이 없습니다.</Text>
+        )}
+      </SectionCard>
+    </ScrollView>
+  );
+}
+
+function SectionCard({
+  title,
+  styles,
+  children,
+}: {
+  title: string;
+  styles: ReturnType<typeof createStyles>;
+  children: React.ReactNode;
+}) {
+  return (
+    <View style={styles.sectionCard}>
+      <Text style={styles.sectionTitle}>{title}</Text>
+      {children}
+    </View>
+  );
+}
+
+function createStyles(theme: ReturnType<typeof useAppTheme>) {
+  return StyleSheet.create({
+    screen: {
+      flex: 1,
+      backgroundColor: theme.colors.surface.base,
+    },
+    content: {
+      paddingHorizontal: theme.space[20],
+      paddingTop: theme.space[16],
+      paddingBottom: theme.space[32],
+      gap: theme.space[16],
+    },
+    appBar: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+    },
+    appBarMeta: {
+      fontSize: theme.typography.meta.fontSize,
+      lineHeight: theme.typography.meta.lineHeight,
+      color: theme.colors.text.tertiary,
+    },
+    backButton: {
+      paddingHorizontal: theme.space[12],
+      paddingVertical: theme.space[8],
+      borderRadius: theme.radius.button,
+      backgroundColor: theme.colors.surface.interactive,
+      borderWidth: StyleSheet.hairlineWidth,
+      borderColor: theme.colors.border.default,
+    },
+    backButtonLabel: {
+      fontSize: theme.typography.buttonService.fontSize,
+      lineHeight: theme.typography.buttonService.lineHeight,
+      fontWeight: '600',
+      color: theme.colors.text.primary,
+    },
+    heroCard: {
+      flexDirection: 'row',
+      gap: theme.space[16],
+      padding: theme.space[16],
+      borderRadius: theme.radius.card,
+      backgroundColor: theme.colors.surface.elevated,
+      borderWidth: StyleSheet.hairlineWidth,
+      borderColor: theme.colors.border.default,
+    },
+    heroImage: {
+      width: 88,
+      height: 88,
+      borderRadius: theme.radius.card,
+      backgroundColor: theme.colors.surface.subtle,
+    },
+    heroMonogramWrap: {
+      width: 88,
+      height: 88,
+      borderRadius: theme.radius.card,
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: theme.colors.surface.interactive,
+    },
+    heroMonogram: {
+      fontSize: 28,
+      fontWeight: '700',
+      color: theme.colors.text.brand,
+    },
+    heroCopy: {
+      flex: 1,
+      gap: theme.space[4],
+    },
+    heroTitle: {
+      fontSize: 28,
+      lineHeight: 34,
+      fontWeight: '700',
+      color: theme.colors.text.primary,
+    },
+    heroMeta: {
+      fontSize: theme.typography.body.fontSize,
+      lineHeight: theme.typography.body.lineHeight,
+      color: theme.colors.text.secondary,
+    },
+    heroBody: {
+      marginTop: theme.space[4],
+      fontSize: theme.typography.body.fontSize,
+      lineHeight: theme.typography.body.lineHeight,
+      color: theme.colors.text.secondary,
+    },
+    linkRow: {
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+      gap: theme.space[8],
+    },
+    linkChip: {
+      paddingHorizontal: theme.space[12],
+      paddingVertical: theme.space[8],
+      borderRadius: theme.radius.chip,
+      backgroundColor: theme.colors.surface.interactive,
+      borderWidth: StyleSheet.hairlineWidth,
+      borderColor: theme.colors.border.default,
+    },
+    linkChipLabel: {
+      fontSize: theme.typography.chip.fontSize,
+      lineHeight: theme.typography.chip.lineHeight,
+      fontWeight: '600',
+      color: theme.colors.text.secondary,
+    },
+    sectionCard: {
+      gap: theme.space[12],
+      padding: theme.space[16],
+      borderRadius: theme.radius.card,
+      backgroundColor: theme.colors.surface.elevated,
+      borderWidth: StyleSheet.hairlineWidth,
+      borderColor: theme.colors.border.default,
+    },
+    sectionTitle: {
+      fontSize: theme.typography.sectionTitle.fontSize,
+      lineHeight: theme.typography.sectionTitle.lineHeight,
+      fontWeight: '700',
+      color: theme.colors.text.primary,
+    },
+    primaryCard: {
+      gap: theme.space[8],
+      padding: theme.space[16],
+      borderRadius: theme.radius.card,
+      backgroundColor: theme.colors.surface.interactive,
+    },
+    primaryCardTitle: {
+      fontSize: theme.typography.body.fontSize,
+      lineHeight: theme.typography.body.lineHeight,
+      fontWeight: '700',
+      color: theme.colors.text.primary,
+    },
+    primaryCardMeta: {
+      fontSize: theme.typography.meta.fontSize,
+      lineHeight: theme.typography.meta.lineHeight,
+      color: theme.colors.text.secondary,
+    },
+    primaryCardBody: {
+      fontSize: theme.typography.body.fontSize,
+      lineHeight: theme.typography.body.lineHeight,
+      color: theme.colors.text.secondary,
+    },
+    releaseCard: {
+      flexDirection: 'row',
+      gap: theme.space[12],
+      padding: theme.space[16],
+      borderRadius: theme.radius.card,
+      backgroundColor: theme.colors.surface.interactive,
+    },
+    releaseArtwork: {
+      width: 72,
+      height: 72,
+      borderRadius: theme.radius.button,
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: theme.colors.surface.subtle,
+      overflow: 'hidden',
+    },
+    releaseArtworkImage: {
+      width: '100%',
+      height: '100%',
+    },
+    releaseArtworkFallback: {
+      fontSize: 22,
+      fontWeight: '700',
+      color: theme.colors.text.brand,
+    },
+    releaseCopy: {
+      flex: 1,
+      gap: theme.space[4],
+    },
+    albumRow: {
+      gap: theme.space[12],
+      paddingRight: theme.space[8],
+    },
+    albumCard: {
+      width: 172,
+      gap: theme.space[8],
+      padding: theme.space[12],
+      borderRadius: theme.radius.card,
+      backgroundColor: theme.colors.surface.interactive,
+    },
+    albumArtwork: {
+      width: '100%',
+      aspectRatio: 1,
+      borderRadius: theme.radius.button,
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: theme.colors.surface.subtle,
+      overflow: 'hidden',
+    },
+    albumArtworkImage: {
+      width: '100%',
+      height: '100%',
+    },
+    albumArtworkFallback: {
+      fontSize: 22,
+      fontWeight: '700',
+      color: theme.colors.text.brand,
+    },
+    albumTitle: {
+      fontSize: theme.typography.body.fontSize,
+      lineHeight: theme.typography.body.lineHeight,
+      fontWeight: '700',
+      color: theme.colors.text.primary,
+    },
+    albumMeta: {
+      fontSize: theme.typography.meta.fontSize,
+      lineHeight: theme.typography.meta.lineHeight,
+      color: theme.colors.text.secondary,
+    },
+    timelineList: {
+      gap: theme.space[12],
+    },
+    timelineRow: {
+      flexDirection: 'row',
+      alignItems: 'flex-start',
+      gap: theme.space[12],
+    },
+    timelineDot: {
+      width: 10,
+      height: 10,
+      marginTop: 6,
+      borderRadius: theme.radius.chip,
+      backgroundColor: theme.colors.text.brand,
+    },
+    timelineCopy: {
+      flex: 1,
+      gap: theme.space[4],
+    },
+    timelineTitle: {
+      fontSize: theme.typography.body.fontSize,
+      lineHeight: theme.typography.body.lineHeight,
+      fontWeight: '600',
+      color: theme.colors.text.primary,
+    },
+    timelineMeta: {
+      fontSize: theme.typography.meta.fontSize,
+      lineHeight: theme.typography.meta.lineHeight,
+      color: theme.colors.text.secondary,
+    },
+    metaButton: {
+      paddingHorizontal: theme.space[12],
+      paddingVertical: theme.space[8],
+      borderRadius: theme.radius.chip,
+      backgroundColor: theme.colors.surface.base,
+      borderWidth: StyleSheet.hairlineWidth,
+      borderColor: theme.colors.border.default,
+    },
+    metaButtonLabel: {
+      fontSize: theme.typography.meta.fontSize,
+      lineHeight: theme.typography.meta.lineHeight,
+      color: theme.colors.text.secondary,
+      fontWeight: '600',
+    },
+    emptyCopy: {
+      fontSize: theme.typography.body.fontSize,
+      lineHeight: theme.typography.body.lineHeight,
+      color: theme.colors.text.secondary,
+    },
+    stateContainer: {
+      flex: 1,
+      justifyContent: 'center',
+      paddingHorizontal: theme.space[24],
+      backgroundColor: theme.colors.surface.base,
+      gap: theme.space[12],
+    },
+    eyebrow: {
+      fontSize: theme.typography.meta.fontSize,
+      lineHeight: theme.typography.meta.lineHeight,
+      letterSpacing: 1.2,
+      fontWeight: '700',
+      color: theme.colors.text.brand,
+    },
+    title: {
+      fontSize: 28,
+      lineHeight: 34,
+      fontWeight: '700',
+      color: theme.colors.text.primary,
+    },
+    body: {
+      fontSize: theme.typography.body.fontSize,
+      lineHeight: theme.typography.body.lineHeight,
+      color: theme.colors.text.secondary,
+    },
+    retryButton: {
+      alignSelf: 'flex-start',
+      paddingHorizontal: theme.space[16],
+      paddingVertical: theme.space[12],
+      borderRadius: theme.radius.button,
+      backgroundColor: theme.colors.text.brand,
+    },
+    retryButtonLabel: {
+      fontSize: theme.typography.buttonPrimary.fontSize,
+      lineHeight: theme.typography.buttonPrimary.lineHeight,
+      fontWeight: '700',
+      color: theme.colors.text.inverse,
+    },
+    buttonPressed: {
+      opacity: 0.76,
+    },
+  });
+}

--- a/mobile/src/README.md
+++ b/mobile/src/README.md
@@ -12,7 +12,7 @@
   - `context.ts`: dataset -> indexed selector context
   - `adapters.ts`: raw JSON -> display model 변환 규칙
   - `index.ts`: shared selectors entrypoint
-    - team / release detail selector 외에 calendar month snapshot / radar snapshot / search result selector 포함
+    - team / entity detail / release detail selector 외에 calendar month snapshot / radar snapshot / search result selector 포함
 - `services/`: data source / external handoff / helper
   - `datasetSource.ts`: bundled-static vs preview-remote source selector
   - `activeDataset.ts`: runtime selection을 실제 dataset payload로 로드하는 entrypoint

--- a/mobile/src/features/entityDetailScreen.test.tsx
+++ b/mobile/src/features/entityDetailScreen.test.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import { Text } from 'react-native';
+
+import ArtistDetailScreen from '../../app/artists/[slug]';
+
+jest.mock('expo-router', () => {
+  const useLocalSearchParams = jest.fn(() => ({ slug: 'yena' }));
+  const useRouter = jest.fn(() => ({
+    back: jest.fn(),
+    push: jest.fn(),
+  }));
+
+  function Stack({ children }: { children?: React.ReactNode }) {
+    return children ?? null;
+  }
+
+  Stack.Screen = function StackScreen() {
+    return null;
+  };
+
+  return {
+    Stack,
+    useLocalSearchParams,
+    useRouter,
+    __mock: {
+      useLocalSearchParams,
+      useRouter,
+    },
+  };
+});
+
+const { __mock } = jest.requireMock('expo-router') as {
+  __mock: {
+    useLocalSearchParams: jest.Mock;
+    useRouter: jest.Mock;
+  };
+};
+
+async function renderArtistDetail() {
+  let tree: renderer.ReactTestRenderer;
+
+  await act(async () => {
+    tree = renderer.create(<ArtistDetailScreen />);
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+
+  return tree!;
+}
+
+function hasText(tree: renderer.ReactTestRenderer, value: string): boolean {
+  return tree.root.findAllByType(Text).some((node) => node.props.children === value);
+}
+
+describe('mobile entity detail screen', () => {
+  beforeEach(() => {
+    __mock.useRouter.mockReturnValue({
+      back: jest.fn(),
+      push: jest.fn(),
+    });
+  });
+
+  test('renders populated entity detail sections for a tracked team', async () => {
+    __mock.useLocalSearchParams.mockReturnValue({ slug: 'yena' });
+    const tree = await renderArtistDetail();
+
+    expect(tree.root.findByProps({ testID: 'entity-detail-title' }).props.children).toBe('YENA');
+    expect(tree.root.findByProps({ testID: 'entity-next-upcoming-card' })).toBeDefined();
+    expect(tree.root.findByProps({ testID: 'entity-latest-release-card' })).toBeDefined();
+    expect(tree.root.findByProps({ testID: 'entity-source-timeline' })).toBeDefined();
+  });
+
+  test('renders safe empty states for sparse teams', async () => {
+    __mock.useLocalSearchParams.mockReturnValue({ slug: 'atheart' });
+    const tree = await renderArtistDetail();
+
+    expect(tree.root.findByProps({ testID: 'entity-detail-title' }).props.children).toBe('AtHeart');
+    expect(hasText(tree, '등록된 최근 앨범이 없습니다.')).toBe(true);
+  });
+
+  test('renders a safe recovery state for missing slugs', async () => {
+    __mock.useLocalSearchParams.mockReturnValue({ slug: 'no-such-team' });
+    const tree = await renderArtistDetail();
+
+    expect(tree.root.findByProps({ testID: 'entity-missing-state' })).toBeDefined();
+    expect(hasText(tree, '해당 팀 데이터를 찾지 못했습니다.')).toBe(true);
+  });
+});

--- a/mobile/src/features/route-shell.smoke.test.tsx
+++ b/mobile/src/features/route-shell.smoke.test.tsx
@@ -5,7 +5,7 @@ import CalendarTabScreen from '../../app/(tabs)/calendar';
 import RadarTabScreen from '../../app/(tabs)/radar';
 import SearchTabScreen from '../../app/(tabs)/search';
 import RootLayout from '../../app/_layout';
-import ArtistDetailPlaceholderScreen from '../../app/artists/[slug]';
+import ArtistDetailScreen from '../../app/artists/[slug]';
 import IndexRoute from '../../app/index';
 import ReleaseDetailPlaceholderScreen from '../../app/releases/[id]';
 
@@ -104,10 +104,10 @@ describe('mobile route shell smoke', () => {
 
   test('artist detail placeholder handles valid and missing slug safely', () => {
     mockUseLocalSearchParams.mockReturnValueOnce({ slug: 'blackpink' });
-    expect(() => renderTree(<ArtistDetailPlaceholderScreen />)).not.toThrow();
+    expect(() => renderTree(<ArtistDetailScreen />)).not.toThrow();
 
     mockUseLocalSearchParams.mockReturnValueOnce({});
-    expect(() => renderTree(<ArtistDetailPlaceholderScreen />)).not.toThrow();
+    expect(() => renderTree(<ArtistDetailScreen />)).not.toThrow();
   });
 
   test('release detail placeholder handles valid and missing id safely', () => {

--- a/mobile/src/selectors/index.test.ts
+++ b/mobile/src/selectors/index.test.ts
@@ -3,6 +3,7 @@ import type { MobileRawDataset } from '../types';
 import {
   selectCalendarMonthSnapshot,
   createSelectorContext,
+  selectEntityDetailSnapshot,
   selectLatestReleaseSummaryBySlug,
   selectMonthReleaseSummaries,
   selectRadarSnapshot,
@@ -364,6 +365,18 @@ describe('mobile selector/adapters scaffold', () => {
     expect(snapshot.changeFeed).toHaveLength(0);
     expect(snapshot.longGap[0]?.team.slug).toBe('weeekly');
     expect(snapshot.rookie[0]?.team.slug).toBe('atheart');
+  });
+
+  test('builds an entity detail snapshot with upcoming, albums, and ordered timeline rows', () => {
+    const snapshot = selectEntityDetailSnapshot(dataset, 'yena');
+
+    expect(snapshot).not.toBeNull();
+    expect(snapshot?.team.slug).toBe('yena');
+    expect(snapshot?.nextUpcoming?.headline).toContain('3월 11일');
+    expect(snapshot?.latestRelease?.releaseTitle).toBe('LOVE CATCHER');
+    expect(snapshot?.recentAlbums[0]?.releaseTitle).toBe('LOVE CATCHER');
+    expect(snapshot?.sourceTimeline[0]?.kind).toBe('upcoming_source');
+    expect(snapshot?.sourceTimeline.at(-1)?.kind).toBe('artist_source');
   });
 
   test('resolves a release detail model by normalized release id', () => {

--- a/mobile/src/selectors/index.ts
+++ b/mobile/src/selectors/index.ts
@@ -1,5 +1,7 @@
 import type {
   CalendarMonthSnapshotModel,
+  EntityDetailSnapshotModel,
+  EntityTimelineItemModel,
   MobileRawDataset,
   RadarLongGapItemModel,
   RadarRookieItemModel,
@@ -501,6 +503,116 @@ export function selectReleaseDetailById(
   const displayGroup = team?.display_name?.trim() || detail.group;
 
   return adaptReleaseDetail(detail.group, displayGroup, detail, context.artworkByReleaseId.get(releaseId));
+}
+
+function resolveTimelineSortKey(item: EntityTimelineItemModel): string {
+  if (item.kind === 'artist_source') {
+    return '';
+  }
+
+  const match = item.meta.match(/\d{4}-\d{2}(?:-\d{2})?/);
+  return match?.[0] ?? '';
+}
+
+function resolveTimelineRank(item: EntityTimelineItemModel): number {
+  switch (item.kind) {
+    case 'upcoming_source':
+      return 0;
+    case 'release_source':
+      return 1;
+    case 'artist_source':
+    default:
+      return 2;
+  }
+}
+
+export function selectEntityDetailSnapshot(
+  input: MobileSelectorContext | MobileRawDataset,
+  slug: string,
+): EntityDetailSnapshotModel | null {
+  const context = resolveContext(input);
+  const team = selectTeamSummaryBySlug(context, slug);
+
+  if (!team) {
+    return null;
+  }
+
+  const upcomingEvents = selectUpcomingEventsBySlug(context, slug);
+  const nextUpcoming = upcomingEvents[0] ?? null;
+  const latestRelease = selectLatestReleaseSummaryBySlug(context, slug);
+  const recentAlbums = selectRecentReleaseSummariesBySlug(context, slug).filter(
+    (release) => release.stream === 'album',
+  );
+
+  const sourceTimeline: EntityTimelineItemModel[] = [];
+
+  if (team.artistSourceUrl) {
+    sourceTimeline.push({
+      id: `${team.slug}-artist-source`,
+      kind: 'artist_source',
+      title: '아티스트 기준 소스',
+      meta: '대표 엔티티 소스',
+      sourceUrl: team.artistSourceUrl,
+    });
+  }
+
+  for (const upcoming of upcomingEvents) {
+    if (!upcoming.sourceUrl) {
+      continue;
+    }
+
+    const dateLabel =
+      upcoming.datePrecision === 'exact'
+        ? upcoming.scheduledDate ?? '날짜 미정'
+        : `${upcoming.scheduledMonth ?? '날짜 미정'} · 날짜 미정`;
+
+    sourceTimeline.push({
+      id: `${upcoming.id}-source`,
+      kind: 'upcoming_source',
+      title: upcoming.releaseLabel ?? upcoming.headline,
+      meta: `${dateLabel} · ${upcoming.status ?? '예정'}`,
+      sourceUrl: upcoming.sourceUrl,
+    });
+  }
+
+  for (const release of selectRecentReleaseSummariesBySlug(context, slug)) {
+    if (!release.sourceUrl) {
+      continue;
+    }
+
+    sourceTimeline.push({
+      id: `${release.id}-source`,
+      kind: 'release_source',
+      title: release.releaseTitle,
+      meta: `${release.releaseDate} · ${release.releaseKind ?? 'release'}`,
+      sourceUrl: release.sourceUrl,
+    });
+  }
+
+  sourceTimeline.sort((left, right) => {
+    const dateDelta = compareIsoDateDescending(
+      resolveTimelineSortKey(left),
+      resolveTimelineSortKey(right),
+    );
+    if (dateDelta !== 0) {
+      return dateDelta;
+    }
+
+    const rankDelta = resolveTimelineRank(left) - resolveTimelineRank(right);
+    if (rankDelta !== 0) {
+      return rankDelta;
+    }
+
+    return left.title.localeCompare(right.title);
+  });
+
+  return {
+    team,
+    nextUpcoming,
+    latestRelease,
+    recentAlbums,
+    sourceTimeline,
+  };
 }
 
 function parseIsoDate(value: string | undefined): number | null {

--- a/mobile/src/types/displayModels.ts
+++ b/mobile/src/types/displayModels.ts
@@ -210,3 +210,21 @@ export interface RadarSnapshotModel {
   longGap: RadarLongGapItemModel[];
   rookie: RadarRookieItemModel[];
 }
+
+export type EntityTimelineItemKind = 'artist_source' | 'upcoming_source' | 'release_source';
+
+export interface EntityTimelineItemModel {
+  id: string;
+  kind: EntityTimelineItemKind;
+  title: string;
+  meta: string;
+  sourceUrl?: string;
+}
+
+export interface EntityDetailSnapshotModel {
+  team: TeamSummaryModel;
+  nextUpcoming: UpcomingEventModel | null;
+  latestRelease: ReleaseSummaryModel | null;
+  recentAlbums: ReleaseSummaryModel[];
+  sourceTimeline: EntityTimelineItemModel[];
+}


### PR DESCRIPTION
## Summary
- replace the mobile artist detail placeholder with a shared selector-backed entity detail screen
- render identity, official links, next upcoming, latest release, recent albums, and source timeline with safe states
- add selector and screen tests for populated, sparse, and invalid slug cases

## Verification
- cd mobile && npm run lint
- cd mobile && npm run typecheck
- cd mobile && npm run test
- cd mobile && CI=1 npx expo export --platform web --output-dir /tmp/idol-song-app-mobile-entity-detail-export
- git diff --check

Closes #337