### PR TITLE
Add mobile analytics instrumentation

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -37,7 +37,7 @@
 - `src/config/runtime.ts`
   - 앱 런타임에서 쓰는 validated config accessor
 - `src/config/debugMetadata.ts`
-  - debug-only build version / dataset version / commit hash helper
+  - debug-only build version / dataset version / commit hash / recent analytics event helper
 - `src/config/featureGates.ts`
   - gate registry / helper / off fallback definition
 - `src/services/datasetSource.ts`
@@ -54,6 +54,8 @@
   - search recent-query persistence helper
 - `src/services/handoff.ts`
   - canonical-open / search-fallback / browser-fallback handoff service layer
+- `src/services/analytics.ts`
+  - env-gated mobile analytics event registry + low-noise debug event buffer
 - `src/components/feedback/FeedbackState.tsx`
   - shared loading / empty / error / retry state components
 - `src/tokens/`

--- a/mobile/app/(tabs)/calendar.tsx
+++ b/mobile/app/(tabs)/calendar.tsx
@@ -1,5 +1,5 @@
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
   Modal,
   Pressable,
@@ -32,6 +32,11 @@ import {
   loadActiveMobileDataset,
   type ActiveMobileDataset,
 } from '../../src/services/activeDataset';
+import {
+  trackAnalyticsEvent,
+  trackDatasetDegraded,
+  trackDatasetLoadFailed,
+} from '../../src/services/analytics';
 import { useAppTheme } from '../../src/tokens/theme';
 import type {
   CalendarDayBadgeKind,
@@ -167,6 +172,16 @@ function moveMonthKey(month: string, offset: number): string {
   return buildMonthKey(next);
 }
 
+function getSelectedDayCounts(snapshot: CalendarMonthSnapshotModel, isoDate: string): {
+  releaseCount: number;
+  upcomingCount: number;
+} {
+  return {
+    releaseCount: snapshot.releases.filter((release) => release.releaseDate === isoDate).length,
+    upcomingCount: snapshot.exactUpcoming.filter((event) => event.scheduledDate === isoDate).length,
+  };
+}
+
 function getBadgePalette(
   theme: ReturnType<typeof useAppTheme>,
   kind: CalendarDayBadgeKind,
@@ -208,6 +223,7 @@ export default function CalendarTabScreen() {
   const [selectedDayIso, setSelectedDayIso] = useState<string | null>(routeState.selectedDayIso);
   const [isSheetOpen, setIsSheetOpen] = useState(routeState.isSheetOpen);
   const styles = useMemo(() => createStyles(theme), [theme]);
+  const datasetEventKeyRef = useRef<string | null>(null);
 
   useEffect(() => {
     setActiveMonth(routeState.activeMonth);
@@ -231,6 +247,17 @@ export default function CalendarTabScreen() {
           return;
         }
 
+        const datasetEventKey =
+          source.runtimeState.mode === 'degraded' || source.issues.length > 0
+            ? `degraded:${source.selection.kind}:${source.runtimeState.mode}:${source.issues.join('|')}`
+            : `ready:${source.selection.kind}`;
+        if (datasetEventKeyRef.current !== datasetEventKey) {
+          datasetEventKeyRef.current = datasetEventKey;
+          if (source.runtimeState.mode === 'degraded' || source.issues.length > 0) {
+            trackDatasetDegraded('calendar', source);
+          }
+        }
+
         const snapshot = selectCalendarMonthSnapshot(source.dataset, activeMonth, todayIsoDate);
         const nextKind =
           snapshot.releaseCount === 0 && snapshot.upcomingCount === 0 ? 'empty' : 'ready';
@@ -246,12 +273,19 @@ export default function CalendarTabScreen() {
           return;
         }
 
+        const message =
+          error instanceof Error
+            ? error.message
+            : 'Calendar dataset could not be loaded right now.';
+        const datasetEventKey = `error:${message}`;
+        if (datasetEventKeyRef.current !== datasetEventKey) {
+          datasetEventKeyRef.current = datasetEventKey;
+          trackDatasetLoadFailed('calendar', message);
+        }
+
         setState({
           kind: 'error',
-          message:
-            error instanceof Error
-              ? error.message
-              : 'Calendar dataset could not be loaded right now.',
+          message,
         });
       });
 
@@ -344,22 +378,55 @@ export default function CalendarTabScreen() {
   }
 
   function jumpToToday() {
+    trackAnalyticsEvent('calendar_quick_jump_used', {
+      target: 'today',
+      fromMonth: activeMonth,
+      toMonth: currentMonth,
+    });
     setFilterMode('all');
     jumpToMonth(currentMonth, todayIsoDate);
   }
 
   function jumpToNearestUpcoming() {
-    if (!globalNearestUpcoming?.scheduledDate) {
+    if (!source || !globalNearestUpcoming?.scheduledDate) {
       return;
     }
 
+    const nextMonth = globalNearestUpcoming.scheduledDate.slice(0, 7);
+    const baseSnapshot = selectCalendarMonthSnapshot(source.dataset, nextMonth, todayIsoDate);
+    const nextSnapshot = applyCalendarFilter(baseSnapshot, 'all');
+    const counts = getSelectedDayCounts(nextSnapshot, globalNearestUpcoming.scheduledDate);
+
+    trackAnalyticsEvent('calendar_quick_jump_used', {
+      target: 'nearest_upcoming',
+      fromMonth: activeMonth,
+      toMonth: nextMonth,
+    });
+    trackAnalyticsEvent('calendar_date_drill_opened', {
+      date: globalNearestUpcoming.scheduledDate,
+      source: 'nearest_upcoming',
+      filterMode: 'all',
+      releaseCount: counts.releaseCount,
+      upcomingCount: counts.upcomingCount,
+    });
     setFilterMode('all');
-    setActiveMonth(globalNearestUpcoming.scheduledDate.slice(0, 7));
+    setActiveMonth(nextMonth);
     setSelectedDayIso(globalNearestUpcoming.scheduledDate);
     setIsSheetOpen(true);
   }
 
-  function openDaySheet(isoDate: string) {
+  function openDaySheet(isoDate: string, sourceLabel: 'grid' | 'nearest_upcoming' = 'grid') {
+    if (filteredSnapshot) {
+      const counts = getSelectedDayCounts(filteredSnapshot, isoDate);
+      trackAnalyticsEvent('calendar_date_drill_opened', {
+        date: isoDate,
+        source: sourceLabel,
+        filterMode,
+        releaseCount: counts.releaseCount,
+        upcomingCount: counts.upcomingCount,
+      });
+    }
+
     setSelectedDayIso((current) =>
       resolveNextCalendarSelection(
         current ?? isoDate,
@@ -372,6 +439,18 @@ export default function CalendarTabScreen() {
 
   function closeDaySheet() {
     setIsSheetOpen(false);
+  }
+
+  function handleFilterChange(nextFilterMode: CalendarFilterMode) {
+    if (filterMode === nextFilterMode || !filteredSnapshot) {
+      return;
+    }
+
+    trackAnalyticsEvent('calendar_filter_changed', {
+      filterMode: nextFilterMode,
+      month: filteredSnapshot.month,
+    });
+    setFilterMode(nextFilterMode);
   }
 
   if (state.kind === 'loading') {
@@ -530,7 +609,7 @@ export default function CalendarTabScreen() {
                 accessibilityLabel={`${label} 필터`}
                 accessibilityRole="button"
                 accessibilityState={{ selected: filterMode === mode }}
-                onPress={() => setFilterMode(mode)}
+                onPress={() => handleFilterChange(mode)}
                 style={({ pressed }) => [
                   styles.controlChip,
                   filterMode === mode ? styles.controlChipActive : null,

--- a/mobile/app/(tabs)/radar.tsx
+++ b/mobile/app/(tabs)/radar.tsx
@@ -1,5 +1,5 @@
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
   Pressable,
   ScrollView,
@@ -22,6 +22,7 @@ import {
   loadActiveMobileDataset,
   type ActiveMobileDataset,
 } from '../../src/services/activeDataset';
+import { trackDatasetDegraded, trackDatasetLoadFailed } from '../../src/services/analytics';
 import { useAppTheme } from '../../src/tokens/theme';
 import type {
   RadarLongGapItemModel,
@@ -86,6 +87,7 @@ export default function RadarTabScreen() {
   const routeState = useMemo(() => resolveRadarRouteState(params), [params]);
   const [hideEmptySections, setHideEmptySections] = useState(routeState.hideEmptySections);
   const [state, setState] = useState<RadarScreenState>({ kind: 'loading' });
+  const datasetEventKeyRef = useRef<string | null>(null);
   const today = useMemo(() => new Date(), []);
   const todayIsoDate = useMemo(() => today.toISOString().slice(0, 10), [today]);
 
@@ -103,6 +105,17 @@ export default function RadarTabScreen() {
           return;
         }
 
+        const datasetEventKey =
+          source.runtimeState.mode === 'degraded' || source.issues.length > 0
+            ? `degraded:${source.selection.kind}:${source.runtimeState.mode}:${source.issues.join('|')}`
+            : `ready:${source.selection.kind}`;
+        if (datasetEventKeyRef.current !== datasetEventKey) {
+          datasetEventKeyRef.current = datasetEventKey;
+          if (source.runtimeState.mode === 'degraded' || source.issues.length > 0) {
+            trackDatasetDegraded('radar', source);
+          }
+        }
+
         setState({
           kind: 'ready',
           source,
@@ -114,12 +127,19 @@ export default function RadarTabScreen() {
           return;
         }
 
+        const message =
+          error instanceof Error
+            ? error.message
+            : 'Radar dataset could not be loaded right now.';
+        const datasetEventKey = `error:${message}`;
+        if (datasetEventKeyRef.current !== datasetEventKey) {
+          datasetEventKeyRef.current = datasetEventKey;
+          trackDatasetLoadFailed('radar', message);
+        }
+
         setState({
           kind: 'error',
-          message:
-            error instanceof Error
-              ? error.message
-              : 'Radar dataset could not be loaded right now.',
+          message,
         });
       });
 

--- a/mobile/app/(tabs)/search.tsx
+++ b/mobile/app/(tabs)/search.tsx
@@ -1,5 +1,5 @@
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import React, { useDeferredValue, useEffect, useMemo, useState } from 'react';
+import React, { useDeferredValue, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Pressable,
   ScrollView,
@@ -25,6 +25,12 @@ import {
   selectTeamSummaryBySlug,
 } from '../../src/selectors';
 import { loadActiveMobileDataset, type ActiveMobileDataset } from '../../src/services/activeDataset';
+import {
+  trackAnalyticsEvent,
+  trackDatasetDegraded,
+  trackDatasetLoadFailed,
+  type SearchSubmitSource,
+} from '../../src/services/analytics';
 import { clearRecentQueries, persistRecentQuery, readRecentQueries } from '../../src/services/recentQueries';
 import { useAppTheme } from '../../src/tokens/theme';
 import type {
@@ -95,6 +101,7 @@ export default function SearchTabScreen() {
   const [activeSegment, setActiveSegment] = useState<SearchSegment>(routeState.activeSegment);
   const [recentQueries, setRecentQueries] = useState<string[]>([]);
   const deferredQuery = useDeferredValue(query);
+  const datasetEventKeyRef = useRef<string | null>(null);
 
   useEffect(() => {
     setQuery(routeState.query);
@@ -111,6 +118,18 @@ export default function SearchTabScreen() {
           return;
         }
 
+        const datasetEventKey =
+          source.runtimeState.mode === 'degraded' || source.issues.length > 0
+            ? `degraded:${source.selection.kind}:${source.runtimeState.mode}:${source.issues.join('|')}`
+            : `ready:${source.selection.kind}`;
+
+        if (datasetEventKeyRef.current !== datasetEventKey) {
+          datasetEventKeyRef.current = datasetEventKey;
+          if (source.runtimeState.mode === 'degraded' || source.issues.length > 0) {
+            trackDatasetDegraded('search', source);
+          }
+        }
+
         setRecentQueries(history);
         setState({
           kind: 'ready',
@@ -122,12 +141,19 @@ export default function SearchTabScreen() {
           return;
         }
 
+        const message =
+          error instanceof Error
+            ? error.message
+            : 'Search dataset could not be loaded right now.';
+        const datasetEventKey = `error:${message}`;
+        if (datasetEventKeyRef.current !== datasetEventKey) {
+          datasetEventKeyRef.current = datasetEventKey;
+          trackDatasetLoadFailed('search', message);
+        }
+
         setState({
           kind: 'error',
-          message:
-            error instanceof Error
-              ? error.message
-              : 'Search dataset could not be loaded right now.',
+          message,
         });
       });
 
@@ -200,18 +226,58 @@ export default function SearchTabScreen() {
     setRecentQueries(history);
   }
 
-  async function handleSubmitQuery(nextQuery = query) {
+  function buildSearchSubmissionMetrics(nextQuery: string): {
+    hadResults: boolean;
+    resultCounts: {
+      entities: number;
+      releases: number;
+      upcoming: number;
+    };
+  } {
+    if (!selectorContext) {
+      return {
+        hadResults: false,
+        resultCounts: {
+          entities: 0,
+          releases: 0,
+          upcoming: 0,
+        },
+      };
+    }
+
+    const nextResults = selectSearchResults(selectorContext, nextQuery);
+    const resultCounts = {
+      entities: nextResults.entities.length,
+      releases: nextResults.releases.length,
+      upcoming: nextResults.upcoming.length,
+    };
+
+    return {
+      hadResults: resultCounts.entities + resultCounts.releases + resultCounts.upcoming > 0,
+      resultCounts,
+    };
+  }
+
+  async function handleSubmitQuery(nextQuery = query, submitSource: SearchSubmitSource = 'input') {
     const normalized = nextQuery.trim();
     if (!normalized) {
       return;
     }
 
+    const metrics = buildSearchSubmissionMetrics(normalized);
+    trackAnalyticsEvent('search_submitted', {
+      query: normalized,
+      submitSource,
+      activeSegment,
+      resultCounts: metrics.resultCounts,
+      hadResults: metrics.hadResults,
+    });
     await rememberQuery(normalized);
   }
 
   async function handleRecentQueryPress(nextQuery: string) {
     setQuery(nextQuery);
-    await rememberQuery(nextQuery);
+    await handleSubmitQuery(nextQuery, 'recent');
   }
 
   async function handleClearHistory() {
@@ -231,6 +297,44 @@ export default function SearchTabScreen() {
       pathname: '/releases/[id]',
       params: { id: releaseId },
     });
+  }
+
+  function handleTeamResultPress(result: SearchTeamResultModel) {
+    trackAnalyticsEvent('search_result_opened', {
+      query: query.trim(),
+      activeSegment,
+      resultType: 'team',
+      targetId: result.team.slug,
+      matchKind: result.matchKind,
+    });
+    openTeamDetail(result.team.slug);
+  }
+
+  function handleReleaseResultPress(release: ReleaseSummaryModel, matchKind: string) {
+    trackAnalyticsEvent('search_result_opened', {
+      query: query.trim(),
+      activeSegment,
+      resultType: 'release',
+      targetId: release.id,
+      matchKind,
+    });
+    openReleaseDetail(release.id);
+  }
+
+  function handleUpcomingResultPress(result: SearchUpcomingResultModel) {
+    const slug = teamSlugByGroup.get(result.upcoming.group);
+    if (!slug) {
+      return;
+    }
+
+    trackAnalyticsEvent('search_result_opened', {
+      query: query.trim(),
+      activeSegment,
+      resultType: 'upcoming',
+      targetId: slug,
+      matchKind: result.matchKind,
+    });
+    openTeamDetail(slug);
   }
 
   if (state.kind === 'loading') {
@@ -417,9 +521,10 @@ export default function SearchTabScreen() {
             ? results.entities.map((result) => (
                 <Pressable
                   key={result.team.slug}
+                  testID={`search-team-result-press-${result.team.slug}`}
                   accessibilityLabel={buildTeamResultAccessibilityLabel(result)}
                   accessibilityRole="button"
-                  onPress={() => openTeamDetail(result.team.slug)}
+                  onPress={() => handleTeamResultPress(result)}
                   style={({ pressed }) => [styles.resultRow, pressed ? styles.segmentButtonPressed : null]}
                 >
                   <View style={styles.resultLeadingBadge}>
@@ -440,9 +545,10 @@ export default function SearchTabScreen() {
             ? results.releases.map((result) => (
                 <Pressable
                   key={result.release.id}
+                  testID={`search-release-result-press-${result.release.id}`}
                   accessibilityLabel={buildReleaseResultAccessibilityLabel(result.release, result.matchKind)}
                   accessibilityRole="button"
-                  onPress={() => openReleaseDetail(result.release.id)}
+                  onPress={() => handleReleaseResultPress(result.release, result.matchKind)}
                   style={({ pressed }) => [styles.resultRow, pressed ? styles.segmentButtonPressed : null]}
                 >
                   <View style={styles.resultLeadingBadge}>
@@ -463,16 +569,12 @@ export default function SearchTabScreen() {
             ? results.upcoming.map((result) => (
                 <Pressable
                   key={result.upcoming.id}
+                  testID={`search-upcoming-result-press-${result.upcoming.id}`}
                   accessibilityLabel={buildUpcomingResultAccessibilityLabel(result)}
                   accessibilityRole="button"
                   accessibilityState={{ disabled: !teamSlugByGroup.get(result.upcoming.group) }}
                   disabled={!teamSlugByGroup.get(result.upcoming.group)}
-                  onPress={() => {
-                    const slug = teamSlugByGroup.get(result.upcoming.group);
-                    if (slug) {
-                      openTeamDetail(slug);
-                    }
-                  }}
+                  onPress={() => handleUpcomingResultPress(result)}
                   style={({ pressed }) => [
                     styles.resultRow,
                     !teamSlugByGroup.get(result.upcoming.group) ? styles.disabledButton : null,

--- a/mobile/app/artists/[slug].tsx
+++ b/mobile/app/artists/[slug].tsx
@@ -1,5 +1,5 @@
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
   Image,
   Linking,
@@ -19,6 +19,7 @@ import {
   loadActiveMobileDataset,
   type ActiveMobileDataset,
 } from '../../src/services/activeDataset';
+import { trackDatasetDegraded, trackDatasetLoadFailed } from '../../src/services/analytics';
 import { useAppTheme } from '../../src/tokens/theme';
 import type {
   EntityDetailSnapshotModel,
@@ -134,6 +135,7 @@ export default function ArtistDetailScreen() {
   const slug = getSingleParam(params.slug)?.trim() ?? '';
   const [reloadCount, setReloadCount] = useState(0);
   const [state, setState] = useState<EntityDetailScreenState>({ kind: 'loading' });
+  const datasetEventKeyRef = useRef<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -156,6 +158,17 @@ export default function ArtistDetailScreen() {
           return;
         }
 
+        const datasetEventKey =
+          source.runtimeState.mode === 'degraded' || source.issues.length > 0
+            ? `degraded:${source.selection.kind}:${source.runtimeState.mode}:${source.issues.join('|')}`
+            : `ready:${source.selection.kind}`;
+        if (datasetEventKeyRef.current !== datasetEventKey) {
+          datasetEventKeyRef.current = datasetEventKey;
+          if (source.runtimeState.mode === 'degraded' || source.issues.length > 0) {
+            trackDatasetDegraded('entity_detail', source);
+          }
+        }
+
         const snapshot = selectEntityDetailSnapshot(source.dataset, slug);
         if (!snapshot) {
           setState({
@@ -176,12 +189,19 @@ export default function ArtistDetailScreen() {
           return;
         }
 
+        const message =
+          error instanceof Error
+            ? error.message
+            : '팀 상세 데이터를 불러오지 못했습니다.';
+        const datasetEventKey = `error:${message}`;
+        if (datasetEventKeyRef.current !== datasetEventKey) {
+          datasetEventKeyRef.current = datasetEventKey;
+          trackDatasetLoadFailed('entity_detail', message);
+        }
+
         setState({
           kind: 'error',
-          message:
-            error instanceof Error
-              ? error.message
-              : '팀 상세 데이터를 불러오지 못했습니다.',
+          message,
         });
       });
 

--- a/mobile/app/debug/metadata.tsx
+++ b/mobile/app/debug/metadata.tsx
@@ -3,20 +3,22 @@ import { StyleSheet, Text, View } from 'react-native';
 
 import { getDebugMetadata, isDebugMetadataAvailable } from '../../src/config/debugMetadata';
 
-const metadata = getDebugMetadata();
-const rows = [
-  ['Profile', metadata.profile],
-  ['Runtime mode', metadata.runtimeMode],
-  ['Runtime issues', metadata.runtimeIssues.length > 0 ? metadata.runtimeIssues.join(' | ') : 'None'],
-  ['Build version', metadata.buildVersion],
-  ['Dataset version', metadata.datasetVersion ?? 'Unavailable'],
-  ['Commit hash', metadata.commitSha ?? 'Unavailable'],
-  ['Data source mode', metadata.dataSourceMode],
-  ['Remote dataset URL', metadata.remoteDatasetUrl ?? 'Bundled-only'],
-];
-
 export default function DebugMetadataScreen() {
   const available = isDebugMetadataAvailable();
+  const metadata = getDebugMetadata();
+  const rows = [
+    ['Profile', metadata.profile],
+    ['Runtime mode', metadata.runtimeMode],
+    ['Runtime issues', metadata.runtimeIssues.length > 0 ? metadata.runtimeIssues.join(' | ') : 'None'],
+    ['Build version', metadata.buildVersion],
+    ['Dataset version', metadata.datasetVersion ?? 'Unavailable'],
+    ['Commit hash', metadata.commitSha ?? 'Unavailable'],
+    ['Data source mode', metadata.dataSourceMode],
+    ['Remote dataset URL', metadata.remoteDatasetUrl ?? 'Bundled-only'],
+    ['Analytics enabled', metadata.analyticsEnabled ? 'Yes' : 'No'],
+    ['Analytics event count', `${metadata.analyticsEventCount}`],
+    ['Latest analytics event', metadata.latestAnalyticsEvent ?? 'None'],
+  ] as const;
 
   return (
     <View style={styles.container}>

--- a/mobile/app/releases/[id].tsx
+++ b/mobile/app/releases/[id].tsx
@@ -1,5 +1,5 @@
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
   Image,
   Pressable,
@@ -26,6 +26,11 @@ import {
   type ServiceHandoffFailure,
   type ServiceHandoffResolution,
 } from '../../src/services/handoff';
+import {
+  trackAnalyticsEvent,
+  trackDatasetDegraded,
+  trackDatasetLoadFailed,
+} from '../../src/services/analytics';
 import { useAppTheme } from '../../src/tokens/theme';
 import type { MobileTheme } from '../../src/tokens/theme';
 import type { ReleaseDetailModel, TrackModel, YoutubeVideoStatus } from '../../src/types';
@@ -230,6 +235,7 @@ export default function ReleaseDetailScreen() {
   const [reloadCount, setReloadCount] = useState(0);
   const [handoffFeedback, setHandoffFeedback] = useState<string | null>(null);
   const [state, setState] = useState<ReleaseDetailScreenState>({ kind: 'loading' });
+  const datasetEventKeyRef = useRef<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -253,6 +259,17 @@ export default function ReleaseDetailScreen() {
           return;
         }
 
+        const datasetEventKey =
+          source.runtimeState.mode === 'degraded' || source.issues.length > 0
+            ? `degraded:${source.selection.kind}:${source.runtimeState.mode}:${source.issues.join('|')}`
+            : `ready:${source.selection.kind}`;
+        if (datasetEventKeyRef.current !== datasetEventKey) {
+          datasetEventKeyRef.current = datasetEventKey;
+          if (source.runtimeState.mode === 'degraded' || source.issues.length > 0) {
+            trackDatasetDegraded('release_detail', source);
+          }
+        }
+
         const detail = selectReleaseDetailById(source.dataset, releaseId);
         if (!detail) {
           setState({
@@ -273,12 +290,19 @@ export default function ReleaseDetailScreen() {
           return;
         }
 
+        const message =
+          error instanceof Error
+            ? error.message
+            : '릴리즈 상세 데이터를 불러오지 못했습니다.';
+        const datasetEventKey = `error:${message}`;
+        if (datasetEventKeyRef.current !== datasetEventKey) {
+          datasetEventKeyRef.current = datasetEventKey;
+          trackDatasetLoadFailed('release_detail', message);
+        }
+
         setState({
           kind: 'error',
-          message:
-            error instanceof Error
-              ? error.message
-              : '릴리즈 상세 데이터를 불러오지 못했습니다.',
+          message,
         });
       });
 
@@ -290,7 +314,20 @@ export default function ReleaseDetailScreen() {
   async function handleHandoff(
     handoff: ServiceHandoffResolution | ServiceHandoffFailure,
   ) {
+    trackAnalyticsEvent('service_handoff_attempted', {
+      surface: 'release_detail',
+      service: handoff.service,
+      mode: handoff.mode,
+    });
     const result = await openServiceHandoff(handoff);
+    trackAnalyticsEvent('service_handoff_completed', {
+      surface: 'release_detail',
+      service: result.service,
+      mode: result.mode,
+      ok: result.ok,
+      target: result.target ?? null,
+      failureCode: result.ok ? null : result.code,
+    });
 
     if (!result.ok) {
       setHandoffFeedback(result.feedback.message);

--- a/mobile/src/README.md
+++ b/mobile/src/README.md
@@ -22,6 +22,7 @@
   - `datasetCache.ts`: static dataset artifact cache entry helper
   - `recentQueries.ts`: recent-query persistence helper
   - `handoff.ts`: canonical-open / search-fallback / browser-fallback resolver + opener
+  - `analytics.ts`: env-gated event emitter + debug recent-event buffer
 - `tokens/`: design token / theme
   - `theme.tsx`: theme provider + `useAppTheme()` access convention
   - `colors.ts`, `spacing.ts`, `radii.ts`, `typography.ts`, `sizes.ts`, `elevation.ts`, `motion.ts`
@@ -44,6 +45,12 @@ handoff 관련 규칙:
 - later UI는 raw `Linking.openURL`을 직접 호출하지 않는다.
 - canonical URL validation, search fallback URL builder, browser fallback choice는 `services/handoff.ts`에서 중앙화한다.
 - 실패는 explicit result object로 돌려서 UI가 toast/inline feedback을 붙일 수 있게 한다.
+
+analytics 관련 규칙:
+
+- analytics는 `featureGates.analytics`가 꺼져 있으면 아무 이벤트도 내보내지 않는다.
+- search submit / date drill-in / service handoff / degraded-or-error dataset state만 low-noise 기준으로 추적한다.
+- 최근 이벤트 확인은 `config/debugMetadata.ts`와 hidden `debug/metadata` route를 통해서만 한다.
 
 feedback state 관련 규칙:
 

--- a/mobile/src/config/debugMetadata.test.ts
+++ b/mobile/src/config/debugMetadata.test.ts
@@ -1,5 +1,6 @@
 import type { MobileRuntimeConfig, RuntimeConfigState } from './runtime';
 import { getDebugMetadata, isDebugMetadataAvailable } from './debugMetadata';
+import { resetAnalyticsEvents, trackAnalyticsEvent } from '../services/analytics';
 
 const previewRuntimeConfig: MobileRuntimeConfig = {
   profile: 'preview',
@@ -35,7 +36,43 @@ const previewRuntimeState: RuntimeConfigState = {
 };
 
 describe('debug metadata helpers', () => {
+  let consoleInfoSpy: jest.SpyInstance;
+
+  beforeAll(() => {
+    consoleInfoSpy = jest.spyOn(console, 'info').mockImplementation(() => undefined);
+  });
+
+  beforeEach(() => {
+    resetAnalyticsEvents();
+  });
+
+  afterAll(() => {
+    consoleInfoSpy.mockRestore();
+  });
+
   test('returns the stable debug metadata fields for preview builds', () => {
+    trackAnalyticsEvent(
+      'dataset_degraded',
+      {
+        surface: 'search',
+        activeSource: 'bundled-static',
+        runtimeMode: 'normal',
+        issueCount: 1,
+      },
+      {
+        ...previewRuntimeConfig,
+        services: {
+          ...previewRuntimeConfig.services,
+          analyticsWriteKey: 'write-key',
+        },
+        featureGates: {
+          ...previewRuntimeConfig.featureGates,
+          analytics: true,
+        },
+      },
+      () => '2026-03-09T00:00:00.000Z',
+    );
+
     expect(getDebugMetadata(previewRuntimeState)).toEqual({
       profile: 'preview',
       runtimeMode: 'normal',
@@ -47,6 +84,8 @@ describe('debug metadata helpers', () => {
       remoteDatasetUrl: 'https://example.com/dataset.json',
       analyticsEnabled: false,
       radarEnabled: true,
+      analyticsEventCount: 1,
+      latestAnalyticsEvent: 'dataset_degraded @ 2026-03-09T00:00:00.000Z',
     });
   });
 

--- a/mobile/src/config/debugMetadata.ts
+++ b/mobile/src/config/debugMetadata.ts
@@ -4,6 +4,7 @@ import {
   type MobileRuntimeConfig,
   type RuntimeConfigState,
 } from './runtime';
+import { getLatestAnalyticsEvent, getRecentAnalyticsEvents } from '../services/analytics';
 
 export type MobileDebugMetadata = {
   profile: MobileRuntimeConfig['profile'];
@@ -16,6 +17,8 @@ export type MobileDebugMetadata = {
   remoteDatasetUrl: string | null;
   analyticsEnabled: boolean;
   radarEnabled: boolean;
+  analyticsEventCount: number;
+  latestAnalyticsEvent: string | null;
 };
 
 export function isDebugMetadataAvailable(runtimeConfig: MobileRuntimeConfig = getRuntimeConfig()): boolean {
@@ -26,6 +29,8 @@ export function getDebugMetadata(
   runtimeState: RuntimeConfigState = getRuntimeConfigState(),
 ): MobileDebugMetadata {
   const runtimeConfig = runtimeState.config;
+  const recentAnalyticsEvents = getRecentAnalyticsEvents();
+  const latestAnalyticsEvent = getLatestAnalyticsEvent();
 
   return {
     profile: runtimeConfig.profile,
@@ -38,5 +43,9 @@ export function getDebugMetadata(
     remoteDatasetUrl: runtimeConfig.dataSource.remoteDatasetUrl,
     analyticsEnabled: runtimeConfig.featureGates.analytics,
     radarEnabled: runtimeConfig.featureGates.radar,
+    analyticsEventCount: recentAnalyticsEvents.length,
+    latestAnalyticsEvent: latestAnalyticsEvent
+      ? `${latestAnalyticsEvent.name} @ ${latestAnalyticsEvent.occurredAt}`
+      : null,
   };
 }

--- a/mobile/src/features/calendarControls.test.tsx
+++ b/mobile/src/features/calendarControls.test.tsx
@@ -3,6 +3,7 @@ import renderer, { act } from 'react-test-renderer';
 import { Text } from 'react-native';
 
 import CalendarTabScreen from '../../app/(tabs)/calendar';
+import { trackAnalyticsEvent, trackDatasetDegraded, trackDatasetLoadFailed } from '../services/analytics';
 
 jest.mock('expo-router', () => {
   const useLocalSearchParams = jest.fn(() => ({}));
@@ -33,6 +34,14 @@ const { __mock } = jest.requireMock('expo-router') as {
     useLocalSearchParams: jest.Mock;
   };
 };
+jest.mock('../services/analytics', () => ({
+  trackAnalyticsEvent: jest.fn(),
+  trackDatasetDegraded: jest.fn(),
+  trackDatasetLoadFailed: jest.fn(),
+}));
+const mockTrackAnalyticsEvent = jest.mocked(trackAnalyticsEvent);
+const mockTrackDatasetDegraded = jest.mocked(trackDatasetDegraded);
+const mockTrackDatasetLoadFailed = jest.mocked(trackDatasetLoadFailed);
 
 async function renderCalendarScreen() {
   let tree: renderer.ReactTestRenderer;
@@ -54,6 +63,9 @@ describe('calendar controls', () => {
     jest.useFakeTimers();
     jest.setSystemTime(new Date('2026-03-07T09:00:00.000Z'));
     __mock.useLocalSearchParams.mockReturnValue({});
+    mockTrackAnalyticsEvent.mockClear();
+    mockTrackDatasetDegraded.mockClear();
+    mockTrackDatasetLoadFailed.mockClear();
   });
 
   afterEach(() => {
@@ -101,6 +113,21 @@ describe('calendar controls', () => {
     expect(tree.root.findByProps({ testID: 'calendar-month-title' }).props.children).toBe('2026년 3월');
     expect(tree.root.findByProps({ testID: 'calendar-bottom-sheet' })).toBeDefined();
     expect(hasText(tree, '2026년 3월 11일')).toBe(true);
+    expect(mockTrackAnalyticsEvent).toHaveBeenCalledWith(
+      'calendar_quick_jump_used',
+      expect.objectContaining({
+        target: 'nearest_upcoming',
+        fromMonth: '2026-04',
+        toMonth: '2026-03',
+      }),
+    );
+    expect(mockTrackAnalyticsEvent).toHaveBeenCalledWith(
+      'calendar_date_drill_opened',
+      expect.objectContaining({
+        date: '2026-03-11',
+        source: 'nearest_upcoming',
+      }),
+    );
   });
 
   test('keeps month-only items outside the grid and applies compact filters', async () => {
@@ -113,6 +140,13 @@ describe('calendar controls', () => {
     });
 
     expect(hasText(tree, '현재 필터에서는 month-only 예정 신호를 숨깁니다.')).toBe(true);
+    expect(mockTrackAnalyticsEvent).toHaveBeenCalledWith(
+      'calendar_filter_changed',
+      expect.objectContaining({
+        filterMode: 'releases',
+        month: '2026-03',
+      }),
+    );
 
     await act(async () => {
       tree.root.findByProps({ testID: 'calendar-filter-upcoming' }).props.onPress();
@@ -123,5 +157,13 @@ describe('calendar controls', () => {
     });
 
     expect(hasText(tree, '이 날짜에는 등록된 일정이 없습니다.')).toBe(true);
+    expect(mockTrackAnalyticsEvent).toHaveBeenCalledWith(
+      'calendar_date_drill_opened',
+      expect.objectContaining({
+        date: '2026-03-03',
+        source: 'grid',
+        filterMode: 'upcoming',
+      }),
+    );
   });
 });

--- a/mobile/src/features/releaseDetailScreen.test.tsx
+++ b/mobile/src/features/releaseDetailScreen.test.tsx
@@ -4,6 +4,11 @@ import { Text } from 'react-native';
 
 import ReleaseDetailScreen from '../../app/releases/[id]';
 import {
+  trackAnalyticsEvent,
+  trackDatasetDegraded,
+  trackDatasetLoadFailed,
+} from '../services/analytics';
+import {
   openServiceHandoff,
   type ServiceHandoffFailure,
   type ServiceHandoffResolution,
@@ -56,6 +61,12 @@ jest.mock('../services/handoff', () => {
   };
 });
 
+jest.mock('../services/analytics', () => ({
+  trackAnalyticsEvent: jest.fn(),
+  trackDatasetDegraded: jest.fn(),
+  trackDatasetLoadFailed: jest.fn(),
+}));
+
 const { __mock } = jest.requireMock('expo-router') as {
   __mock: {
     useLocalSearchParams: jest.Mock;
@@ -64,6 +75,9 @@ const { __mock } = jest.requireMock('expo-router') as {
 };
 
 const mockOpenServiceHandoff = openServiceHandoff as jest.MockedFunction<typeof openServiceHandoff>;
+const mockTrackAnalyticsEvent = jest.mocked(trackAnalyticsEvent);
+const mockTrackDatasetDegraded = jest.mocked(trackDatasetDegraded);
+const mockTrackDatasetLoadFailed = jest.mocked(trackDatasetLoadFailed);
 
 async function renderReleaseDetail() {
   let tree: renderer.ReactTestRenderer;
@@ -88,6 +102,9 @@ describe('mobile release detail screen', () => {
       push: jest.fn(),
     });
     mockOpenServiceHandoff.mockClear();
+    mockTrackAnalyticsEvent.mockClear();
+    mockTrackDatasetDegraded.mockClear();
+    mockTrackDatasetLoadFailed.mockClear();
   });
 
   test('renders populated release detail sections for a canonical release', async () => {
@@ -145,6 +162,21 @@ describe('mobile release detail screen', () => {
       service: 'spotify',
       mode: 'searchFallback',
     });
+    expect(mockTrackAnalyticsEvent).toHaveBeenCalledWith(
+      'service_handoff_attempted',
+      expect.objectContaining({
+        surface: 'release_detail',
+        service: 'spotify',
+      }),
+    );
+    expect(mockTrackAnalyticsEvent).toHaveBeenCalledWith(
+      'service_handoff_completed',
+      expect.objectContaining({
+        surface: 'release_detail',
+        service: 'spotify',
+        ok: true,
+      }),
+    );
   });
 
   test('keeps the route stable and shows retryable feedback when handoff fails', async () => {
@@ -174,5 +206,14 @@ describe('mobile release detail screen', () => {
       true,
     );
     expect(tree.root.findByProps({ testID: 'release-detail-title' }).props.children).toBe('LOVE CATCHER');
+    expect(mockTrackAnalyticsEvent).toHaveBeenCalledWith(
+      'service_handoff_completed',
+      expect.objectContaining({
+        surface: 'release_detail',
+        service: 'spotify',
+        ok: false,
+        failureCode: 'handoff_open_failed',
+      }),
+    );
   });
 });

--- a/mobile/src/features/searchTab.test.tsx
+++ b/mobile/src/features/searchTab.test.tsx
@@ -2,6 +2,7 @@ import renderer, { act } from 'react-test-renderer';
 import { Text } from 'react-native';
 
 import SearchTabScreen from '../../app/(tabs)/search';
+import { trackAnalyticsEvent, trackDatasetDegraded, trackDatasetLoadFailed } from '../services/analytics';
 import { persistRecentQuery, readRecentQueries } from '../services/recentQueries';
 import { resetStorageAdapter, setStorageAdapter, type KeyValueStorageAdapter } from '../services/storage';
 
@@ -33,6 +34,12 @@ jest.mock('expo-router', () => {
   };
 });
 
+jest.mock('../services/analytics', () => ({
+  trackAnalyticsEvent: jest.fn(),
+  trackDatasetDegraded: jest.fn(),
+  trackDatasetLoadFailed: jest.fn(),
+}));
+
 const { __mock } = jest.requireMock('expo-router') as {
   __mock: {
     push: jest.Mock;
@@ -40,6 +47,9 @@ const { __mock } = jest.requireMock('expo-router') as {
     useLocalSearchParams: jest.Mock;
   };
 };
+const mockTrackAnalyticsEvent = jest.mocked(trackAnalyticsEvent);
+const mockTrackDatasetDegraded = jest.mocked(trackDatasetDegraded);
+const mockTrackDatasetLoadFailed = jest.mocked(trackDatasetLoadFailed);
 
 async function renderSearchScreen() {
   let tree: renderer.ReactTestRenderer;
@@ -62,6 +72,10 @@ describe('mobile search tab', () => {
     setStorageAdapter(createMemoryStorage());
     __mock.useLocalSearchParams.mockReturnValue({});
     __mock.setParams.mockClear();
+    __mock.push.mockClear();
+    mockTrackAnalyticsEvent.mockClear();
+    mockTrackDatasetDegraded.mockClear();
+    mockTrackDatasetLoadFailed.mockClear();
   });
 
   afterEach(() => {
@@ -76,6 +90,20 @@ describe('mobile search tab', () => {
     });
 
     expect(tree.root.findByProps({ testID: 'search-team-result-yena' })).toBeDefined();
+
+    await act(async () => {
+      tree.root.findByProps({ testID: 'search-team-result-press-yena' }).props.onPress();
+    });
+
+    expect(mockTrackAnalyticsEvent).toHaveBeenCalledWith(
+      'search_result_opened',
+      expect.objectContaining({
+        query: '최예나',
+        activeSegment: 'entities',
+        resultType: 'team',
+        targetId: 'yena',
+      }),
+    );
 
     await act(async () => {
       tree.root.findByProps({ testID: 'search-segment-releases' }).props.onPress();
@@ -98,6 +126,13 @@ describe('mobile search tab', () => {
     });
 
     await expect(readRecentQueries()).resolves.toEqual(['최예나']);
+    expect(mockTrackAnalyticsEvent).toHaveBeenCalledWith(
+      'search_submitted',
+      expect.objectContaining({
+        query: '최예나',
+        submitSource: 'input',
+      }),
+    );
   });
 
   test('shows recent queries when idle and allows clearing history', async () => {
@@ -113,6 +148,23 @@ describe('mobile search tab', () => {
 
     expect(await readRecentQueries()).toEqual([]);
     expect(hasText(tree, '최근 검색이 없습니다.')).toBe(true);
+
+    await act(async () => {
+      await persistRecentQuery('최예나');
+    });
+
+    const rerendered = await renderSearchScreen();
+    await act(async () => {
+      rerendered.root.findByProps({ testID: 'recent-query-최예나' }).props.onPress();
+    });
+
+    expect(mockTrackAnalyticsEvent).toHaveBeenCalledWith(
+      'search_submitted',
+      expect.objectContaining({
+        query: '최예나',
+        submitSource: 'recent',
+      }),
+    );
   });
 
   test('restores query and segment state from route params', async () => {

--- a/mobile/src/services/analytics.test.ts
+++ b/mobile/src/services/analytics.test.ts
@@ -1,0 +1,166 @@
+import type { MobileRuntimeConfig } from '../config/runtime';
+import { createBundledDatasetSelection } from './datasetSource';
+
+import {
+  getLatestAnalyticsEvent,
+  getRecentAnalyticsEvents,
+  resetAnalyticsEvents,
+  trackDatasetDegraded,
+  trackDatasetLoadFailed,
+  trackAnalyticsEvent,
+} from './analytics';
+
+const analyticsEnabledRuntime: MobileRuntimeConfig = {
+  profile: 'preview',
+  dataSource: {
+    mode: 'preview-static',
+    remoteDatasetUrl: null,
+    datasetVersion: 'preview-v1',
+  },
+  services: {
+    apiBaseUrl: 'https://example.com/api',
+    analyticsWriteKey: 'write-key',
+  },
+  logging: {
+    level: 'debug',
+  },
+  featureGates: {
+    radar: true,
+    analytics: true,
+    remoteRefresh: false,
+    mvEmbed: true,
+    shareActions: true,
+  },
+  build: {
+    version: '0.1.0',
+    commitSha: 'abc123',
+  },
+};
+
+describe('mobile analytics service', () => {
+  let consoleInfoSpy: jest.SpyInstance;
+
+  beforeAll(() => {
+    consoleInfoSpy = jest.spyOn(console, 'info').mockImplementation(() => undefined);
+  });
+
+  beforeEach(() => {
+    resetAnalyticsEvents();
+  });
+
+  afterAll(() => {
+    consoleInfoSpy.mockRestore();
+  });
+
+  test('does not emit events when analytics gate is disabled', () => {
+    const emitted = trackAnalyticsEvent(
+      'search_submitted',
+      {
+        query: '최예나',
+        submitSource: 'input',
+        activeSegment: 'entities',
+        resultCounts: {
+          entities: 1,
+          releases: 0,
+          upcoming: 0,
+        },
+        hadResults: true,
+      },
+      {
+        ...analyticsEnabledRuntime,
+        featureGates: {
+          ...analyticsEnabledRuntime.featureGates,
+          analytics: false,
+        },
+      },
+    );
+
+    expect(emitted).toBe(false);
+    expect(getRecentAnalyticsEvents()).toEqual([]);
+  });
+
+  test('stores recent events when analytics gate is enabled', () => {
+    const emitted = trackAnalyticsEvent(
+      'calendar_quick_jump_used',
+      {
+        target: 'today',
+        fromMonth: '2026-04',
+        toMonth: '2026-03',
+      },
+      analyticsEnabledRuntime,
+      () => '2026-03-09T00:00:00.000Z',
+    );
+
+    expect(emitted).toBe(true);
+    expect(getLatestAnalyticsEvent()).toEqual({
+      name: 'calendar_quick_jump_used',
+      payload: {
+        target: 'today',
+        fromMonth: '2026-04',
+        toMonth: '2026-03',
+      },
+      occurredAt: '2026-03-09T00:00:00.000Z',
+      profile: 'preview',
+      dataSourceMode: 'preview-static',
+      buildVersion: '0.1.0',
+    });
+  });
+
+  test('keeps only the most recent 50 events', () => {
+    for (let index = 0; index < 55; index += 1) {
+      trackAnalyticsEvent(
+        'dataset_load_failed',
+        {
+          surface: 'search',
+          errorMessage: `error-${index}`,
+        },
+        analyticsEnabledRuntime,
+        () => `2026-03-09T00:00:${`${index}`.padStart(2, '0')}.000Z`,
+      );
+    }
+
+    const events = getRecentAnalyticsEvents();
+    expect(events).toHaveLength(50);
+    expect(events[0]?.payload).toEqual({
+      surface: 'search',
+      errorMessage: 'error-54',
+    });
+    expect(events.at(-1)?.payload).toEqual({
+      surface: 'search',
+      errorMessage: 'error-5',
+    });
+  });
+
+  test('builds dataset degraded and load failed events from active dataset state', () => {
+    trackDatasetDegraded(
+      'calendar',
+      {
+        selection: createBundledDatasetSelection('preview-v1', 'runtime_degraded'),
+        runtimeState: {
+          mode: 'degraded',
+          config: analyticsEnabledRuntime,
+          issues: [],
+        },
+        issues: ['Runtime config is degraded.'],
+      },
+      analyticsEnabledRuntime,
+      () => '2026-03-09T00:00:00.000Z',
+    );
+
+    trackDatasetLoadFailed(
+      'release_detail',
+      'Release detail dataset could not be loaded right now.',
+      analyticsEnabledRuntime,
+      () => '2026-03-09T00:00:01.000Z',
+    );
+
+    expect(getRecentAnalyticsEvents().map((event) => event.name)).toEqual([
+      'dataset_load_failed',
+      'dataset_degraded',
+    ]);
+    expect(getLatestAnalyticsEvent()?.payload).toEqual({
+      surface: 'release_detail',
+      errorMessage: 'Release detail dataset could not be loaded right now.',
+    });
+  });
+});

--- a/mobile/src/services/analytics.ts
+++ b/mobile/src/services/analytics.ts
@@ -1,0 +1,176 @@
+import type { MobileRuntimeConfig } from '../config/runtime';
+import { getRuntimeConfig } from '../config/runtime';
+import type { ActiveMobileDataset } from './activeDataset';
+
+import type {
+  MusicService,
+  ServiceHandoffFailureCode,
+  ServiceHandoffMode,
+  ServiceHandoffTarget,
+} from './handoff';
+
+export type AnalyticsSurface =
+  | 'search'
+  | 'calendar'
+  | 'radar'
+  | 'entity_detail'
+  | 'release_detail';
+
+export type SearchSegment = 'entities' | 'releases' | 'upcoming';
+export type CalendarFilterMode = 'all' | 'releases' | 'upcoming';
+export type SearchSubmitSource = 'input' | 'recent';
+
+export type AnalyticsEventMap = {
+  search_submitted: {
+    query: string;
+    submitSource: 'input' | 'recent';
+    activeSegment: SearchSegment;
+    resultCounts: {
+      entities: number;
+      releases: number;
+      upcoming: number;
+    };
+    hadResults: boolean;
+  };
+  search_result_opened: {
+    query: string;
+    activeSegment: SearchSegment;
+    resultType: 'team' | 'release' | 'upcoming';
+    targetId: string;
+    matchKind: string;
+  };
+  calendar_date_drill_opened: {
+    date: string;
+    source: 'grid' | 'nearest_upcoming';
+    filterMode: CalendarFilterMode;
+    releaseCount: number;
+    upcomingCount: number;
+  };
+  calendar_quick_jump_used: {
+    target: 'today' | 'nearest_upcoming';
+    fromMonth: string;
+    toMonth: string;
+  };
+  calendar_filter_changed: {
+    filterMode: CalendarFilterMode;
+    month: string;
+  };
+  service_handoff_attempted: {
+    surface: 'release_detail';
+    service: MusicService;
+    mode: ServiceHandoffMode;
+  };
+  service_handoff_completed: {
+    surface: 'release_detail';
+    service: MusicService;
+    mode: ServiceHandoffMode;
+    ok: boolean;
+    target: ServiceHandoffTarget | null;
+    failureCode: ServiceHandoffFailureCode | null;
+  };
+  dataset_degraded: {
+    surface: AnalyticsSurface;
+    activeSource: string;
+    runtimeMode: 'normal' | 'degraded';
+    issueCount: number;
+  };
+  dataset_load_failed: {
+    surface: AnalyticsSurface;
+    errorMessage: string;
+  };
+};
+
+export type AnalyticsEventName = keyof AnalyticsEventMap;
+
+export type AnalyticsEventRecord<Name extends AnalyticsEventName = AnalyticsEventName> = {
+  name: Name;
+  payload: AnalyticsEventMap[Name];
+  occurredAt: string;
+  profile: MobileRuntimeConfig['profile'];
+  dataSourceMode: MobileRuntimeConfig['dataSource']['mode'];
+  buildVersion: string;
+};
+
+const MAX_DEBUG_EVENTS = 50;
+
+let recentAnalyticsEvents: AnalyticsEventRecord[] = [];
+
+function pushDebugEvent(event: AnalyticsEventRecord): void {
+  recentAnalyticsEvents = [event, ...recentAnalyticsEvents].slice(0, MAX_DEBUG_EVENTS);
+}
+
+export function trackAnalyticsEvent<Name extends AnalyticsEventName>(
+  name: Name,
+  payload: AnalyticsEventMap[Name],
+  runtimeConfig: MobileRuntimeConfig = getRuntimeConfig(),
+  now: () => string = () => new Date().toISOString(),
+): boolean {
+  if (!runtimeConfig.featureGates.analytics) {
+    return false;
+  }
+
+  const event: AnalyticsEventRecord<Name> = {
+    name,
+    payload,
+    occurredAt: now(),
+    profile: runtimeConfig.profile,
+    dataSourceMode: runtimeConfig.dataSource.mode,
+    buildVersion: runtimeConfig.build.version,
+  };
+
+  pushDebugEvent(event);
+
+  if (runtimeConfig.logging.level !== 'error') {
+    console.info('[mobile-analytics]', event.name, event.payload);
+  }
+
+  return true;
+}
+
+export function getRecentAnalyticsEvents(): AnalyticsEventRecord[] {
+  return [...recentAnalyticsEvents];
+}
+
+export function getLatestAnalyticsEvent(): AnalyticsEventRecord | null {
+  return recentAnalyticsEvents[0] ?? null;
+}
+
+export function resetAnalyticsEvents(): void {
+  recentAnalyticsEvents = [];
+}
+
+export function trackDatasetDegraded(
+  surface: AnalyticsSurface,
+  source: Pick<ActiveMobileDataset, 'issues' | 'runtimeState' | 'selection'>,
+  runtimeConfig: MobileRuntimeConfig = getRuntimeConfig(),
+  now?: () => string,
+): boolean {
+  return trackAnalyticsEvent(
+    'dataset_degraded',
+    {
+      surface,
+      activeSource: source.selection.kind,
+      runtimeMode: source.runtimeState.mode,
+      issueCount: source.issues.length,
+    },
+    runtimeConfig,
+    now,
+  );
+}
+
+export function trackDatasetLoadFailed(
+  surface: AnalyticsSurface,
+  errorMessage: string,
+  runtimeConfig: MobileRuntimeConfig = getRuntimeConfig(),
+  now?: () => string,
+): boolean {
+  return trackAnalyticsEvent(
+    'dataset_load_failed',
+    {
+      surface,
+      errorMessage,
+    },
+    runtimeConfig,
+    now,
+  );
+}


### PR DESCRIPTION
## Summary
- add a gated mobile analytics service with low-noise event tracking and debug metadata exposure
- instrument calendar, search, radar, entity detail, and release detail flows for analytics and degraded dataset diagnostics
- cover analytics behavior with service, screen, and debug metadata tests

## Verification
- cd mobile && npm run lint
- cd mobile && npm run typecheck
- cd mobile && npm run test
- cd mobile && CI=1 npx expo export --platform web --output-dir /tmp/idol-song-app-mobile-analytics-export
- git diff --check

Closes #343