### PR TITLE
feat: implement mobile release detail screen

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -2,7 +2,7 @@
 
 이 디렉터리는 `Expo + React Native + Expo Router` 기반 모바일 앱 워크스페이스다.
 
-현재 단계는 workspace bootstrap과 router shell, 그리고 calendar / search / radar tab, entity detail route의 data-backed container까지 포함한다.
+현재 단계는 workspace bootstrap과 router shell, 그리고 calendar / search / radar tab, entity detail route, release detail route의 data-backed container까지 포함한다.
 
 - route/layout expectations는 `docs/specs/mobile/expo-implementation-guide.md`를 따른다.
 - route/param 계약은 `docs/specs/mobile/route-param-contracts.md`를 따른다.
@@ -16,6 +16,7 @@
   - `radar` tab은 shared radar snapshot 기반 section stack까지 연결됨
   - `search` tab은 query state + recent query persistence + segmented result container까지 연결됨
   - `artists/[slug]` route는 shared entity detail snapshot 기반 detail screen까지 연결됨
+  - `releases/[id]` route는 shared release detail model 기반 detail screen까지 연결됨
   - hidden `debug/metadata` route for internal metadata inspection
 - `assets/`
   - placeholder / service icon / badge fallback asset inventory
@@ -342,7 +343,7 @@ profile 차이는 아래 범위로만 제한한다.
 - smoke
   - root redirect
   - tab shell render
-  - artist/release detail placeholder render
+  - artist/release detail route render
 
 device/e2e automation은 아직 포함하지 않는다.
 

