### PR TITLE
Harden mobile dataset disclosures and RN audit

### DIFF
--- a/docs/specs/mobile/README.md
+++ b/docs/specs/mobile/README.md
@@ -90,13 +90,17 @@
    - 외부 서비스/데이터 의존 리스크와 완화 전략
 42. `accessibility-audit-2026-03-09.md`
    - 구현된 모바일 화면에 대한 접근성/동적 글자 크기 점검 기록
+43. `decision-log-review-checklist.md`
+   - 결정 로그 기준 구현 점검 체크리스트
+44. `rn-implementation-audit-2026-03-10.md`
+   - RN 구현 중복/신뢰도 경로 감사 기록
 
 ### Screen Specs
-43. `calendar-screen.md`
-44. `radar-screen.md`
-45. `search-screen.md`
-46. `team-detail-screen.md`
-47. `release-detail-screen.md`
+45. `calendar-screen.md`
+46. `radar-screen.md`
+47. `search-screen.md`
+48. `team-detail-screen.md`
+49. `release-detail-screen.md`
 
 ## 읽는 순서
 1. `master-spec.md`
@@ -138,9 +142,11 @@
 37. `state-restoration-spec.md`
 38. `feature-gate-matrix.md`
 39. `external-dependency-risk-spec.md`
-40. 각 화면 스펙
-41. `edge-case-catalog.md`
-42. `qa-acceptance-spec.md`
+40. `decision-log-review-checklist.md`
+41. `rn-implementation-audit-2026-03-10.md`
+42. 각 화면 스펙
+43. `edge-case-catalog.md`
+44. `qa-acceptance-spec.md`
 
 ## 구현 원칙
 - 모바일은 웹과 다른 레이아웃을 사용한다.

--- a/docs/specs/mobile/decision-log-review-checklist.md
+++ b/docs/specs/mobile/decision-log-review-checklist.md
@@ -1,0 +1,38 @@
+# Decision Log Review Checklist
+
+이 체크리스트는 모바일 구현이 [decision-log.md](/Users/gimtaehun/Desktop/idol-song-app/docs/specs/mobile/decision-log.md)의 고정 판단을 어기지 않는지 빠르게 점검하기 위한 것이다.
+
+## 공통 체크
+
+- `D-01` 앱 내 직접 음원 재생 미지원
+  - 화면이 raw audio playback UI를 새로 만들지 않았는가
+  - 서비스 handoff만 제공하는가
+- `D-02` 외부 서비스 handoff 우선
+  - Spotify / YouTube Music / YouTube MV 이동 경로가 살아 있는가
+  - canonical / search fallback / browser fallback 규칙이 유지되는가
+- `D-03` 팀 페이지는 실용 허브
+  - 팀 상세 순서가 `다음 컴백 -> 최신 발매 -> 최근 앨범`을 유지하는가
+- `D-04` 앨범 상세는 독립 소비 화면
+  - release detail이 팀 페이지 보조 패널로 축소되지 않았는가
+  - 트랙/서비스/MV 상태가 독립적으로 보이는가
+- `D-05` 날짜 drill-in은 bottom sheet
+  - calendar 탭이 full route push 대신 sheet drill-in을 유지하는가
+- `D-07` alias-aware search
+  - 한글명, 약칭, 표기 변형 검색 결과가 끊기지 않는가
+- `D-08` 태그는 액션이 아님
+  - chip/status badge가 button처럼 동작하지 않는가
+- `D-09` 레이더의 주 CTA는 팀 페이지
+  - radar 카드에서 팀 진입이 서비스 액션보다 앞서는가
+
+## 데이터 / 신뢰도 체크
+
+- dataset degraded/error 처리가 화면마다 복제되지 않았는가
+- source confidence / external dependency notice가 필요한 surface에서 빠지지 않았는가
+- 없는 데이터를 placeholder로 꾸며서 있는 것처럼 보이게 하지 않았는가
+- fallback은 명시적 notice로 보이고, silent substitution이 아닌가
+
+## 테스트 체크
+
+- 변경한 surface에 screen-level regression test가 있는가
+- shared helper를 도입했다면 helper 단위 테스트가 있는가
+- route/export smoke가 깨지지 않는가

--- a/docs/specs/mobile/rn-implementation-audit-2026-03-10.md
+++ b/docs/specs/mobile/rn-implementation-audit-2026-03-10.md
@@ -1,0 +1,32 @@
+# RN Implementation Audit 2026-03-10
+
+대상 이슈: `#463`, `#464`, `#465`
+
+## 목적
+
+React Native 구현이 모바일 결정 로그와 비기능 요구를 얼마나 일관되게 따르고 있는지 점검하고, 중복 구현이나 source-confidence 불일치를 줄이는 데 목적이 있다.
+
+## 확인 결과
+
+- `calendar`, `search`, `radar`, `entity detail`, `release detail` 5개 주요 surface가 모두 같은 dataset loading 패턴을 반복하고 있었다.
+- degraded / error analytics와 event dedupe 로직이 화면별로 복제되어 유지보수성이 낮았다.
+- source-confidence / external dependency disclosure는 화면별 기준이 조금씩 달랐고, 일부는 아예 없었다.
+- 결정 로그 핵심 판단 자체를 뒤집는 구현은 찾지 못했다.
+  - 앱 내 직접 재생 추가 없음
+  - 팀 페이지 실용 허브 순서 유지
+  - release detail 독립 소비 화면 유지
+  - calendar bottom sheet drill-in 유지
+  - alias-aware search 유지
+
+## 이번 정리로 바뀐 점
+
+- `useActiveDatasetScreen`으로 dataset load/degraded/error analytics 경로를 중앙화했다.
+- `surfaceDisclosures` helper로 dataset risk, entity source confidence, release dependency disclosure를 공통화했다.
+- 5개 주요 surface가 같은 degraded/error/fallback 언어와 구조를 쓰도록 맞췄다.
+- release detail / entity detail은 데이터 공백을 placeholder로 숨기지 않고 explicit notice로 노출한다.
+
+## 남은 운영 규칙
+
+- 새 surface가 dataset을 직접 로드할 경우 shared hook으로 올릴 수 있는지 먼저 검토한다.
+- source-confidence / external dependency 관련 새 notice는 `surfaceDisclosures.ts` 확장을 우선한다.
+- 결정 로그 변경이 없으면 화면 스펙보다 checklist 기준으로 회귀를 막는다.

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -8,6 +8,8 @@
 - route/param 계약은 `docs/specs/mobile/route-param-contracts.md`를 따른다.
 - 세부 모듈 구조는 `docs/specs/mobile/implementation-work-breakdown.md`를 따른다.
 - 접근성 점검 기록은 `docs/specs/mobile/accessibility-audit-2026-03-09.md`를 따른다.
+- decision-log 구현 점검 기준은 `docs/specs/mobile/decision-log-review-checklist.md`를 따른다.
+- RN 구현 감사 메모는 `docs/specs/mobile/rn-implementation-audit-2026-03-10.md`를 따른다.
 
 ## 현재 포함 범위
 
@@ -44,6 +46,10 @@
   - bundled static data vs preview remote data selection layer
 - `src/services/activeDataset.ts`
   - active dataset source resolution + dataset load entrypoint
+- `src/features/useActiveDatasetScreen.ts`
+  - dataset loading / degraded analytics / error handling 공통 hook
+- `src/features/surfaceDisclosures.ts`
+  - dataset risk / source confidence / external dependency notice 공통 helper
 - `src/services/datasetFailurePolicy.ts`
   - runtime misconfiguration / remote dataset unavailable fallback policy
 - `src/services/storage.ts`

