### PR TITLE
Implement mobile deep-link state restoration

### DIFF
--- a/docs/specs/mobile/route-param-contracts.md
+++ b/docs/specs/mobile/route-param-contracts.md
@@ -38,13 +38,26 @@ Path: `/releases/[id]`
 - example: `blackpink-deadline-2026-02-27`
 
 ### 4.3 Calendar month state
-- route param으로 강제하지 않는다.
-- v1은 in-memory state 또는 persisted screen state로 유지한다.
-- optional future extension: `?month=2026-04`
+- 기본 진입 경로는 `/(tabs)/calendar`다.
+- state restoration용 optional query param:
+  - `month=2026-04`
+  - `date=2026-04-18`
+  - `filter=all|releases|upcoming`
+  - `sheet=open`
+- `sheet=open`은 valid `date`가 있을 때만 유효하다.
+- invalid month/date/filter는 안전하게 무시하고 현재 월 기본 상태로 복구한다.
 
 ### 4.4 Search state
-- v1은 query를 permanent route param으로 노출하지 않는다.
-- optional future extension: `?q=투바투&segment=team`
+- 기본 진입 경로는 `/(tabs)/search`다.
+- state restoration용 optional query param:
+  - `q=투바투`
+  - `segment=entities|releases|upcoming`
+- `segment`는 non-empty `q`가 있을 때만 적용한다.
+
+### 4.5 Radar state
+- 기본 진입 경로는 `/(tabs)/radar`다.
+- state restoration용 optional query param:
+  - `hideEmpty=1`
 
 ## 5. Param validation
 - missing slug/id는 screen crash 원인이 되어서는 안 된다.
@@ -52,8 +65,8 @@ Path: `/releases/[id]`
 - selector가 데이터를 찾지 못하면 404-style empty/error state를 보여준다.
 
 ## 6. Deep-link 정책
-- internal deep-link는 team detail, release detail 두 종류만 우선 지원한다.
-- bottom sheet나 filter state deep-link는 v1 비범위다.
+- internal deep-link는 team detail, release detail, tab restoration query까지 지원한다.
+- calendar date-detail sheet는 dedicated route 대신 tab query state 복원으로만 다룬다.
 - external handoff 복귀 시 기존 route stack을 유지해야 한다.
 
 ## 7. Back behavior

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -12,9 +12,12 @@
 
 - `app/`
   - Expo Router root layout / tab shell / detail route scaffold
-  - `calendar` tab은 active dataset + shared selector 기반 container까지 연결됨
-  - `radar` tab은 shared radar snapshot 기반 section stack까지 연결됨
-  - `search` tab은 query state + recent query persistence + segmented result container까지 연결됨
+- `calendar` tab은 active dataset + shared selector 기반 container까지 연결됨
+  - optional `month/date/filter/sheet` query로 state restoration 지원
+- `radar` tab은 shared radar snapshot 기반 section stack까지 연결됨
+  - optional `hideEmpty=1` query로 tab state restoration 지원
+- `search` tab은 query state + recent query persistence + segmented result container까지 연결됨
+  - optional `q/segment` query로 state restoration 지원
   - `artists/[slug]` route는 shared entity detail snapshot 기반 detail screen까지 연결됨
   - `releases/[id]` route는 shared release detail model 기반 detail screen까지 연결됨
   - hidden `debug/metadata` route for internal metadata inspection

