### PR TITLE
Apply radar degraded and partial state handling

### DIFF
--- a/mobile/app/(tabs)/radar.tsx
+++ b/mobile/app/(tabs)/radar.tsx
@@ -35,7 +35,13 @@ import type {
 type RadarScreenState =
   | { kind: 'loading' }
   | { kind: 'error'; message: string }
-  | { kind: 'ready'; source: ActiveMobileDataset; snapshot: RadarSnapshotModel };
+  | {
+      kind: 'ready';
+      source: ActiveMobileDataset;
+      snapshot: RadarSnapshotModel;
+      dataState: 'default' | 'partial' | 'degraded';
+      partialSections: string[];
+    };
 
 function formatUpcomingMeta(card: RadarUpcomingCardModel): string {
   const status = card.upcoming.status ?? '예정';
@@ -74,6 +80,61 @@ function buildLongGapAccessibilityLabel(item: RadarLongGapItemModel): string {
 
 function buildRookieAccessibilityLabel(item: RadarRookieItemModel): string {
   return `${item.team.displayName} 팀 열기, ${formatRookieMeta(item)}`;
+}
+
+function buildRadarPartialSections(snapshot: RadarSnapshotModel): string[] {
+  const sections = new Set<string>();
+
+  if (snapshot.featuredUpcoming && !snapshot.featuredUpcoming.upcoming.releaseLabel) {
+    sections.add('가장 가까운 컴백');
+  }
+
+  if (snapshot.weeklyUpcoming.some((item) => !item.upcoming.confidence)) {
+    sections.add('이번 주 예정');
+  }
+
+  if (snapshot.changeFeed.some((item) => !item.sourceUrl)) {
+    sections.add('일정 변경');
+  }
+
+  if (snapshot.longGap.some((item) => !item.latestRelease)) {
+    sections.add('장기 공백 레이더');
+  }
+
+  if (snapshot.rookie.some((item) => !item.latestRelease)) {
+    sections.add('루키 레이더');
+  }
+
+  return [...sections];
+}
+
+function resolveRadarDataState(
+  source: ActiveMobileDataset,
+  partialSections: string[],
+): 'default' | 'partial' | 'degraded' {
+  if (source.runtimeState.mode === 'degraded' || source.issues.length > 0) {
+    return 'degraded';
+  }
+
+  if (partialSections.length > 0) {
+    return 'partial';
+  }
+
+  return 'default';
+}
+
+function buildRadarDegradedBody(source: ActiveMobileDataset): string {
+  const issueSummary =
+    source.issues.length > 0 ? ` 현재 상태: ${source.issues.join(' / ')}.` : '';
+  return `최근 데이터 동기화가 완전하지 않아 일부 레이더 정보만 표시됩니다.${issueSummary} 다시 시도해 최신 상태를 확인하세요.`;
+}
+
+function buildRadarPartialBody(partialSections: string[]): string {
+  if (partialSections.length === 1) {
+    return `${partialSections[0]} 섹션은 아직 일부 정보만 표시됩니다. 가능한 범위 안에서 최소 카드만 유지합니다.`;
+  }
+
+  return `${partialSections.join(', ')} 섹션은 아직 일부 정보만 표시됩니다. 가능한 범위 안에서 최소 카드만 유지합니다.`;
 }
 
 export default function RadarTabScreen() {
@@ -116,10 +177,15 @@ export default function RadarTabScreen() {
           }
         }
 
+        const snapshot = selectRadarSnapshot(source.dataset, todayIsoDate);
+        const partialSections = buildRadarPartialSections(snapshot);
+
         setState({
           kind: 'ready',
           source,
-          snapshot: selectRadarSnapshot(source.dataset, todayIsoDate),
+          snapshot,
+          dataState: resolveRadarDataState(source, partialSections),
+          partialSections,
         });
       })
       .catch((error: unknown) => {
@@ -191,6 +257,7 @@ export default function RadarTabScreen() {
         action={{
           label: '다시 시도',
           onPress: () => setReloadCount((count) => count + 1),
+          testID: 'radar-error-retry',
         }}
         body={state.message}
         eyebrow="LOAD ERROR"
@@ -200,7 +267,7 @@ export default function RadarTabScreen() {
     );
   }
 
-  const { snapshot, source } = state;
+  const { dataState, partialSections, snapshot, source } = state;
 
   return (
     <ScrollView style={styles.screen} contentContainerStyle={styles.content}>
@@ -239,6 +306,27 @@ export default function RadarTabScreen() {
           </Pressable>
         </View>
       </View>
+
+      {dataState === 'degraded' ? (
+        <InlineFeedbackNotice
+          action={{
+            label: '다시 시도',
+            onPress: () => setReloadCount((count) => count + 1),
+            testID: 'radar-degraded-retry',
+          }}
+          body={buildRadarDegradedBody(source)}
+          testID="radar-degraded-notice"
+          title="발매 후 정보 보강 중"
+        />
+      ) : null}
+
+      {partialSections.length > 0 ? (
+        <InlineFeedbackNotice
+          body={buildRadarPartialBody(partialSections)}
+          testID="radar-partial-notice"
+          title="일부 정보만 표시됩니다."
+        />
+      ) : null}
 
       <View style={styles.summaryStrip}>
         <View style={styles.summaryCard}>

--- a/mobile/src/features/radarTab.test.tsx
+++ b/mobile/src/features/radarTab.test.tsx
@@ -1,27 +1,119 @@
+import React from 'react';
 import renderer, { act } from 'react-test-renderer';
+import { Text } from 'react-native';
 
 import RadarTabScreen from '../../app/(tabs)/radar';
+import { type RuntimeConfigState } from '../config/runtime';
+import { selectRadarSnapshot } from '../selectors';
+import {
+  loadActiveMobileDataset,
+  type ActiveMobileDataset,
+} from '../services/activeDataset';
+import { trackDatasetDegraded, trackDatasetLoadFailed } from '../services/analytics';
+import { cloneBundledDatasetFixture } from '../services/bundledDatasetFixture';
+import { createBundledDatasetSelection } from '../services/datasetSource';
 
 jest.mock('expo-router', () => {
   const useLocalSearchParams = jest.fn(() => ({}));
+  const push = jest.fn();
+  const setParams = jest.fn();
 
   return {
     useRouter: () => ({
-      push: jest.fn(),
-      setParams: jest.fn(),
+      push,
+      setParams,
     }),
     useLocalSearchParams,
     __mock: {
+      push,
+      setParams,
       useLocalSearchParams,
     },
   };
 });
 
+jest.mock('../services/activeDataset', () => {
+  const actual = jest.requireActual('../services/activeDataset');
+
+  return {
+    ...actual,
+    loadActiveMobileDataset: jest.fn(),
+  };
+});
+
+jest.mock('../selectors', () => {
+  const actual = jest.requireActual('../selectors');
+
+  return {
+    ...actual,
+    selectRadarSnapshot: jest.fn(actual.selectRadarSnapshot),
+  };
+});
+
+jest.mock('../services/analytics', () => ({
+  trackDatasetDegraded: jest.fn(),
+  trackDatasetLoadFailed: jest.fn(),
+}));
+
 const { __mock } = jest.requireMock('expo-router') as {
   __mock: {
+    push: jest.Mock;
+    setParams: jest.Mock;
     useLocalSearchParams: jest.Mock;
   };
 };
+
+const mockLoadActiveMobileDataset = jest.mocked(loadActiveMobileDataset);
+const mockSelectRadarSnapshot = jest.mocked(selectRadarSnapshot);
+const mockTrackDatasetDegraded = jest.mocked(trackDatasetDegraded);
+const mockTrackDatasetLoadFailed = jest.mocked(trackDatasetLoadFailed);
+
+function createRuntimeState(
+  overrides: Partial<RuntimeConfigState> = {},
+): RuntimeConfigState {
+  return {
+    mode: 'normal',
+    issues: [],
+    config: {
+      profile: 'development',
+      dataSource: {
+        mode: 'bundled-static',
+        remoteDatasetUrl: null,
+        datasetVersion: 'fixture-v1',
+      },
+      services: {
+        apiBaseUrl: null,
+        analyticsWriteKey: null,
+      },
+      logging: {
+        level: 'verbose',
+      },
+      featureGates: {
+        radar: true,
+        analytics: false,
+        remoteRefresh: false,
+        mvEmbed: true,
+        shareActions: true,
+      },
+      build: {
+        version: '0.1.0',
+        commitSha: 'test-sha',
+      },
+    },
+    ...overrides,
+  };
+}
+
+function createSource(overrides: Partial<ActiveMobileDataset> = {}): ActiveMobileDataset {
+  return {
+    dataset: cloneBundledDatasetFixture(),
+    selection: createBundledDatasetSelection('fixture-v1', 'profile_default'),
+    runtimeState: createRuntimeState(),
+    sourceLabel: 'Bundled static dataset',
+    issues: [],
+    ...overrides,
+  };
+}
 
 async function renderRadarScreen() {
   let tree: renderer.ReactTestRenderer;
@@ -35,9 +127,25 @@ async function renderRadarScreen() {
   return tree!;
 }
 
+function hasText(tree: renderer.ReactTestRenderer, value: string): boolean {
+  return tree.root.findAllByType(Text).some((node) => node.props.children === value);
+}
+
 describe('mobile radar tab', () => {
   beforeEach(() => {
     __mock.useLocalSearchParams.mockReturnValue({});
+    __mock.push.mockClear();
+    __mock.setParams.mockClear();
+    mockLoadActiveMobileDataset.mockClear();
+    mockSelectRadarSnapshot.mockClear();
+    mockTrackDatasetDegraded.mockClear();
+    mockTrackDatasetLoadFailed.mockClear();
+    mockLoadActiveMobileDataset.mockResolvedValue(createSource());
+
+    const actualSelectors = jest.requireActual('../selectors') as typeof import('../selectors');
+    mockSelectRadarSnapshot.mockImplementation((input, todayIsoDate) =>
+      actualSelectors.selectRadarSnapshot(input, todayIsoDate),
+    );
   });
 
   test('renders radar sections from shared selector data', async () => {
@@ -48,6 +156,109 @@ describe('mobile radar tab', () => {
     expect(tree.root.findByProps({ testID: 'radar-weekly-card-yena' })).toBeDefined();
     expect(tree.root.findByProps({ testID: 'radar-long-gap-card-weeekly' })).toBeDefined();
     expect(tree.root.findByProps({ testID: 'radar-rookie-card-atheart' })).toBeDefined();
+    expect(tree.root.findAllByProps({ testID: 'radar-degraded-notice' })).toHaveLength(0);
+    expect(tree.root.findAllByProps({ testID: 'radar-partial-notice' })).toHaveLength(0);
+  });
+
+  test('shows a degraded-state notice while keeping usable cards visible', async () => {
+    mockLoadActiveMobileDataset.mockResolvedValue(
+      createSource({
+        runtimeState: createRuntimeState({ mode: 'degraded' }),
+        issues: ['Preview remote dataset is unavailable.'],
+        sourceLabel: 'Bundled static dataset',
+      }),
+    );
+
+    const tree = await renderRadarScreen();
+
+    expect(tree.root.findByProps({ testID: 'radar-degraded-notice' })).toBeDefined();
+    expect(tree.root.findByProps({ testID: 'radar-featured-card' })).toBeDefined();
+    expect(mockTrackDatasetDegraded).toHaveBeenCalledWith(
+      'radar',
+      expect.objectContaining({
+        issues: ['Preview remote dataset is unavailable.'],
+      }),
+    );
+    const loadCallsBeforeRetry = mockLoadActiveMobileDataset.mock.calls.length;
+
+    await act(async () => {
+      tree.root.findByProps({ testID: 'radar-degraded-retry' }).props.onPress();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockLoadActiveMobileDataset.mock.calls.length).toBe(loadCallsBeforeRetry + 1);
+  });
+
+  test('surfaces a partial-data notice without blocking section fallback rendering', async () => {
+    const source = createSource();
+    const actualSelectors = jest.requireActual('../selectors') as typeof import('../selectors');
+    const baseSnapshot = actualSelectors.selectRadarSnapshot(source.dataset, '2026-03-09');
+
+    mockLoadActiveMobileDataset.mockResolvedValue(source);
+    mockSelectRadarSnapshot.mockReturnValue({
+      ...baseSnapshot,
+      featuredUpcoming: baseSnapshot.featuredUpcoming
+        ? {
+            ...baseSnapshot.featuredUpcoming,
+            upcoming: {
+              ...baseSnapshot.featuredUpcoming.upcoming,
+              releaseLabel: undefined,
+            },
+          }
+        : null,
+      weeklyUpcoming: baseSnapshot.weeklyUpcoming.map((item, index) =>
+        index === 0
+          ? {
+              ...item,
+              upcoming: {
+                ...item.upcoming,
+                confidence: undefined,
+              },
+            }
+          : item,
+      ),
+      longGap: baseSnapshot.longGap.map((item, index) =>
+        index === 0
+          ? {
+              ...item,
+              latestRelease: null,
+            }
+          : item,
+      ),
+    });
+
+    const tree = await renderRadarScreen();
+
+    expect(tree.root.findByProps({ testID: 'radar-partial-notice' })).toBeDefined();
+    expect(hasText(tree, 'YENA confirms a March 11 comeback')).toBe(true);
+    expect(hasText(tree, '가장 가까운 컴백, 이번 주 예정, 장기 공백 레이더 섹션은 아직 일부 정보만 표시됩니다. 가능한 범위 안에서 최소 카드만 유지합니다.')).toBe(true);
+    expect(tree.root.findByProps({ testID: 'radar-long-gap-card-weeekly' })).toBeDefined();
+  });
+
+  test('renders retryable blocking feedback when the dataset cannot be loaded at all', async () => {
+    mockLoadActiveMobileDataset
+      .mockRejectedValueOnce(new Error('Radar dataset could not be loaded right now.'))
+      .mockResolvedValue(createSource());
+
+    const tree = await renderRadarScreen();
+
+    expect(tree.root.findByProps({ testID: 'radar-error-retry' })).toBeDefined();
+    expect(hasText(tree, 'Radar dataset could not be loaded right now.')).toBe(true);
+    expect(mockTrackDatasetLoadFailed).toHaveBeenCalledWith(
+      'radar',
+      'Radar dataset could not be loaded right now.',
+    );
+    const loadCallsBeforeRetry = mockLoadActiveMobileDataset.mock.calls.length;
+
+    await act(async () => {
+      tree.root.findByProps({ testID: 'radar-error-retry' }).props.onPress();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockLoadActiveMobileDataset.mock.calls.length).toBe(loadCallsBeforeRetry + 1);
+    expect(tree.root.findByProps({ testID: 'radar-featured-card' })).toBeDefined();
   });
 
   test('restores the hide-empty toggle state from route params', async () => {


### PR DESCRIPTION
## Summary
- add degraded and partial data notices to the mobile radar tab while keeping section-level empty states localized
- keep blocking dataset failures on a full-screen retry state and add regression tests for degraded, partial, and retry flows
- preserve hide-empty behavior while ensuring partial sections still render minimum cards

Closes #445