### PR TITLE
Fix release detail lookup regressions for known rows

### DIFF
--- a/backend/src/route-contract.test.ts
+++ b/backend/src/route-contract.test.ts
@@ -15,6 +15,8 @@ const UPCOMING_SIGNAL_ID = '55555555-5555-4555-8555-555555555555';
 const UPCOMING_REVIEW_ID = '66666666-6666-4666-8666-666666666666';
 const MV_REVIEW_ID = '77777777-7777-4777-8777-777777777777';
 const IVE_ENTITY_ID = '88888888-8888-4888-8888-888888888888';
+const BLACKPINK_DEADLINE_UNRESOLVED_RELEASE_ID = '99999999-9999-4999-8999-999999999991';
+const BLACKPINK_DEADLINE_VERIFIED_RELEASE_ID = '99999999-9999-4999-8999-999999999992';
 const CALLER_REQUEST_ID = 'web-search-trace-yena-001';
 
 const TEST_CONFIG: AppConfig = {
@@ -275,6 +277,76 @@ function buildReleaseDetailPayload(releaseId: string) {
     notes: {
       summary: 'double title track',
     },
+  };
+}
+
+function buildBlackpinkDeadlinePayload(releaseId: string, releaseDate: string, detailStatus: string, titleStatus: string, youtubeMusicStatus: string) {
+  return {
+    release: {
+      release_id: releaseId,
+      entity_slug: 'blackpink',
+      display_name: 'BLACKPINK',
+      release_title: 'DEADLINE',
+      release_date: releaseDate,
+      stream: 'album',
+      release_kind: 'ep',
+    },
+    detail_metadata: {
+      status: detailStatus,
+      provenance: detailStatus === 'verified' ? 'releaseDetails.existing_row' : 'releaseDetails.missing_row',
+    },
+    title_track_metadata: {
+      status: titleStatus,
+      provenance: titleStatus === 'verified' ? 'releaseDetails.existing_title_flags' : 'releaseDetails.missing_row',
+    },
+    artwork: {
+      image_url: 'https://cdn.example.com/deadline.jpg',
+      source_url: 'https://artwork.example.com/deadline',
+      is_placeholder: false,
+    },
+    service_links: {
+      spotify: {
+        url: 'https://open.spotify.com/album/deadline',
+        status: 'canonical',
+        provenance: 'releaseDetails.spotify_url',
+      },
+      youtube_music: {
+        url: 'https://music.youtube.com/playlist?list=PLBLACKPINK',
+        status: youtubeMusicStatus,
+        provenance: youtubeMusicStatus === 'canonical' ? 'releaseDetails.youtube_music_url' : 'ytmusicapi exact album search match',
+      },
+    },
+    tracks: [
+      {
+        track_id: 'bp-track-1',
+        order: 1,
+        title: 'JUMP',
+        is_title_track: true,
+        spotify: {
+          url: 'https://open.spotify.com/track/bp-jump',
+          status: 'canonical',
+          provenance: 'releaseDetails.spotify_url',
+        },
+        youtube_music: null,
+      },
+      {
+        track_id: 'bp-track-2',
+        order: 2,
+        title: 'Ready For Love',
+        is_title_track: false,
+        spotify: null,
+        youtube_music: null,
+      },
+    ],
+    mv: {
+      url: 'https://www.youtube.com/watch?v=2GJfWMYCWY0',
+      video_id: '2GJfWMYCWY0',
+      status: 'manual_override',
+      provenance: 'official artist channel watch URL',
+    },
+    credits: [],
+    charts: [],
+    notes: null,
   };
 }
 
@@ -560,6 +632,41 @@ class FakeDb {
         ]);
       }
 
+      if (params[0] === 'blackpink' && params[3] === 'album') {
+        return this.result<Row>([
+          {
+            release_id: BLACKPINK_DEADLINE_UNRESOLVED_RELEASE_ID,
+            entity_slug: 'blackpink',
+            normalized_release_title: 'deadline',
+            release_date: '2026-02-26',
+            stream: 'album',
+            payload: buildBlackpinkDeadlinePayload(
+              BLACKPINK_DEADLINE_UNRESOLVED_RELEASE_ID,
+              '2026-02-26',
+              'unresolved',
+              'unresolved',
+              'manual_override',
+            ),
+            generated_at: NOW,
+          } as unknown as Row,
+          {
+            release_id: BLACKPINK_DEADLINE_VERIFIED_RELEASE_ID,
+            entity_slug: 'blackpink',
+            normalized_release_title: 'deadline',
+            release_date: '2026-02-27',
+            stream: 'album',
+            payload: buildBlackpinkDeadlinePayload(
+              BLACKPINK_DEADLINE_VERIFIED_RELEASE_ID,
+              '2026-02-27',
+              'verified',
+              'verified',
+              'canonical',
+            ),
+            generated_at: NOW,
+          } as unknown as Row,
+        ]);
+      }
+
       return this.result<Row>([]);
     }
 