--- a/mobile/app/releases/[id].tsx
+++ b/mobile/app/releases/[id].tsx
@@ -1,5 +1,44 @@
-import { Stack, useLocalSearchParams } from 'expo-router';
-import { StyleSheet, Text, View } from 'react-native';
+import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  Image,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+
+import { selectReleaseDetailById } from '../../src/selectors';
+import {
+  loadActiveMobileDataset,
+  type ActiveMobileDataset,
+} from '../../src/services/activeDataset';
+import {
+  openServiceHandoff,
+  resolveServiceHandoff,
+  resolveServiceHandoffGroup,
+  type MusicService,
+  type ServiceHandoffFailure,
+  type ServiceHandoffResolution,
+} from '../../src/services/handoff';
+import { useAppTheme } from '../../src/tokens/theme';
+import type { MobileTheme } from '../../src/tokens/theme';
+import type { ReleaseDetailModel, TrackModel, YoutubeVideoStatus } from '../../src/types';
+
+type ReleaseDetailScreenState =
+  | { kind: 'loading' }
+  | { kind: 'error'; message: string }
+  | { kind: 'missing'; reason: string }
+  | { kind: 'ready'; source: ActiveMobileDataset; detail: ReleaseDetailModel };
+
+type ServiceButtonSpec = {
+  key: MusicService;
+  label: string;
+  handoff: ServiceHandoffResolution | ServiceHandoffFailure;
+  testID: string;
+};
 
 function getSingleParam(value: string | string[] | undefined): string | null {
   if (Array.isArray(value)) {
@@ -9,54 +48,677 @@ function getSingleParam(value: string | string[] | undefined): string | null {
   return value ?? null;
 }
 
-export default function ReleaseDetailPlaceholderScreen() {
-  const params = useLocalSearchParams<{ id?: string | string[] }>();
-  const id = getSingleParam(params.id);
-  const isValid = typeof id === 'string' && id.trim().length > 0;
+function getReleaseKindLabel(detail: ReleaseDetailModel): string {
+  if (detail.releaseKind?.trim()) {
+    return detail.releaseKind.trim().toUpperCase();
+  }
+
+  if (detail.stream === 'song') {
+    return 'SONG';
+  }
+
+  if (detail.stream === 'album') {
+    return 'ALBUM';
+  }
+
+  return 'RELEASE';
+}
+
+function getCoverMonogram(detail: ReleaseDetailModel): string {
+  const token = detail.displayGroup.trim() || detail.releaseTitle.trim();
+  return token.slice(0, 2).toUpperCase();
+}
+
+function resolveYoutubeMvUrl(detail: ReleaseDetailModel): string | null {
+  if (detail.youtubeVideoUrl) {
+    return detail.youtubeVideoUrl;
+  }
+
+  if (detail.youtubeVideoId) {
+    return `https://www.youtube.com/watch?v=${detail.youtubeVideoId}`;
+  }
+
+  return null;
+}
+
+function formatReleaseMeta(detail: ReleaseDetailModel): string {
+  return `${detail.releaseDate} · ${getReleaseKindLabel(detail)}`;
+}
+
+function getMvStatusCopy(status?: YoutubeVideoStatus): string | null {
+  switch (status) {
+    case 'manual_override':
+      return '공식 MV 링크가 정리됐지만 앱 임베드 대신 외부 재생으로 엽니다.';
+    case 'relation_match':
+      return '공식 MV가 확인돼 외부 서비스로 바로 열 수 있습니다.';
+    case 'needs_review':
+      return '공식 MV 후보가 있어도 아직 검토가 끝나지 않았습니다.';
+    case 'no_mv':
+      return '현재는 공식 MV가 등록되지 않았습니다.';
+    case 'unresolved':
+      return '공식 MV가 아직 확정되지 않았습니다.';
+    default:
+      return null;
+  }
+}
+
+function buildAlbumServiceButtons(detail: ReleaseDetailModel): ServiceButtonSpec[] {
+  const query = `${detail.displayGroup} ${detail.releaseTitle}`;
+  const handoffs = resolveServiceHandoffGroup({
+    query,
+    spotifyUrl: detail.spotifyUrl,
+    youtubeMusicUrl: detail.youtubeMusicUrl,
+    youtubeMvUrl: resolveYoutubeMvUrl(detail),
+  });
+
+  const buttons: ServiceButtonSpec[] = [
+    {
+      key: 'spotify',
+      label: 'Spotify',
+      handoff: handoffs.spotify,
+      testID: 'release-service-spotify',
+    },
+    {
+      key: 'youtubeMusic',
+      label: 'YouTube Music',
+      handoff: handoffs.youtubeMusic,
+      testID: 'release-service-youtube-music',
+    },
+    {
+      key: 'youtubeMv',
+      label: 'YouTube MV',
+      handoff: handoffs.youtubeMv,
+      testID: 'release-service-youtube-mv',
+    },
+  ];
+
+  return buttons.filter((item) => item.key !== 'youtubeMv' || resolveYoutubeMvUrl(detail) !== null);
+}
+
+function buildTrackServiceButtons(detail: ReleaseDetailModel, track: TrackModel): ServiceButtonSpec[] {
+  const query = `${detail.displayGroup} ${track.title}`;
+
+  return [
+    {
+      key: 'spotify',
+      label: 'Spotify',
+      handoff: resolveServiceHandoff({
+        service: 'spotify',
+        query,
+        canonicalUrl: track.spotifyUrl,
+      }),
+      testID: `release-track-${track.order}-spotify`,
+    },
+    {
+      key: 'youtubeMusic',
+      label: 'YT Music',
+      handoff: resolveServiceHandoff({
+        service: 'youtubeMusic',
+        query,
+        canonicalUrl: track.youtubeMusicUrl,
+      }),
+      testID: `release-track-${track.order}-youtube-music`,
+    },
+  ];
+}
+
+function ReleaseCover({
+  detail,
+  styles,
+}: {
+  detail: ReleaseDetailModel;
+  styles: ReturnType<typeof createStyles>;
+}) {
+  if (detail.coverImageUrl) {
+    return <Image source={{ uri: detail.coverImageUrl }} style={styles.coverImage} />;
+  }
 
   return (
-    <View style={styles.container}>
-      <Stack.Screen options={{ title: isValid ? id : 'Release Detail' }} />
-      <Text style={styles.eyebrow}>PUSH DETAIL</Text>
-      <Text style={styles.title}>Release Detail</Text>
-      <Text style={styles.body}>
-        {isValid
-          ? `id param is wired: ${id}`
-          : 'Missing or invalid id. The final screen should show a safe empty or recovery state instead of crashing.'}
-      </Text>
-      <Text style={styles.meta}>Path contract: /releases/[id]</Text>
+    <View style={styles.coverFallback}>
+      <Text style={styles.coverFallbackText}>{getCoverMonogram(detail)}</Text>
     </View>
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: 'center',
-    paddingHorizontal: 24,
-    backgroundColor: '#fcfbf8',
-  },
-  eyebrow: {
-    marginBottom: 8,
-    fontSize: 12,
-    fontWeight: '600',
-    letterSpacing: 1.2,
-    color: '#87634d',
-  },
-  title: {
-    marginBottom: 12,
-    fontSize: 28,
-    fontWeight: '700',
-    color: '#1f1b17',
-  },
-  body: {
-    marginBottom: 12,
-    fontSize: 16,
-    lineHeight: 24,
-    color: '#5e554d',
-  },
-  meta: {
-    fontSize: 13,
-    color: '#8a7e72',
-  },
-});
+function ServiceButton({
+  label,
+  onPress,
+  styles,
+  tone,
+  testID,
+}: {
+  label: string;
+  onPress: () => void;
+  styles: ReturnType<typeof createStyles>;
+  tone: 'spotify' | 'youtubeMusic' | 'youtubeMv';
+  testID: string;
+}) {
+  return (
+    <Pressable
+      accessibilityRole="button"
+      onPress={onPress}
+      style={[styles.serviceButton, styles[`${tone}Button`]]}
+      testID={testID}
+    >
+      <Text style={[styles.serviceButtonLabel, styles[`${tone}ButtonLabel`]]}>{label}</Text>
+    </Pressable>
+  );
+}
+
+export default function ReleaseDetailScreen() {
+  const router = useRouter();
+  const params = useLocalSearchParams<{ id?: string | string[] }>();
+  const theme = useAppTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+  const releaseId = getSingleParam(params.id)?.trim() ?? '';
+  const [reloadCount, setReloadCount] = useState(0);
+  const [handoffFeedback, setHandoffFeedback] = useState<string | null>(null);
+  const [state, setState] = useState<ReleaseDetailScreenState>({ kind: 'loading' });
+
+  useEffect(() => {
+    let cancelled = false;
+
+    if (!releaseId) {
+      setState({
+        kind: 'missing',
+        reason: '릴리즈 ID가 없거나 잘못되어 상세 화면을 열 수 없습니다.',
+      });
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    setHandoffFeedback(null);
+    setState({ kind: 'loading' });
+
+    void loadActiveMobileDataset()
+      .then((source) => {
+        if (cancelled) {
+          return;
+        }
+
+        const detail = selectReleaseDetailById(source.dataset, releaseId);
+        if (!detail) {
+          setState({
+            kind: 'missing',
+            reason: '해당 릴리즈 상세 데이터를 찾지 못했습니다.',
+          });
+          return;
+        }
+
+        setState({
+          kind: 'ready',
+          source,
+          detail,
+        });
+      })
+      .catch((error: unknown) => {
+        if (cancelled) {
+          return;
+        }
+
+        setState({
+          kind: 'error',
+          message:
+            error instanceof Error
+              ? error.message
+              : '릴리즈 상세 데이터를 불러오지 못했습니다.',
+        });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [releaseId, reloadCount]);
+
+  async function handleHandoff(
+    handoff: ServiceHandoffResolution | ServiceHandoffFailure,
+  ) {
+    const result = await openServiceHandoff(handoff);
+
+    if (!result.ok) {
+      setHandoffFeedback(result.feedback.message);
+      return;
+    }
+
+    setHandoffFeedback(null);
+  }
+
+  const screenTitle =
+    state.kind === 'ready' ? state.detail.releaseTitle : releaseId || 'Release Detail';
+
+  if (state.kind === 'loading') {
+    return (
+      <View style={styles.stateContainer}>
+        <Stack.Screen options={{ title: screenTitle }} />
+        <ActivityIndicator color={theme.colors.text.brand} />
+        <Text style={styles.eyebrow}>DETAIL LOADING</Text>
+        <Text style={styles.stateTitle}>Release Detail</Text>
+        <Text style={styles.stateBody}>앨범 액션, 트랙 리스트, MV 상태를 불러오는 중입니다.</Text>
+      </View>
+    );
+  }
+
+  if (state.kind === 'error') {
+    return (
+      <View style={styles.stateContainer}>
+        <Stack.Screen options={{ title: screenTitle }} />
+        <Text style={styles.eyebrow}>LOAD ERROR</Text>
+        <Text style={styles.stateTitle}>Release Detail</Text>
+        <Text style={styles.stateBody}>{state.message}</Text>
+        <Pressable style={styles.retryButton} onPress={() => setReloadCount((count) => count + 1)}>
+          <Text style={styles.retryButtonLabel}>다시 시도</Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  if (state.kind === 'missing') {
+    return (
+      <View style={styles.stateContainer} testID="release-missing-state">
+        <Stack.Screen options={{ title: screenTitle }} />
+        <Text style={styles.eyebrow}>MISSING DETAIL</Text>
+        <Text style={styles.stateTitle}>Release Detail</Text>
+        <Text style={styles.stateBody}>{state.reason}</Text>
+        <Pressable style={styles.retryButton} onPress={() => router.back()}>
+          <Text style={styles.retryButtonLabel}>이전 화면으로</Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  const { detail, source } = state;
+  const albumServiceButtons = buildAlbumServiceButtons(detail);
+  const mvUrl = resolveYoutubeMvUrl(detail);
+  const mvStatusCopy = getMvStatusCopy(detail.youtubeVideoStatus);
+
+  return (
+    <ScrollView
+      style={styles.screen}
+      contentContainerStyle={styles.content}
+      showsVerticalScrollIndicator={false}
+    >
+      <Stack.Screen options={{ title: detail.releaseTitle }} />
+
+      <Pressable style={styles.backButton} onPress={() => router.back()}>
+        <Text style={styles.backButtonLabel}>뒤로</Text>
+      </Pressable>
+
+      <Text style={styles.eyebrow}>{source.sourceLabel}</Text>
+
+      <View style={styles.heroCard}>
+        <ReleaseCover detail={detail} styles={styles} />
+        <View style={styles.heroCopy}>
+          <Text style={styles.releaseTitle} testID="release-detail-title">
+            {detail.releaseTitle}
+          </Text>
+          <Text style={styles.releaseMeta}>{formatReleaseMeta(detail)}</Text>
+          <View style={styles.identityRow}>
+            <View style={styles.kindChip}>
+              <Text style={styles.kindChipLabel}>{getReleaseKindLabel(detail)}</Text>
+            </View>
+            <Text style={styles.groupLabel}>{detail.displayGroup}</Text>
+          </View>
+        </View>
+      </View>
+
+      <View style={styles.section}>
+        <Text style={styles.sectionTitle}>앨범 액션</Text>
+        <View style={styles.serviceButtonRow}>
+          {albumServiceButtons.map((button) => (
+            <ServiceButton
+              key={button.key}
+              label={button.label}
+              onPress={() => void handleHandoff(button.handoff)}
+              styles={styles}
+              tone={button.key}
+              testID={button.testID}
+            />
+          ))}
+        </View>
+      </View>
+
+      {handoffFeedback ? (
+        <View style={styles.feedbackCard}>
+          <Text style={styles.feedbackText}>{handoffFeedback}</Text>
+        </View>
+      ) : null}
+
+      <View style={styles.section}>
+        <Text style={styles.sectionTitle}>트랙 리스트</Text>
+        {detail.tracks.length > 0 ? (
+          <View style={styles.trackList}>
+            {detail.tracks.map((track) => (
+              <View
+                key={`${detail.id}-${track.order}`}
+                style={styles.trackRow}
+                testID={`release-track-row-${track.order}`}
+              >
+                <Text style={styles.trackOrder}>{track.order}</Text>
+                <View style={styles.trackCopy}>
+                  <View style={styles.trackTitleRow}>
+                    <Text style={styles.trackTitle}>{track.title}</Text>
+                    {track.isTitleTrack ? (
+                      <View
+                        style={styles.titleTrackBadge}
+                        testID={`release-track-title-badge-${track.order}`}
+                      >
+                        <Text style={styles.titleTrackBadgeLabel}>타이틀</Text>
+                      </View>
+                    ) : null}
+                  </View>
+                </View>
+                <View style={styles.trackServiceButtons}>
+                  {buildTrackServiceButtons(detail, track).map((button) => (
+                    <ServiceButton
+                      key={`${track.order}-${button.key}`}
+                      label={button.label}
+                      onPress={() => void handleHandoff(button.handoff)}
+                      styles={styles}
+                      tone={button.key}
+                      testID={button.testID}
+                    />
+                  ))}
+                </View>
+              </View>
+            ))}
+          </View>
+        ) : (
+          <View style={styles.emptyCard} testID="release-empty-tracks">
+            <Text style={styles.emptyCardText}>트랙 정보가 아직 정리되지 않았습니다.</Text>
+          </View>
+        )}
+      </View>
+
+      {detail.notes ? (
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>메모</Text>
+          <View style={styles.metaCard}>
+            <Text style={styles.metaBody}>{detail.notes}</Text>
+          </View>
+        </View>
+      ) : null}
+
+      {mvUrl ? (
+        <View style={styles.section} testID="release-mv-card">
+          <Text style={styles.sectionTitle}>공식 MV</Text>
+          <View style={styles.metaCard}>
+            {mvStatusCopy ? <Text style={styles.metaBody}>{mvStatusCopy}</Text> : null}
+            <ServiceButton
+              label="YouTube MV"
+              onPress={() =>
+                void handleHandoff(
+                  resolveServiceHandoff({
+                    service: 'youtubeMv',
+                    query: `${detail.displayGroup} ${detail.releaseTitle}`,
+                    canonicalUrl: mvUrl,
+                  }),
+                )
+              }
+              styles={styles}
+              tone="youtubeMv"
+              testID="release-mv-button"
+            />
+          </View>
+        </View>
+      ) : detail.youtubeVideoStatus ? (
+        <View style={styles.section} testID="release-mv-state">
+          <Text style={styles.sectionTitle}>MV 상태</Text>
+          <View style={styles.metaCard}>
+            <Text style={styles.metaBody}>{mvStatusCopy ?? '공식 MV 정보가 아직 정리되지 않았습니다.'}</Text>
+            {detail.youtubeVideoProvenance ? (
+              <Text style={styles.metaSubtle}>{detail.youtubeVideoProvenance}</Text>
+            ) : null}
+          </View>
+        </View>
+      ) : null}
+    </ScrollView>
+  );
+}
+
+function createStyles(theme: MobileTheme) {
+  return StyleSheet.create({
+    screen: {
+      flex: 1,
+      backgroundColor: theme.colors.surface.base,
+    },
+    content: {
+      paddingHorizontal: theme.space[20],
+      paddingTop: theme.space[24],
+      paddingBottom: theme.space[32],
+      gap: theme.space[20],
+    },
+    stateContainer: {
+      flex: 1,
+      justifyContent: 'center',
+      paddingHorizontal: theme.space[24],
+      backgroundColor: theme.colors.surface.base,
+    },
+    eyebrow: {
+      ...theme.typography.meta,
+      marginBottom: theme.space[8],
+      color: theme.colors.text.brand,
+      textTransform: 'uppercase',
+    },
+    stateTitle: {
+      ...theme.typography.screenTitle,
+      marginBottom: theme.space[12],
+      color: theme.colors.text.primary,
+    },
+    stateBody: {
+      ...theme.typography.body,
+      color: theme.colors.text.secondary,
+    },
+    retryButton: {
+      alignSelf: 'flex-start',
+      marginTop: theme.space[16],
+      paddingHorizontal: theme.space[16],
+      paddingVertical: theme.space[12],
+      borderRadius: theme.radius.button,
+      backgroundColor: theme.colors.surface.interactive,
+    },
+    retryButtonLabel: {
+      ...theme.typography.buttonPrimary,
+      color: theme.colors.text.primary,
+    },
+    backButton: {
+      alignSelf: 'flex-start',
+      paddingHorizontal: theme.space[12],
+      paddingVertical: theme.space[8],
+      borderRadius: theme.radius.button,
+      backgroundColor: theme.colors.surface.interactive,
+    },
+    backButtonLabel: {
+      ...theme.typography.buttonService,
+      color: theme.colors.text.primary,
+    },
+    heroCard: {
+      flexDirection: 'row',
+      gap: theme.space[16],
+      padding: theme.space[16],
+      borderRadius: theme.radius.card,
+      backgroundColor: theme.colors.surface.elevated,
+      borderWidth: 1,
+      borderColor: theme.colors.border.subtle,
+    },
+    coverImage: {
+      width: 120,
+      height: 120,
+      borderRadius: theme.radius.card,
+      backgroundColor: theme.colors.surface.subtle,
+    },
+    coverFallback: {
+      width: 120,
+      height: 120,
+      alignItems: 'center',
+      justifyContent: 'center',
+      borderRadius: theme.radius.card,
+      backgroundColor: theme.colors.surface.interactive,
+      borderWidth: 1,
+      borderColor: theme.colors.border.default,
+    },
+    coverFallbackText: {
+      ...theme.typography.screenTitle,
+      color: theme.colors.text.brand,
+    },
+    heroCopy: {
+      flex: 1,
+      justifyContent: 'space-between',
+      gap: theme.space[8],
+    },
+    releaseTitle: {
+      ...theme.typography.screenTitle,
+      color: theme.colors.text.primary,
+    },
+    releaseMeta: {
+      ...theme.typography.body,
+      color: theme.colors.text.secondary,
+    },
+    identityRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: theme.space[8],
+      flexWrap: 'wrap',
+    },
+    kindChip: {
+      paddingHorizontal: theme.space[8],
+      paddingVertical: theme.space[4],
+      borderRadius: theme.radius.chip,
+      backgroundColor: theme.colors.surface.interactive,
+    },
+    kindChipLabel: {
+      ...theme.typography.chip,
+      color: theme.colors.text.brand,
+    },
+    groupLabel: {
+      ...theme.typography.meta,
+      color: theme.colors.text.secondary,
+    },
+    section: {
+      gap: theme.space[12],
+    },
+    sectionTitle: {
+      ...theme.typography.sectionTitle,
+      color: theme.colors.text.primary,
+    },
+    serviceButtonRow: {
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+      gap: theme.space[8],
+    },
+    serviceButton: {
+      minHeight: 40,
+      minWidth: 104,
+      alignItems: 'center',
+      justifyContent: 'center',
+      paddingHorizontal: theme.space[12],
+      paddingVertical: theme.space[12],
+      borderRadius: theme.radius.button,
+    },
+    spotifyButton: {
+      backgroundColor: theme.colors.service.spotify.bg,
+    },
+    youtubeMusicButton: {
+      backgroundColor: theme.colors.service.youtubeMusic.bg,
+    },
+    youtubeMvButton: {
+      backgroundColor: theme.colors.service.youtubeMv.bg,
+    },
+    serviceButtonLabel: {
+      ...theme.typography.buttonService,
+    },
+    spotifyButtonLabel: {
+      color: theme.colors.service.spotify.icon,
+    },
+    youtubeMusicButtonLabel: {
+      color: theme.colors.service.youtubeMusic.icon,
+    },
+    youtubeMvButtonLabel: {
+      color: theme.colors.service.youtubeMv.icon,
+    },
+    feedbackCard: {
+      padding: theme.space[12],
+      borderRadius: theme.radius.card,
+      backgroundColor: theme.colors.surface.elevated,
+      borderWidth: 1,
+      borderColor: theme.colors.border.default,
+    },
+    feedbackText: {
+      ...theme.typography.meta,
+      color: theme.colors.text.secondary,
+    },
+    trackList: {
+      gap: theme.space[12],
+    },
+    trackRow: {
+      flexDirection: 'row',
+      gap: theme.space[12],
+      alignItems: 'flex-start',
+      padding: theme.space[12],
+      borderRadius: theme.radius.card,
+      backgroundColor: theme.colors.surface.elevated,
+      borderWidth: 1,
+      borderColor: theme.colors.border.subtle,
+    },
+    trackOrder: {
+      ...theme.typography.cardTitle,
+      width: 18,
+      color: theme.colors.text.secondary,
+    },
+    trackCopy: {
+      flex: 1,
+      gap: theme.space[4],
+    },
+    trackTitleRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: theme.space[8],
+      flexWrap: 'wrap',
+    },
+    trackTitle: {
+      ...theme.typography.cardTitle,
+      color: theme.colors.text.primary,
+      flexShrink: 1,
+    },
+    titleTrackBadge: {
+      paddingHorizontal: theme.space[8],
+      paddingVertical: theme.space[4],
+      borderRadius: theme.radius.chip,
+      backgroundColor: theme.colors.status.title.bg,
+    },
+    titleTrackBadgeLabel: {
+      ...theme.typography.chip,
+      color: theme.colors.status.title.text,
+    },
+    trackServiceButtons: {
+      gap: theme.space[8],
+    },
+    emptyCard: {
+      padding: theme.space[16],
+      borderRadius: theme.radius.card,
+      backgroundColor: theme.colors.surface.elevated,
+      borderWidth: 1,
+      borderColor: theme.colors.border.subtle,
+    },
+    emptyCardText: {
+      ...theme.typography.body,
+      color: theme.colors.text.secondary,
+    },
+    metaCard: {
+      gap: theme.space[12],
+      padding: theme.space[16],
+      borderRadius: theme.radius.card,
+      backgroundColor: theme.colors.surface.elevated,
+      borderWidth: 1,
+      borderColor: theme.colors.border.subtle,
+    },
+    metaBody: {
+      ...theme.typography.body,
+      color: theme.colors.text.secondary,
+    },
+    metaSubtle: {
+      ...theme.typography.meta,
+      color: theme.colors.text.tertiary,
+    },
+  });
+}

--- a/mobile/src/README.md
+++ b/mobile/src/README.md
@@ -8,7 +8,7 @@
   - `runtime.ts`: mobile profile / env validation + safe degraded runtime state
   - `debugMetadata.ts`: debug-only build/dataset/commit/runtime-state metadata helper
 - `features/`: 화면 composition / binding
-- `selectors/`: display model selector / adapter
+  - `selectors/`: display model selector / adapter
   - `context.ts`: dataset -> indexed selector context
   - `adapters.ts`: raw JSON -> display model 변환 규칙
   - `index.ts`: shared selectors entrypoint

--- a/mobile/src/features/releaseDetailScreen.test.tsx
+++ b/mobile/src/features/releaseDetailScreen.test.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import { Text } from 'react-native';
+
+import ReleaseDetailScreen from '../../app/releases/[id]';
+
+jest.mock('expo-router', () => {
+  const useLocalSearchParams = jest.fn(() => ({ id: 'yena--love-catcher--2026-03-11--album' }));
+  const useRouter = jest.fn(() => ({
+    back: jest.fn(),
+    push: jest.fn(),
+  }));
+
+  function Stack({ children }: { children?: React.ReactNode }) {
+    return children ?? null;
+  }
+
+  Stack.Screen = function StackScreen() {
+    return null;
+  };
+
+  return {
+    Stack,
+    useLocalSearchParams,
+    useRouter,
+    __mock: {
+      useLocalSearchParams,
+      useRouter,
+    },
+  };
+});
+
+const { __mock } = jest.requireMock('expo-router') as {
+  __mock: {
+    useLocalSearchParams: jest.Mock;
+    useRouter: jest.Mock;
+  };
+};
+
+async function renderReleaseDetail() {
+  let tree: renderer.ReactTestRenderer;
+
+  await act(async () => {
+    tree = renderer.create(<ReleaseDetailScreen />);
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+
+  return tree!;
+}
+
+function hasText(tree: renderer.ReactTestRenderer, value: string): boolean {
+  return tree.root.findAllByType(Text).some((node) => node.props.children === value);
+}
+
+describe('mobile release detail screen', () => {
+  beforeEach(() => {
+    __mock.useRouter.mockReturnValue({
+      back: jest.fn(),
+      push: jest.fn(),
+    });
+  });
+
+  test('renders populated release detail sections for a canonical release', async () => {
+    __mock.useLocalSearchParams.mockReturnValue({ id: 'yena--love-catcher--2026-03-11--album' });
+    const tree = await renderReleaseDetail();
+
+    expect(tree.root.findByProps({ testID: 'release-detail-title' }).props.children).toBe('LOVE CATCHER');
+    expect(tree.root.findByProps({ testID: 'release-service-spotify' })).toBeDefined();
+    expect(tree.root.findByProps({ testID: 'release-service-youtube-music' })).toBeDefined();
+    expect(tree.root.findByProps({ testID: 'release-service-youtube-mv' })).toBeDefined();
+    expect(tree.root.findByProps({ testID: 'release-track-row-1' })).toBeDefined();
+    expect(tree.root.findByProps({ testID: 'release-track-title-badge-1' })).toBeDefined();
+    expect(tree.root.findByProps({ testID: 'release-mv-card' })).toBeDefined();
+  });
+
+  test('renders safe partial states for releases without track or mv links', async () => {
+    __mock.useLocalSearchParams.mockReturnValue({ id: 'atheart--glow-up--2025-11-18--song' });
+    const tree = await renderReleaseDetail();
+
+    expect(tree.root.findByProps({ testID: 'release-detail-title' }).props.children).toBe('Glow Up');
+    expect(tree.root.findByProps({ testID: 'release-empty-tracks' })).toBeDefined();
+    expect(tree.root.findByProps({ testID: 'release-mv-state' })).toBeDefined();
+    expect(hasText(tree, '현재는 공식 MV가 등록되지 않았습니다.')).toBe(true);
+  });
+
+  test('renders a safe recovery state for missing release ids', async () => {
+    __mock.useLocalSearchParams.mockReturnValue({ id: 'no-such-release' });
+    const tree = await renderReleaseDetail();
+
+    expect(tree.root.findByProps({ testID: 'release-missing-state' })).toBeDefined();
+    expect(hasText(tree, '해당 릴리즈 상세 데이터를 찾지 못했습니다.')).toBe(true);
+  });
+});

--- a/mobile/src/features/route-shell.smoke.test.tsx
+++ b/mobile/src/features/route-shell.smoke.test.tsx
@@ -7,7 +7,7 @@ import SearchTabScreen from '../../app/(tabs)/search';
 import RootLayout from '../../app/_layout';
 import ArtistDetailScreen from '../../app/artists/[slug]';
 import IndexRoute from '../../app/index';
-import ReleaseDetailPlaceholderScreen from '../../app/releases/[id]';
+import ReleaseDetailScreen from '../../app/releases/[id]';
 
 jest.mock('expo-router', () => {
   const React = jest.requireActual<typeof import('react')>('react');
@@ -110,11 +110,11 @@ describe('mobile route shell smoke', () => {
     expect(() => renderTree(<ArtistDetailScreen />)).not.toThrow();
   });
 
-  test('release detail placeholder handles valid and missing id safely', () => {
+  test('release detail screen handles valid and missing id safely', () => {
     mockUseLocalSearchParams.mockReturnValueOnce({ id: 'blackpink-deadline-2026-02-26' });
-    expect(() => renderTree(<ReleaseDetailPlaceholderScreen />)).not.toThrow();
+    expect(() => renderTree(<ReleaseDetailScreen />)).not.toThrow();
 
     mockUseLocalSearchParams.mockReturnValueOnce({});
-    expect(() => renderTree(<ReleaseDetailPlaceholderScreen />)).not.toThrow();
+    expect(() => renderTree(<ReleaseDetailScreen />)).not.toThrow();
   });
 });

--- a/mobile/src/services/bundledDatasetFixture.ts
+++ b/mobile/src/services/bundledDatasetFixture.ts
@@ -214,6 +214,7 @@ const bundledDatasetFixture: MobileRawDataset = {
       release_kind: 'ep',
       spotify_url: 'https://open.spotify.com/album/example-love-catcher',
       youtube_music_url: 'https://music.youtube.com/playlist?list=example-love-catcher',
+      youtube_video_url: 'https://www.youtube.com/watch?v=LoVeCaTcHr1',
       youtube_video_status: 'manual_override',
       notes: 'Representative EP detail.',
       tracks: [
@@ -273,15 +274,9 @@ const bundledDatasetFixture: MobileRawDataset = {
       release_kind: 'single',
       spotify_url: 'https://open.spotify.com/track/example-glow-up',
       youtube_music_url: 'https://music.youtube.com/watch?v=example-glow-up',
-      youtube_video_status: 'manual_override',
-      notes: 'Representative rookie detail.',
-      tracks: [
-        {
-          order: 1,
-          title: 'Glow Up',
-          is_title_track: true,
-        },
-      ],
+      youtube_video_status: 'no_mv',
+      notes: 'Representative rookie detail with incomplete catalog metadata.',
+      tracks: [],
     },
   ],
   releaseHistory: [


### PR DESCRIPTION
## Summary
- implement the mobile release detail screen from shared release detail selectors
- render album actions, track list, title-track badges, and MV state with safe missing/error fallbacks
- add release-detail fixture coverage and route/screen regression tests

## Verification
- cd mobile && npm run lint
- cd mobile && npm run typecheck
- cd mobile && npm run test
- cd mobile && CI=1 npx expo export --platform web --output-dir /tmp/idol-song-app-mobile-release-detail-export
- git diff --check

Closes #338