--- a/mobile/app/(tabs)/calendar.tsx
+++ b/mobile/app/(tabs)/calendar.tsx
@@ -1,5 +1,5 @@
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import {
   Modal,
   Pressable,
@@ -18,25 +18,19 @@ import {
   resolveInitialCalendarSelection,
   resolveNextCalendarSelection,
 } from '../../src/features/calendarGrid';
+import { buildDatasetRiskDisclosure } from '../../src/features/surfaceDisclosures';
 import {
   areRouteParamsEqual,
   buildCalendarRouteParams,
   resolveCalendarRouteState,
   type CalendarFilterMode,
 } from '../../src/features/routeState';
+import { useActiveDatasetScreen } from '../../src/features/useActiveDatasetScreen';
 import {
   selectCalendarMonthSnapshot,
   selectNearestExactUpcomingEvent,
 } from '../../src/selectors';
-import {
-  loadActiveMobileDataset,
-  type ActiveMobileDataset,
-} from '../../src/services/activeDataset';
-import {
-  trackAnalyticsEvent,
-  trackDatasetDegraded,
-  trackDatasetLoadFailed,
-} from '../../src/services/analytics';
+import { trackAnalyticsEvent } from '../../src/services/analytics';
 import { useAppTheme } from '../../src/tokens/theme';
 import type {
   CalendarDayBadgeKind,
@@ -45,20 +39,6 @@ import type {
   ReleaseSummaryModel,
   UpcomingEventModel,
 } from '../../src/types';
-
-type CalendarScreenState =
-  | {
-      kind: 'loading';
-    }
-  | {
-      kind: 'error';
-      message: string;
-    }
-  | {
-      kind: 'ready' | 'empty';
-      source: ActiveMobileDataset;
-      snapshot: CalendarMonthSnapshotModel;
-    };
 
 function buildMonthKey(date: Date): string {
   const year = date.getFullYear();
@@ -210,7 +190,6 @@ export default function CalendarTabScreen() {
   }>();
   const theme = useAppTheme();
   const [reloadCount, setReloadCount] = useState(0);
-  const [state, setState] = useState<CalendarScreenState>({ kind: 'loading' });
   const today = useMemo(() => new Date(), []);
   const currentMonth = useMemo(() => buildMonthKey(today), [today]);
   const todayIsoDate = useMemo(() => today.toISOString().slice(0, 10), [today]);
@@ -222,8 +201,12 @@ export default function CalendarTabScreen() {
   const [filterMode, setFilterMode] = useState<CalendarFilterMode>(routeState.filterMode);
   const [selectedDayIso, setSelectedDayIso] = useState<string | null>(routeState.selectedDayIso);
   const [isSheetOpen, setIsSheetOpen] = useState(routeState.isSheetOpen);
+  const datasetState = useActiveDatasetScreen({
+    surface: 'calendar',
+    reloadKey: reloadCount,
+    fallbackErrorMessage: 'Calendar dataset could not be loaded right now.',
+  });
   const styles = useMemo(() => createStyles(theme), [theme]);
-  const datasetEventKeyRef = useRef<string | null>(null);
 
   useEffect(() => {
     setActiveMonth(routeState.activeMonth);
@@ -237,65 +220,11 @@ export default function CalendarTabScreen() {
     routeState.selectedDayIso,
   ]);
 
-  useEffect(() => {
-    let cancelled = false;
-    setState({ kind: 'loading' });
-
-    void loadActiveMobileDataset()
-      .then((source) => {
-        if (cancelled) {
-          return;
-        }
-
-        const datasetEventKey =
-          source.runtimeState.mode === 'degraded' || source.issues.length > 0
-            ? `degraded:${source.selection.kind}:${source.runtimeState.mode}:${source.issues.join('|')}`
-            : `ready:${source.selection.kind}`;
-        if (datasetEventKeyRef.current !== datasetEventKey) {
-          datasetEventKeyRef.current = datasetEventKey;
-          if (source.runtimeState.mode === 'degraded' || source.issues.length > 0) {
-            trackDatasetDegraded('calendar', source);
-          }
-        }
-
-        const snapshot = selectCalendarMonthSnapshot(source.dataset, activeMonth, todayIsoDate);
-        const nextKind =
-          snapshot.releaseCount === 0 && snapshot.upcomingCount === 0 ? 'empty' : 'ready';
-
-        setState({
-          kind: nextKind,
-          source,
-          snapshot,
-        });
-      })
-      .catch((error: unknown) => {
-        if (cancelled) {
-          return;
-        }
-
-        const message =
-          error instanceof Error
-            ? error.message
-            : 'Calendar dataset could not be loaded right now.';
-        const datasetEventKey = `error:${message}`;
-        if (datasetEventKeyRef.current !== datasetEventKey) {
-          datasetEventKeyRef.current = datasetEventKey;
-          trackDatasetLoadFailed('calendar', message);
-        }
-
-        setState({
-          kind: 'error',
-          message,
-        });
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [activeMonth, reloadCount, todayIsoDate]);
-
-  const snapshot = state.kind === 'ready' || state.kind === 'empty' ? state.snapshot : null;
-  const source = state.kind === 'ready' || state.kind === 'empty' ? state.source : null;
+  const source = datasetState.kind === 'ready' ? datasetState.source : null;
+  const snapshot = useMemo(
+    () => (source ? selectCalendarMonthSnapshot(source.dataset, activeMonth, todayIsoDate) : null),
+    [activeMonth, source, todayIsoDate],
+  );
   const globalNearestUpcoming = useMemo(() => {
     if (!source) {
       return null;
@@ -307,6 +236,9 @@ export default function CalendarTabScreen() {
     () => (snapshot ? applyCalendarFilter(snapshot, filterMode) : null),
     [filterMode, snapshot],
   );
+  const datasetRiskDisclosure = source
+    ? buildDatasetRiskDisclosure(source, '캘린더', 'calendar-dataset-risk-notice')
+    : null;
 
   useEffect(() => {
     if (!filteredSnapshot) {
@@ -453,7 +385,7 @@ export default function CalendarTabScreen() {
     setFilterMode(nextFilterMode);
   }
 
-  if (state.kind === 'loading') {
+  if (datasetState.kind === 'loading') {
     return (
       <ScreenFeedbackState
         body="현재 월 데이터와 예정 신호를 불러오는 중입니다."
@@ -464,14 +396,14 @@ export default function CalendarTabScreen() {
     );
   }
 
-  if (state.kind === 'error') {
+  if (datasetState.kind === 'error') {
     return (
       <ScreenFeedbackState
         action={{
           label: '다시 시도',
           onPress: () => setReloadCount((count) => count + 1),
         }}
-        body={state.message}
+        body={datasetState.message}
         eyebrow="LOAD ERROR"
         title="Calendar"
         variant="error"
@@ -480,7 +412,14 @@ export default function CalendarTabScreen() {
   }
 
   if (!filteredSnapshot || !source) {
-    return null;
+    return (
+      <ScreenFeedbackState
+        body="현재 월 데이터를 찾지 못했습니다."
+        eyebrow="EMPTY MONTH"
+        title="Calendar"
+        variant="empty"
+      />
+    );
   }
 
   return (
@@ -530,12 +469,17 @@ export default function CalendarTabScreen() {
           </Text>
         </View>
 
+        {datasetRiskDisclosure ? (
+          <InlineFeedbackNotice
+            body={datasetRiskDisclosure.body}
+            testID={datasetRiskDisclosure.testID}
+            title={datasetRiskDisclosure.title}
+          />
+        ) : null}
+
         <View style={styles.sourceCard}>
           <Text style={styles.sourceLabel}>Active source</Text>
           <Text style={styles.sourceValue}>{source.sourceLabel}</Text>
-          {source.issues.length ? (
-            <Text style={styles.sourceIssue}>{source.issues.join(' / ')}</Text>
-          ) : null}
         </View>
 
         <View style={styles.sectionCard}>
@@ -746,7 +690,7 @@ export default function CalendarTabScreen() {
               ))}
             </View>
 
-            {state.kind === 'empty' ? (
+            {filteredSnapshot.releaseCount === 0 && filteredSnapshot.upcomingCount === 0 ? (
               <InlineFeedbackNotice
                 body={`현재 dataset source에는 ${formatMonthLabel(filteredSnapshot.month)} 기준 발매나 예정 컴백이 없습니다.`}
               />

--- a/mobile/app/(tabs)/radar.tsx
+++ b/mobile/app/(tabs)/radar.tsx
@@ -1,5 +1,5 @@
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import {
   Linking,
   Modal,
@@ -14,6 +14,7 @@ import {
   InlineFeedbackNotice,
   ScreenFeedbackState,
 } from '../../src/components/feedback/FeedbackState';
+import { buildDatasetRiskDisclosure } from '../../src/features/surfaceDisclosures';
 import {
   areRouteParamsEqual,
   buildRadarRouteParams,
@@ -22,12 +23,9 @@ import {
   type RadarFilterStatus,
   type RadarSectionKey,
 } from '../../src/features/routeState';
+import { useActiveDatasetScreen } from '../../src/features/useActiveDatasetScreen';
 import { selectRadarSnapshot } from '../../src/selectors';
-import {
-  loadActiveMobileDataset,
-  type ActiveMobileDataset,
-} from '../../src/services/activeDataset';
-import { trackDatasetDegraded, trackDatasetLoadFailed } from '../../src/services/analytics';
+import { type ActiveMobileDataset } from '../../src/services/activeDataset';
 import { useAppTheme } from '../../src/tokens/theme';
 import type {
   RadarChangeFeedItemModel,
@@ -39,17 +37,6 @@ import type {
   UpcomingConfidence,
   UpcomingStatus,
 } from '../../src/types';
-
-type RadarScreenState =
-  | { kind: 'loading' }
-  | { kind: 'error'; message: string }
-  | {
-      kind: 'ready';
-      source: ActiveMobileDataset;
-      snapshot: RadarSnapshotModel;
-      dataState: 'default' | 'partial' | 'degraded';
-      partialSections: string[];
-    };
 
 const DEFAULT_ENABLED_SECTIONS: RadarSectionKey[] = ['weekly', 'change', 'longGap', 'rookie'];
 
@@ -182,12 +169,6 @@ function resolveRadarDataState(
   return 'default';
 }
 
-function buildRadarDegradedBody(source: ActiveMobileDataset): string {
-  const issueSummary =
-    source.issues.length > 0 ? ` 현재 상태: ${source.issues.join(' / ')}.` : '';
-  return `최근 데이터 동기화가 완전하지 않아 일부 레이더 정보만 표시됩니다.${issueSummary} 다시 시도해 최신 상태를 확인하세요.`;
-}
-
 function buildRadarPartialBody(partialSections: string[]): string {
   if (partialSections.length === 1) {
     return `${partialSections[0]} 섹션은 아직 일부 정보만 표시됩니다. 가능한 범위 안에서 최소 카드만 유지합니다.`;
@@ -279,8 +260,11 @@ export default function RadarTabScreen() {
   const [actTypeFilter, setActTypeFilter] = useState(routeState.actTypeFilter);
   const [enabledSections, setEnabledSections] = useState(routeState.enabledSections);
   const [isFilterSheetOpen, setIsFilterSheetOpen] = useState(false);
-  const [state, setState] = useState<RadarScreenState>({ kind: 'loading' });
-  const datasetEventKeyRef = useRef<string | null>(null);
+  const datasetState = useActiveDatasetScreen({
+    surface: 'radar',
+    reloadKey: reloadCount,
+    fallbackErrorMessage: 'Radar dataset could not be loaded right now.',
+  });
   const today = useMemo(() => new Date(), []);
   const todayIsoDate = useMemo(() => today.toISOString().slice(0, 10), [today]);
 
@@ -290,63 +274,21 @@ export default function RadarTabScreen() {
     setEnabledSections(routeState.enabledSections);
   }, [routeState]);
 
-  useEffect(() => {
-    let cancelled = false;
-    setState({ kind: 'loading' });
-
-    void loadActiveMobileDataset()
-      .then((source) => {
-        if (cancelled) {
-          return;
-        }
-
-        const datasetEventKey =
-          source.runtimeState.mode === 'degraded' || source.issues.length > 0
-            ? `degraded:${source.selection.kind}:${source.runtimeState.mode}:${source.issues.join('|')}`
-            : `ready:${source.selection.kind}`;
-        if (datasetEventKeyRef.current !== datasetEventKey) {
-          datasetEventKeyRef.current = datasetEventKey;
-          if (source.runtimeState.mode === 'degraded' || source.issues.length > 0) {
-            trackDatasetDegraded('radar', source);
-          }
-        }
-
-        const snapshot = selectRadarSnapshot(source.dataset, todayIsoDate);
-        const partialSections = buildRadarPartialSections(snapshot);
-
-        setState({
-          kind: 'ready',
-          source,
-          snapshot,
-          dataState: resolveRadarDataState(source, partialSections),
-          partialSections,
-        });
-      })
-      .catch((error: unknown) => {
-        if (cancelled) {
-          return;
-        }
-
-        const message =
-          error instanceof Error
-            ? error.message
-            : 'Radar dataset could not be loaded right now.';
-        const datasetEventKey = `error:${message}`;
-        if (datasetEventKeyRef.current !== datasetEventKey) {
-          datasetEventKeyRef.current = datasetEventKey;
-          trackDatasetLoadFailed('radar', message);
-        }
-
-        setState({
-          kind: 'error',
-          message,
-        });
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [reloadCount, todayIsoDate]);
+  const source = datasetState.kind === 'ready' ? datasetState.source : null;
+  const snapshot = useMemo(
+    () => (source ? selectRadarSnapshot(source.dataset, todayIsoDate) : null),
+    [source, todayIsoDate],
+  );
+  const partialSections = useMemo(
+    () => (snapshot ? buildRadarPartialSections(snapshot) : []),
+    [snapshot],
+  );
+  const dataState = useMemo(
+    () => (source ? resolveRadarDataState(source, partialSections) : 'default'),
+    [partialSections, source],
+  );
+  const datasetRiskDisclosure =
+    source ? buildDatasetRiskDisclosure(source, '레이더', 'radar-dataset-risk-notice') : null;
 
   useEffect(() => {
     const currentRouteParams = buildRadarRouteParams({
@@ -392,7 +334,7 @@ export default function RadarTabScreen() {
     setEnabledSections(DEFAULT_ENABLED_SECTIONS);
   }
 
-  if (state.kind === 'loading') {
+  if (datasetState.kind === 'loading') {
     return (
       <ScreenFeedbackState
         body="가장 가까운 컴백과 레이더 요약을 불러오는 중입니다."
@@ -403,7 +345,7 @@ export default function RadarTabScreen() {
     );
   }
 
-  if (state.kind === 'error') {
+  if (datasetState.kind === 'error') {
     return (
       <ScreenFeedbackState
         action={{
@@ -411,7 +353,7 @@ export default function RadarTabScreen() {
           onPress: () => setReloadCount((count) => count + 1),
           testID: 'radar-error-retry',
         }}
-        body={state.message}
+        body={datasetState.message}
         eyebrow="LOAD ERROR"
         title="레이더"
         variant="error"
@@ -419,7 +361,17 @@ export default function RadarTabScreen() {
     );
   }
 
-  const { dataState, partialSections, snapshot, source } = state;
+  if (!snapshot || !source) {
+    return (
+      <ScreenFeedbackState
+        body="레이더 스냅샷을 찾지 못했습니다."
+        eyebrow="EMPTY SNAPSHOT"
+        title="레이더"
+        variant="empty"
+      />
+    );
+  }
+
   const filteredFutureUpcoming = filterUpcomingCards(snapshot.futureUpcoming, statusFilter, actTypeFilter);
   const filteredWeeklyUpcoming = filterUpcomingCards(snapshot.weeklyUpcoming, statusFilter, actTypeFilter);
   const filteredChangeFeed = filterChangeFeedItems(snapshot.changeFeed, statusFilter, actTypeFilter);
@@ -464,16 +416,16 @@ export default function RadarTabScreen() {
           </View>
         </View>
 
-        {dataState === 'degraded' ? (
+        {dataState === 'degraded' && datasetRiskDisclosure ? (
           <InlineFeedbackNotice
             action={{
               label: '다시 시도',
               onPress: () => setReloadCount((count) => count + 1),
               testID: 'radar-degraded-retry',
             }}
-            body={buildRadarDegradedBody(source)}
-            testID="radar-degraded-notice"
-            title="발매 후 정보 보강 중"
+            body={datasetRiskDisclosure.body}
+            testID={datasetRiskDisclosure.testID}
+            title={datasetRiskDisclosure.title}
           />
         ) : null}
 

--- a/mobile/app/(tabs)/search.tsx
+++ b/mobile/app/(tabs)/search.tsx
@@ -1,5 +1,5 @@
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import React, { useDeferredValue, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useDeferredValue, useEffect, useMemo, useState } from 'react';
 import {
   Pressable,
   ScrollView,
@@ -13,22 +13,21 @@ import {
   InlineFeedbackNotice,
   ScreenFeedbackState,
 } from '../../src/components/feedback/FeedbackState';
+import { buildDatasetRiskDisclosure } from '../../src/features/surfaceDisclosures';
 import {
   areRouteParamsEqual,
   buildSearchRouteParams,
   resolveSearchRouteState,
   type SearchSegment,
 } from '../../src/features/routeState';
+import { useActiveDatasetScreen } from '../../src/features/useActiveDatasetScreen';
 import {
   createSelectorContext,
   selectSearchResults,
   selectTeamSummaryBySlug,
 } from '../../src/selectors';
-import { loadActiveMobileDataset, type ActiveMobileDataset } from '../../src/services/activeDataset';
 import {
   trackAnalyticsEvent,
-  trackDatasetDegraded,
-  trackDatasetLoadFailed,
   type SearchSubmitSource,
 } from '../../src/services/analytics';
 import { clearRecentQueries, persistRecentQuery, readRecentQueries } from '../../src/services/recentQueries';
@@ -39,11 +38,6 @@ import type {
   SearchUpcomingResultModel,
   TeamSummaryModel,
 } from '../../src/types';
-
-type SearchScreenState =
-  | { kind: 'loading' }
-  | { kind: 'error'; message: string }
-  | { kind: 'ready'; source: ActiveMobileDataset };
 
 function formatReleaseMeta(release: ReleaseSummaryModel): string {
   const releaseKind = release.releaseKind ?? 'release';
@@ -96,12 +90,15 @@ export default function SearchTabScreen() {
   const routeState = useMemo(() => resolveSearchRouteState(params), [params]);
 
   const [reloadCount, setReloadCount] = useState(0);
-  const [state, setState] = useState<SearchScreenState>({ kind: 'loading' });
+  const datasetState = useActiveDatasetScreen({
+    surface: 'search',
+    reloadKey: reloadCount,
+    fallbackErrorMessage: 'Search dataset could not be loaded right now.',
+  });
   const [query, setQuery] = useState(routeState.query);
   const [activeSegment, setActiveSegment] = useState<SearchSegment>(routeState.activeSegment);
   const [recentQueries, setRecentQueries] = useState<string[]>([]);
   const deferredQuery = useDeferredValue(query);
-  const datasetEventKeyRef = useRef<string | null>(null);
 
   useEffect(() => {
     setQuery(routeState.query);
@@ -110,52 +107,14 @@ export default function SearchTabScreen() {
 
   useEffect(() => {
     let cancelled = false;
-    setState({ kind: 'loading' });
 
-    void Promise.all([loadActiveMobileDataset(), readRecentQueries()])
-      .then(([source, history]) => {
-        if (cancelled) {
-          return;
-        }
+    void readRecentQueries().then((history) => {
+      if (cancelled) {
+        return;
+      }
 
-        const datasetEventKey =
-          source.runtimeState.mode === 'degraded' || source.issues.length > 0
-            ? `degraded:${source.selection.kind}:${source.runtimeState.mode}:${source.issues.join('|')}`
-            : `ready:${source.selection.kind}`;
-
-        if (datasetEventKeyRef.current !== datasetEventKey) {
-          datasetEventKeyRef.current = datasetEventKey;
-          if (source.runtimeState.mode === 'degraded' || source.issues.length > 0) {
-            trackDatasetDegraded('search', source);
-          }
-        }
-
-        setRecentQueries(history);
-        setState({
-          kind: 'ready',
-          source,
-        });
-      })
-      .catch((error: unknown) => {
-        if (cancelled) {
-          return;
-        }
-
-        const message =
-          error instanceof Error
-            ? error.message
-            : 'Search dataset could not be loaded right now.';
-        const datasetEventKey = `error:${message}`;
-        if (datasetEventKeyRef.current !== datasetEventKey) {
-          datasetEventKeyRef.current = datasetEventKey;
-          trackDatasetLoadFailed('search', message);
-        }
-
-        setState({
-          kind: 'error',
-          message,
-        });
-      });
+      setRecentQueries(history);
+    });
 
     return () => {
       cancelled = true;
@@ -163,12 +122,16 @@ export default function SearchTabScreen() {
   }, [reloadCount]);
 
   const selectorContext = useMemo(() => {
-    if (state.kind !== 'ready') {
+    if (datasetState.kind !== 'ready') {
       return null;
     }
 
-    return createSelectorContext(state.source.dataset);
-  }, [state]);
+    return createSelectorContext(datasetState.source.dataset);
+  }, [datasetState]);
+  const datasetRiskDisclosure =
+    datasetState.kind === 'ready'
+      ? buildDatasetRiskDisclosure(datasetState.source, '검색', 'search-dataset-risk-notice')
+      : null;
 
   const results = useMemo(() => {
     if (!selectorContext) {
@@ -337,7 +300,7 @@ export default function SearchTabScreen() {
     openTeamDetail(slug);
   }
 
-  if (state.kind === 'loading') {
+  if (datasetState.kind === 'loading') {
     return (
       <ScreenFeedbackState
         body="검색 대상 팀, 발매, 예정 데이터를 불러오는 중입니다."
@@ -348,14 +311,14 @@ export default function SearchTabScreen() {
     );
   }
 
-  if (state.kind === 'error') {
+  if (datasetState.kind === 'error') {
     return (
       <ScreenFeedbackState
         action={{
           label: '다시 시도',
           onPress: () => setReloadCount((count) => count + 1),
         }}
-        body={state.message}
+        body={datasetState.message}
         eyebrow="LOAD ERROR"
         title="Search"
         variant="error"
@@ -387,6 +350,14 @@ export default function SearchTabScreen() {
         <Text accessibilityRole="header" style={styles.title}>Search</Text>
         <Text style={styles.body}>한글 별칭, 영문 그룹명, 릴리즈명, 예정 headline까지 같은 selector semantics로 찾습니다.</Text>
       </View>
+
+      {datasetRiskDisclosure ? (
+        <InlineFeedbackNotice
+          body={datasetRiskDisclosure.body}
+          testID={datasetRiskDisclosure.testID}
+          title={datasetRiskDisclosure.title}
+        />
+      ) : null}
 
       <View style={styles.searchCard}>
         <TextInput

--- a/mobile/app/artists/[slug].tsx
+++ b/mobile/app/artists/[slug].tsx
@@ -1,5 +1,5 @@
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import {
   Image,
   Linking,
@@ -14,11 +14,12 @@ import {
   InlineFeedbackNotice,
   ScreenFeedbackState,
 } from '../../src/components/feedback/FeedbackState';
-import { selectEntityDetailSnapshot } from '../../src/selectors';
 import {
-  loadActiveMobileDataset,
-  type ActiveMobileDataset,
-} from '../../src/services/activeDataset';
+  buildDatasetRiskDisclosure,
+  buildEntitySourceDisclosure,
+} from '../../src/features/surfaceDisclosures';
+import { useActiveDatasetScreen } from '../../src/features/useActiveDatasetScreen';
+import { selectEntityDetailSnapshot } from '../../src/selectors';
 import {
   openServiceHandoff,
   resolveServiceHandoff,
@@ -26,20 +27,12 @@ import {
   type ServiceHandoffFailure,
   type ServiceHandoffResolution,
 } from '../../src/services/handoff';
-import { trackDatasetDegraded, trackDatasetLoadFailed } from '../../src/services/analytics';
 import { useAppTheme } from '../../src/tokens/theme';
 import type {
-  EntityDetailSnapshotModel,
   ReleaseSummaryModel,
   TeamSummaryModel,
   UpcomingEventModel,
 } from '../../src/types';
-
-type EntityDetailScreenState =
-  | { kind: 'loading' }
-  | { kind: 'error'; message: string }
-  | { kind: 'missing'; reason: string }
-  | { kind: 'ready'; source: ActiveMobileDataset; snapshot: EntityDetailSnapshotModel };
 
 type OfficialLinkItem = {
   key: string;
@@ -238,82 +231,19 @@ export default function ArtistDetailScreen() {
   const [reloadCount, setReloadCount] = useState(0);
   const [handoffFeedback, setHandoffFeedback] = useState<string | null>(null);
   const [showAdditionalInfo, setShowAdditionalInfo] = useState(false);
-  const [state, setState] = useState<EntityDetailScreenState>({ kind: 'loading' });
-  const datasetEventKeyRef = useRef<string | null>(null);
+  const datasetState = useActiveDatasetScreen({
+    surface: 'entity_detail',
+    reloadKey: reloadCount,
+    fallbackErrorMessage: '팀 상세 데이터를 불러오지 못했습니다.',
+  });
+  const snapshot = useMemo(
+    () => (datasetState.kind === 'ready' && slug ? selectEntityDetailSnapshot(datasetState.source.dataset, slug) : null),
+    [datasetState, slug],
+  );
 
   useEffect(() => {
-    let cancelled = false;
-
-    if (!slug) {
-      setState({
-        kind: 'missing',
-        reason: '팀 slug가 없거나 잘못되어 화면을 열 수 없습니다.',
-      });
-      return () => {
-        cancelled = true;
-      };
-    }
-
     setHandoffFeedback(null);
     setShowAdditionalInfo(false);
-    setState({ kind: 'loading' });
-
-    void loadActiveMobileDataset()
-      .then((source) => {
-        if (cancelled) {
-          return;
-        }
-
-        const datasetEventKey =
-          source.runtimeState.mode === 'degraded' || source.issues.length > 0
-            ? `degraded:${source.selection.kind}:${source.runtimeState.mode}:${source.issues.join('|')}`
-            : `ready:${source.selection.kind}`;
-        if (datasetEventKeyRef.current !== datasetEventKey) {
-          datasetEventKeyRef.current = datasetEventKey;
-          if (source.runtimeState.mode === 'degraded' || source.issues.length > 0) {
-            trackDatasetDegraded('entity_detail', source);
-          }
-        }
-
-        const snapshot = selectEntityDetailSnapshot(source.dataset, slug);
-        if (!snapshot) {
-          setState({
-            kind: 'missing',
-            reason: '해당 팀 데이터를 찾지 못했습니다.',
-          });
-          return;
-        }
-
-        setState({
-          kind: 'ready',
-          source,
-          snapshot,
-        });
-      })
-      .catch((error: unknown) => {
-        if (cancelled) {
-          return;
-        }
-
-        const message =
-          error instanceof Error
-            ? error.message
-            : '팀 상세 데이터를 불러오지 못했습니다.';
-        const datasetEventKey = `error:${message}`;
-        if (datasetEventKeyRef.current !== datasetEventKey) {
-          datasetEventKeyRef.current = datasetEventKey;
-          trackDatasetLoadFailed('entity_detail', message);
-        }
-
-        setState({
-          kind: 'error',
-          message,
-        });
-      });
-
-    return () => {
-      cancelled = true;
-    };
   }, [reloadCount, slug]);
 
   async function handleHandoff(
@@ -328,12 +258,28 @@ export default function ArtistDetailScreen() {
     setHandoffFeedback(null);
   }
 
-  const screenTitle =
-    state.kind === 'ready'
-      ? state.snapshot.team.displayName
-      : slug || 'Team Detail';
+  const screenTitle = snapshot?.team.displayName ?? slug ?? 'Team Detail';
 
-  if (state.kind === 'loading') {
+  if (!slug) {
+    return (
+      <>
+        <Stack.Screen options={{ title: screenTitle }} />
+        <ScreenFeedbackState
+          action={{
+            label: '검색으로 이동',
+            onPress: () => router.push('/(tabs)/search'),
+          }}
+          body="팀 slug가 없거나 잘못되어 화면을 열 수 없습니다."
+          eyebrow="SAFE RECOVERY"
+          testID="entity-missing-state"
+          title="팀 상세"
+          variant="empty"
+        />
+      </>
+    );
+  }
+
+  if (datasetState.kind === 'loading') {
     return (
       <>
         <Stack.Screen options={{ title: screenTitle }} />
@@ -347,7 +293,7 @@ export default function ArtistDetailScreen() {
     );
   }
 
-  if (state.kind === 'error') {
+  if (datasetState.kind === 'error') {
     return (
       <>
         <Stack.Screen options={{ title: screenTitle }} />
@@ -356,7 +302,7 @@ export default function ArtistDetailScreen() {
             label: '다시 시도',
             onPress: () => setReloadCount((count) => count + 1),
           }}
-          body={state.message}
+          body={datasetState.message}
           eyebrow="LOAD ERROR"
           title="팀 상세"
           variant="error"
@@ -365,7 +311,7 @@ export default function ArtistDetailScreen() {
     );
   }
 
-  if (state.kind === 'missing') {
+  if (!snapshot || datasetState.kind !== 'ready') {
     return (
       <>
         <Stack.Screen options={{ title: screenTitle }} />
@@ -374,7 +320,7 @@ export default function ArtistDetailScreen() {
             label: '검색으로 이동',
             onPress: () => router.push('/(tabs)/search'),
           }}
-          body={state.reason}
+          body="해당 팀 데이터를 찾지 못했습니다."
           eyebrow="SAFE RECOVERY"
           testID="entity-missing-state"
           title="팀 상세"
@@ -384,7 +330,12 @@ export default function ArtistDetailScreen() {
     );
   }
 
-  const { snapshot } = state;
+  const datasetRiskDisclosure = buildDatasetRiskDisclosure(
+    datasetState.source,
+    '팀 상세',
+    'entity-dataset-risk-notice',
+  );
+  const entitySourceDisclosure = buildEntitySourceDisclosure(snapshot);
   const officialLinks = buildOfficialLinks(snapshot.team);
   const latestReleaseServiceButtons = snapshot.latestRelease
     ? buildLatestReleaseServiceButtons(snapshot.latestRelease)
@@ -451,6 +402,22 @@ export default function ArtistDetailScreen() {
           </Pressable>
         ) : null}
       </View>
+
+      {datasetRiskDisclosure ? (
+        <InlineFeedbackNotice
+          body={datasetRiskDisclosure.body}
+          testID={datasetRiskDisclosure.testID}
+          title={datasetRiskDisclosure.title}
+        />
+      ) : null}
+
+      {entitySourceDisclosure ? (
+        <InlineFeedbackNotice
+          body={entitySourceDisclosure.body}
+          testID={entitySourceDisclosure.testID}
+          title={entitySourceDisclosure.title}
+        />
+      ) : null}
 
       <SectionCard title="다음 컴백" styles={styles}>
         {snapshot.nextUpcoming ? (

--- a/mobile/app/releases/[id].tsx
+++ b/mobile/app/releases/[id].tsx
@@ -1,5 +1,5 @@
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import {
   Image,
   Pressable,
@@ -13,11 +13,12 @@ import {
   InlineFeedbackNotice,
   ScreenFeedbackState,
 } from '../../src/components/feedback/FeedbackState';
-import { selectReleaseDetailById } from '../../src/selectors';
 import {
-  loadActiveMobileDataset,
-  type ActiveMobileDataset,
-} from '../../src/services/activeDataset';
+  buildDatasetRiskDisclosure,
+  buildReleaseDependencyDisclosure,
+} from '../../src/features/surfaceDisclosures';
+import { useActiveDatasetScreen } from '../../src/features/useActiveDatasetScreen';
+import { selectReleaseDetailById } from '../../src/selectors';
 import {
   openServiceHandoff,
   resolveServiceHandoff,
@@ -28,18 +29,10 @@ import {
 } from '../../src/services/handoff';
 import {
   trackAnalyticsEvent,
-  trackDatasetDegraded,
-  trackDatasetLoadFailed,
 } from '../../src/services/analytics';
 import { useAppTheme } from '../../src/tokens/theme';
 import type { MobileTheme } from '../../src/tokens/theme';
 import type { ReleaseDetailModel, TrackModel, YoutubeVideoStatus } from '../../src/types';
-
-type ReleaseDetailScreenState =
-  | { kind: 'loading' }
-  | { kind: 'error'; message: string }
-  | { kind: 'missing'; reason: string }
-  | { kind: 'ready'; source: ActiveMobileDataset; detail: ReleaseDetailModel };
 
 type ServiceButtonSpec = {
   accessibilityHint?: string;
@@ -234,81 +227,18 @@ export default function ReleaseDetailScreen() {
   const releaseId = getSingleParam(params.id)?.trim() ?? '';
   const [reloadCount, setReloadCount] = useState(0);
   const [handoffFeedback, setHandoffFeedback] = useState<string | null>(null);
-  const [state, setState] = useState<ReleaseDetailScreenState>({ kind: 'loading' });
-  const datasetEventKeyRef = useRef<string | null>(null);
+  const datasetState = useActiveDatasetScreen({
+    surface: 'release_detail',
+    reloadKey: reloadCount,
+    fallbackErrorMessage: '릴리즈 상세 데이터를 불러오지 못했습니다.',
+  });
+  const detail = useMemo(
+    () => (datasetState.kind === 'ready' && releaseId ? selectReleaseDetailById(datasetState.source.dataset, releaseId) : null),
+    [datasetState, releaseId],
+  );
 
   useEffect(() => {
-    let cancelled = false;
-
-    if (!releaseId) {
-      setState({
-        kind: 'missing',
-        reason: '릴리즈 ID가 없거나 잘못되어 상세 화면을 열 수 없습니다.',
-      });
-      return () => {
-        cancelled = true;
-      };
-    }
-
     setHandoffFeedback(null);
-    setState({ kind: 'loading' });
-
-    void loadActiveMobileDataset()
-      .then((source) => {
-        if (cancelled) {
-          return;
-        }
-
-        const datasetEventKey =
-          source.runtimeState.mode === 'degraded' || source.issues.length > 0
-            ? `degraded:${source.selection.kind}:${source.runtimeState.mode}:${source.issues.join('|')}`
-            : `ready:${source.selection.kind}`;
-        if (datasetEventKeyRef.current !== datasetEventKey) {
-          datasetEventKeyRef.current = datasetEventKey;
-          if (source.runtimeState.mode === 'degraded' || source.issues.length > 0) {
-            trackDatasetDegraded('release_detail', source);
-          }
-        }
-
-        const detail = selectReleaseDetailById(source.dataset, releaseId);
-        if (!detail) {
-          setState({
-            kind: 'missing',
-            reason: '해당 릴리즈 상세 데이터를 찾지 못했습니다.',
-          });
-          return;
-        }
-
-        setState({
-          kind: 'ready',
-          source,
-          detail,
-        });
-      })
-      .catch((error: unknown) => {
-        if (cancelled) {
-          return;
-        }
-
-        const message =
-          error instanceof Error
-            ? error.message
-            : '릴리즈 상세 데이터를 불러오지 못했습니다.';
-        const datasetEventKey = `error:${message}`;
-        if (datasetEventKeyRef.current !== datasetEventKey) {
-          datasetEventKeyRef.current = datasetEventKey;
-          trackDatasetLoadFailed('release_detail', message);
-        }
-
-        setState({
-          kind: 'error',
-          message,
-        });
-      });
-
-    return () => {
-      cancelled = true;
-    };
   }, [releaseId, reloadCount]);
 
   async function handleHandoff(
@@ -337,10 +267,28 @@ export default function ReleaseDetailScreen() {
     setHandoffFeedback(null);
   }
 
-  const screenTitle =
-    state.kind === 'ready' ? state.detail.releaseTitle : releaseId || 'Release Detail';
+  const screenTitle = detail?.releaseTitle ?? releaseId ?? 'Release Detail';
 
-  if (state.kind === 'loading') {
+  if (!releaseId) {
+    return (
+      <>
+        <Stack.Screen options={{ title: screenTitle }} />
+        <ScreenFeedbackState
+          action={{
+            label: '이전 화면으로',
+            onPress: () => router.back(),
+          }}
+          body="릴리즈 ID가 없거나 잘못되어 상세 화면을 열 수 없습니다."
+          eyebrow="MISSING DETAIL"
+          testID="release-missing-state"
+          title="Release Detail"
+          variant="empty"
+        />
+      </>
+    );
+  }
+
+  if (datasetState.kind === 'loading') {
     return (
       <>
         <Stack.Screen options={{ title: screenTitle }} />
@@ -354,7 +302,7 @@ export default function ReleaseDetailScreen() {
     );
   }
 
-  if (state.kind === 'error') {
+  if (datasetState.kind === 'error') {
     return (
       <>
         <Stack.Screen options={{ title: screenTitle }} />
@@ -363,7 +311,7 @@ export default function ReleaseDetailScreen() {
             label: '다시 시도',
             onPress: () => setReloadCount((count) => count + 1),
           }}
-          body={state.message}
+          body={datasetState.message}
           eyebrow="LOAD ERROR"
           title="Release Detail"
           variant="error"
@@ -372,7 +320,7 @@ export default function ReleaseDetailScreen() {
     );
   }
 
-  if (state.kind === 'missing') {
+  if (!detail || datasetState.kind !== 'ready') {
     return (
       <>
         <Stack.Screen options={{ title: screenTitle }} />
@@ -381,7 +329,7 @@ export default function ReleaseDetailScreen() {
             label: '이전 화면으로',
             onPress: () => router.back(),
           }}
-          body={state.reason}
+          body="해당 릴리즈 상세 데이터를 찾지 못했습니다."
           eyebrow="MISSING DETAIL"
           testID="release-missing-state"
           title="Release Detail"
@@ -391,7 +339,12 @@ export default function ReleaseDetailScreen() {
     );
   }
 
-  const { detail, source } = state;
+  const datasetRiskDisclosure = buildDatasetRiskDisclosure(
+    datasetState.source,
+    '릴리즈 상세',
+    'release-dataset-risk-notice',
+  );
+  const releaseDependencyDisclosure = buildReleaseDependencyDisclosure(detail);
   const albumServiceButtons = buildAlbumServiceButtons(detail);
   const mvUrl = resolveYoutubeMvUrl(detail);
   const mvStatusCopy = getMvStatusCopy(detail.youtubeVideoStatus);
@@ -414,7 +367,15 @@ export default function ReleaseDetailScreen() {
         <Text style={styles.backButtonLabel}>뒤로</Text>
       </Pressable>
 
-      <Text style={styles.eyebrow}>{source.sourceLabel}</Text>
+      <Text style={styles.eyebrow}>{datasetState.source.sourceLabel}</Text>
+
+      {datasetRiskDisclosure ? (
+        <InlineFeedbackNotice
+          body={datasetRiskDisclosure.body}
+          testID={datasetRiskDisclosure.testID}
+          title={datasetRiskDisclosure.title}
+        />
+      ) : null}
 
       <View style={styles.heroCard}>
         <ReleaseCover detail={detail} styles={styles} />
@@ -451,6 +412,14 @@ export default function ReleaseDetailScreen() {
 
       {handoffFeedback ? (
         <InlineFeedbackNotice body={handoffFeedback} testID="release-handoff-feedback" tone="error" />
+      ) : null}
+
+      {releaseDependencyDisclosure ? (
+        <InlineFeedbackNotice
+          body={releaseDependencyDisclosure.body}
+          testID={releaseDependencyDisclosure.testID}
+          title={releaseDependencyDisclosure.title}
+        />
       ) : null}
 
       <View style={styles.section}>

--- a/mobile/src/README.md
+++ b/mobile/src/README.md
@@ -9,6 +9,8 @@
   - `runtime.ts`: mobile profile / env validation + safe degraded runtime state
   - `debugMetadata.ts`: debug-only build/dataset/commit/runtime-state metadata helper
 - `features/`: 화면 composition / binding
+  - `useActiveDatasetScreen.ts`: dataset loading / degraded analytics / error state 공통 hook
+  - `surfaceDisclosures.ts`: dataset risk / source confidence / external dependency notice helper
   - `selectors/`: display model selector / adapter
   - `context.ts`: dataset -> indexed selector context
   - `adapters.ts`: raw JSON -> display model 변환 규칙

--- a/mobile/src/features/calendarControls.test.tsx
+++ b/mobile/src/features/calendarControls.test.tsx
@@ -3,7 +3,7 @@ import renderer, { act } from 'react-test-renderer';
 import { Text } from 'react-native';
 
 import CalendarTabScreen from '../../app/(tabs)/calendar';
-import { trackAnalyticsEvent, trackDatasetDegraded, trackDatasetLoadFailed } from '../services/analytics';
+import { trackAnalyticsEvent } from '../services/analytics';
 
 jest.mock('expo-router', () => {
   const useLocalSearchParams = jest.fn(() => ({}));
@@ -40,8 +40,6 @@ jest.mock('../services/analytics', () => ({
   trackDatasetLoadFailed: jest.fn(),
 }));
 const mockTrackAnalyticsEvent = jest.mocked(trackAnalyticsEvent);
-const mockTrackDatasetDegraded = jest.mocked(trackDatasetDegraded);
-const mockTrackDatasetLoadFailed = jest.mocked(trackDatasetLoadFailed);
 
 async function renderCalendarScreen() {
   let tree: renderer.ReactTestRenderer;
@@ -64,8 +62,6 @@ describe('calendar controls', () => {
     jest.setSystemTime(new Date('2026-03-07T09:00:00.000Z'));
     __mock.useLocalSearchParams.mockReturnValue({});
     mockTrackAnalyticsEvent.mockClear();
-    mockTrackDatasetDegraded.mockClear();
-    mockTrackDatasetLoadFailed.mockClear();
   });
 
   afterEach(() => {

--- a/mobile/src/features/radarTab.test.tsx
+++ b/mobile/src/features/radarTab.test.tsx
@@ -157,7 +157,7 @@ describe('mobile radar tab', () => {
     expect(tree.root.findByProps({ testID: 'radar-change-card-p1harmony' })).toBeDefined();
     expect(tree.root.findByProps({ testID: 'radar-long-gap-card-weeekly' })).toBeDefined();
     expect(tree.root.findByProps({ testID: 'radar-rookie-card-atheart' })).toBeDefined();
-    expect(tree.root.findAllByProps({ testID: 'radar-degraded-notice' })).toHaveLength(0);
+    expect(tree.root.findAllByProps({ testID: 'radar-dataset-risk-notice' })).toHaveLength(0);
     expect(tree.root.findAllByProps({ testID: 'radar-partial-notice' })).toHaveLength(0);
   });
 
@@ -172,7 +172,7 @@ describe('mobile radar tab', () => {
 
     const tree = await renderRadarScreen();
 
-    expect(tree.root.findByProps({ testID: 'radar-degraded-notice' })).toBeDefined();
+    expect(tree.root.findByProps({ testID: 'radar-dataset-risk-notice' })).toBeDefined();
     expect(tree.root.findByProps({ testID: 'radar-featured-card' })).toBeDefined();
     expect(mockTrackDatasetDegraded).toHaveBeenCalledWith(
       'radar',

--- a/mobile/src/features/releaseDetailScreen.test.tsx
+++ b/mobile/src/features/releaseDetailScreen.test.tsx
@@ -3,11 +3,7 @@ import renderer, { act } from 'react-test-renderer';
 import { Text } from 'react-native';
 
 import ReleaseDetailScreen from '../../app/releases/[id]';
-import {
-  trackAnalyticsEvent,
-  trackDatasetDegraded,
-  trackDatasetLoadFailed,
-} from '../services/analytics';
+import { trackAnalyticsEvent } from '../services/analytics';
 import {
   openServiceHandoff,
   type ServiceHandoffFailure,
@@ -76,8 +72,6 @@ const { __mock } = jest.requireMock('expo-router') as {
 
 const mockOpenServiceHandoff = openServiceHandoff as jest.MockedFunction<typeof openServiceHandoff>;
 const mockTrackAnalyticsEvent = jest.mocked(trackAnalyticsEvent);
-const mockTrackDatasetDegraded = jest.mocked(trackDatasetDegraded);
-const mockTrackDatasetLoadFailed = jest.mocked(trackDatasetLoadFailed);
 
 async function renderReleaseDetail() {
   let tree: renderer.ReactTestRenderer;
@@ -103,8 +97,6 @@ describe('mobile release detail screen', () => {
     });
     mockOpenServiceHandoff.mockClear();
     mockTrackAnalyticsEvent.mockClear();
-    mockTrackDatasetDegraded.mockClear();
-    mockTrackDatasetLoadFailed.mockClear();
   });
 
   test('renders populated release detail sections for a canonical release', async () => {
@@ -130,6 +122,7 @@ describe('mobile release detail screen', () => {
     expect(tree.root.findByProps({ testID: 'release-detail-title' }).props.children).toBe('Glow Up');
     expect(tree.root.findByProps({ testID: 'release-empty-tracks' })).toBeDefined();
     expect(tree.root.findByProps({ testID: 'release-mv-state' })).toBeDefined();
+    expect(tree.root.findByProps({ testID: 'release-detail-quality-notice' })).toBeDefined();
     expect(hasText(tree, '현재는 공식 MV가 등록되지 않았습니다.')).toBe(true);
   });
 

--- a/mobile/src/features/route-shell.smoke.test.tsx
+++ b/mobile/src/features/route-shell.smoke.test.tsx
@@ -48,6 +48,53 @@ jest.mock('expo-router', () => {
   };
 });
 
+jest.mock('../features/useActiveDatasetScreen', () => {
+  const { cloneBundledDatasetFixture } = jest.requireActual('../services/bundledDatasetFixture');
+  const { createBundledDatasetSelection } = jest.requireActual('../services/datasetSource');
+
+  return {
+    useActiveDatasetScreen: jest.fn(() => ({
+      kind: 'ready',
+      source: {
+        dataset: cloneBundledDatasetFixture(),
+        selection: createBundledDatasetSelection('fixture-v1', 'profile_default'),
+        runtimeState: {
+          mode: 'normal',
+          issues: [],
+          config: {
+            profile: 'development',
+            dataSource: {
+              mode: 'bundled-static',
+              remoteDatasetUrl: null,
+              datasetVersion: 'fixture-v1',
+            },
+            services: {
+              apiBaseUrl: null,
+              analyticsWriteKey: null,
+            },
+            logging: {
+              level: 'verbose',
+            },
+            featureGates: {
+              radar: true,
+              analytics: false,
+              remoteRefresh: false,
+              mvEmbed: true,
+              shareActions: true,
+            },
+            build: {
+              version: '0.1.0',
+              commitSha: 'test-sha',
+            },
+          },
+        },
+        sourceLabel: 'Bundled static dataset',
+        issues: [],
+      },
+    })),
+  };
+});
+
 const { __mock } = jest.requireMock('expo-router') as {
   __mock: {
     useRouter: jest.Mock;

--- a/mobile/src/features/searchTab.test.tsx
+++ b/mobile/src/features/searchTab.test.tsx
@@ -2,7 +2,7 @@ import renderer, { act } from 'react-test-renderer';
 import { Text } from 'react-native';
 
 import SearchTabScreen from '../../app/(tabs)/search';
-import { trackAnalyticsEvent, trackDatasetDegraded, trackDatasetLoadFailed } from '../services/analytics';
+import { trackAnalyticsEvent } from '../services/analytics';
 import { persistRecentQuery, readRecentQueries } from '../services/recentQueries';
 import { resetStorageAdapter, setStorageAdapter, type KeyValueStorageAdapter } from '../services/storage';
 
@@ -48,8 +48,6 @@ const { __mock } = jest.requireMock('expo-router') as {
   };
 };
 const mockTrackAnalyticsEvent = jest.mocked(trackAnalyticsEvent);
-const mockTrackDatasetDegraded = jest.mocked(trackDatasetDegraded);
-const mockTrackDatasetLoadFailed = jest.mocked(trackDatasetLoadFailed);
 
 async function renderSearchScreen() {
   let tree: renderer.ReactTestRenderer;
@@ -74,8 +72,6 @@ describe('mobile search tab', () => {
     __mock.setParams.mockClear();
     __mock.push.mockClear();
     mockTrackAnalyticsEvent.mockClear();
-    mockTrackDatasetDegraded.mockClear();
-    mockTrackDatasetLoadFailed.mockClear();
   });
 
   afterEach(() => {

--- a/mobile/src/features/surfaceDisclosures.test.ts
+++ b/mobile/src/features/surfaceDisclosures.test.ts
@@ -1,0 +1,75 @@
+import {
+  buildDatasetRiskDisclosure,
+  buildEntitySourceDisclosure,
+  buildReleaseDependencyDisclosure,
+} from './surfaceDisclosures';
+
+describe('surface disclosure helpers', () => {
+  test('builds dataset risk disclosure only for degraded sources', () => {
+    expect(
+      buildDatasetRiskDisclosure(
+        {
+          sourceLabel: 'Bundled static dataset',
+          runtimeState: { mode: 'normal' },
+          issues: [],
+        },
+        '레이더',
+        'radar-risk',
+      ),
+    ).toBeNull();
+
+    expect(
+      buildDatasetRiskDisclosure(
+        {
+          sourceLabel: 'Bundled static dataset',
+          runtimeState: { mode: 'degraded' },
+          issues: ['Preview remote dataset is unavailable.'],
+        },
+        '레이더',
+        'radar-risk',
+      ),
+    ).toMatchObject({
+      title: '데이터 최신화 유의',
+      testID: 'radar-risk',
+    });
+  });
+
+  test('flags entity source-confidence gaps', () => {
+    expect(
+      buildEntitySourceDisclosure({
+        team: {
+          slug: 'demo',
+          group: 'Demo',
+          displayName: 'Demo',
+          actType: 'group',
+          youtubeChannelUrls: [],
+          searchTokens: [],
+        },
+        nextUpcoming: null,
+        latestRelease: null,
+        recentAlbums: [],
+        sourceTimeline: [],
+      }),
+    ).toMatchObject({
+      title: '소스 신뢰도',
+      testID: 'entity-source-confidence-notice',
+    });
+  });
+
+  test('flags release dependency gaps', () => {
+    expect(
+      buildReleaseDependencyDisclosure({
+        id: 'demo',
+        group: 'Demo',
+        displayGroup: 'Demo',
+        releaseTitle: 'Demo Release',
+        releaseDate: '2026-01-01',
+        tracks: [],
+        youtubeVideoStatus: 'unresolved',
+      }),
+    ).toMatchObject({
+      title: '외부 링크 및 메타 상태',
+      testID: 'release-detail-quality-notice',
+    });
+  });
+});

--- a/mobile/src/features/surfaceDisclosures.ts
+++ b/mobile/src/features/surfaceDisclosures.ts
@@ -1,0 +1,98 @@
+import type { ActiveMobileDataset } from '../services/activeDataset';
+import type { EntityDetailSnapshotModel, ReleaseDetailModel } from '../types';
+
+export type SurfaceDisclosure = {
+  title: string;
+  body: string;
+  testID: string;
+};
+
+function summarizeIssues(issues: string[]): string {
+  if (issues.length === 0) {
+    return 'runtime 이슈는 없지만 최신 동기화 상태를 다시 확인해 주세요.';
+  }
+
+  return issues.join(' / ');
+}
+
+export function buildDatasetRiskDisclosure(
+  source: Pick<ActiveMobileDataset, 'issues' | 'sourceLabel'> & {
+    runtimeState: Pick<ActiveMobileDataset['runtimeState'], 'mode'>;
+  },
+  surfaceLabel: string,
+  testID: string,
+): SurfaceDisclosure | null {
+  if (source.runtimeState.mode !== 'degraded' && source.issues.length === 0) {
+    return null;
+  }
+
+  return {
+    title: '데이터 최신화 유의',
+    body: `${surfaceLabel} 화면은 현재 ${source.sourceLabel} 기준으로 유지되고 있습니다. ${summarizeIssues(source.issues)} 일부 정보는 늦게 채워지거나 최소 정보만 표시될 수 있습니다.`,
+    testID,
+  };
+}
+
+export function buildEntitySourceDisclosure(
+  snapshot: EntityDetailSnapshotModel,
+): SurfaceDisclosure | null {
+  const gaps: string[] = [];
+
+  if (!snapshot.team.artistSourceUrl) {
+    gaps.push('아티스트 출처');
+  }
+
+  if (snapshot.nextUpcoming && !snapshot.nextUpcoming.sourceUrl) {
+    gaps.push('다음 컴백 출처');
+  }
+
+  if (snapshot.latestRelease && !snapshot.latestRelease.sourceUrl) {
+    gaps.push('최신 발매 출처');
+  }
+
+  if (snapshot.sourceTimeline.length === 0) {
+    gaps.push('소스 타임라인');
+  }
+
+  if (gaps.length === 0) {
+    return null;
+  }
+
+  return {
+    title: '소스 신뢰도',
+    body: `${gaps.join(', ')} 정보가 아직 비어 있거나 연결되지 않았습니다. 이 화면은 실용 허브를 우선하므로, 없는 출처는 숨기고 확인 가능한 정보만 남깁니다.`,
+    testID: 'entity-source-confidence-notice',
+  };
+}
+
+export function buildReleaseDependencyDisclosure(
+  detail: ReleaseDetailModel,
+): SurfaceDisclosure | null {
+  const issues: string[] = [];
+
+  if (detail.tracks.length === 0) {
+    issues.push('트랙 메타데이터 미완료');
+  }
+
+  if (!detail.spotifyUrl || !detail.youtubeMusicUrl) {
+    issues.push('음원 서비스 링크 일부 누락');
+  }
+
+  if (detail.youtubeVideoStatus === 'needs_review' || detail.youtubeVideoStatus === 'unresolved') {
+    issues.push('공식 MV 미확정');
+  }
+
+  if (detail.youtubeVideoStatus === 'no_mv') {
+    issues.push('공식 MV 미제공');
+  }
+
+  if (issues.length === 0) {
+    return null;
+  }
+
+  return {
+    title: '외부 링크 및 메타 상태',
+    body: `${issues.join(' / ')}. canonical 링크가 비어 있으면 검색 fallback 또는 상태 안내만 남기고, 없는 정보를 placeholder로 꾸미지 않습니다.`,
+    testID: 'release-detail-quality-notice',
+  };
+}

--- a/mobile/src/features/useActiveDatasetScreen.ts
+++ b/mobile/src/features/useActiveDatasetScreen.ts
@@ -1,0 +1,93 @@
+import React from 'react';
+
+import type { ActiveMobileDataset } from '../services/activeDataset';
+import { loadActiveMobileDataset } from '../services/activeDataset';
+import {
+  trackDatasetDegraded,
+  trackDatasetLoadFailed,
+  type AnalyticsSurface,
+} from '../services/analytics';
+
+export type ActiveDatasetScreenState =
+  | {
+      kind: 'loading';
+    }
+  | {
+      kind: 'error';
+      message: string;
+    }
+  | {
+      kind: 'ready';
+      source: ActiveMobileDataset;
+    };
+
+type UseActiveDatasetScreenOptions = {
+  surface: AnalyticsSurface;
+  reloadKey: number;
+  fallbackErrorMessage: string;
+};
+
+export function buildActiveDatasetEventKey(source: Pick<ActiveMobileDataset, 'issues' | 'runtimeState' | 'selection'>): string {
+  if (source.runtimeState.mode === 'degraded' || source.issues.length > 0) {
+    return `degraded:${source.selection.kind}:${source.runtimeState.mode}:${source.issues.join('|')}`;
+  }
+
+  return `ready:${source.selection.kind}`;
+}
+
+export function useActiveDatasetScreen({
+  fallbackErrorMessage,
+  reloadKey,
+  surface,
+}: UseActiveDatasetScreenOptions): ActiveDatasetScreenState {
+  const [state, setState] = React.useState<ActiveDatasetScreenState>({ kind: 'loading' });
+  const datasetEventKeyRef = React.useRef<string | null>(null);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    setState({ kind: 'loading' });
+
+    void loadActiveMobileDataset()
+      .then((source) => {
+        if (cancelled) {
+          return;
+        }
+
+        const datasetEventKey = buildActiveDatasetEventKey(source);
+        if (datasetEventKeyRef.current !== datasetEventKey) {
+          datasetEventKeyRef.current = datasetEventKey;
+          if (source.runtimeState.mode === 'degraded' || source.issues.length > 0) {
+            trackDatasetDegraded(surface, source);
+          }
+        }
+
+        setState({
+          kind: 'ready',
+          source,
+        });
+      })
+      .catch((error: unknown) => {
+        if (cancelled) {
+          return;
+        }
+
+        const message = error instanceof Error ? error.message : fallbackErrorMessage;
+        const datasetEventKey = `error:${message}`;
+        if (datasetEventKeyRef.current !== datasetEventKey) {
+          datasetEventKeyRef.current = datasetEventKey;
+          trackDatasetLoadFailed(surface, message);
+        }
+
+        setState({
+          kind: 'error',
+          message,
+        });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [fallbackErrorMessage, reloadKey, surface]);
+
+  return state;
+}


### PR DESCRIPTION
## Summary
- centralize mobile dataset loading/degraded analytics in a shared hook
- standardize dataset/source/dependency disclosures across the main mobile surfaces
- document decision-log review and RN implementation audit findings

## Verification
- cd mobile && npm run lint
- cd mobile && npm run typecheck
- cd mobile && npm run test
- cd mobile && CI=1 npx expo export --platform web --output-dir /tmp/idol-song-app-mobile-rn-audit-export
- git diff --check

Closes #463
Closes #464
Closes #465