@@ -574,6 +681,26 @@ class FakeDb {
             release_date: '2026-02-23',
             stream: 'album',
             payload: buildReleaseDetailPayload(IVE_RELEASE_ID),
+            generated_at: NOW,
+          } as unknown as Row,
+        ]);
+      }
+
+      if (releaseId === BLACKPINK_DEADLINE_VERIFIED_RELEASE_ID) {
+        return this.result<Row>([
+          {
+            release_id: BLACKPINK_DEADLINE_VERIFIED_RELEASE_ID,
+            entity_slug: 'blackpink',
+            normalized_release_title: 'deadline',
+            release_date: '2026-02-27',
+            stream: 'album',
+            payload: buildBlackpinkDeadlinePayload(
+              BLACKPINK_DEADLINE_VERIFIED_RELEASE_ID,
+              '2026-02-27',
+              'verified',
+              'verified',
+              'canonical',
+            ),
             generated_at: NOW,
           } as unknown as Row,
         ]);
@@ -1066,6 +1193,28 @@ test('GET /v1/releases/lookup resolves legacy key to release id', async (t) => {
   assert.equal(body.data.release_id, IVE_RELEASE_ID);
   assert.equal(body.data.canonical_path, `/v1/releases/${IVE_RELEASE_ID}`);
   assert.equal(body.data.release.release_title, 'REVIVE+');
+});
+
+test('GET /v1/releases/lookup prefers adjacent verified candidate over sparse exact duplicate', async (t) => {
+  const app = createTestApp(t);
+  const response = await app.inject({
+    method: 'GET',
+    url: '/v1/releases/lookup',
+    query: {
+      entity_slug: 'BLACKPINK',
+      title: 'DEADLINE',
+      date: '2026-02-26',
+      stream: 'album',
+    },
+  });
+
+  assert.equal(response.statusCode, 200);
+  const body = parseJson(response);
+  assertReadMeta(body.meta, '/v1/releases/lookup');
+  assert.equal(body.data.release_id, BLACKPINK_DEADLINE_VERIFIED_RELEASE_ID);
+  assert.equal(body.data.canonical_path, `/v1/releases/${BLACKPINK_DEADLINE_VERIFIED_RELEASE_ID}`);
+  assert.equal(body.data.release.release_date, '2026-02-27');
+  assert.equal(body.data.release.release_title, 'DEADLINE');
 });
 
 test('GET /v1/releases/:id returns release detail payload with title tracks', async (t) => {

--- a/backend/src/routes/releases.ts
+++ b/backend/src/routes/releases.ts
@@ -94,6 +94,19 @@ type ReleaseLookupData = {
   release: ReleaseCore;
 };
 
+type ReleaseLookupResolution = {
+  row: ReleaseDetailProjectionRow;
+  data: ReleaseLookupData;
+};
+
+type ScoredReleaseLookupCandidate = {
+  row: ReleaseDetailProjectionRow;
+  data: ReleaseLookupData;
+  detail: ReleaseDetailData;
+  score: number;
+  dayDistance: number;
+};
+
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 const VALID_STREAMS = new Set(['album', 'song']);
@@ -267,6 +280,96 @@ function buildLookupData(row: ReleaseDetailProjectionRow): ReleaseLookupData | n
   };
 }
 
+function getVerificationRank(status: string | null): number {
+  switch (status) {
+    case 'verified':
+      return 4;
+    case 'manual_override':
+      return 3;
+    case 'relation_match':
+      return 2;
+    case 'inferred':
+    case 'needs_review':
+      return 1;
+    default:
+      return 0;
+  }
+}
+
+function getServiceLinkRank(link: ServiceLink | null): number {
+  if (link === null) {
+    return 0;
+  }
+  return getVerificationRank(link.status ?? null);
+}
+
+function getDayDistance(lookupDate: string, candidateDate: string): number {
+  const lookupTime = Date.parse(`${lookupDate}T00:00:00Z`);
+  const candidateTime = Date.parse(`${candidateDate}T00:00:00Z`);
+  if (!Number.isFinite(lookupTime) || !Number.isFinite(candidateTime)) {
+    return Number.POSITIVE_INFINITY;
+  }
+  return Math.abs(candidateTime - lookupTime) / 86_400_000;
+}
+
+function scoreReleaseLookupCandidate(candidate: ReleaseDetailData, lookupDate: string): number {
+  const detailRank = getVerificationRank(candidate.detail_metadata.status);
+  const titleRank = getVerificationRank(candidate.title_track_metadata.status);
+  const mvRank = getVerificationRank(candidate.mv.status);
+  const spotifyRank = getServiceLinkRank(candidate.service_links.spotify);
+  const youtubeMusicRank = getServiceLinkRank(candidate.service_links.youtube_music);
+  const trackCountBonus = Math.min(candidate.tracks.length, 12);
+  const exactDateBonus = candidate.release.release_date === lookupDate ? 5 : 0;
+
+  return detailRank * 100 + titleRank * 40 + mvRank * 15 + spotifyRank * 6 + youtubeMusicRank * 6 + trackCountBonus + exactDateBonus;
+}
+
+function resolveReleaseLookupCandidate(
+  rows: ReleaseDetailProjectionRow[],
+  lookupDate: string,
+): ReleaseLookupResolution | null {
+  const candidates = rows
+    .map((row) => {
+      const detail = normalizeReleaseDetailPayload(row.payload, row.release_id);
+      if (detail === null) {
+        return null;
+      }
+
+      const lookupData: ReleaseLookupData = {
+        release_id: row.release_id,
+        canonical_path: `/v1/releases/${row.release_id}`,
+        release: detail.release,
+      };
+
+      return {
+        row,
+        data: lookupData,
+        detail,
+        score: scoreReleaseLookupCandidate(detail, lookupDate),
+        dayDistance: getDayDistance(lookupDate, detail.release.release_date),
+      };
+    })
+    .filter((candidate): candidate is ScoredReleaseLookupCandidate => candidate !== null)
+    .sort((left, right) => {
+      if (left.score !== right.score) {
+        return right.score - left.score;
+      }
+      if (left.dayDistance !== right.dayDistance) {
+        return left.dayDistance - right.dayDistance;
+      }
+      return right.data.release.release_date.localeCompare(left.data.release.release_date);
+    });
+
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  return {
+    row: candidates[0].row,
+    data: candidates[0].data,
+  };
+}
+
 export function registerReleaseRoutes(app: FastifyInstance, context: ReleaseRouteContext): void {
   app.get('/v1/releases/lookup', async (request) => {
     const { entity_slug, title, date, stream } = request.query as ReleaseLookupQuery;
@@ -305,15 +408,16 @@ export function registerReleaseRoutes(app: FastifyInstance, context: ReleaseRout
         from release_detail_projection
         where entity_slug = $1
           and normalized_release_title = projection_normalize_text($2)
-          and release_date = $3::date
           and stream = $4
-        limit 1
+          and release_date between ($3::date - interval '1 day') and ($3::date + interval '1 day')
+        order by release_date desc
+        limit 5
       `,
       [lookup.entity_slug, lookup.normalized_release_title, lookup.release_date, lookup.stream]
     );
 
-    const row = result.rows[0];
-    if (!row) {
+    const resolution = resolveReleaseLookupCandidate(result.rows, lookup.release_date);
+    if (!resolution) {
       throw routeError(404, 'not_found', 'No release matched the supplied legacy lookup key.', {
         lookup: {
           entity_slug,
@@ -324,15 +428,10 @@ export function registerReleaseRoutes(app: FastifyInstance, context: ReleaseRout
       });
     }
 
-    const data = buildLookupData(row);
-    if (data === null) {
-      throw routeError(500, 'stale_projection', 'release_detail_projection returned an unexpected payload shape.');
-    }
-
     return buildReadDataEnvelope(
       request,
       context.config.appTimezone,
-      data,
+      resolution.data,
       {
         lookup: {
           entity_slug,
@@ -341,7 +440,7 @@ export function registerReleaseRoutes(app: FastifyInstance, context: ReleaseRout
           stream,
         },
       },
-      toIsoString(row.generated_at),
+      toIsoString(resolution.row.generated_at),
     );
   });
 

--- a/docs/specs/backend/shared-read-api-contracts.md
+++ b/docs/specs/backend/shared-read-api-contracts.md
@@ -445,6 +445,7 @@ lookup helper:
 용도:
 
 - legacy JSON exact key에서 API `release_id`로 넘어가는 migration helper
+- exact key가 sparse duplicate row를 가리켜도, 같은 `entity_slug + normalized release_title + stream` 조합에서 `±1일` 안의 richer canonical candidate가 있으면 그 row로 canonicalize한다
 
 lookup helper response:
 


### PR DESCRIPTION
## Summary
- make  reconcile adjacent duplicate release rows and prefer the richer canonical candidate
- lock the BLACKPINK DEADLINE duplicate-date regression in backend route-contract tests
- document the adjacent-day canonicalization rule in the shared read API contract

## Verification
- cd backend && npm run build
- cd backend && npx tsx --test ./src/route-contract.test.ts ./src/runtime-failures.test.ts ./src/lib/logging.test.ts
- source ~/.config/idol-song-app/neon.env && PORT=3226 APP_TIMEZONE=Asia/Seoul npm run start
- curl "http://127.0.0.1:3226/v1/releases/lookup?entity_slug=BLACKPINK&title=DEADLINE&date=2026-02-26&stream=album"
- curl "http://127.0.0.1:3226/v1/releases/75d59b7a-9f0e-526c-9920-3a156c1a9e36"
- cd web && npm run lint && npm run build
- git diff --check

Closes #387