--- a/mobile/app/(tabs)/calendar.tsx
+++ b/mobile/app/(tabs)/calendar.tsx
@@ -1,3 +1,4 @@
+import { useLocalSearchParams, useRouter } from 'expo-router';
 import React, { useEffect, useMemo, useState } from 'react';
 import {
   Modal,
@@ -17,6 +18,12 @@ import {
   resolveInitialCalendarSelection,
   resolveNextCalendarSelection,
 } from '../../src/features/calendarGrid';
+import {
+  areRouteParamsEqual,
+  buildCalendarRouteParams,
+  resolveCalendarRouteState,
+  type CalendarFilterMode,
+} from '../../src/features/routeState';
 import {
   selectCalendarMonthSnapshot,
   selectNearestExactUpcomingEvent,
@@ -47,8 +54,6 @@ type CalendarScreenState =
       source: ActiveMobileDataset;
       snapshot: CalendarMonthSnapshotModel;
     };
-
-type CalendarFilterMode = 'all' | 'releases' | 'upcoming';
 
 function buildMonthKey(date: Date): string {
   const year = date.getFullYear();
@@ -144,17 +149,40 @@ function getBadgePalette(
 }
 
 export default function CalendarTabScreen() {
+  const router = useRouter();
+  const params = useLocalSearchParams<{
+    date?: string | string[];
+    filter?: string | string[];
+    month?: string | string[];
+    sheet?: string | string[];
+  }>();
   const theme = useAppTheme();
   const [reloadCount, setReloadCount] = useState(0);
-  const [activeMonth, setActiveMonth] = useState(buildMonthKey(new Date()));
-  const [filterMode, setFilterMode] = useState<CalendarFilterMode>('all');
-  const [selectedDayIso, setSelectedDayIso] = useState<string | null>(null);
-  const [isSheetOpen, setIsSheetOpen] = useState(false);
   const [state, setState] = useState<CalendarScreenState>({ kind: 'loading' });
   const today = useMemo(() => new Date(), []);
   const currentMonth = useMemo(() => buildMonthKey(today), [today]);
   const todayIsoDate = useMemo(() => today.toISOString().slice(0, 10), [today]);
+  const routeState = useMemo(
+    () => resolveCalendarRouteState(params, currentMonth),
+    [currentMonth, params],
+  );
+  const [activeMonth, setActiveMonth] = useState(routeState.activeMonth);
+  const [filterMode, setFilterMode] = useState<CalendarFilterMode>(routeState.filterMode);
+  const [selectedDayIso, setSelectedDayIso] = useState<string | null>(routeState.selectedDayIso);
+  const [isSheetOpen, setIsSheetOpen] = useState(routeState.isSheetOpen);
   const styles = useMemo(() => createStyles(theme), [theme]);
+
+  useEffect(() => {
+    setActiveMonth(routeState.activeMonth);
+    setFilterMode(routeState.filterMode);
+    setSelectedDayIso(routeState.selectedDayIso);
+    setIsSheetOpen(routeState.isSheetOpen);
+  }, [
+    routeState.activeMonth,
+    routeState.filterMode,
+    routeState.isSheetOpen,
+    routeState.selectedDayIso,
+  ]);
 
   useEffect(() => {
     let cancelled = false;
@@ -232,6 +260,40 @@ export default function CalendarTabScreen() {
   }, [filteredSnapshot, selectedDayIso, todayIsoDate]);
 
   const selectedDay = monthGrid?.selectedDay ?? null;
+
+  useEffect(() => {
+    const currentRouteParams = buildCalendarRouteParams({
+      activeMonth: routeState.activeMonth,
+      currentMonth,
+      filterMode: routeState.filterMode,
+      isSheetOpen: routeState.isSheetOpen,
+      selectedDayIso: routeState.selectedDayIso,
+    });
+    const nextRouteParams = buildCalendarRouteParams({
+      activeMonth,
+      currentMonth,
+      filterMode,
+      isSheetOpen,
+      selectedDayIso,
+    });
+
+    if (areRouteParamsEqual(currentRouteParams, nextRouteParams)) {
+      return;
+    }
+
+    router.setParams(nextRouteParams);
+  }, [
+    activeMonth,
+    currentMonth,
+    filterMode,
+    isSheetOpen,
+    routeState.activeMonth,
+    routeState.filterMode,
+    routeState.isSheetOpen,
+    routeState.selectedDayIso,
+    router,
+    selectedDayIso,
+  ]);
 
   function jumpToMonth(month: string, isoDate: string) {
     setActiveMonth(month);

--- a/mobile/app/(tabs)/radar.tsx
+++ b/mobile/app/(tabs)/radar.tsx
@@ -1,4 +1,4 @@
-import { useRouter } from 'expo-router';
+import { useLocalSearchParams, useRouter } from 'expo-router';
 import React, { useEffect, useMemo, useState } from 'react';
 import {
   Pressable,
@@ -12,6 +12,11 @@ import {
   InlineFeedbackNotice,
   ScreenFeedbackState,
 } from '../../src/components/feedback/FeedbackState';
+import {
+  areRouteParamsEqual,
+  buildRadarRouteParams,
+  resolveRadarRouteState,
+} from '../../src/features/routeState';
 import { selectRadarSnapshot } from '../../src/selectors';
 import {
   loadActiveMobileDataset,
@@ -60,13 +65,21 @@ function resolveBadgeLabel(team: TeamSummaryModel): string {
 
 export default function RadarTabScreen() {
   const router = useRouter();
+  const params = useLocalSearchParams<{
+    hideEmpty?: string | string[];
+  }>();
   const theme = useAppTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
   const [reloadCount, setReloadCount] = useState(0);
-  const [hideEmptySections, setHideEmptySections] = useState(false);
+  const routeState = useMemo(() => resolveRadarRouteState(params), [params]);
+  const [hideEmptySections, setHideEmptySections] = useState(routeState.hideEmptySections);
   const [state, setState] = useState<RadarScreenState>({ kind: 'loading' });
   const today = useMemo(() => new Date(), []);
   const todayIsoDate = useMemo(() => today.toISOString().slice(0, 10), [today]);
+
+  useEffect(() => {
+    setHideEmptySections(routeState.hideEmptySections);
+  }, [routeState.hideEmptySections]);
 
   useEffect(() => {
     let cancelled = false;
@@ -102,6 +115,21 @@ export default function RadarTabScreen() {
       cancelled = true;
     };
   }, [reloadCount, todayIsoDate]);
+
+  useEffect(() => {
+    const currentRouteParams = buildRadarRouteParams({
+      hideEmptySections: routeState.hideEmptySections,
+    });
+    const nextRouteParams = buildRadarRouteParams({
+      hideEmptySections,
+    });
+
+    if (areRouteParamsEqual(currentRouteParams, nextRouteParams)) {
+      return;
+    }
+
+    router.setParams(nextRouteParams);
+  }, [hideEmptySections, routeState.hideEmptySections, router]);
 
   function openSearchTab() {
     router.push('/(tabs)/search');
@@ -162,6 +190,7 @@ export default function RadarTabScreen() {
           <Pressable
             testID="radar-filter-button"
             accessibilityRole="button"
+            accessibilityState={{ selected: hideEmptySections }}
             onPress={() => setHideEmptySections((value) => !value)}
             style={({ pressed }) => [
               styles.appBarButton,

--- a/mobile/app/(tabs)/search.tsx
+++ b/mobile/app/(tabs)/search.tsx
@@ -1,4 +1,4 @@
-import { useRouter } from 'expo-router';
+import { useLocalSearchParams, useRouter } from 'expo-router';
 import React, { useDeferredValue, useEffect, useMemo, useState } from 'react';
 import {
   Pressable,
@@ -13,6 +13,12 @@ import {
   InlineFeedbackNotice,
   ScreenFeedbackState,
 } from '../../src/components/feedback/FeedbackState';
+import {
+  areRouteParamsEqual,
+  buildSearchRouteParams,
+  resolveSearchRouteState,
+  type SearchSegment,
+} from '../../src/features/routeState';
 import {
   createSelectorContext,
   selectSearchResults,
@@ -32,8 +38,6 @@ type SearchScreenState =
   | { kind: 'loading' }
   | { kind: 'error'; message: string }
   | { kind: 'ready'; source: ActiveMobileDataset };
-
-type SearchSegment = 'entities' | 'releases' | 'upcoming';
 
 function formatReleaseMeta(release: ReleaseSummaryModel): string {
   const releaseKind = release.releaseKind ?? 'release';
@@ -65,15 +69,25 @@ function formatSuggestedLabel(team: TeamSummaryModel): string {
 
 export default function SearchTabScreen() {
   const router = useRouter();
+  const params = useLocalSearchParams<{
+    q?: string | string[];
+    segment?: string | string[];
+  }>();
   const theme = useAppTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
+  const routeState = useMemo(() => resolveSearchRouteState(params), [params]);
 
   const [reloadCount, setReloadCount] = useState(0);
   const [state, setState] = useState<SearchScreenState>({ kind: 'loading' });
-  const [query, setQuery] = useState('');
-  const [activeSegment, setActiveSegment] = useState<SearchSegment>('entities');
+  const [query, setQuery] = useState(routeState.query);
+  const [activeSegment, setActiveSegment] = useState<SearchSegment>(routeState.activeSegment);
   const [recentQueries, setRecentQueries] = useState<string[]>([]);
   const deferredQuery = useDeferredValue(query);
+
+  useEffect(() => {
+    setQuery(routeState.query);
+    setActiveSegment(routeState.activeSegment);
+  }, [routeState.activeSegment, routeState.query]);
 
   useEffect(() => {
     let cancelled = false;
@@ -151,6 +165,23 @@ export default function SearchTabScreen() {
 
     return entries;
   }, [selectorContext]);
+
+  useEffect(() => {
+    const currentRouteParams = buildSearchRouteParams({
+      activeSegment: routeState.activeSegment,
+      query: routeState.query,
+    });
+    const nextRouteParams = buildSearchRouteParams({
+      activeSegment,
+      query,
+    });
+
+    if (areRouteParamsEqual(currentRouteParams, nextRouteParams)) {
+      return;
+    }
+
+    router.setParams(nextRouteParams);
+  }, [activeSegment, query, routeState.activeSegment, routeState.query, router]);
 
   async function rememberQuery(nextQuery: string) {
     const history = await persistRecentQuery(nextQuery);

--- a/mobile/src/features/calendarBottomSheet.test.tsx
+++ b/mobile/src/features/calendarBottomSheet.test.tsx
@@ -4,6 +4,20 @@ import { Text } from 'react-native';
 
 import CalendarTabScreen from '../../app/(tabs)/calendar';
 
+jest.mock('expo-router', () => {
+  const useLocalSearchParams = jest.fn(() => ({}));
+
+  return {
+    useLocalSearchParams,
+    useRouter: () => ({
+      setParams: jest.fn(),
+    }),
+    __mock: {
+      useLocalSearchParams,
+    },
+  };
+});
+
 jest.mock('react-native/Libraries/Modal/Modal', () => {
   const React = jest.requireActual<typeof import('react')>('react');
 
@@ -13,6 +27,12 @@ jest.mock('react-native/Libraries/Modal/Modal', () => {
       visible ? React.createElement(React.Fragment, null, children) : null,
   };
 });
+
+const { __mock } = jest.requireMock('expo-router') as {
+  __mock: {
+    useLocalSearchParams: jest.Mock;
+  };
+};
 
 async function renderCalendarScreen() {
   let tree: renderer.ReactTestRenderer;
@@ -29,6 +49,7 @@ describe('calendar selected-day bottom sheet', () => {
   beforeEach(() => {
     jest.useFakeTimers();
     jest.setSystemTime(new Date('2026-03-07T09:00:00.000Z'));
+    __mock.useLocalSearchParams.mockReturnValue({});
   });
 
   afterEach(() => {
@@ -77,5 +98,22 @@ describe('calendar selected-day bottom sheet', () => {
     });
 
     expect(tree.root.findByProps({ testID: 'calendar-bottom-sheet' })).toBeDefined();
+  });
+
+  test('restores month, selected date, filter, and sheet state from route params', async () => {
+    __mock.useLocalSearchParams.mockReturnValue({
+      month: '2026-03',
+      date: '2026-03-11',
+      filter: 'upcoming',
+      sheet: 'open',
+    });
+
+    const tree = await renderCalendarScreen();
+
+    expect(tree.root.findByProps({ testID: 'calendar-bottom-sheet' })).toBeDefined();
+    expect(tree.root.findByProps({ testID: 'calendar-month-title' }).props.children).toBe('2026년 3월');
+    expect(tree.root.findByProps({ testID: 'calendar-filter-upcoming' }).props.accessibilityState.selected).toBe(
+      true,
+    );
   });
 });

--- a/mobile/src/features/calendarControls.test.tsx
+++ b/mobile/src/features/calendarControls.test.tsx
@@ -4,6 +4,20 @@ import { Text } from 'react-native';
 
 import CalendarTabScreen from '../../app/(tabs)/calendar';
 
+jest.mock('expo-router', () => {
+  const useLocalSearchParams = jest.fn(() => ({}));
+
+  return {
+    useLocalSearchParams,
+    useRouter: () => ({
+      setParams: jest.fn(),
+    }),
+    __mock: {
+      useLocalSearchParams,
+    },
+  };
+});
+
 jest.mock('react-native/Libraries/Modal/Modal', () => {
   const React = jest.requireActual<typeof import('react')>('react');
 
@@ -13,6 +27,12 @@ jest.mock('react-native/Libraries/Modal/Modal', () => {
       visible ? React.createElement(React.Fragment, null, children) : null,
   };
 });
+
+const { __mock } = jest.requireMock('expo-router') as {
+  __mock: {
+    useLocalSearchParams: jest.Mock;
+  };
+};
 
 async function renderCalendarScreen() {
   let tree: renderer.ReactTestRenderer;
@@ -33,6 +53,7 @@ describe('calendar controls', () => {
   beforeEach(() => {
     jest.useFakeTimers();
     jest.setSystemTime(new Date('2026-03-07T09:00:00.000Z'));
+    __mock.useLocalSearchParams.mockReturnValue({});
   });
 
   afterEach(() => {

--- a/mobile/src/features/radarTab.test.tsx
+++ b/mobile/src/features/radarTab.test.tsx
@@ -2,11 +2,26 @@ import renderer, { act } from 'react-test-renderer';
 
 import RadarTabScreen from '../../app/(tabs)/radar';
 
-jest.mock('expo-router', () => ({
-  useRouter: () => ({
-    push: jest.fn(),
-  }),
-}));
+jest.mock('expo-router', () => {
+  const useLocalSearchParams = jest.fn(() => ({}));
+
+  return {
+    useRouter: () => ({
+      push: jest.fn(),
+      setParams: jest.fn(),
+    }),
+    useLocalSearchParams,
+    __mock: {
+      useLocalSearchParams,
+    },
+  };
+});
+
+const { __mock } = jest.requireMock('expo-router') as {
+  __mock: {
+    useLocalSearchParams: jest.Mock;
+  };
+};
 
 async function renderRadarScreen() {
   let tree: renderer.ReactTestRenderer;
@@ -21,6 +36,10 @@ async function renderRadarScreen() {
 }
 
 describe('mobile radar tab', () => {
+  beforeEach(() => {
+    __mock.useLocalSearchParams.mockReturnValue({});
+  });
+
   test('renders radar sections from shared selector data', async () => {
     const tree = await renderRadarScreen();
 
@@ -28,6 +47,15 @@ describe('mobile radar tab', () => {
     expect(tree.root.findByProps({ testID: 'radar-weekly-card-yena' })).toBeDefined();
     expect(tree.root.findByProps({ testID: 'radar-long-gap-card-weeekly' })).toBeDefined();
     expect(tree.root.findByProps({ testID: 'radar-rookie-card-atheart' })).toBeDefined();
+  });
+
+  test('restores the hide-empty toggle state from route params', async () => {
+    __mock.useLocalSearchParams.mockReturnValue({ hideEmpty: '1' });
+    const tree = await renderRadarScreen();
+
+    expect(tree.root.findByProps({ testID: 'radar-filter-button' }).props.accessibilityState.selected).toBe(
+      true,
+    );
   });
 
   test('hides empty sections when the filter toggle is active', async () => {

--- a/mobile/src/features/route-shell.smoke.test.tsx
+++ b/mobile/src/features/route-shell.smoke.test.tsx
@@ -14,6 +14,7 @@ jest.mock('expo-router', () => {
   const useLocalSearchParams = jest.fn(() => ({}));
   const useRouter = jest.fn(() => ({
     push: jest.fn(),
+    setParams: jest.fn(),
   }));
 
   function Redirect({ href }: { href: string }) {
@@ -83,6 +84,7 @@ describe('mobile route shell smoke', () => {
   beforeEach(() => {
     mockUseRouter.mockReturnValue({
       push: jest.fn(),
+      setParams: jest.fn(),
     });
   });
 

--- a/mobile/src/features/routeState.test.ts
+++ b/mobile/src/features/routeState.test.ts
@@ -1,0 +1,90 @@
+import {
+  buildCalendarRouteParams,
+  buildSearchRouteParams,
+  buildRadarRouteParams,
+  resolveCalendarRouteState,
+  resolveRadarRouteState,
+  resolveSearchRouteState,
+} from './routeState';
+
+describe('mobile route state helpers', () => {
+  test('restores calendar route state safely from valid params', () => {
+    expect(
+      resolveCalendarRouteState(
+        {
+          month: '2026-03',
+          date: '2026-03-11',
+          filter: 'upcoming',
+          sheet: 'open',
+        },
+        '2026-03',
+      ),
+    ).toEqual({
+      activeMonth: '2026-03',
+      filterMode: 'upcoming',
+      isSheetOpen: true,
+      selectedDayIso: '2026-03-11',
+    });
+  });
+
+  test('drops invalid or incomplete calendar params safely', () => {
+    expect(
+      resolveCalendarRouteState(
+        {
+          month: '2026-3',
+          date: 'oops',
+          filter: 'broken',
+          sheet: 'open',
+        },
+        '2026-03',
+      ),
+    ).toEqual({
+      activeMonth: '2026-03',
+      filterMode: 'all',
+      isSheetOpen: false,
+      selectedDayIso: null,
+    });
+  });
+
+  test('search restoration only keeps segment when query is present', () => {
+    expect(resolveSearchRouteState({ q: '최예나', segment: 'upcoming' })).toEqual({
+      query: '최예나',
+      activeSegment: 'upcoming',
+    });
+    expect(resolveSearchRouteState({ segment: 'releases' })).toEqual({
+      query: '',
+      activeSegment: 'entities',
+    });
+  });
+
+  test('radar restoration only accepts the explicit hide-empty flag', () => {
+    expect(resolveRadarRouteState({ hideEmpty: '1' })).toEqual({ hideEmptySections: true });
+    expect(resolveRadarRouteState({ hideEmpty: '0' })).toEqual({ hideEmptySections: false });
+  });
+
+  test('builders emit sparse route params for restoration only', () => {
+    expect(
+      buildCalendarRouteParams({
+        activeMonth: '2026-03',
+        currentMonth: '2026-03',
+        filterMode: 'all',
+        isSheetOpen: false,
+        selectedDayIso: '2026-03-11',
+      }),
+    ).toEqual({
+      month: undefined,
+      filter: undefined,
+      date: undefined,
+      sheet: undefined,
+    });
+
+    expect(buildSearchRouteParams({ query: '최예나', activeSegment: 'upcoming' })).toEqual({
+      q: '최예나',
+      segment: 'upcoming',
+    });
+
+    expect(buildRadarRouteParams({ hideEmptySections: true })).toEqual({
+      hideEmpty: '1',
+    });
+  });
+});

--- a/mobile/src/features/routeState.ts
+++ b/mobile/src/features/routeState.ts
@@ -1,0 +1,147 @@
+export type CalendarFilterMode = 'all' | 'releases' | 'upcoming';
+export type SearchSegment = 'entities' | 'releases' | 'upcoming';
+
+type RouteParamValue = string | string[] | undefined;
+
+type CalendarRouteParams = {
+  date?: RouteParamValue;
+  filter?: RouteParamValue;
+  month?: RouteParamValue;
+  sheet?: RouteParamValue;
+};
+
+type SearchRouteParams = {
+  q?: RouteParamValue;
+  segment?: RouteParamValue;
+};
+
+type RadarRouteParams = {
+  hideEmpty?: RouteParamValue;
+};
+
+export type CalendarRouteState = {
+  activeMonth: string;
+  filterMode: CalendarFilterMode;
+  isSheetOpen: boolean;
+  selectedDayIso: string | null;
+};
+
+export type SearchRouteState = {
+  activeSegment: SearchSegment;
+  query: string;
+};
+
+export type RadarRouteState = {
+  hideEmptySections: boolean;
+};
+
+export function getSingleRouteParam(value: RouteParamValue): string | null {
+  if (Array.isArray(value)) {
+    return value[0] ?? null;
+  }
+
+  return value ?? null;
+}
+
+function isIsoMonth(value: string | null): value is string {
+  return value !== null && /^\d{4}-\d{2}$/.test(value);
+}
+
+function isIsoDate(value: string | null): value is string {
+  return value !== null && /^\d{4}-\d{2}-\d{2}$/.test(value);
+}
+
+function resolveFilterMode(value: string | null): CalendarFilterMode {
+  return value === 'releases' || value === 'upcoming' ? value : 'all';
+}
+
+function resolveSearchSegment(value: string | null): SearchSegment {
+  return value === 'releases' || value === 'upcoming' ? value : 'entities';
+}
+
+export function resolveCalendarRouteState(
+  params: CalendarRouteParams,
+  todayMonth: string,
+): CalendarRouteState {
+  const monthParam = getSingleRouteParam(params.month);
+  const dateParam = getSingleRouteParam(params.date);
+  const resolvedDate = isIsoDate(dateParam) ? dateParam : null;
+  const derivedMonth = resolvedDate ? resolvedDate.slice(0, 7) : null;
+  const resolvedMonth = isIsoMonth(monthParam)
+    ? monthParam
+    : derivedMonth ?? todayMonth;
+  const selectedDayIso =
+    resolvedDate && resolvedDate.slice(0, 7) === resolvedMonth ? resolvedDate : null;
+
+  return {
+    activeMonth: resolvedMonth,
+    filterMode: resolveFilterMode(getSingleRouteParam(params.filter)),
+    isSheetOpen: getSingleRouteParam(params.sheet) === 'open' && selectedDayIso !== null,
+    selectedDayIso,
+  };
+}
+
+export function buildCalendarRouteParams(args: {
+  activeMonth: string;
+  currentMonth: string;
+  filterMode: CalendarFilterMode;
+  isSheetOpen: boolean;
+  selectedDayIso: string | null;
+}) {
+  const includeMonth =
+    args.activeMonth !== args.currentMonth ||
+    args.filterMode !== 'all' ||
+    args.isSheetOpen;
+
+  return {
+    month: includeMonth ? args.activeMonth : undefined,
+    filter: args.filterMode !== 'all' ? args.filterMode : undefined,
+    date: args.isSheetOpen && args.selectedDayIso ? args.selectedDayIso : undefined,
+    sheet: args.isSheetOpen && args.selectedDayIso ? 'open' : undefined,
+  };
+}
+
+export function resolveSearchRouteState(params: SearchRouteParams): SearchRouteState {
+  const query = getSingleRouteParam(params.q)?.trim() ?? '';
+  const segment = resolveSearchSegment(getSingleRouteParam(params.segment));
+
+  return {
+    activeSegment: query ? segment : 'entities',
+    query,
+  };
+}
+
+export function buildSearchRouteParams(args: {
+  activeSegment: SearchSegment;
+  query: string;
+}) {
+  const normalizedQuery = args.query.trim();
+
+  return {
+    q: normalizedQuery || undefined,
+    segment: normalizedQuery ? args.activeSegment : undefined,
+  };
+}
+
+export function resolveRadarRouteState(params: RadarRouteParams): RadarRouteState {
+  const hideEmptyValue = getSingleRouteParam(params.hideEmpty);
+
+  return {
+    hideEmptySections: hideEmptyValue === '1',
+  };
+}
+
+export function buildRadarRouteParams(args: { hideEmptySections: boolean }) {
+  return {
+    hideEmpty: args.hideEmptySections ? '1' : undefined,
+  };
+}
+
+export function areRouteParamsEqual(
+  left: Record<string, string | undefined>,
+  right: Record<string, string | undefined>,
+): boolean {
+  const keys = Array.from(new Set([...Object.keys(left), ...Object.keys(right)])).sort();
+
+  return keys.every((key) => (left[key] ?? undefined) === (right[key] ?? undefined));
+}

--- a/mobile/src/features/searchTab.test.tsx
+++ b/mobile/src/features/searchTab.test.tsx
@@ -23,12 +23,23 @@ function createMemoryStorage(): KeyValueStorageAdapter {
 
 jest.mock('expo-router', () => {
   const push = jest.fn();
+  const setParams = jest.fn();
+  const useLocalSearchParams = jest.fn(() => ({}));
 
   return {
-    useRouter: () => ({ push }),
-    __mock: { push },
+    useRouter: () => ({ push, setParams }),
+    useLocalSearchParams,
+    __mock: { push, setParams, useLocalSearchParams },
   };
 });
+
+const { __mock } = jest.requireMock('expo-router') as {
+  __mock: {
+    push: jest.Mock;
+    setParams: jest.Mock;
+    useLocalSearchParams: jest.Mock;
+  };
+};
 
 async function renderSearchScreen() {
   let tree: renderer.ReactTestRenderer;
@@ -49,6 +60,8 @@ function hasText(tree: renderer.ReactTestRenderer, value: string): boolean {
 describe('mobile search tab', () => {
   beforeEach(() => {
     setStorageAdapter(createMemoryStorage());
+    __mock.useLocalSearchParams.mockReturnValue({});
+    __mock.setParams.mockClear();
   });
 
   afterEach(() => {
@@ -100,5 +113,24 @@ describe('mobile search tab', () => {
 
     expect(await readRecentQueries()).toEqual([]);
     expect(hasText(tree, '최근 검색이 없습니다.')).toBe(true);
+  });
+
+  test('restores query and segment state from route params', async () => {
+    __mock.useLocalSearchParams.mockReturnValue({
+      q: '최예나',
+      segment: 'upcoming',
+    });
+
+    const tree = await renderSearchScreen();
+
+    expect(tree.root.findByProps({ testID: 'search-input' }).props.value).toBe('최예나');
+    expect(
+      tree.root.findByProps({ testID: 'search-segment-upcoming' }).props.accessibilityState.selected,
+    ).toBe(true);
+    expect(
+      tree.root.findByProps({
+        testID: 'search-upcoming-result-yena--yena-confirms-a-march-11-comeback--2026-03-11--album',
+      }),
+    ).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary
- add shared route-state parsing/build helpers for calendar, search, and radar tabs
- restore and sync calendar sheet, month, date, and filter state through Expo Router params
- restore search query/segment and radar hide-empty state with regression tests and docs updates

## Verification
- cd mobile && npm run lint
- cd mobile && npm run typecheck
- cd mobile && npm run test
- cd mobile && CI=1 npx expo export --platform web --output-dir /tmp/idol-song-app-mobile-route-restore-export
- git diff --check

Closes #341