### PR TITLE
Add shared mobile feedback states

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -50,6 +50,8 @@
   - search recent-query persistence helper
 - `src/services/handoff.ts`
   - canonical-open / search-fallback / browser-fallback handoff service layer
+- `src/components/feedback/FeedbackState.tsx`
+  - shared loading / empty / error / retry state components
 - `src/tokens/`
   - semantic token constants + theme provider + `useAppTheme()` access convention
 - `src/selectors/`

--- a/mobile/app/(tabs)/calendar.tsx
+++ b/mobile/app/(tabs)/calendar.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import {
-  ActivityIndicator,
   Modal,
   Pressable,
   ScrollView,
@@ -9,6 +8,10 @@ import {
   View,
 } from 'react-native';
 
+import {
+  InlineFeedbackNotice,
+  ScreenFeedbackState,
+} from '../../src/components/feedback/FeedbackState';
 import {
   buildCalendarMonthGrid,
   resolveInitialCalendarSelection,
@@ -274,25 +277,27 @@ export default function CalendarTabScreen() {
 
   if (state.kind === 'loading') {
     return (
-      <View style={styles.stateContainer}>
-        <ActivityIndicator color={theme.colors.text.brand} />
-        <Text style={styles.eyebrow}>DATASET LOADING</Text>
-        <Text style={styles.title}>Calendar</Text>
-        <Text style={styles.body}>현재 월 데이터와 예정 신호를 불러오는 중입니다.</Text>
-      </View>
+      <ScreenFeedbackState
+        body="현재 월 데이터와 예정 신호를 불러오는 중입니다."
+        eyebrow="DATASET LOADING"
+        title="Calendar"
+        variant="loading"
+      />
     );
   }
 
   if (state.kind === 'error') {
     return (
-      <View style={styles.stateContainer}>
-        <Text style={styles.eyebrow}>LOAD ERROR</Text>
-        <Text style={styles.title}>Calendar</Text>
-        <Text style={styles.body}>{state.message}</Text>
-        <Pressable style={styles.retryButton} onPress={() => setReloadCount((count) => count + 1)}>
-          <Text style={styles.retryButtonLabel}>다시 시도</Text>
-        </Pressable>
-      </View>
+      <ScreenFeedbackState
+        action={{
+          label: '다시 시도',
+          onPress: () => setReloadCount((count) => count + 1),
+        }}
+        body={state.message}
+        eyebrow="LOAD ERROR"
+        title="Calendar"
+        variant="error"
+      />
     );
   }
 
@@ -538,9 +543,9 @@ export default function CalendarTabScreen() {
             </View>
 
             {state.kind === 'empty' ? (
-              <Text style={styles.body}>
-                현재 dataset source에는 {formatMonthLabel(filteredSnapshot.month)} 기준 발매나 예정 컴백이 없습니다.
-              </Text>
+              <InlineFeedbackNotice
+                body={`현재 dataset source에는 ${formatMonthLabel(filteredSnapshot.month)} 기준 발매나 예정 컴백이 없습니다.`}
+              />
             ) : null}
           </View>
         ) : null}
@@ -554,7 +559,7 @@ export default function CalendarTabScreen() {
             month-only 예정 신호는 날짜 셀에 넣지 않고 월 컨텍스트 버킷으로 유지합니다.
           </Text>
           {filterMode === 'releases' ? (
-            <Text style={styles.body}>현재 필터에서는 month-only 예정 신호를 숨깁니다.</Text>
+            <InlineFeedbackNotice body="현재 필터에서는 month-only 예정 신호를 숨깁니다." />
           ) : filteredSnapshot.monthOnlyUpcoming.length ? (
             filteredSnapshot.monthOnlyUpcoming.map((event) => (
               <View key={event.id} style={styles.row}>
@@ -564,7 +569,7 @@ export default function CalendarTabScreen() {
               </View>
             ))
           ) : (
-            <Text style={styles.body}>현재 월에 month-only 예정 신호가 없습니다.</Text>
+            <InlineFeedbackNotice body="현재 월에 month-only 예정 신호가 없습니다." />
           )}
         </View>
       </ScrollView>
@@ -612,7 +617,7 @@ export default function CalendarTabScreen() {
                 bounces={false}
               >
                 {selectedDay.isEmpty ? (
-                  <Text style={styles.body}>이 날짜에는 등록된 일정이 없습니다.</Text>
+                  <InlineFeedbackNotice body="이 날짜에는 등록된 일정이 없습니다." />
                 ) : (
                   <>
                     {selectedDay.releases.length ? (

--- a/mobile/app/(tabs)/radar.tsx
+++ b/mobile/app/(tabs)/radar.tsx
@@ -1,7 +1,6 @@
 import { useRouter } from 'expo-router';
 import React, { useEffect, useMemo, useState } from 'react';
 import {
-  ActivityIndicator,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -9,6 +8,10 @@ import {
   View,
 } from 'react-native';
 
+import {
+  InlineFeedbackNotice,
+  ScreenFeedbackState,
+} from '../../src/components/feedback/FeedbackState';
 import { selectRadarSnapshot } from '../../src/selectors';
 import {
   loadActiveMobileDataset,
@@ -113,25 +116,27 @@ export default function RadarTabScreen() {
 
   if (state.kind === 'loading') {
     return (
-      <View style={styles.stateContainer}>
-        <ActivityIndicator color={theme.colors.text.brand} />
-        <Text style={styles.eyebrow}>DATA-BACKED TAB</Text>
-        <Text style={styles.title}>레이더</Text>
-        <Text style={styles.body}>가장 가까운 컴백과 레이더 요약을 불러오는 중입니다.</Text>
-      </View>
+      <ScreenFeedbackState
+        body="가장 가까운 컴백과 레이더 요약을 불러오는 중입니다."
+        eyebrow="DATA-BACKED TAB"
+        title="레이더"
+        variant="loading"
+      />
     );
   }
 
   if (state.kind === 'error') {
     return (
-      <View style={styles.stateContainer}>
-        <Text style={styles.eyebrow}>LOAD ERROR</Text>
-        <Text style={styles.title}>레이더</Text>
-        <Text style={styles.body}>{state.message}</Text>
-        <Pressable style={styles.retryButton} onPress={() => setReloadCount((count) => count + 1)}>
-          <Text style={styles.retryButtonLabel}>다시 시도</Text>
-        </Pressable>
-      </View>
+      <ScreenFeedbackState
+        action={{
+          label: '다시 시도',
+          onPress: () => setReloadCount((count) => count + 1),
+        }}
+        body={state.message}
+        eyebrow="LOAD ERROR"
+        title="레이더"
+        variant="error"
+      />
     );
   }
 
@@ -313,7 +318,7 @@ function RadarFeaturedSection({
           <Text style={styles.featuredMeta}>{formatUpcomingMeta(item)}</Text>
         </Pressable>
       ) : (
-        <Text style={styles.emptyCopy}>가까운 컴백 일정이 없습니다.</Text>
+        <InlineFeedbackNotice body="가까운 컴백 일정이 없습니다." />
       )}
     </View>
   );
@@ -343,7 +348,7 @@ function RadarSection<T>({
       <View style={styles.sectionHeader}>
         <Text style={styles.sectionTitle}>{title}</Text>
       </View>
-      {items.length === 0 ? <Text style={styles.emptyCopy}>{emptyCopy}</Text> : null}
+      {items.length === 0 ? <InlineFeedbackNotice body={emptyCopy} /> : null}
       {items.map(renderItem)}
     </View>
   );

--- a/mobile/app/(tabs)/search.tsx
+++ b/mobile/app/(tabs)/search.tsx
@@ -1,7 +1,6 @@
 import { useRouter } from 'expo-router';
 import React, { useDeferredValue, useEffect, useMemo, useState } from 'react';
 import {
-  ActivityIndicator,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -10,6 +9,10 @@ import {
   View,
 } from 'react-native';
 
+import {
+  InlineFeedbackNotice,
+  ScreenFeedbackState,
+} from '../../src/components/feedback/FeedbackState';
 import {
   createSelectorContext,
   selectSearchResults,
@@ -189,25 +192,27 @@ export default function SearchTabScreen() {
 
   if (state.kind === 'loading') {
     return (
-      <View style={styles.stateContainer}>
-        <ActivityIndicator color={theme.colors.text.brand} />
-        <Text style={styles.eyebrow}>DATASET LOADING</Text>
-        <Text style={styles.title}>Search</Text>
-        <Text style={styles.body}>검색 대상 팀, 발매, 예정 데이터를 불러오는 중입니다.</Text>
-      </View>
+      <ScreenFeedbackState
+        body="검색 대상 팀, 발매, 예정 데이터를 불러오는 중입니다."
+        eyebrow="DATASET LOADING"
+        title="Search"
+        variant="loading"
+      />
     );
   }
 
   if (state.kind === 'error') {
     return (
-      <View style={styles.stateContainer}>
-        <Text style={styles.eyebrow}>LOAD ERROR</Text>
-        <Text style={styles.title}>Search</Text>
-        <Text style={styles.body}>{state.message}</Text>
-        <Pressable style={styles.retryButton} onPress={() => setReloadCount((count) => count + 1)}>
-          <Text style={styles.retryButtonLabel}>다시 시도</Text>
-        </Pressable>
-      </View>
+      <ScreenFeedbackState
+        action={{
+          label: '다시 시도',
+          onPress: () => setReloadCount((count) => count + 1),
+        }}
+        body={state.message}
+        eyebrow="LOAD ERROR"
+        title="Search"
+        variant="error"
+      />
     );
   }
 
@@ -321,7 +326,7 @@ export default function SearchTabScreen() {
                 ))}
               </View>
             ) : (
-              <Text style={styles.body}>최근 검색이 없습니다.</Text>
+              <InlineFeedbackNotice body="최근 검색이 없습니다." />
             )}
           </View>
 
@@ -354,7 +359,7 @@ export default function SearchTabScreen() {
           </View>
 
           {activeRows.length === 0 ? (
-            <Text style={styles.body}>검색 결과가 없습니다.</Text>
+            <InlineFeedbackNotice body="검색 결과가 없습니다." />
           ) : null}
 
           {activeSegment === 'entities'

--- a/mobile/app/artists/[slug].tsx
+++ b/mobile/app/artists/[slug].tsx
@@ -1,7 +1,6 @@
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
 import React, { useEffect, useMemo, useState } from 'react';
 import {
-  ActivityIndicator,
   Image,
   Linking,
   Pressable,
@@ -11,6 +10,10 @@ import {
   View,
 } from 'react-native';
 
+import {
+  InlineFeedbackNotice,
+  ScreenFeedbackState,
+} from '../../src/components/feedback/FeedbackState';
 import { selectEntityDetailSnapshot } from '../../src/selectors';
 import {
   loadActiveMobileDataset,
@@ -190,43 +193,52 @@ export default function ArtistDetailScreen() {
 
   if (state.kind === 'loading') {
     return (
-      <View style={styles.stateContainer}>
+      <>
         <Stack.Screen options={{ title: screenTitle }} />
-        <ActivityIndicator color={theme.colors.text.brand} />
-        <Text style={styles.eyebrow}>DETAIL LOADING</Text>
-        <Text style={styles.title}>팀 상세</Text>
-        <Text style={styles.body}>팀 요약, 다음 컴백, 최근 앨범을 불러오는 중입니다.</Text>
-      </View>
+        <ScreenFeedbackState
+          body="팀 요약, 다음 컴백, 최근 앨범을 불러오는 중입니다."
+          eyebrow="DETAIL LOADING"
+          title="팀 상세"
+          variant="loading"
+        />
+      </>
     );
   }
 
   if (state.kind === 'error') {
     return (
-      <View style={styles.stateContainer}>
+      <>
         <Stack.Screen options={{ title: screenTitle }} />
-        <Text style={styles.eyebrow}>LOAD ERROR</Text>
-        <Text style={styles.title}>팀 상세</Text>
-        <Text style={styles.body}>{state.message}</Text>
-        <Pressable style={styles.retryButton} onPress={() => setReloadCount((count) => count + 1)}>
-          <Text style={styles.retryButtonLabel}>다시 시도</Text>
-        </Pressable>
-      </View>
+        <ScreenFeedbackState
+          action={{
+            label: '다시 시도',
+            onPress: () => setReloadCount((count) => count + 1),
+          }}
+          body={state.message}
+          eyebrow="LOAD ERROR"
+          title="팀 상세"
+          variant="error"
+        />
+      </>
     );
   }
 
   if (state.kind === 'missing') {
     return (
-      <View style={styles.stateContainer}>
+      <>
         <Stack.Screen options={{ title: screenTitle }} />
-        <Text testID="entity-missing-state" style={styles.eyebrow}>
-          SAFE RECOVERY
-        </Text>
-        <Text style={styles.title}>팀 상세</Text>
-        <Text style={styles.body}>{state.reason}</Text>
-        <Pressable style={styles.retryButton} onPress={() => router.push('/(tabs)/search')}>
-          <Text style={styles.retryButtonLabel}>검색으로 이동</Text>
-        </Pressable>
-      </View>
+        <ScreenFeedbackState
+          action={{
+            label: '검색으로 이동',
+            onPress: () => router.push('/(tabs)/search'),
+          }}
+          body={state.reason}
+          eyebrow="SAFE RECOVERY"
+          testID="entity-missing-state"
+          title="팀 상세"
+          variant="empty"
+        />
+      </>
     );
   }
 
@@ -331,7 +343,7 @@ export default function ArtistDetailScreen() {
             </View>
           </Pressable>
         ) : (
-          <Text style={styles.emptyCopy}>최신 발매 정보가 없습니다.</Text>
+          <InlineFeedbackNotice body="최신 발매 정보가 없습니다." />
         )}
       </SectionCard>
 
@@ -366,7 +378,7 @@ export default function ArtistDetailScreen() {
             ))}
           </ScrollView>
         ) : (
-          <Text style={styles.emptyCopy}>등록된 최근 앨범이 없습니다.</Text>
+          <InlineFeedbackNotice body="등록된 최근 앨범이 없습니다." />
         )}
       </SectionCard>
 
@@ -393,7 +405,7 @@ export default function ArtistDetailScreen() {
             ))}
           </View>
         ) : (
-          <Text style={styles.emptyCopy}>표시할 소스 타임라인이 없습니다.</Text>
+          <InlineFeedbackNotice body="표시할 소스 타임라인이 없습니다." />
         )}
       </SectionCard>
     </ScrollView>

--- a/mobile/app/releases/[id].tsx
+++ b/mobile/app/releases/[id].tsx
@@ -1,7 +1,6 @@
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
 import React, { useEffect, useMemo, useState } from 'react';
 import {
-  ActivityIndicator,
   Image,
   Pressable,
   ScrollView,
@@ -10,6 +9,10 @@ import {
   View,
 } from 'react-native';
 
+import {
+  InlineFeedbackNotice,
+  ScreenFeedbackState,
+} from '../../src/components/feedback/FeedbackState';
 import { selectReleaseDetailById } from '../../src/selectors';
 import {
   loadActiveMobileDataset,
@@ -289,41 +292,52 @@ export default function ReleaseDetailScreen() {
 
   if (state.kind === 'loading') {
     return (
-      <View style={styles.stateContainer}>
+      <>
         <Stack.Screen options={{ title: screenTitle }} />
-        <ActivityIndicator color={theme.colors.text.brand} />
-        <Text style={styles.eyebrow}>DETAIL LOADING</Text>
-        <Text style={styles.stateTitle}>Release Detail</Text>
-        <Text style={styles.stateBody}>앨범 액션, 트랙 리스트, MV 상태를 불러오는 중입니다.</Text>
-      </View>
+        <ScreenFeedbackState
+          body="앨범 액션, 트랙 리스트, MV 상태를 불러오는 중입니다."
+          eyebrow="DETAIL LOADING"
+          title="Release Detail"
+          variant="loading"
+        />
+      </>
     );
   }
 
   if (state.kind === 'error') {
     return (
-      <View style={styles.stateContainer}>
+      <>
         <Stack.Screen options={{ title: screenTitle }} />
-        <Text style={styles.eyebrow}>LOAD ERROR</Text>
-        <Text style={styles.stateTitle}>Release Detail</Text>
-        <Text style={styles.stateBody}>{state.message}</Text>
-        <Pressable style={styles.retryButton} onPress={() => setReloadCount((count) => count + 1)}>
-          <Text style={styles.retryButtonLabel}>다시 시도</Text>
-        </Pressable>
-      </View>
+        <ScreenFeedbackState
+          action={{
+            label: '다시 시도',
+            onPress: () => setReloadCount((count) => count + 1),
+          }}
+          body={state.message}
+          eyebrow="LOAD ERROR"
+          title="Release Detail"
+          variant="error"
+        />
+      </>
     );
   }
 
   if (state.kind === 'missing') {
     return (
-      <View style={styles.stateContainer} testID="release-missing-state">
+      <>
         <Stack.Screen options={{ title: screenTitle }} />
-        <Text style={styles.eyebrow}>MISSING DETAIL</Text>
-        <Text style={styles.stateTitle}>Release Detail</Text>
-        <Text style={styles.stateBody}>{state.reason}</Text>
-        <Pressable style={styles.retryButton} onPress={() => router.back()}>
-          <Text style={styles.retryButtonLabel}>이전 화면으로</Text>
-        </Pressable>
-      </View>
+        <ScreenFeedbackState
+          action={{
+            label: '이전 화면으로',
+            onPress: () => router.back(),
+          }}
+          body={state.reason}
+          eyebrow="MISSING DETAIL"
+          testID="release-missing-state"
+          title="Release Detail"
+          variant="empty"
+        />
+      </>
     );
   }
 
@@ -379,9 +393,7 @@ export default function ReleaseDetailScreen() {
       </View>
 
       {handoffFeedback ? (
-        <View style={styles.feedbackCard}>
-          <Text style={styles.feedbackText}>{handoffFeedback}</Text>
-        </View>
+        <InlineFeedbackNotice body={handoffFeedback} testID="release-handoff-feedback" tone="error" />
       ) : null}
 
       <View style={styles.section}>
@@ -424,9 +436,10 @@ export default function ReleaseDetailScreen() {
             ))}
           </View>
         ) : (
-          <View style={styles.emptyCard} testID="release-empty-tracks">
-            <Text style={styles.emptyCardText}>트랙 정보가 아직 정리되지 않았습니다.</Text>
-          </View>
+          <InlineFeedbackNotice
+            body="트랙 정보가 아직 정리되지 않았습니다."
+            testID="release-empty-tracks"
+          />
         )}
       </View>
 
@@ -464,12 +477,10 @@ export default function ReleaseDetailScreen() {
       ) : detail.youtubeVideoStatus ? (
         <View style={styles.section} testID="release-mv-state">
           <Text style={styles.sectionTitle}>MV 상태</Text>
-          <View style={styles.metaCard}>
-            <Text style={styles.metaBody}>{mvStatusCopy ?? '공식 MV 정보가 아직 정리되지 않았습니다.'}</Text>
-            {detail.youtubeVideoProvenance ? (
-              <Text style={styles.metaSubtle}>{detail.youtubeVideoProvenance}</Text>
-            ) : null}
-          </View>
+          <InlineFeedbackNotice
+            body={mvStatusCopy ?? '공식 MV 정보가 아직 정리되지 않았습니다.'}
+            title={detail.youtubeVideoProvenance}
+          />
         </View>
       ) : null}
     </ScrollView>

--- a/mobile/src/README.md
+++ b/mobile/src/README.md
@@ -3,6 +3,7 @@
 이 디렉터리는 화면 구현과 분리된 재사용 모듈 구역이다.
 
 - `components/`: 표시 컴포넌트
+  - `feedback/`: screen-level loading/empty/error/retry + inline notice 공용 컴포넌트
 - `config/`: validated runtime config accessor
   - `featureGates.ts`: gate registry / fallback metadata / helper
   - `runtime.ts`: mobile profile / env validation + safe degraded runtime state
@@ -43,6 +44,12 @@ handoff 관련 규칙:
 - later UI는 raw `Linking.openURL`을 직접 호출하지 않는다.
 - canonical URL validation, search fallback URL builder, browser fallback choice는 `services/handoff.ts`에서 중앙화한다.
 - 실패는 explicit result object로 돌려서 UI가 toast/inline feedback을 붙일 수 있게 한다.
+
+feedback state 관련 규칙:
+
+- screen-level loading / empty / error / retry는 `components/feedback/FeedbackState.tsx`를 우선 사용한다.
+- section 안의 empty / warning / retry copy도 가능하면 `InlineFeedbackNotice`로 통일한다.
+- 화면이 직접 `ActivityIndicator + 문구 + retry button` 조합을 반복해서 만들지 않는다.
 
 failure-policy 관련 규칙:
 

--- a/mobile/src/components/feedback/FeedbackState.test.tsx
+++ b/mobile/src/components/feedback/FeedbackState.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import { Text } from 'react-native';
+
+import { InlineFeedbackNotice, ScreenFeedbackState } from './FeedbackState';
+
+function hasText(tree: renderer.ReactTestRenderer, value: string): boolean {
+  return tree.root.findAllByType(Text).some((node) => node.props.children === value);
+}
+
+describe('shared feedback state components', () => {
+  test('renders a screen-level loading state with copy', async () => {
+    let tree: renderer.ReactTestRenderer;
+
+    await act(async () => {
+      tree = renderer.create(
+        <ScreenFeedbackState
+          body="데이터를 불러오는 중입니다."
+          eyebrow="LOADING"
+          title="Calendar"
+          variant="loading"
+        />,
+      );
+    });
+
+    expect(hasText(tree!, 'LOADING')).toBe(true);
+    expect(hasText(tree!, 'Calendar')).toBe(true);
+    expect(hasText(tree!, '데이터를 불러오는 중입니다.')).toBe(true);
+  });
+
+  test('renders an inline notice action and calls the handler', async () => {
+    const onPress = jest.fn();
+    let tree: renderer.ReactTestRenderer;
+
+    await act(async () => {
+      tree = renderer.create(
+        <InlineFeedbackNotice
+          action={{
+            label: '다시 시도',
+            onPress,
+            testID: 'inline-feedback-action',
+          }}
+          body="검색 결과가 없습니다."
+          title="검색 상태"
+        />,
+      );
+    });
+
+    expect(hasText(tree!, '검색 상태')).toBe(true);
+    expect(hasText(tree!, '검색 결과가 없습니다.')).toBe(true);
+
+    await act(async () => {
+      tree!.root.findByProps({ testID: 'inline-feedback-action' }).props.onPress();
+    });
+
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mobile/src/components/feedback/FeedbackState.tsx
+++ b/mobile/src/components/feedback/FeedbackState.tsx
@@ -1,0 +1,174 @@
+import React from 'react';
+import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
+
+import { useAppTheme, type MobileTheme } from '../../tokens/theme';
+
+type FeedbackTone = 'neutral' | 'error';
+
+type FeedbackAction = {
+  label: string;
+  onPress: () => void;
+  testID?: string;
+};
+
+type ScreenFeedbackStateProps = {
+  body: string;
+  eyebrow: string;
+  title: string;
+  variant: 'loading' | 'empty' | 'error';
+  action?: FeedbackAction;
+  testID?: string;
+};
+
+type InlineFeedbackNoticeProps = {
+  body: string;
+  title?: string;
+  tone?: FeedbackTone;
+  action?: FeedbackAction;
+  testID?: string;
+};
+
+export function ScreenFeedbackState({
+  action,
+  body,
+  eyebrow,
+  testID,
+  title,
+  variant,
+}: ScreenFeedbackStateProps) {
+  const theme = useAppTheme();
+  const styles = React.useMemo(() => createStyles(theme), [theme]);
+
+  return (
+    <View style={styles.screenContainer} testID={testID}>
+      {variant === 'loading' ? <ActivityIndicator color={theme.colors.text.brand} /> : null}
+      <Text style={styles.eyebrow}>{eyebrow}</Text>
+      <Text style={styles.screenTitle}>{title}</Text>
+      <Text style={styles.body}>{body}</Text>
+      {action ? (
+        <Pressable
+          accessibilityRole="button"
+          onPress={action.onPress}
+          style={({ pressed }) => [
+            styles.primaryAction,
+            pressed ? styles.primaryActionPressed : null,
+          ]}
+          testID={action.testID}
+        >
+          <Text style={styles.primaryActionLabel}>{action.label}</Text>
+        </Pressable>
+      ) : null}
+    </View>
+  );
+}
+
+export function InlineFeedbackNotice({
+  action,
+  body,
+  testID,
+  title,
+  tone = 'neutral',
+}: InlineFeedbackNoticeProps) {
+  const theme = useAppTheme();
+  const styles = React.useMemo(() => createStyles(theme), [theme]);
+
+  return (
+    <View
+      style={[styles.inlineCard, tone === 'error' ? styles.inlineCardError : null]}
+      testID={testID}
+    >
+      {title ? <Text style={styles.inlineTitle}>{title}</Text> : null}
+      <Text
+        style={[styles.body, tone === 'error' ? styles.inlineBodyError : null]}
+      >
+        {body}
+      </Text>
+      {action ? (
+        <Pressable
+          accessibilityRole="button"
+          onPress={action.onPress}
+          style={({ pressed }) => [
+            styles.secondaryAction,
+            pressed ? styles.secondaryActionPressed : null,
+          ]}
+          testID={action.testID}
+        >
+          <Text style={styles.secondaryActionLabel}>{action.label}</Text>
+        </Pressable>
+      ) : null}
+    </View>
+  );
+}
+
+function createStyles(theme: MobileTheme) {
+  return StyleSheet.create({
+    screenContainer: {
+      flex: 1,
+      justifyContent: 'center',
+      paddingHorizontal: theme.space[24],
+      gap: theme.space[12],
+      backgroundColor: theme.colors.surface.base,
+    },
+    eyebrow: {
+      ...theme.typography.meta,
+      color: theme.colors.text.brand,
+      textTransform: 'uppercase',
+    },
+    screenTitle: {
+      ...theme.typography.screenTitle,
+      color: theme.colors.text.primary,
+    },
+    body: {
+      ...theme.typography.body,
+      color: theme.colors.text.secondary,
+    },
+    primaryAction: {
+      alignSelf: 'flex-start',
+      marginTop: theme.space[4],
+      paddingHorizontal: theme.space[16],
+      paddingVertical: theme.space[12],
+      borderRadius: theme.radius.button,
+      backgroundColor: theme.colors.surface.interactive,
+    },
+    primaryActionPressed: {
+      opacity: 0.84,
+    },
+    primaryActionLabel: {
+      ...theme.typography.buttonPrimary,
+      color: theme.colors.text.primary,
+    },
+    inlineCard: {
+      gap: theme.space[8],
+      padding: theme.space[16],
+      borderRadius: theme.radius.card,
+      backgroundColor: theme.colors.surface.base,
+      borderWidth: 1,
+      borderColor: theme.colors.border.subtle,
+    },
+    inlineCardError: {
+      borderColor: theme.colors.text.danger,
+      backgroundColor: theme.colors.surface.elevated,
+    },
+    inlineTitle: {
+      ...theme.typography.sectionTitle,
+      color: theme.colors.text.primary,
+    },
+    inlineBodyError: {
+      color: theme.colors.text.danger,
+    },
+    secondaryAction: {
+      alignSelf: 'flex-start',
+      paddingHorizontal: theme.space[12],
+      paddingVertical: theme.space[8],
+      borderRadius: theme.radius.button,
+      backgroundColor: theme.colors.surface.interactive,
+    },
+    secondaryActionPressed: {
+      opacity: 0.84,
+    },
+    secondaryActionLabel: {
+      ...theme.typography.buttonService,
+      color: theme.colors.text.primary,
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- add shared mobile screen and inline feedback state components
- apply the shared loading/error/empty/retry patterns across calendar, search, radar, entity detail, and release detail
- add feedback component coverage and update mobile docs

Closes #340