### PR TITLE
Implement shared mobile action and layout primitives

### DIFF
--- a/mobile/app/(tabs)/calendar.tsx
+++ b/mobile/app/(tabs)/calendar.tsx
@@ -10,10 +10,13 @@ import {
 
 import { DateDetailSheet } from '../../src/components/calendar/DateDetailSheet';
 import { DayCell } from '../../src/components/calendar/DayCell';
+import { SegmentedControl } from '../../src/components/controls/SegmentedControl';
 import {
   InlineFeedbackNotice,
   ScreenFeedbackState,
 } from '../../src/components/feedback/FeedbackState';
+import { AppBar } from '../../src/components/layout/AppBar';
+import { SummaryStrip } from '../../src/components/layout/SummaryStrip';
 import {
   buildCalendarMonthGrid,
   resolveInitialCalendarSelection,
@@ -173,6 +176,19 @@ export default function CalendarTabScreen() {
   const datasetRiskDisclosure = source
     ? buildDatasetRiskDisclosure(source, '캘린더', 'calendar-dataset-risk-notice')
     : null;
+  const groupSlugByGroup = useMemo(() => {
+    const entries = new Map<string, string>();
+
+    if (!source) {
+      return entries;
+    }
+
+    for (const profile of source.dataset.artistProfiles) {
+      entries.set(profile.group, profile.slug);
+    }
+
+    return entries;
+  }, [source]);
 
   useEffect(() => {
     if (!filteredSnapshot) {
@@ -307,6 +323,26 @@ export default function CalendarTabScreen() {
     setIsSheetOpen(false);
   }
 
+  function openReleaseDetail(releaseId: string) {
+    router.push({
+      pathname: '/releases/[id]',
+      params: { id: releaseId },
+    });
+  }
+
+  function openTeamDetailByGroup(group: string) {
+    const slug = groupSlugByGroup.get(group);
+
+    if (!slug) {
+      return;
+    }
+
+    router.push({
+      pathname: '/artists/[slug]',
+      params: { slug },
+    });
+  }
+
   function handleFilterChange(nextFilterMode: CalendarFilterMode) {
     if (filterMode === nextFilterMode || !filteredSnapshot) {
       return;
@@ -359,49 +395,29 @@ export default function CalendarTabScreen() {
   return (
     <>
       <ScrollView style={styles.screen} contentContainerStyle={styles.content}>
-        <View style={styles.appBar}>
-          <Pressable
-            testID="calendar-month-prev"
-            accessibilityHint="이전 달 일정을 봅니다."
-            accessibilityLabel={`${formatMonthLabel(moveMonthKey(activeMonth, -1))}로 이동`}
-            accessibilityRole="button"
-            onPress={() => moveToRelativeMonth(-1)}
-            style={({ pressed }) => [
-              styles.monthButton,
-              pressed ? styles.monthButtonPressed : null,
-            ]}
-          >
-            <Text style={styles.monthButtonLabel}>이전</Text>
-          </Pressable>
-
-          <View style={styles.monthTitleWrap}>
-            <Text style={styles.eyebrow}>DATA-BACKED TAB</Text>
-            <Text accessibilityRole="header" testID="calendar-month-title" style={styles.title}>
-              {formatMonthLabel(filteredSnapshot.month)}
-            </Text>
-          </View>
-
-          <Pressable
-            testID="calendar-month-next"
-            accessibilityHint="다음 달 일정을 봅니다."
-            accessibilityLabel={`${formatMonthLabel(moveMonthKey(activeMonth, 1))}로 이동`}
-            accessibilityRole="button"
-            onPress={() => moveToRelativeMonth(1)}
-            style={({ pressed }) => [
-              styles.monthButton,
-              pressed ? styles.monthButtonPressed : null,
-            ]}
-          >
-            <Text style={styles.monthButtonLabel}>다음</Text>
-          </Pressable>
-        </View>
-
-        <View style={styles.header}>
-          <Text style={styles.eyebrow}>DATA-BACKED TAB</Text>
-          <Text style={styles.body}>
-            현재 월 grid, compact filter, quick jump, month-only bucket을 shared selector와 dataset source 위에서 렌더링합니다.
-          </Text>
-        </View>
+        <AppBar
+          leadingAction={{
+            accessibilityHint: '이전 달 일정을 봅니다.',
+            accessibilityLabel: `${formatMonthLabel(moveMonthKey(activeMonth, -1))}로 이동`,
+            label: '이전',
+            onPress: () => moveToRelativeMonth(-1),
+            testID: 'calendar-month-prev',
+          }}
+          subtitle={source.sourceLabel}
+          testID="calendar-app-bar"
+          title={formatMonthLabel(filteredSnapshot.month)}
+          titleTestID="calendar-month-title"
+          trailingActions={[
+            {
+              accessibilityHint: '다음 달 일정을 봅니다.',
+              accessibilityLabel: `${formatMonthLabel(moveMonthKey(activeMonth, 1))}로 이동`,
+              key: 'next',
+              label: '다음',
+              onPress: () => moveToRelativeMonth(1),
+              testID: 'calendar-month-next',
+            },
+          ]}
+        />
 
         {datasetRiskDisclosure ? (
           <InlineFeedbackNotice
@@ -410,11 +426,6 @@ export default function CalendarTabScreen() {
             title={datasetRiskDisclosure.title}
           />
         ) : null}
-
-        <View style={styles.sourceCard}>
-          <Text style={styles.sourceLabel}>Active source</Text>
-          <Text style={styles.sourceValue}>{source.sourceLabel}</Text>
-        </View>
 
         <View style={styles.sectionCard}>
           <View style={styles.calendarHeader}>
@@ -474,57 +485,31 @@ export default function CalendarTabScreen() {
             <Text style={styles.sectionMeta}>{formatFilterLabel(filterMode)}</Text>
           </View>
 
-          <View style={styles.controlRow}>
-            {([
-              ['all', '전체'],
-              ['releases', '발매'],
-              ['upcoming', '예정'],
-            ] as const).map(([mode, label]) => (
-              <Pressable
-                key={mode}
-                testID={`calendar-filter-${mode}`}
-                accessibilityHint="월간 캘린더 표시 범위를 바꿉니다."
-                accessibilityLabel={`${label} 필터`}
-                accessibilityRole="button"
-                accessibilityState={{ selected: filterMode === mode }}
-                onPress={() => handleFilterChange(mode)}
-                style={({ pressed }) => [
-                  styles.controlChip,
-                  filterMode === mode ? styles.controlChipActive : null,
-                  pressed ? styles.controlChipPressed : null,
-                ]}
-              >
-                <Text
-                  style={filterMode === mode ? styles.controlChipActiveLabel : styles.controlChipLabel}
-                >
-                  {label}
-                </Text>
-              </Pressable>
-            ))}
-          </View>
+          <SegmentedControl
+            items={[
+              { key: 'all', label: '전체' },
+              { key: 'releases', label: '발매' },
+              { key: 'upcoming', label: '예정' },
+            ]}
+            onChange={(key) => handleFilterChange(key as CalendarFilterMode)}
+            selectedKey={filterMode}
+            testID="calendar-filter"
+          />
         </View>
 
-        <View style={styles.summaryGrid}>
-          <View style={styles.summaryCard}>
-            <Text style={styles.summaryLabel}>이번 달 발매</Text>
-            <Text style={styles.summaryValue}>{filteredSnapshot.releaseCount}</Text>
-          </View>
-          <View style={styles.summaryCard}>
-            <Text style={styles.summaryLabel}>예정 컴백</Text>
-            <Text style={styles.summaryValue}>{filteredSnapshot.upcomingCount}</Text>
-          </View>
-          <View style={styles.summaryCard}>
-            <Text style={styles.summaryLabel}>가장 가까운 일정</Text>
-            <Text style={styles.summaryValueSmall}>
-              {filteredSnapshot.nearestUpcoming?.displayGroup ?? '없음'}
-            </Text>
-            <Text style={styles.summaryMeta}>
-              {filteredSnapshot.nearestUpcoming
-                ? formatUpcomingLabel(filteredSnapshot.nearestUpcoming)
-                : 'exact 일정 없음'}
-            </Text>
-          </View>
-        </View>
+        <SummaryStrip
+          items={[
+            { key: 'release-count', label: '이번 달 발매', value: filteredSnapshot.releaseCount },
+            { key: 'upcoming-count', label: '예정 컴백', value: filteredSnapshot.upcomingCount },
+            {
+              key: 'nearest-upcoming',
+              label: '가장 가까운 일정',
+              value: filteredSnapshot.nearestUpcoming?.displayGroup ?? '없음',
+            },
+          ]}
+          layout="wrap"
+          testID="calendar-summary-strip"
+        />
 
         {monthGrid ? (
           <View style={styles.sectionCard}>
@@ -556,7 +541,21 @@ export default function CalendarTabScreen() {
                       );
                     }
 
-                    return <DayCell key={cell.isoDate} cell={cell} onPress={openDaySheet} />;
+                    return (
+                      <DayCell
+                        key={cell.isoDate}
+                        badges={cell.badges}
+                        dateNumber={cell.dayNumber}
+                        extraCount={cell.overflowCount}
+                        isCurrentMonth={cell.isCurrentMonth}
+                        isSelected={cell.isSelected}
+                        isToday={cell.isToday}
+                        isoDate={cell.isoDate}
+                        onPress={() => openDaySheet(cell.isoDate)}
+                        releaseCount={cell.releaseCount}
+                        upcomingCount={cell.upcomingCount}
+                      />
+                    );
                   })}
                 </View>
               ))}
@@ -595,7 +594,16 @@ export default function CalendarTabScreen() {
       </ScrollView>
 
       {selectedDay ? (
-        <DateDetailSheet onClose={closeDaySheet} selectedDay={selectedDay} visible={isSheetOpen} />
+        <DateDetailSheet
+          isOpen={isSheetOpen}
+          onClose={closeDaySheet}
+          onPressRelease={openReleaseDetail}
+          onPressTeam={openTeamDetailByGroup}
+          scheduledRows={selectedDay.exactUpcoming}
+          summary={formatMonthLabel(filteredSnapshot.month)}
+          title={selectedDay.label}
+          verifiedRows={selectedDay.releases}
+        />
       ) : null}
     </>
   );

--- a/mobile/app/(tabs)/radar.tsx
+++ b/mobile/app/(tabs)/radar.tsx
@@ -10,10 +10,13 @@ import {
   View,
 } from 'react-native';
 
+import { ActionButton } from '../../src/components/actions/ActionButton';
 import {
   InlineFeedbackNotice,
   ScreenFeedbackState,
 } from '../../src/components/feedback/FeedbackState';
+import { AppBar } from '../../src/components/layout/AppBar';
+import { SummaryStrip } from '../../src/components/layout/SummaryStrip';
 import { buildDatasetRiskDisclosure } from '../../src/features/surfaceDisclosures';
 import {
   areRouteParamsEqual,
@@ -387,33 +390,27 @@ export default function RadarTabScreen() {
   return (
     <>
       <ScrollView style={styles.screen} contentContainerStyle={styles.content}>
-        <View style={styles.appBar}>
-          <View style={styles.appBarCopy}>
-            <Text style={styles.eyebrow}>DATA-BACKED TAB</Text>
-            <Text accessibilityRole="header" style={styles.title}>레이더</Text>
-            <Text style={styles.body}>{source.sourceLabel}</Text>
-          </View>
-          <View style={styles.appBarActions}>
-            <Pressable
-              testID="radar-search-button"
-              accessibilityLabel="검색 탭으로 이동"
-              accessibilityRole="button"
-              onPress={openSearchTab}
-              style={({ pressed }) => [styles.appBarButton, pressed ? styles.buttonPressed : null]}
-            >
-              <Text style={styles.appBarButtonLabel}>검색</Text>
-            </Pressable>
-            <Pressable
-              testID="radar-filter-button"
-              accessibilityLabel="레이더 필터 열기"
-              accessibilityRole="button"
-              accessibilityState={{ selected: hasNonDefaultFilters || isFilterSheetOpen }}
-              onPress={() => setIsFilterSheetOpen(true)}
-              style={({ pressed }) => [styles.appBarButton, pressed ? styles.buttonPressed : null]}
-            >
-              <Text style={styles.appBarButtonLabel}>필터</Text>
-            </Pressable>
-          </View>
+        <AppBar subtitle={source.sourceLabel} testID="radar-app-bar" title="레이더" />
+        <View style={styles.appBarActions}>
+          <Pressable
+            testID="radar-search-button"
+            accessibilityLabel="검색 탭으로 이동"
+            accessibilityRole="button"
+            onPress={openSearchTab}
+            style={({ pressed }) => [styles.appBarButton, pressed ? styles.buttonPressed : null]}
+          >
+            <Text style={styles.appBarButtonLabel}>검색</Text>
+          </Pressable>
+          <Pressable
+            testID="radar-filter-button"
+            accessibilityLabel="레이더 필터 열기"
+            accessibilityRole="button"
+            accessibilityState={{ selected: hasNonDefaultFilters || isFilterSheetOpen }}
+            onPress={() => setIsFilterSheetOpen(true)}
+            style={({ pressed }) => [styles.appBarButton, pressed ? styles.buttonPressed : null]}
+          >
+            <Text style={styles.appBarButtonLabel}>필터</Text>
+          </Pressable>
         </View>
 
         {dataState === 'degraded' && datasetRiskDisclosure ? (
@@ -437,20 +434,14 @@ export default function RadarTabScreen() {
           />
         ) : null}
 
-        <View style={styles.summaryStrip}>
-          <View style={styles.summaryCard}>
-            <Text style={styles.summaryValue}>{filteredWeeklyUpcoming.length}</Text>
-            <Text style={styles.summaryLabel}>이번 주 예정</Text>
-          </View>
-          <View style={styles.summaryCard}>
-            <Text style={styles.summaryValue}>{filteredChangeFeed.length}</Text>
-            <Text style={styles.summaryLabel}>일정 변경</Text>
-          </View>
-          <View style={styles.summaryCard}>
-            <Text style={styles.summaryValue}>{filteredLongGap.length}</Text>
-            <Text style={styles.summaryLabel}>장기 공백</Text>
-          </View>
-        </View>
+        <SummaryStrip
+          items={[
+            { key: 'weekly', label: '이번 주 예정', value: filteredWeeklyUpcoming.length },
+            { key: 'change', label: '일정 변경', value: filteredChangeFeed.length },
+            { key: 'long-gap', label: '장기 공백', value: filteredLongGap.length },
+          ]}
+          testID="radar-summary-strip"
+        />
 
         <RadarFeaturedSection
           item={featuredUpcoming}
@@ -771,21 +762,18 @@ function RadarActionRow({
 }) {
   return (
     <View style={styles.actionRow}>
-      <Pressable
-        accessibilityRole="button"
+      <ActionButton
+        accessibilityLabel={primaryLabel}
+        label={primaryLabel}
         onPress={onPressPrimary}
-        style={({ pressed }) => [styles.primaryActionButton, pressed ? styles.buttonPressed : null]}
-      >
-        <Text style={styles.primaryActionLabel}>{primaryLabel}</Text>
-      </Pressable>
+      />
       {sourceUrl && sourceLabel && onOpenSource ? (
-        <Pressable
-          accessibilityRole="link"
+        <ActionButton
+          accessibilityLabel={sourceLabel}
+          label={sourceLabel}
           onPress={onOpenSource}
-          style={({ pressed }) => [styles.metaActionButton, pressed ? styles.buttonPressed : null]}
-        >
-          <Text style={styles.metaActionLabel}>{sourceLabel}</Text>
-        </Pressable>
+          tone="meta"
+        />
       ) : null}
     </View>
   );
@@ -903,22 +891,17 @@ function RadarFilterSheet({
           </View>
 
           <View style={styles.actionRow}>
-            <Pressable
-              accessibilityRole="button"
+            <ActionButton
+              label="초기화"
               onPress={onReset}
-              style={({ pressed }) => [styles.secondaryActionButton, pressed ? styles.buttonPressed : null]}
               testID="radar-filter-reset"
-            >
-              <Text style={styles.secondaryActionLabel}>초기화</Text>
-            </Pressable>
-            <Pressable
-              accessibilityRole="button"
+              tone="secondary"
+            />
+            <ActionButton
+              label="닫기"
               onPress={onClose}
-              style={({ pressed }) => [styles.primaryActionButton, pressed ? styles.buttonPressed : null]}
               testID="radar-filter-close"
-            >
-              <Text style={styles.primaryActionLabel}>닫기</Text>
-            </Pressable>
+            />
           </View>
         </View>
       </View>

--- a/mobile/app/(tabs)/search.tsx
+++ b/mobile/app/(tabs)/search.tsx
@@ -9,10 +9,14 @@ import {
   View,
 } from 'react-native';
 
+import { ActionButton } from '../../src/components/actions/ActionButton';
+import { SegmentedControl } from '../../src/components/controls/SegmentedControl';
 import {
   InlineFeedbackNotice,
   ScreenFeedbackState,
 } from '../../src/components/feedback/FeedbackState';
+import { TeamIdentityRow } from '../../src/components/identity/TeamIdentityRow';
+import { AppBar } from '../../src/components/layout/AppBar';
 import { buildDatasetRiskDisclosure } from '../../src/features/surfaceDisclosures';
 import {
   areRouteParamsEqual,
@@ -345,11 +349,11 @@ export default function SearchTabScreen() {
 
   return (
     <ScrollView style={styles.screen} contentContainerStyle={styles.content}>
-      <View style={styles.header}>
-        <Text style={styles.eyebrow}>SEARCH TAB</Text>
-        <Text accessibilityRole="header" style={styles.title}>Search</Text>
-        <Text style={styles.body}>한글 별칭, 영문 그룹명, 릴리즈명, 예정 headline까지 같은 selector semantics로 찾습니다.</Text>
-      </View>
+      <AppBar
+        subtitle="한글 별칭, 영문 그룹명, 릴리즈명, 예정 headline까지 같은 selector semantics로 찾습니다."
+        testID="search-app-bar"
+        title="Search"
+      />
 
       {datasetRiskDisclosure ? (
         <InlineFeedbackNotice
@@ -387,35 +391,16 @@ export default function SearchTabScreen() {
         ) : null}
       </View>
 
-      <View style={styles.segmentRow}>
-        {([
-          ['entities', '팀'],
-          ['releases', '발매'],
-          ['upcoming', '예정'],
-        ] as const).map(([segment, label]) => (
-          <Pressable
-            key={segment}
-            testID={`search-segment-${segment}`}
-            accessibilityLabel={`${label} 결과 ${segmentCounts[segment]}건`}
-            accessibilityHint="검색 결과 구간을 바꿉니다."
-            accessibilityRole="button"
-            accessibilityState={{ selected: activeSegment === segment }}
-            onPress={() => setActiveSegment(segment)}
-            style={({ pressed }) => [
-              styles.segmentButton,
-              activeSegment === segment ? styles.segmentButtonActive : null,
-              pressed ? styles.segmentButtonPressed : null,
-            ]}
-          >
-            <Text style={activeSegment === segment ? styles.segmentLabelActive : styles.segmentLabel}>
-              {label}
-            </Text>
-            <Text style={activeSegment === segment ? styles.segmentCountActive : styles.segmentCount}>
-              {segmentCounts[segment]}
-            </Text>
-          </Pressable>
-        ))}
-      </View>
+      <SegmentedControl
+        items={[
+          { count: segmentCounts.entities, key: 'entities', label: '팀' },
+          { count: segmentCounts.releases, key: 'releases', label: '발매' },
+          { count: segmentCounts.upcoming, key: 'upcoming', label: '예정' },
+        ]}
+        onChange={(key) => setActiveSegment(key as SearchSegment)}
+        selectedKey={activeSegment}
+        testID="search-segment"
+      />
 
       {!query.trim() ? (
         <>
@@ -459,20 +444,25 @@ export default function SearchTabScreen() {
             <Text accessibilityRole="header" style={styles.sectionTitle}>추천 팀</Text>
             <View style={styles.suggestedGrid}>
               {suggestedTeams.map((team) => (
-                <Pressable
+                <View
                   key={team.slug}
+                  style={styles.resultCard}
                   testID={`suggested-team-${team.slug}`}
-                  accessibilityLabel={`${team.displayName} 팀 열기`}
-                  accessibilityRole="button"
-                  onPress={() => openTeamDetail(team.slug)}
-                  style={({ pressed }) => [styles.suggestedCard, pressed ? styles.segmentButtonPressed : null]}
                 >
-                  <View style={styles.suggestedBadge}>
-                    <Text style={styles.suggestedBadgeLabel}>{formatSuggestedLabel(team)}</Text>
-                  </View>
-                  <Text style={styles.suggestedTitle}>{team.displayName}</Text>
-                  <Text style={styles.suggestedMeta}>{team.agency ?? 'Tracked team'}</Text>
-                </Pressable>
+                  <TeamIdentityRow
+                    badgeImageUrl={team.badge?.imageUrl}
+                    meta={team.agency ?? 'Tracked team'}
+                    monogram={formatSuggestedLabel(team)}
+                    name={team.displayName}
+                    testID={`suggested-team-copy-${team.slug}`}
+                  />
+                  <ActionButton
+                    accessibilityLabel={`${team.displayName} 팀 열기`}
+                    label="팀 페이지"
+                    onPress={() => openTeamDetail(team.slug)}
+                    testID={`suggested-team-open-${team.slug}`}
+                  />
+                </View>
               ))}
             </View>
           </View>
@@ -490,83 +480,65 @@ export default function SearchTabScreen() {
 
           {activeSegment === 'entities'
             ? results.entities.map((result) => (
-                <Pressable
-                  key={result.team.slug}
-                  testID={`search-team-result-press-${result.team.slug}`}
-                  accessibilityLabel={buildTeamResultAccessibilityLabel(result)}
-                  accessibilityRole="button"
-                  onPress={() => handleTeamResultPress(result)}
-                  style={({ pressed }) => [styles.resultRow, pressed ? styles.segmentButtonPressed : null]}
-                >
-                  <View style={styles.resultLeadingBadge}>
-                    <Text style={styles.resultLeadingBadgeLabel}>
-                      {result.team.badge?.monogram ?? result.team.displayName.slice(0, 2).toUpperCase()}
-                    </Text>
-                  </View>
-                  <View testID={`search-team-result-${result.team.slug}`} style={styles.resultCopy}>
-                    <Text style={styles.resultTitle}>{result.team.displayName}</Text>
-                    <Text style={styles.resultBody}>{formatTeamMeta(result)}</Text>
-                    <Text style={styles.resultMeta}>{result.matchKind}</Text>
-                  </View>
-                </Pressable>
+                <View key={result.team.slug} style={styles.resultCard}>
+                  <TeamIdentityRow
+                    badgeImageUrl={result.team.badge?.imageUrl}
+                    meta={formatTeamMeta(result)}
+                    monogram={result.team.badge?.monogram}
+                    name={result.team.displayName}
+                    testID={`search-team-result-${result.team.slug}`}
+                  />
+                  <Text style={styles.resultMeta}>{result.matchKind}</Text>
+                  <ActionButton
+                    accessibilityLabel={buildTeamResultAccessibilityLabel(result)}
+                    label="팀 페이지"
+                    onPress={() => handleTeamResultPress(result)}
+                    testID={`search-team-result-press-${result.team.slug}`}
+                  />
+                </View>
               ))
             : null}
 
           {activeSegment === 'releases'
             ? results.releases.map((result) => (
-                <Pressable
-                  key={result.release.id}
-                  testID={`search-release-result-press-${result.release.id}`}
-                  accessibilityLabel={buildReleaseResultAccessibilityLabel(result.release, result.matchKind)}
-                  accessibilityRole="button"
-                  onPress={() => handleReleaseResultPress(result.release, result.matchKind)}
-                  style={({ pressed }) => [styles.resultRow, pressed ? styles.segmentButtonPressed : null]}
-                >
-                  <View style={styles.resultLeadingBadge}>
-                    <Text style={styles.resultLeadingBadgeLabel}>{result.release.displayGroup.slice(0, 2)}</Text>
-                  </View>
-                  <View testID={`search-release-result-${result.release.id}`} style={styles.resultCopy}>
-                    <Text style={styles.resultTitle}>{result.release.releaseTitle}</Text>
-                    <Text style={styles.resultBody}>{result.release.displayGroup}</Text>
-                    <Text style={styles.resultMeta}>
-                      {formatReleaseMeta(result.release)} · {result.matchKind}
-                    </Text>
-                  </View>
-                </Pressable>
+                <View key={result.release.id} style={styles.resultCard}>
+                  <TeamIdentityRow
+                    meta={`${result.release.displayGroup} · ${formatReleaseMeta(result.release)}`}
+                    monogram={result.release.displayGroup.slice(0, 2)}
+                    name={result.release.releaseTitle}
+                    testID={`search-release-result-${result.release.id}`}
+                  />
+                  <Text style={styles.resultMeta}>{result.matchKind}</Text>
+                  <ActionButton
+                    accessibilityLabel={buildReleaseResultAccessibilityLabel(result.release, result.matchKind)}
+                    label="릴리즈 상세"
+                    onPress={() => handleReleaseResultPress(result.release, result.matchKind)}
+                    testID={`search-release-result-press-${result.release.id}`}
+                  />
+                </View>
               ))
             : null}
 
           {activeSegment === 'upcoming'
             ? results.upcoming.map((result) => (
-                <Pressable
-                  key={result.upcoming.id}
-                  testID={`search-upcoming-result-press-${result.upcoming.id}`}
-                  accessibilityLabel={buildUpcomingResultAccessibilityLabel(result)}
-                  accessibilityRole="button"
-                  accessibilityState={{ disabled: !teamSlugByGroup.get(result.upcoming.group) }}
-                  disabled={!teamSlugByGroup.get(result.upcoming.group)}
-                  onPress={() => handleUpcomingResultPress(result)}
-                  style={({ pressed }) => [
-                    styles.resultRow,
-                    !teamSlugByGroup.get(result.upcoming.group) ? styles.disabledButton : null,
-                    pressed ? styles.segmentButtonPressed : null,
-                  ]}
-                >
-                  <View style={styles.resultLeadingBadge}>
-                    <Text style={styles.resultLeadingBadgeLabel}>
-                      {result.upcoming.displayGroup.slice(0, 2)}
-                    </Text>
-                  </View>
-                  <View testID={`search-upcoming-result-${result.upcoming.id}`} style={styles.resultCopy}>
-                    <Text style={styles.resultTitle}>{result.upcoming.displayGroup}</Text>
-                    <Text style={styles.resultBody}>
-                      {result.upcoming.releaseLabel ?? result.upcoming.headline}
-                    </Text>
-                    <Text style={styles.resultMeta}>
-                      {formatUpcomingMeta(result)} · {result.matchKind}
-                    </Text>
-                  </View>
-                </Pressable>
+                <View key={result.upcoming.id} style={styles.resultCard}>
+                  <TeamIdentityRow
+                    meta={result.upcoming.releaseLabel ?? result.upcoming.headline}
+                    monogram={result.upcoming.displayGroup.slice(0, 2)}
+                    name={result.upcoming.displayGroup}
+                    testID={`search-upcoming-result-${result.upcoming.id}`}
+                  />
+                  <Text style={styles.resultMeta}>
+                    {formatUpcomingMeta(result)} · {result.matchKind}
+                  </Text>
+                  <ActionButton
+                    accessibilityLabel={buildUpcomingResultAccessibilityLabel(result)}
+                    disabled={!teamSlugByGroup.get(result.upcoming.group)}
+                    label="팀 페이지"
+                    onPress={() => handleUpcomingResultPress(result)}
+                    testID={`search-upcoming-result-press-${result.upcoming.id}`}
+                  />
+                </View>
               ))
             : null}
         </View>
@@ -593,28 +565,6 @@ function createStyles(theme: ReturnType<typeof useAppTheme>) {
       paddingHorizontal: theme.space[24],
       gap: theme.space[12],
       backgroundColor: theme.colors.surface.base,
-    },
-    header: {
-      gap: theme.space[8],
-    },
-    eyebrow: {
-      color: theme.colors.text.brand,
-      fontSize: theme.typography.meta.fontSize,
-      fontWeight: theme.typography.meta.fontWeight,
-      letterSpacing: theme.typography.meta.letterSpacing,
-    },
-    title: {
-      color: theme.colors.text.primary,
-      fontSize: theme.typography.screenTitle.fontSize,
-      lineHeight: theme.typography.screenTitle.lineHeight,
-      fontWeight: theme.typography.screenTitle.fontWeight,
-      letterSpacing: theme.typography.screenTitle.letterSpacing,
-    },
-    body: {
-      color: theme.colors.text.secondary,
-      fontSize: theme.typography.body.fontSize,
-      lineHeight: theme.typography.body.lineHeight,
-      fontWeight: theme.typography.body.fontWeight,
     },
     searchCard: {
       borderRadius: theme.radius.card,
@@ -649,56 +599,8 @@ function createStyles(theme: ReturnType<typeof useAppTheme>) {
       flexShrink: 1,
       textAlign: 'center',
     },
-    segmentRow: {
-      flexDirection: 'row',
-      gap: theme.space[8],
-    },
-    segmentButton: {
-      flex: 1,
-      minHeight: 48,
-      borderRadius: theme.radius.button,
-      borderWidth: 1,
-      borderColor: theme.colors.border.subtle,
-      backgroundColor: theme.colors.surface.elevated,
-      paddingHorizontal: theme.space[12],
-      paddingVertical: theme.space[12],
-      gap: theme.space[4],
-      alignItems: 'center',
-    },
-    segmentButtonActive: {
-      borderColor: theme.colors.border.focus,
-      backgroundColor: theme.colors.surface.interactive,
-    },
     segmentButtonPressed: {
       backgroundColor: theme.colors.surface.interactive,
-    },
-    segmentLabel: {
-      color: theme.colors.text.primary,
-      fontSize: theme.typography.buttonService.fontSize,
-      lineHeight: theme.typography.buttonService.lineHeight,
-      fontWeight: theme.typography.buttonService.fontWeight,
-      flexShrink: 1,
-      textAlign: 'center',
-    },
-    segmentLabelActive: {
-      color: theme.colors.text.brand,
-      fontSize: theme.typography.buttonService.fontSize,
-      lineHeight: theme.typography.buttonService.lineHeight,
-      fontWeight: theme.typography.buttonService.fontWeight,
-      flexShrink: 1,
-      textAlign: 'center',
-    },
-    segmentCount: {
-      color: theme.colors.text.tertiary,
-      fontSize: theme.typography.meta.fontSize,
-      lineHeight: theme.typography.meta.lineHeight,
-      fontWeight: theme.typography.meta.fontWeight,
-    },
-    segmentCountActive: {
-      color: theme.colors.text.brand,
-      fontSize: theme.typography.meta.fontSize,
-      lineHeight: theme.typography.meta.lineHeight,
-      fontWeight: theme.typography.meta.fontWeight,
     },
     sectionCard: {
       borderRadius: theme.radius.card,
@@ -751,82 +653,11 @@ function createStyles(theme: ReturnType<typeof useAppTheme>) {
     suggestedGrid: {
       gap: theme.space[8],
     },
-    suggestedCard: {
-      borderRadius: theme.radius.button,
-      borderWidth: 1,
-      borderColor: theme.colors.border.subtle,
-      backgroundColor: theme.colors.surface.base,
-      padding: theme.space[12],
+    resultCard: {
       gap: theme.space[8],
-    },
-    suggestedBadge: {
-      alignSelf: 'flex-start',
-      minWidth: 40,
-      borderRadius: theme.radius.chip,
-      backgroundColor: theme.colors.status.title.bg,
-      paddingHorizontal: theme.space[12],
-      paddingVertical: theme.space[4],
-    },
-    suggestedBadgeLabel: {
-      color: theme.colors.status.title.text,
-      fontSize: theme.typography.buttonService.fontSize,
-      lineHeight: theme.typography.buttonService.lineHeight,
-      fontWeight: theme.typography.buttonService.fontWeight,
-      textAlign: 'center',
-    },
-    suggestedTitle: {
-      color: theme.colors.text.primary,
-      fontSize: theme.typography.cardTitle.fontSize,
-      lineHeight: theme.typography.cardTitle.lineHeight,
-      fontWeight: theme.typography.cardTitle.fontWeight,
-    },
-    suggestedMeta: {
-      color: theme.colors.text.secondary,
-      fontSize: theme.typography.body.fontSize,
-      lineHeight: theme.typography.body.lineHeight,
-      fontWeight: theme.typography.body.fontWeight,
-    },
-    resultRow: {
-      flexDirection: 'row',
-      gap: theme.space[12],
       paddingTop: theme.space[12],
       borderTopWidth: 1,
       borderTopColor: theme.colors.border.subtle,
-    },
-    disabledButton: {
-      opacity: 0.5,
-    },
-    resultLeadingBadge: {
-      width: 44,
-      height: 44,
-      borderRadius: theme.radius.button,
-      backgroundColor: theme.colors.surface.base,
-      borderWidth: 1,
-      borderColor: theme.colors.border.subtle,
-      alignItems: 'center',
-      justifyContent: 'center',
-    },
-    resultLeadingBadgeLabel: {
-      color: theme.colors.text.primary,
-      fontSize: theme.typography.buttonService.fontSize,
-      lineHeight: theme.typography.buttonService.lineHeight,
-      fontWeight: theme.typography.buttonService.fontWeight,
-    },
-    resultCopy: {
-      flex: 1,
-      gap: theme.space[4],
-    },
-    resultTitle: {
-      color: theme.colors.text.primary,
-      fontSize: theme.typography.cardTitle.fontSize,
-      lineHeight: theme.typography.cardTitle.lineHeight,
-      fontWeight: theme.typography.cardTitle.fontWeight,
-    },
-    resultBody: {
-      color: theme.colors.text.secondary,
-      fontSize: theme.typography.body.fontSize,
-      lineHeight: theme.typography.body.lineHeight,
-      fontWeight: theme.typography.body.fontWeight,
     },
     resultMeta: {
       color: theme.colors.text.tertiary,

--- a/mobile/app/releases/[id].tsx
+++ b/mobile/app/releases/[id].tsx
@@ -156,6 +156,7 @@ function buildTrackServiceButtons(detail: ReleaseDetailModel, track: TrackModel)
         query,
         canonicalUrl: track.spotifyUrl,
       }),
+      service: 'spotify',
       testID: `release-track-${track.order}-spotify`,
       tone: 'spotify',
     },
@@ -168,6 +169,7 @@ function buildTrackServiceButtons(detail: ReleaseDetailModel, track: TrackModel)
         query,
         canonicalUrl: track.youtubeMusicUrl,
       }),
+      service: 'youtubeMusic',
       testID: `release-track-${track.order}-youtube-music`,
       tone: 'youtubeMusic',
     },
@@ -396,12 +398,32 @@ export default function ReleaseDetailScreen() {
             {detail.tracks.map((track) => (
               <TrackRow
                 key={`${detail.id}-${track.order}`}
-                buttons={buildTrackServiceButtons(detail, track).map((button) => ({
-                  ...button,
-                  onPress: () => void handleHandoff(button.handoff),
-                }))}
+                isTitleTrack={track.isTitleTrack}
+                order={track.order}
+                spotifyButton={buildTrackServiceButtons(detail, track)
+                  .filter((button) => button.service === 'spotify')
+                  .map((button) => ({
+                    accessibilityHint: button.accessibilityHint,
+                    accessibilityLabel: button.accessibilityLabel,
+                    disabled: button.disabled,
+                    label: button.label,
+                    mode: button.mode,
+                    onPress: () => void handleHandoff(button.handoff),
+                    testID: button.testID,
+                  }))[0]}
                 testIDPrefix="release-track-row"
-                track={track}
+                title={track.title}
+                youtubeMusicButton={buildTrackServiceButtons(detail, track)
+                  .filter((button) => button.service === 'youtubeMusic')
+                  .map((button) => ({
+                    accessibilityHint: button.accessibilityHint,
+                    accessibilityLabel: button.accessibilityLabel,
+                    disabled: button.disabled,
+                    label: button.label,
+                    mode: button.mode,
+                    onPress: () => void handleHandoff(button.handoff),
+                    testID: button.testID,
+                  }))[0]}
               />
             ))}
           </View>

--- a/mobile/src/components/actions/ActionButton.tsx
+++ b/mobile/src/components/actions/ActionButton.tsx
@@ -1,0 +1,153 @@
+import React, { memo, useMemo } from 'react';
+import {
+  ActivityIndicator,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+
+import { useAppTheme } from '../../tokens/theme';
+import type { MobileTheme } from '../../tokens/theme';
+
+export type ActionButtonTone = 'primary' | 'secondary' | 'meta';
+
+export interface ActionButtonProps {
+  accessibilityHint?: string;
+  accessibilityLabel?: string;
+  disabled?: boolean;
+  fullWidth?: boolean;
+  label: string;
+  loading?: boolean;
+  onPress?: () => void;
+  testID?: string;
+  tone?: ActionButtonTone;
+}
+
+function ActionButtonComponent({
+  accessibilityHint,
+  accessibilityLabel,
+  disabled = false,
+  fullWidth = false,
+  label,
+  loading = false,
+  onPress,
+  testID,
+  tone = 'primary',
+}: ActionButtonProps) {
+  const theme = useAppTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+  const isDisabled = disabled || loading;
+
+  return (
+    <Pressable
+      accessibilityHint={accessibilityHint}
+      accessibilityLabel={accessibilityLabel ?? label}
+      accessibilityRole="button"
+      accessibilityState={{ busy: loading, disabled: isDisabled }}
+      disabled={isDisabled}
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.button,
+        tone === 'primary' ? styles.primaryButton : null,
+        tone === 'secondary' ? styles.secondaryButton : null,
+        tone === 'meta' ? styles.metaButton : null,
+        fullWidth ? styles.fullWidthButton : null,
+        pressed && !isDisabled ? styles.pressed : null,
+        isDisabled ? styles.disabled : null,
+      ]}
+      testID={testID}
+    >
+      {loading ? (
+        <View style={styles.loadingRow}>
+          <ActivityIndicator
+            color={tone === 'primary' ? theme.colors.text.inverse : theme.colors.text.primary}
+            size="small"
+          />
+          <Text
+            allowFontScaling
+            style={[
+              styles.label,
+              tone === 'primary' ? styles.primaryLabel : styles.secondaryLabel,
+            ]}
+          >
+            {label}
+          </Text>
+        </View>
+      ) : (
+        <Text
+          allowFontScaling
+          style={[
+            styles.label,
+            tone === 'primary' ? styles.primaryLabel : null,
+            tone === 'secondary' ? styles.secondaryLabel : null,
+            tone === 'meta' ? styles.metaLabel : null,
+          ]}
+        >
+          {label}
+        </Text>
+      )}
+    </Pressable>
+  );
+}
+
+function createStyles(theme: MobileTheme) {
+  return StyleSheet.create({
+    button: {
+      minHeight: 44,
+      alignItems: 'center',
+      justifyContent: 'center',
+      borderRadius: theme.radius.button,
+      paddingHorizontal: theme.space[16],
+      paddingVertical: theme.space[12],
+    },
+    fullWidthButton: {
+      width: '100%',
+    },
+    primaryButton: {
+      backgroundColor: theme.colors.text.brand,
+    },
+    secondaryButton: {
+      backgroundColor: theme.colors.surface.interactive,
+      borderWidth: 1,
+      borderColor: theme.colors.border.default,
+    },
+    metaButton: {
+      alignSelf: 'flex-start',
+      minHeight: 32,
+      paddingHorizontal: 0,
+      paddingVertical: 0,
+      borderRadius: 0,
+      backgroundColor: 'transparent',
+    },
+    pressed: {
+      opacity: 0.84,
+    },
+    disabled: {
+      opacity: 0.5,
+    },
+    loadingRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: theme.space[8],
+    },
+    label: {
+      ...theme.typography.buttonPrimary,
+      flexShrink: 1,
+      textAlign: 'center',
+    },
+    primaryLabel: {
+      color: theme.colors.text.inverse,
+    },
+    secondaryLabel: {
+      color: theme.colors.text.primary,
+    },
+    metaLabel: {
+      ...theme.typography.meta,
+      color: theme.colors.text.secondary,
+      textDecorationLine: 'underline',
+    },
+  });
+}
+
+export const ActionButton = memo(ActionButtonComponent);

--- a/mobile/src/components/actions/ServiceButton.tsx
+++ b/mobile/src/components/actions/ServiceButton.tsx
@@ -3,6 +3,7 @@ import {
   Pressable,
   StyleSheet,
   Text,
+  View,
 } from 'react-native';
 
 import { useAppTheme } from '../../tokens/theme';
@@ -15,9 +16,11 @@ export interface ServiceButtonProps {
   accessibilityLabel: string;
   disabled?: boolean;
   label: string;
+  mode?: 'canonical' | 'searchFallback';
   onPress?: () => void;
+  service?: ServiceButtonTone;
   testID?: string;
-  tone: ServiceButtonTone;
+  tone?: ServiceButtonTone;
 }
 
 function ServiceButtonComponent({
@@ -25,12 +28,17 @@ function ServiceButtonComponent({
   accessibilityLabel,
   disabled = false,
   label,
+  mode = 'canonical',
   onPress,
+  service,
   testID,
   tone,
 }: ServiceButtonProps) {
   const theme = useAppTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
+  const resolvedService = service ?? tone ?? 'spotify';
+  const serviceMark =
+    resolvedService === 'spotify' ? 'SP' : resolvedService === 'youtubeMusic' ? 'YM' : 'MV';
 
   return (
     <Pressable
@@ -42,22 +50,30 @@ function ServiceButtonComponent({
       onPress={onPress}
       style={({ pressed }) => [
         styles.button,
-        styles[`${tone}Button`],
+        styles[`${resolvedService}Button`],
         pressed && !disabled ? styles.buttonPressed : null,
         disabled ? styles.buttonDisabled : null,
       ]}
       testID={testID}
     >
-      <Text
-        allowFontScaling
-        style={[
-          styles.buttonLabel,
-          styles[`${tone}ButtonLabel`],
-          disabled ? styles.buttonLabelDisabled : null,
-        ]}
-      >
-        {label}
-      </Text>
+      <View style={styles.buttonContent}>
+        <View style={[styles.mark, styles[`${resolvedService}Mark`]]}>
+          <Text allowFontScaling style={styles.markLabel}>
+            {serviceMark}
+          </Text>
+        </View>
+        <Text
+          allowFontScaling
+          style={[
+            styles.buttonLabel,
+            styles[`${resolvedService}ButtonLabel`],
+            disabled ? styles.buttonLabelDisabled : null,
+          ]}
+        >
+          {label}
+        </Text>
+      </View>
+      {mode === 'searchFallback' ? <Text style={styles.modeHint}>검색 결과</Text> : null}
     </Pressable>
   );
 }
@@ -72,6 +88,12 @@ function createStyles(theme: MobileTheme) {
       paddingHorizontal: theme.space[12],
       paddingVertical: theme.space[12],
       borderRadius: theme.radius.button,
+      gap: theme.space[4],
+    },
+    buttonContent: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: theme.space[8],
     },
     buttonPressed: {
       opacity: 0.84,
@@ -84,6 +106,17 @@ function createStyles(theme: MobileTheme) {
       flexShrink: 1,
       textAlign: 'center',
     },
+    mark: {
+      width: 24,
+      height: 24,
+      alignItems: 'center',
+      justifyContent: 'center',
+      borderRadius: 12,
+    },
+    markLabel: {
+      ...theme.typography.meta,
+      color: theme.colors.text.inverse,
+    },
     buttonLabelDisabled: {
       color: theme.colors.text.tertiary,
     },
@@ -93,11 +126,17 @@ function createStyles(theme: MobileTheme) {
     spotifyButtonLabel: {
       color: theme.colors.service.spotify.icon,
     },
+    spotifyMark: {
+      backgroundColor: theme.colors.service.spotify.icon,
+    },
     youtubeMusicButton: {
       backgroundColor: theme.colors.service.youtubeMusic.bg,
     },
     youtubeMusicButtonLabel: {
       color: theme.colors.service.youtubeMusic.icon,
+    },
+    youtubeMusicMark: {
+      backgroundColor: theme.colors.service.youtubeMusic.icon,
     },
     youtubeMvButton: {
       backgroundColor: theme.colors.service.youtubeMv.bg,
@@ -105,8 +144,14 @@ function createStyles(theme: MobileTheme) {
     youtubeMvButtonLabel: {
       color: theme.colors.service.youtubeMv.icon,
     },
+    youtubeMvMark: {
+      backgroundColor: theme.colors.service.youtubeMv.icon,
+    },
+    modeHint: {
+      ...theme.typography.meta,
+      color: theme.colors.text.tertiary,
+    },
   });
 }
 
 export const ServiceButton = memo(ServiceButtonComponent);
-

--- a/mobile/src/components/actions/ServiceButtonGroup.tsx
+++ b/mobile/src/components/actions/ServiceButtonGroup.tsx
@@ -15,15 +15,27 @@ export interface ServiceButtonGroupItem extends ServiceButtonProps {
 interface ServiceButtonGroupProps {
   buttons: ServiceButtonGroupItem[];
   testID?: string;
+  wrap?: boolean;
 }
 
-function ServiceButtonGroupComponent({ buttons, testID }: ServiceButtonGroupProps) {
+const serviceOrder: Record<string, number> = {
+  spotify: 0,
+  youtubeMusic: 1,
+  youtubeMv: 2,
+};
+
+function ServiceButtonGroupComponent({ buttons, testID, wrap = true }: ServiceButtonGroupProps) {
   const theme = useAppTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
+  const orderedButtons = [...buttons].sort((left, right) => {
+    const leftOrder = serviceOrder[left.service ?? left.tone ?? 'spotify'] ?? 99;
+    const rightOrder = serviceOrder[right.service ?? right.tone ?? 'spotify'] ?? 99;
+    return leftOrder - rightOrder;
+  });
 
   return (
-    <View style={styles.row} testID={testID}>
-      {buttons.map(({ key, ...button }) => (
+    <View style={[styles.row, wrap ? styles.wrapRow : null]} testID={testID}>
+      {orderedButtons.map(({ key, ...button }) => (
         <ServiceButton key={key} {...button} />
       ))}
     </View>
@@ -34,11 +46,12 @@ function createStyles(theme: MobileTheme) {
   return StyleSheet.create({
     row: {
       flexDirection: 'row',
-      flexWrap: 'wrap',
       gap: theme.space[8],
+    },
+    wrapRow: {
+      flexWrap: 'wrap',
     },
   });
 }
 
 export const ServiceButtonGroup = memo(ServiceButtonGroupComponent);
-

--- a/mobile/src/components/calendar/DateDetailSheet.test.tsx
+++ b/mobile/src/components/calendar/DateDetailSheet.test.tsx
@@ -3,7 +3,7 @@ import renderer, { act } from 'react-test-renderer';
 import { Text } from 'react-native';
 
 import { DateDetailSheet } from './DateDetailSheet';
-import type { CalendarSelectedDayModel } from '../../types';
+import type { ReleaseSummaryModel, UpcomingEventModel } from '../../types';
 
 function hasText(tree: renderer.ReactTestRenderer, value: string): boolean {
   return tree.root.findAllByType(Text).some((node) => node.props.children === value);
@@ -12,50 +12,56 @@ function hasText(tree: renderer.ReactTestRenderer, value: string): boolean {
 describe('DateDetailSheet', () => {
   test('renders verified and upcoming sections for a populated date', async () => {
     const onClose = jest.fn();
-    const selectedDay: CalendarSelectedDayModel = {
-      exactUpcoming: [
-        {
-          confidence: 'high',
-          datePrecision: 'exact',
-          displayGroup: 'YENA',
-          group: 'YENA',
-          headline: 'YENA confirms a March 11 comeback',
-          id: 'yena-upcoming',
-          releaseLabel: 'LOVE CATCHER',
-          scheduledDate: '2026-03-11',
-          sourceType: 'official_social',
-          status: 'confirmed',
-        },
-      ],
-      isEmpty: false,
-      isoDate: '2026-03-11',
-      label: '2026년 3월 11일',
-      releases: [
-        {
-          contextTags: [],
-          displayGroup: 'YENA',
-          group: 'YENA',
-          id: 'release-yena',
-          releaseDate: '2026-03-11',
-          releaseKind: 'mini',
-          releaseTitle: 'LOVE CATCHER',
-        },
-      ],
-    };
+    const onPressRelease = jest.fn();
+    const onPressTeam = jest.fn();
+    const scheduledRows: UpcomingEventModel[] = [
+      {
+        confidence: 'high',
+        datePrecision: 'exact',
+        displayGroup: 'YENA',
+        group: 'YENA',
+        headline: 'YENA confirms a March 11 comeback',
+        id: 'yena-upcoming',
+        releaseLabel: 'LOVE CATCHER',
+        scheduledDate: '2026-03-11',
+        sourceType: 'official_social',
+        status: 'confirmed',
+      },
+    ];
+    const verifiedRows: ReleaseSummaryModel[] = [
+      {
+        contextTags: [],
+        displayGroup: 'YENA',
+        group: 'YENA',
+        id: 'release-yena',
+        releaseDate: '2026-03-11',
+        releaseKind: 'mini',
+        releaseTitle: 'LOVE CATCHER',
+      },
+    ];
     let tree: renderer.ReactTestRenderer;
 
     await act(async () => {
       tree = renderer.create(
-        <DateDetailSheet onClose={onClose} selectedDay={selectedDay} visible />,
+        <DateDetailSheet
+          isOpen
+          onClose={onClose}
+          onPressRelease={onPressRelease}
+          onPressTeam={onPressTeam}
+          scheduledRows={scheduledRows}
+          summary="2026년 3월"
+          title="2026년 3월 11일"
+          verifiedRows={verifiedRows}
+        />,
       );
     });
 
     expect(tree!.root.findByProps({ testID: 'calendar-bottom-sheet' })).toBeDefined();
-    expect(hasText(tree!, 'Verified releases')).toBe(true);
-    expect(hasText(tree!, 'Scheduled comebacks')).toBe(true);
+    expect(hasText(tree!, 'LOVE CATCHER')).toBe(true);
+    expect(hasText(tree!, '2026년 3월 11일')).toBe(true);
 
     await act(async () => {
-      tree!.root.findByProps({ testID: 'calendar-sheet-close' }).props.onPress();
+      tree!.root.findByProps({ accessibilityLabel: '시트 닫기' }).props.onPress();
     });
 
     expect(onClose).toHaveBeenCalledTimes(1);

--- a/mobile/src/components/calendar/DateDetailSheet.tsx
+++ b/mobile/src/components/calendar/DateDetailSheet.tsx
@@ -8,14 +8,20 @@ import {
   View,
 } from 'react-native';
 
-import { InlineFeedbackNotice } from '../feedback/FeedbackState';
+import { EmptyStateBlock } from '../feedback/FeedbackState';
+import { SheetHeader } from '../layout/SheetHeader';
+import { ReleaseSummaryRow } from '../release/ReleaseSummaryRow';
+import { UpcomingEventRow } from '../upcoming/UpcomingEventRow';
 import { useAppTheme } from '../../tokens/theme';
 import type { MobileTheme } from '../../tokens/theme';
 import type {
-  CalendarSelectedDayModel,
   ReleaseSummaryModel,
   UpcomingEventModel,
 } from '../../types';
+
+function buildMonogram(value: string): string {
+  return value.slice(0, 2).toUpperCase();
+}
 
 function formatUpcomingLabel(event: UpcomingEventModel): string {
   if (event.datePrecision === 'exact' && event.scheduledDate) {
@@ -34,29 +40,36 @@ function formatReleaseRowMeta(release: ReleaseSummaryModel): string {
   return `${release.releaseDate} · ${kind}`;
 }
 
-function formatSelectedDaySummary(selectedDay: CalendarSelectedDayModel): string {
-  return `발매 ${selectedDay.releases.length} · 예정 ${selectedDay.exactUpcoming.length}`;
-}
-
 interface DateDetailSheetProps {
+  isOpen: boolean;
   onClose: () => void;
-  selectedDay: CalendarSelectedDayModel;
-  visible: boolean;
+  onPressRelease: (releaseId: string) => void;
+  onPressTeam: (group: string) => void;
+  scheduledRows: UpcomingEventModel[];
+  summary?: string;
+  title: string;
+  verifiedRows: ReleaseSummaryModel[];
 }
 
 function DateDetailSheetComponent({
+  isOpen,
   onClose,
-  selectedDay,
-  visible,
+  onPressRelease,
+  onPressTeam,
+  scheduledRows,
+  summary,
+  title,
+  verifiedRows,
 }: DateDetailSheetProps) {
   const theme = useAppTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
+  const isEmpty = verifiedRows.length === 0 && scheduledRows.length === 0;
 
   return (
     <Modal
       transparent
       animationType="slide"
-      visible={visible}
+      visible={isOpen}
       onRequestClose={onClose}
     >
       <View style={styles.sheetOverlay}>
@@ -67,69 +80,100 @@ function DateDetailSheetComponent({
           onPress={onClose}
         />
         <View
-          accessibilityLabel={`${selectedDay.label} 일정 상세`}
+          accessibilityLabel={`${title} 일정 상세`}
           accessibilityViewIsModal
           accessible
           testID="calendar-bottom-sheet"
           style={[
             styles.sheetPanel,
-            selectedDay.isEmpty ? styles.sheetPanelEmpty : null,
+            isEmpty ? styles.sheetPanelEmpty : null,
           ]}
         >
-          <View style={styles.sheetHandle} />
-          <View style={styles.sheetHeader}>
-            <View style={styles.sheetHeaderCopy}>
-              <Text accessibilityRole="header" style={styles.sectionTitle}>
-                {selectedDay.label}
-              </Text>
-              <Text style={styles.sectionMeta}>{formatSelectedDaySummary(selectedDay)}</Text>
-            </View>
-            <Pressable
-              testID="calendar-sheet-close"
-              accessibilityLabel="날짜 상세 닫기"
-              accessibilityRole="button"
-              onPress={onClose}
-              style={styles.sheetCloseButton}
-            >
-              <Text style={styles.sheetCloseLabel}>닫기</Text>
-            </Pressable>
-          </View>
+          <SheetHeader
+            closeButtonTestID="calendar-sheet-close"
+            onClose={onClose}
+            showCloseButton
+            summary={summary}
+            title={title}
+          />
 
           <ScrollView
             style={styles.sheetScroll}
             contentContainerStyle={styles.sheetContent}
             bounces={false}
           >
-            {selectedDay.isEmpty ? (
-              <InlineFeedbackNotice body="이 날짜에는 등록된 일정이 없습니다." />
+            {isEmpty ? (
+              <EmptyStateBlock description="이 날짜에는 등록된 일정이 없습니다." message="일정 없음" />
             ) : (
               <>
-                {selectedDay.releases.length ? (
+                {verifiedRows.length ? (
                   <View style={styles.subsection}>
-                    <Text accessibilityRole="header" style={styles.subsectionTitle}>
-                      Verified releases
-                    </Text>
-                    {selectedDay.releases.map((release) => (
-                      <View key={release.id} style={styles.row}>
-                        <Text style={styles.rowTitle}>{release.displayGroup}</Text>
-                        <Text style={styles.rowBody}>{release.releaseTitle}</Text>
-                        <Text style={styles.rowMeta}>{formatReleaseRowMeta(release)}</Text>
-                      </View>
+                    <Text style={styles.subsectionTitle}>Verified releases</Text>
+                    {verifiedRows.map((release) => (
+                      <ReleaseSummaryRow
+                        key={release.id}
+                        chips={
+                          release.releaseKind
+                            ? [
+                                {
+                                  key: 'kind',
+                                  label: `${release.releaseKind}`.toUpperCase(),
+                                },
+                              ]
+                            : []
+                        }
+                        date={formatReleaseRowMeta(release)}
+                        primaryAction={{
+                          label: '팀 페이지',
+                          onPress: () => onPressTeam(release.group),
+                        }}
+                        secondaryAction={{
+                          label: '상세 보기',
+                          onPress: () => onPressRelease(release.id),
+                        }}
+                        team={{
+                          meta: release.contextTags[0],
+                          monogram: buildMonogram(release.displayGroup),
+                          name: release.displayGroup,
+                        }}
+                        title={release.releaseTitle}
+                      />
                     ))}
                   </View>
                 ) : null}
 
-                {selectedDay.exactUpcoming.length ? (
+                {scheduledRows.length ? (
                   <View style={styles.subsection}>
-                    <Text accessibilityRole="header" style={styles.subsectionTitle}>
-                      Scheduled comebacks
-                    </Text>
-                    {selectedDay.exactUpcoming.map((event) => (
-                      <View key={event.id} style={styles.row}>
-                        <Text style={styles.rowTitle}>{event.displayGroup}</Text>
-                        <Text style={styles.rowBody}>{event.releaseLabel ?? event.headline}</Text>
-                        <Text style={styles.rowMeta}>{formatUpcomingLabel(event)}</Text>
-                      </View>
+                    <Text style={styles.subsectionTitle}>Scheduled comebacks</Text>
+                    {scheduledRows.map((event) => (
+                      <UpcomingEventRow
+                        key={event.id}
+                        confidenceChip={event.confidence ? `신뢰 ${event.confidence}` : undefined}
+                        headline={event.releaseLabel ?? event.headline}
+                        primaryAction={{
+                          label: '팀 페이지',
+                          onPress: () => onPressTeam(event.group),
+                        }}
+                        scheduledDate={formatUpcomingLabel(event)}
+                        sourceLinks={
+                          event.sourceUrl
+                            ? [
+                                {
+                                  key: `${event.id}-source`,
+                                  label: '출처 보기',
+                                  onPress: () => undefined,
+                                  type: 'source',
+                                  url: event.sourceUrl,
+                                },
+                              ]
+                            : []
+                        }
+                        statusChip={event.status ?? '예정'}
+                        team={{
+                          monogram: buildMonogram(event.displayGroup),
+                          name: event.displayGroup,
+                        }}
+                      />
                     ))}
                   </View>
                 ) : null}
@@ -165,36 +209,6 @@ function createStyles(theme: MobileTheme) {
     sheetPanelEmpty: {
       minHeight: 260,
     },
-    sheetHandle: {
-      alignSelf: 'center',
-      width: 52,
-      height: 4,
-      borderRadius: theme.radius.chip,
-      backgroundColor: theme.colors.border.default,
-    },
-    sheetHeader: {
-      flexDirection: 'row',
-      justifyContent: 'space-between',
-      gap: theme.space[12],
-      alignItems: 'flex-start',
-    },
-    sheetHeaderCopy: {
-      flex: 1,
-      gap: theme.space[4],
-    },
-    sheetCloseButton: {
-      minHeight: 44,
-      paddingHorizontal: theme.space[12],
-      paddingVertical: theme.space[8],
-      borderRadius: theme.radius.button,
-      backgroundColor: theme.colors.surface.interactive,
-    },
-    sheetCloseLabel: {
-      ...theme.typography.buttonService,
-      color: theme.colors.text.primary,
-      textAlign: 'center',
-      flexShrink: 1,
-    },
     sheetScroll: {
       flexGrow: 0,
     },
@@ -202,43 +216,14 @@ function createStyles(theme: MobileTheme) {
       gap: theme.space[16],
       paddingBottom: theme.space[16],
     },
-    sectionTitle: {
-      ...theme.typography.sectionTitle,
-      color: theme.colors.text.primary,
-    },
-    sectionMeta: {
-      ...theme.typography.meta,
-      color: theme.colors.text.secondary,
-    },
     subsection: {
       gap: theme.space[12],
     },
     subsectionTitle: {
-      ...theme.typography.cardTitle,
-      color: theme.colors.text.primary,
-    },
-    row: {
-      gap: theme.space[4],
-      padding: theme.space[12],
-      borderRadius: theme.radius.card,
-      backgroundColor: theme.colors.surface.base,
-      borderWidth: 1,
-      borderColor: theme.colors.border.subtle,
-    },
-    rowTitle: {
-      ...theme.typography.cardTitle,
-      color: theme.colors.text.primary,
-    },
-    rowBody: {
-      ...theme.typography.body,
-      color: theme.colors.text.secondary,
-    },
-    rowMeta: {
       ...theme.typography.meta,
-      color: theme.colors.text.tertiary,
+      color: theme.colors.text.secondary,
     },
   });
 }
 
 export const DateDetailSheet = memo(DateDetailSheetComponent);
-

--- a/mobile/src/components/calendar/DayCell.test.tsx
+++ b/mobile/src/components/calendar/DayCell.test.tsx
@@ -29,7 +29,20 @@ describe('DayCell', () => {
     let tree: renderer.ReactTestRenderer;
 
     await act(async () => {
-      tree = renderer.create(<DayCell cell={cell} onPress={onPress} />);
+      tree = renderer.create(
+        <DayCell
+          badges={cell.badges}
+          dateNumber={cell.dayNumber}
+          extraCount={cell.overflowCount}
+          isCurrentMonth={cell.isCurrentMonth}
+          isSelected={cell.isSelected}
+          isToday={cell.isToday}
+          isoDate={cell.isoDate}
+          onPress={onPress}
+          releaseCount={cell.releaseCount}
+          upcomingCount={cell.upcomingCount}
+        />,
+      );
     });
 
     const target = tree!.root.findByProps({ testID: 'calendar-day-2026-03-11' });
@@ -42,6 +55,6 @@ describe('DayCell', () => {
       target.props.onPress();
     });
 
-    expect(onPress).toHaveBeenCalledWith('2026-03-11');
+    expect(onPress).toHaveBeenCalledTimes(1);
   });
 });

--- a/mobile/src/components/calendar/DayCell.tsx
+++ b/mobile/src/components/calendar/DayCell.tsx
@@ -63,26 +63,57 @@ function getBadgePalette(
 }
 
 interface DayCellProps {
-  cell: CalendarDayCellModel;
-  onPress: (isoDate: string) => void;
+  badges: CalendarDayCellModel['badges'];
+  dateNumber: number;
+  extraCount?: number;
+  isCurrentMonth: boolean;
+  isSelected: boolean;
+  isoDate: string;
+  onPress: () => void;
+  releaseCount?: number;
+  upcomingCount?: number;
+  isToday?: boolean;
 }
 
-function DayCellComponent({ cell, onPress }: DayCellProps) {
+function DayCellComponent({
+  badges,
+  dateNumber,
+  extraCount = 0,
+  isCurrentMonth,
+  isSelected,
+  isoDate,
+  isToday = false,
+  onPress,
+  releaseCount = 0,
+  upcomingCount = 0,
+}: DayCellProps) {
   const theme = useAppTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
+  const cell: CalendarDayCellModel = {
+    badges,
+    dayNumber: dateNumber,
+    isCurrentMonth,
+    isSelected,
+    isToday,
+    isoDate,
+    overflowCount: extraCount,
+    releaseCount,
+    upcomingCount,
+  };
 
   return (
     <Pressable
-      testID={`calendar-day-${cell.isoDate}`}
+      testID={`calendar-day-${isoDate}`}
       accessibilityHint="날짜 상세 시트를 엽니다."
       accessibilityLabel={buildCalendarDayAccessibilityLabel(cell)}
       accessibilityRole="button"
       accessibilityState={{ selected: cell.isSelected }}
-      onPress={() => onPress(cell.isoDate)}
+      onPress={onPress}
       style={({ pressed }) => [
         styles.dayCell,
         cell.isToday ? styles.dayCellToday : null,
         cell.isSelected ? styles.dayCellSelected : null,
+        !cell.isCurrentMonth ? styles.dayCellDisabled : null,
         pressed ? styles.dayCellPressed : null,
       ]}
     >
@@ -153,6 +184,9 @@ function createStyles(theme: MobileTheme) {
     },
     dayCellPressed: {
       backgroundColor: theme.colors.surface.interactive,
+    },
+    dayCellDisabled: {
+      opacity: 0.42,
     },
     dayCellHeader: {
       flexDirection: 'row',

--- a/mobile/src/components/controls/SegmentedControl.tsx
+++ b/mobile/src/components/controls/SegmentedControl.tsx
@@ -1,0 +1,122 @@
+import React, { memo, useMemo } from 'react';
+import {
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+
+import { useAppTheme } from '../../tokens/theme';
+import type { MobileTheme } from '../../tokens/theme';
+
+export interface SegmentedControlItem {
+  key: string;
+  label: string;
+  count?: number;
+}
+
+export interface SegmentedControlProps {
+  items: SegmentedControlItem[];
+  isSticky?: boolean;
+  onChange: (key: string) => void;
+  selectedKey: string;
+  testID?: string;
+}
+
+function SegmentedControlComponent({
+  items,
+  isSticky = false,
+  onChange,
+  selectedKey,
+  testID,
+}: SegmentedControlProps) {
+  const theme = useAppTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  return (
+    <View style={[styles.row, isSticky ? styles.stickyRow : null]} testID={testID}>
+      {items.map((item) => {
+        const active = item.key === selectedKey;
+
+        return (
+          <Pressable
+            key={item.key}
+            accessibilityLabel={
+              item.count === undefined ? item.label : `${item.label} ${item.count}건`
+            }
+            accessibilityRole="button"
+            accessibilityState={{ selected: active }}
+            onPress={() => onChange(item.key)}
+            style={({ pressed }) => [
+              styles.segment,
+              active ? styles.segmentActive : null,
+              pressed ? styles.pressed : null,
+            ]}
+            testID={testID ? `${testID}-${item.key}` : undefined}
+          >
+            <Text allowFontScaling style={active ? styles.activeLabel : styles.label}>
+              {item.label}
+            </Text>
+            {item.count !== undefined ? (
+              <Text allowFontScaling style={active ? styles.activeCount : styles.count}>
+                {item.count}
+              </Text>
+            ) : null}
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}
+
+function createStyles(theme: MobileTheme) {
+  return StyleSheet.create({
+    row: {
+      flexDirection: 'row',
+      gap: theme.space[8],
+      padding: theme.space[4],
+      borderRadius: theme.radius.card,
+      backgroundColor: theme.colors.surface.subtle,
+    },
+    stickyRow: {
+      borderWidth: 1,
+      borderColor: theme.colors.border.subtle,
+    },
+    segment: {
+      flex: 1,
+      minHeight: 44,
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: theme.space[4],
+      borderRadius: theme.radius.button,
+      paddingHorizontal: theme.space[8],
+      paddingVertical: theme.space[8],
+    },
+    segmentActive: {
+      backgroundColor: theme.colors.surface.elevated,
+      borderWidth: 1,
+      borderColor: theme.colors.border.default,
+    },
+    pressed: {
+      opacity: 0.84,
+    },
+    label: {
+      ...theme.typography.buttonService,
+      color: theme.colors.text.secondary,
+    },
+    activeLabel: {
+      ...theme.typography.buttonService,
+      color: theme.colors.text.primary,
+    },
+    count: {
+      ...theme.typography.meta,
+      color: theme.colors.text.tertiary,
+    },
+    activeCount: {
+      ...theme.typography.meta,
+      color: theme.colors.text.brand,
+    },
+  });
+}
+
+export const SegmentedControl = memo(SegmentedControlComponent);

--- a/mobile/src/components/feedback/FeedbackState.tsx
+++ b/mobile/src/components/feedback/FeedbackState.tsx
@@ -108,6 +108,49 @@ export function InlineFeedbackNotice({
   );
 }
 
+export function EmptyStateBlock({
+  action,
+  description,
+  message,
+  testID,
+}: {
+  action?: FeedbackAction;
+  description?: string;
+  message: string;
+  testID?: string;
+}) {
+  return (
+    <InlineFeedbackNotice
+      action={action}
+      body={description ?? message}
+      testID={testID}
+      title={description ? message : undefined}
+    />
+  );
+}
+
+export function ErrorStateBlock({
+  backAction,
+  message,
+  retryAction,
+  testID,
+}: {
+  backAction?: FeedbackAction;
+  message: string;
+  retryAction?: FeedbackAction;
+  testID?: string;
+}) {
+  return (
+    <InlineFeedbackNotice
+      action={retryAction ?? backAction}
+      body={message}
+      testID={testID}
+      title="오류"
+      tone="error"
+    />
+  );
+}
+
 function createStyles(theme: MobileTheme) {
   return StyleSheet.create({
     screenContainer: {

--- a/mobile/src/components/filters/FilterSheet.tsx
+++ b/mobile/src/components/filters/FilterSheet.tsx
@@ -1,0 +1,169 @@
+import React, { memo, useMemo } from 'react';
+import {
+  Modal,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+
+import { ActionButton } from '../actions/ActionButton';
+import { SheetHeader } from '../layout/SheetHeader';
+import { useAppTheme } from '../../tokens/theme';
+import type { MobileTheme } from '../../tokens/theme';
+
+export interface FilterSheetOption {
+  key: string;
+  label: string;
+  selected: boolean;
+}
+
+export interface FilterSheetGroup {
+  key: string;
+  label: string;
+  options: FilterSheetOption[];
+}
+
+export interface FilterSheetProps {
+  groups: FilterSheetGroup[];
+  isOpen: boolean;
+  onApply: () => void;
+  onClose: () => void;
+  onReset: () => void;
+  onToggleOption: (groupKey: string, optionKey: string) => void;
+  testID?: string;
+  title?: string;
+}
+
+function FilterSheetComponent({
+  groups,
+  isOpen,
+  onApply,
+  onClose,
+  onReset,
+  onToggleOption,
+  testID,
+  title = '필터',
+}: FilterSheetProps) {
+  const theme = useAppTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  return (
+    <Modal
+      animationType="fade"
+      onRequestClose={onClose}
+      presentationStyle="overFullScreen"
+      transparent
+      visible={isOpen}
+    >
+      <View style={styles.overlay} testID={testID}>
+        <Pressable accessible={false} onPress={onClose} style={styles.backdrop} />
+        <View style={styles.sheet}>
+          <SheetHeader onClose={onClose} showCloseButton summary="적용 전까지 임시 상태를 유지합니다." title={title} />
+          <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
+            {groups.map((group) => (
+              <View key={group.key} style={styles.group}>
+                <Text style={styles.groupTitle}>{group.label}</Text>
+                <View style={styles.optionRow}>
+                  {group.options.map((option) => (
+                    <Pressable
+                      key={option.key}
+                      accessibilityRole="button"
+                      accessibilityState={{ selected: option.selected }}
+                      onPress={() => onToggleOption(group.key, option.key)}
+                      style={({ pressed }) => [
+                        styles.optionChip,
+                        option.selected ? styles.optionChipSelected : null,
+                        pressed ? styles.pressed : null,
+                      ]}
+                      testID={`${testID ?? 'filter-sheet'}-${group.key}-${option.key}`}
+                    >
+                      <Text style={option.selected ? styles.optionLabelSelected : styles.optionLabel}>
+                        {option.label}
+                      </Text>
+                    </Pressable>
+                  ))}
+                </View>
+              </View>
+            ))}
+          </ScrollView>
+          <View style={styles.actions}>
+            <ActionButton label="초기화" onPress={onReset} tone="secondary" />
+            <ActionButton label="적용" onPress={onApply} tone="primary" />
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+function createStyles(theme: MobileTheme) {
+  return StyleSheet.create({
+    overlay: {
+      flex: 1,
+      justifyContent: 'flex-end',
+      backgroundColor: theme.colors.surface.overlay,
+    },
+    backdrop: {
+      flex: 1,
+    },
+    sheet: {
+      maxHeight: '78%',
+      gap: theme.space[16],
+      paddingHorizontal: theme.space[20],
+      paddingTop: theme.space[12],
+      paddingBottom: theme.space[24],
+      borderTopLeftRadius: theme.radius.sheet,
+      borderTopRightRadius: theme.radius.sheet,
+      backgroundColor: theme.colors.surface.elevated,
+    },
+    content: {
+      gap: theme.space[16],
+      paddingBottom: theme.space[8],
+    },
+    group: {
+      gap: theme.space[8],
+    },
+    groupTitle: {
+      ...theme.typography.cardTitle,
+      color: theme.colors.text.primary,
+    },
+    optionRow: {
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+      gap: theme.space[8],
+    },
+    optionChip: {
+      minHeight: 38,
+      justifyContent: 'center',
+      paddingHorizontal: theme.space[12],
+      paddingVertical: theme.space[8],
+      borderRadius: theme.radius.button,
+      backgroundColor: theme.colors.surface.base,
+      borderWidth: 1,
+      borderColor: theme.colors.border.subtle,
+    },
+    optionChipSelected: {
+      backgroundColor: theme.colors.surface.interactive,
+      borderColor: theme.colors.border.focus,
+    },
+    optionLabel: {
+      ...theme.typography.buttonService,
+      color: theme.colors.text.secondary,
+    },
+    optionLabelSelected: {
+      ...theme.typography.buttonService,
+      color: theme.colors.text.primary,
+    },
+    pressed: {
+      opacity: 0.84,
+    },
+    actions: {
+      flexDirection: 'row',
+      gap: theme.space[8],
+    },
+  });
+}
+
+export const FilterSheet = memo(FilterSheetComponent);

--- a/mobile/src/components/identity/TeamIdentityRow.tsx
+++ b/mobile/src/components/identity/TeamIdentityRow.tsx
@@ -1,0 +1,126 @@
+import React, { memo, useMemo } from 'react';
+import {
+  Image,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+
+import { useAppTheme } from '../../tokens/theme';
+import type { MobileTheme } from '../../tokens/theme';
+
+export interface TeamIdentityRowProps {
+  badgeImageUrl?: string;
+  meta?: string;
+  monogram?: string;
+  name: string;
+  onPress?: () => void;
+  testID?: string;
+}
+
+function TeamIdentityRowComponent({
+  badgeImageUrl,
+  meta,
+  monogram,
+  name,
+  onPress,
+  testID,
+}: TeamIdentityRowProps) {
+  const theme = useAppTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+  const content = (
+    <>
+      <View style={styles.badgeWrap}>
+        {badgeImageUrl ? (
+          <Image source={{ uri: badgeImageUrl }} style={styles.badgeImage} />
+        ) : (
+          <View style={styles.badgeFallback}>
+            <Text allowFontScaling style={styles.badgeFallbackLabel}>
+              {(monogram ?? name.slice(0, 2)).toUpperCase()}
+            </Text>
+          </View>
+        )}
+      </View>
+      <View style={styles.copy}>
+        <Text allowFontScaling numberOfLines={1} style={styles.name}>
+          {name}
+        </Text>
+        {meta ? (
+          <Text allowFontScaling numberOfLines={2} style={styles.meta}>
+            {meta}
+          </Text>
+        ) : null}
+      </View>
+    </>
+  );
+
+  if (onPress) {
+    return (
+      <Pressable
+        accessibilityLabel={`${name} 팀 열기`}
+        accessibilityRole="button"
+        onPress={onPress}
+        style={({ pressed }) => [styles.row, pressed ? styles.pressed : null]}
+        testID={testID}
+      >
+        {content}
+      </Pressable>
+    );
+  }
+
+  return (
+    <View style={styles.row} testID={testID}>
+      {content}
+    </View>
+  );
+}
+
+function createStyles(theme: MobileTheme) {
+  return StyleSheet.create({
+    row: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: theme.space[12],
+    },
+    pressed: {
+      opacity: 0.84,
+    },
+    badgeWrap: {
+      width: 40,
+      height: 40,
+      borderRadius: 20,
+      overflow: 'hidden',
+      backgroundColor: theme.colors.surface.interactive,
+    },
+    badgeImage: {
+      width: '100%',
+      height: '100%',
+    },
+    badgeFallback: {
+      flex: 1,
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: theme.colors.surface.interactive,
+    },
+    badgeFallbackLabel: {
+      ...theme.typography.cardTitle,
+      color: theme.colors.text.primary,
+    },
+    copy: {
+      flex: 1,
+      minWidth: 0,
+      gap: theme.space[4],
+    },
+    name: {
+      ...theme.typography.cardTitle,
+      color: theme.colors.text.primary,
+    },
+    meta: {
+      ...theme.typography.meta,
+      color: theme.colors.text.secondary,
+    },
+  });
+}
+
+export const TeamIdentityRow = memo(TeamIdentityRowComponent);

--- a/mobile/src/components/layout/AppBar.tsx
+++ b/mobile/src/components/layout/AppBar.tsx
@@ -1,0 +1,98 @@
+import React, { memo, useMemo } from 'react';
+import {
+  ActivityIndicator,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+
+import { ActionButton, type ActionButtonProps } from '../actions/ActionButton';
+import { useAppTheme } from '../../tokens/theme';
+import type { MobileTheme } from '../../tokens/theme';
+
+export interface AppBarAction extends Omit<ActionButtonProps, 'tone'> {
+  key: string;
+}
+
+export interface AppBarProps {
+  isLoading?: boolean;
+  leadingAction?: Omit<ActionButtonProps, 'tone'>;
+  subtitle?: string;
+  testID?: string;
+  title: string;
+  titleTestID?: string;
+  trailingActions?: AppBarAction[];
+}
+
+function AppBarComponent({
+  isLoading = false,
+  leadingAction,
+  subtitle,
+  testID,
+  title,
+  titleTestID,
+  trailingActions = [],
+}: AppBarProps) {
+  const theme = useAppTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  return (
+    <View style={styles.container} testID={testID}>
+      <View style={styles.actionSlot}>
+        {leadingAction ? <ActionButton {...leadingAction} tone="secondary" /> : null}
+      </View>
+      <View style={styles.copy}>
+        {isLoading ? <ActivityIndicator color={theme.colors.text.brand} size="small" /> : null}
+        <Text accessibilityRole="header" numberOfLines={2} style={styles.title} testID={titleTestID}>
+          {title}
+        </Text>
+        {subtitle ? (
+          <Text numberOfLines={2} style={styles.subtitle}>
+            {subtitle}
+          </Text>
+        ) : null}
+      </View>
+      <View style={styles.trailingActions}>
+        {trailingActions.slice(0, 2).map(({ key, ...action }) => (
+          <ActionButton key={key} {...action} tone="secondary" />
+        ))}
+      </View>
+    </View>
+  );
+}
+
+function createStyles(theme: MobileTheme) {
+  return StyleSheet.create({
+    container: {
+      flexDirection: 'row',
+      alignItems: 'flex-start',
+      gap: theme.space[12],
+    },
+    actionSlot: {
+      minWidth: 68,
+      alignItems: 'flex-start',
+    },
+    copy: {
+      flex: 1,
+      gap: theme.space[4],
+      paddingTop: theme.space[4],
+    },
+    title: {
+      ...theme.typography.sectionTitle,
+      color: theme.colors.text.primary,
+    },
+    subtitle: {
+      ...theme.typography.body,
+      color: theme.colors.text.secondary,
+    },
+    trailingActions: {
+      flexDirection: 'row',
+      justifyContent: 'flex-end',
+      flexWrap: 'wrap',
+      gap: theme.space[8],
+      minWidth: 68,
+    },
+  });
+}
+
+export const AppBar = memo(AppBarComponent);

--- a/mobile/src/components/layout/SheetHeader.tsx
+++ b/mobile/src/components/layout/SheetHeader.tsx
@@ -1,0 +1,100 @@
+import React, { memo, useMemo } from 'react';
+import {
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+
+import { useAppTheme } from '../../tokens/theme';
+import type { MobileTheme } from '../../tokens/theme';
+
+export interface SheetHeaderProps {
+  closeButtonTestID?: string;
+  onClose?: () => void;
+  showCloseButton?: boolean;
+  summary?: string;
+  title: string;
+}
+
+function SheetHeaderComponent({
+  closeButtonTestID,
+  onClose,
+  showCloseButton = false,
+  summary,
+  title,
+}: SheetHeaderProps) {
+  const theme = useAppTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  return (
+    <View style={styles.wrapper}>
+      <View style={styles.handle} />
+      <View style={styles.header}>
+        <View style={styles.copy}>
+          <Text accessibilityRole="header" style={styles.title}>
+            {title}
+          </Text>
+          {summary ? <Text style={styles.summary}>{summary}</Text> : null}
+        </View>
+        {showCloseButton && onClose ? (
+          <Pressable
+            accessibilityLabel="시트 닫기"
+            accessibilityRole="button"
+            onPress={onClose}
+            style={({ pressed }) => [styles.closeButton, pressed ? styles.pressed : null]}
+            testID={closeButtonTestID}
+          >
+            <Text style={styles.closeLabel}>닫기</Text>
+          </Pressable>
+        ) : null}
+      </View>
+    </View>
+  );
+}
+
+function createStyles(theme: MobileTheme) {
+  return StyleSheet.create({
+    wrapper: {
+      gap: theme.space[12],
+    },
+    handle: {
+      alignSelf: 'center',
+      width: 52,
+      height: 4,
+      borderRadius: theme.radius.chip,
+      backgroundColor: theme.colors.border.default,
+    },
+    header: {
+      flexDirection: 'row',
+      alignItems: 'flex-start',
+      justifyContent: 'space-between',
+      gap: theme.space[12],
+    },
+    copy: {
+      flex: 1,
+      gap: theme.space[4],
+    },
+    title: {
+      ...theme.typography.sectionTitle,
+      color: theme.colors.text.primary,
+    },
+    summary: {
+      ...theme.typography.meta,
+      color: theme.colors.text.secondary,
+    },
+    closeButton: {
+      minHeight: 36,
+      justifyContent: 'center',
+    },
+    pressed: {
+      opacity: 0.84,
+    },
+    closeLabel: {
+      ...theme.typography.buttonService,
+      color: theme.colors.text.secondary,
+    },
+  });
+}
+
+export const SheetHeader = memo(SheetHeaderComponent);

--- a/mobile/src/components/layout/SummaryStrip.tsx
+++ b/mobile/src/components/layout/SummaryStrip.tsx
@@ -1,0 +1,77 @@
+import React, { memo, useMemo } from 'react';
+import {
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+
+import { useAppTheme } from '../../tokens/theme';
+import type { MobileTheme } from '../../tokens/theme';
+
+export interface SummaryStripItem {
+  key: string;
+  label: string;
+  value: string | number;
+}
+
+export interface SummaryStripProps {
+  items: SummaryStripItem[];
+  layout?: 'horizontal' | 'wrap';
+  testID?: string;
+}
+
+function SummaryStripComponent({
+  items,
+  layout = 'horizontal',
+  testID,
+}: SummaryStripProps) {
+  const theme = useAppTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  return (
+    <View style={[styles.row, layout === 'wrap' ? styles.wrapRow : null]} testID={testID}>
+      {items.map((item) => (
+        <View key={item.key} style={styles.card}>
+          <Text allowFontScaling style={styles.value}>
+            {item.value}
+          </Text>
+          <Text allowFontScaling style={styles.label}>
+            {item.label}
+          </Text>
+        </View>
+      ))}
+    </View>
+  );
+}
+
+function createStyles(theme: MobileTheme) {
+  return StyleSheet.create({
+    row: {
+      flexDirection: 'row',
+      gap: theme.space[12],
+    },
+    wrapRow: {
+      flexWrap: 'wrap',
+    },
+    card: {
+      flex: 1,
+      minWidth: 92,
+      gap: theme.space[4],
+      padding: theme.space[16],
+      borderRadius: theme.radius.card,
+      backgroundColor: theme.colors.surface.elevated,
+      borderWidth: 1,
+      borderColor: theme.colors.border.subtle,
+    },
+    value: {
+      ...theme.typography.sectionTitle,
+      color: theme.colors.text.primary,
+    },
+    label: {
+      ...theme.typography.meta,
+      color: theme.colors.text.secondary,
+    },
+  });
+}
+
+export const SummaryStrip = memo(SummaryStripComponent);

--- a/mobile/src/components/meta/InfoChip.tsx
+++ b/mobile/src/components/meta/InfoChip.tsx
@@ -1,0 +1,64 @@
+import React, { memo, useMemo } from 'react';
+import {
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+
+import { useAppTheme } from '../../tokens/theme';
+import type { MobileTheme } from '../../tokens/theme';
+
+export type InfoChipTone = 'default' | 'title';
+
+export interface InfoChipProps {
+  label: string;
+  testID?: string;
+  tone?: InfoChipTone;
+}
+
+function InfoChipComponent({ label, testID, tone = 'default' }: InfoChipProps) {
+  const theme = useAppTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  return (
+    <View
+      accessibilityElementsHidden
+      importantForAccessibility="no"
+      style={[styles.chip, tone === 'title' ? styles.titleChip : null]}
+      testID={testID}
+    >
+      <Text allowFontScaling style={[styles.label, tone === 'title' ? styles.titleLabel : null]}>
+        {label}
+      </Text>
+    </View>
+  );
+}
+
+function createStyles(theme: MobileTheme) {
+  return StyleSheet.create({
+    chip: {
+      minHeight: 24,
+      alignItems: 'center',
+      justifyContent: 'center',
+      paddingHorizontal: theme.space[8],
+      paddingVertical: theme.space[4],
+      borderRadius: theme.radius.chip,
+      backgroundColor: theme.colors.surface.interactive,
+      borderWidth: 1,
+      borderColor: theme.colors.border.subtle,
+    },
+    titleChip: {
+      backgroundColor: theme.colors.status.title.bg,
+      borderColor: 'transparent',
+    },
+    label: {
+      ...theme.typography.chip,
+      color: theme.colors.text.secondary,
+    },
+    titleLabel: {
+      color: theme.colors.status.title.text,
+    },
+  });
+}
+
+export const InfoChip = memo(InfoChipComponent);

--- a/mobile/src/components/meta/SourceLinkRow.tsx
+++ b/mobile/src/components/meta/SourceLinkRow.tsx
@@ -1,0 +1,77 @@
+import React, { memo, useMemo } from 'react';
+import {
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+
+import { useAppTheme } from '../../tokens/theme';
+import type { MobileTheme } from '../../tokens/theme';
+
+export type SourceLinkType = 'article' | 'official' | 'source';
+
+export interface SourceLinkRowItem {
+  key: string;
+  label: string;
+  onPress: () => void;
+  type: SourceLinkType;
+  url: string;
+}
+
+export interface SourceLinkRowProps {
+  links: SourceLinkRowItem[];
+  testID?: string;
+}
+
+function SourceLinkRowComponent({ links, testID }: SourceLinkRowProps) {
+  const theme = useAppTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  if (links.length === 0) {
+    return null;
+  }
+
+  return (
+    <View style={styles.row} testID={testID}>
+      {links.map((link) => (
+        <Pressable
+          key={link.key}
+          accessibilityHint="외부 링크를 엽니다."
+          accessibilityLabel={link.label}
+          accessibilityRole="link"
+          onPress={link.onPress}
+          style={({ pressed }) => [styles.link, pressed ? styles.pressed : null]}
+        >
+          <Text allowFontScaling style={styles.linkLabel}>
+            {link.label}
+          </Text>
+        </Pressable>
+      ))}
+    </View>
+  );
+}
+
+function createStyles(theme: MobileTheme) {
+  return StyleSheet.create({
+    row: {
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+      gap: theme.space[12],
+    },
+    link: {
+      minHeight: 28,
+      justifyContent: 'center',
+    },
+    pressed: {
+      opacity: 0.84,
+    },
+    linkLabel: {
+      ...theme.typography.meta,
+      color: theme.colors.text.secondary,
+      textDecorationLine: 'underline',
+    },
+  });
+}
+
+export const SourceLinkRow = memo(SourceLinkRowComponent);

--- a/mobile/src/components/release/AlbumCard.tsx
+++ b/mobile/src/components/release/AlbumCard.tsx
@@ -1,0 +1,125 @@
+import React, { memo, useMemo } from 'react';
+import {
+  Image,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+
+import { InfoChip } from '../meta/InfoChip';
+import { useAppTheme } from '../../tokens/theme';
+import type { MobileTheme } from '../../tokens/theme';
+
+export interface AlbumCardProps {
+  chips?: { key: string; label: string }[];
+  coverImageUrl?: string;
+  date: string;
+  onPress: () => void;
+  testID?: string;
+  title: string;
+}
+
+function AlbumCardComponent({
+  chips = [],
+  coverImageUrl,
+  date,
+  onPress,
+  testID,
+  title,
+}: AlbumCardProps) {
+  const theme = useAppTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  return (
+    <Pressable
+      accessibilityLabel={`${title} 릴리즈 상세 열기`}
+      accessibilityRole="button"
+      onPress={onPress}
+      style={({ pressed }) => [styles.card, pressed ? styles.pressed : null]}
+      testID={testID}
+    >
+      <View style={styles.coverWrap}>
+        {coverImageUrl ? (
+          <Image source={{ uri: coverImageUrl }} style={styles.coverImage} />
+        ) : (
+          <View style={styles.coverFallback}>
+            <Text allowFontScaling style={styles.coverFallbackLabel}>
+              {title.slice(0, 2).toUpperCase()}
+            </Text>
+          </View>
+        )}
+      </View>
+      <View style={styles.copy}>
+        <Text allowFontScaling numberOfLines={2} style={styles.title}>
+          {title}
+        </Text>
+        <Text allowFontScaling style={styles.date}>
+          {date}
+        </Text>
+        {chips.length ? (
+          <View style={styles.chips}>
+            {chips.map((chip) => (
+              <InfoChip key={chip.key} label={chip.label} />
+            ))}
+          </View>
+        ) : null}
+      </View>
+    </Pressable>
+  );
+}
+
+function createStyles(theme: MobileTheme) {
+  return StyleSheet.create({
+    card: {
+      width: 188,
+      gap: theme.space[8],
+      padding: theme.space[12],
+      borderRadius: theme.radius.card,
+      backgroundColor: theme.colors.surface.elevated,
+      borderWidth: 1,
+      borderColor: theme.colors.border.subtle,
+    },
+    pressed: {
+      opacity: 0.84,
+    },
+    coverWrap: {
+      width: '100%',
+      aspectRatio: 1,
+      borderRadius: theme.radius.card,
+      overflow: 'hidden',
+      backgroundColor: theme.colors.surface.interactive,
+    },
+    coverImage: {
+      width: '100%',
+      height: '100%',
+    },
+    coverFallback: {
+      flex: 1,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    coverFallbackLabel: {
+      ...theme.typography.sectionTitle,
+      color: theme.colors.text.primary,
+    },
+    copy: {
+      gap: theme.space[4],
+    },
+    title: {
+      ...theme.typography.cardTitle,
+      color: theme.colors.text.primary,
+    },
+    date: {
+      ...theme.typography.meta,
+      color: theme.colors.text.secondary,
+    },
+    chips: {
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+      gap: theme.space[4],
+    },
+  });
+}
+
+export const AlbumCard = memo(AlbumCardComponent);

--- a/mobile/src/components/release/ReleaseSummaryRow.tsx
+++ b/mobile/src/components/release/ReleaseSummaryRow.tsx
@@ -1,0 +1,109 @@
+import React, { memo, useMemo } from 'react';
+import {
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+
+import { ActionButton } from '../actions/ActionButton';
+import {
+  ServiceButtonGroup,
+  type ServiceButtonGroupItem,
+} from '../actions/ServiceButtonGroup';
+import { TeamIdentityRow, type TeamIdentityRowProps } from '../identity/TeamIdentityRow';
+import { InfoChip } from '../meta/InfoChip';
+import { SourceLinkRow, type SourceLinkRowItem } from '../meta/SourceLinkRow';
+import { useAppTheme } from '../../tokens/theme';
+import type { MobileTheme } from '../../tokens/theme';
+
+export interface ReleaseSummaryRowProps {
+  chips?: { key: string; label: string }[];
+  date: string;
+  primaryAction?: { label: string; onPress: () => void };
+  secondaryAction?: { label: string; onPress: () => void };
+  serviceButtons?: ServiceButtonGroupItem[];
+  sourceLinks?: SourceLinkRowItem[];
+  team: TeamIdentityRowProps;
+  testID?: string;
+  title: string;
+}
+
+function ReleaseSummaryRowComponent({
+  chips = [],
+  date,
+  primaryAction,
+  secondaryAction,
+  serviceButtons = [],
+  sourceLinks = [],
+  team,
+  testID,
+  title,
+}: ReleaseSummaryRowProps) {
+  const theme = useAppTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  return (
+    <View style={styles.card} testID={testID}>
+      <TeamIdentityRow {...team} />
+      <View style={styles.copy}>
+        <Text allowFontScaling style={styles.title}>
+          {title}
+        </Text>
+        <Text allowFontScaling style={styles.meta}>
+          {date}
+        </Text>
+        {chips.length ? (
+          <View style={styles.chips}>
+            {chips.map((chip) => (
+              <InfoChip key={chip.key} label={chip.label} />
+            ))}
+          </View>
+        ) : null}
+      </View>
+      {primaryAction || secondaryAction ? (
+        <View style={styles.actions}>
+          {primaryAction ? <ActionButton {...primaryAction} tone="primary" /> : null}
+          {secondaryAction ? <ActionButton {...secondaryAction} tone="secondary" /> : null}
+        </View>
+      ) : null}
+      {serviceButtons.length ? <ServiceButtonGroup buttons={serviceButtons} /> : null}
+      {sourceLinks.length ? <SourceLinkRow links={sourceLinks} /> : null}
+    </View>
+  );
+}
+
+function createStyles(theme: MobileTheme) {
+  return StyleSheet.create({
+    card: {
+      gap: theme.space[12],
+      padding: theme.space[16],
+      borderRadius: theme.radius.card,
+      backgroundColor: theme.colors.surface.elevated,
+      borderWidth: 1,
+      borderColor: theme.colors.border.subtle,
+    },
+    copy: {
+      gap: theme.space[4],
+    },
+    title: {
+      ...theme.typography.cardTitle,
+      color: theme.colors.text.primary,
+    },
+    meta: {
+      ...theme.typography.meta,
+      color: theme.colors.text.secondary,
+    },
+    chips: {
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+      gap: theme.space[4],
+    },
+    actions: {
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+      gap: theme.space[8],
+    },
+  });
+}
+
+export const ReleaseSummaryRow = memo(ReleaseSummaryRowComponent);

--- a/mobile/src/components/release/TrackRow.test.tsx
+++ b/mobile/src/components/release/TrackRow.test.tsx
@@ -16,22 +16,16 @@ describe('TrackRow', () => {
     await act(async () => {
       tree = renderer.create(
         <TrackRow
-          buttons={[
-            {
-              accessibilityLabel: 'Spotify에서 BLACKHOLE 열기',
-              key: 'spotify',
-              label: 'Spotify',
-              onPress: spotifyPress,
-              testID: 'track-row-spotify',
-              tone: 'spotify',
-            },
-          ]}
-          testIDPrefix="track-row"
-          track={{
-            isTitleTrack: true,
-            order: 1,
-            title: 'BLACKHOLE',
+          isTitleTrack
+          order={1}
+          spotifyButton={{
+            accessibilityLabel: 'Spotify에서 BLACKHOLE 열기',
+            label: 'Spotify',
+            onPress: spotifyPress,
+            testID: 'track-row-spotify',
           }}
+          testIDPrefix="track-row"
+          title="BLACKHOLE"
         />,
       );
     });

--- a/mobile/src/components/release/TrackRow.tsx
+++ b/mobile/src/components/release/TrackRow.tsx
@@ -9,51 +9,88 @@ import {
   ServiceButtonGroup,
   type ServiceButtonGroupItem,
 } from '../actions/ServiceButtonGroup';
+import { InfoChip } from '../meta/InfoChip';
 import { useAppTheme } from '../../tokens/theme';
 import type { MobileTheme } from '../../tokens/theme';
-import type { TrackModel } from '../../types';
 
-interface TrackRowProps {
-  buttons: ServiceButtonGroupItem[];
-  testIDPrefix: string;
-  track: TrackModel;
+interface TrackRowServiceButton {
+  accessibilityHint?: string;
+  accessibilityLabel: string;
+  disabled?: boolean;
+  label: string;
+  mode?: 'canonical' | 'searchFallback';
+  onPress: () => void;
+  testID?: string;
 }
 
-function TrackRowComponent({ buttons, testIDPrefix, track }: TrackRowProps) {
+interface TrackRowProps {
+  isTitleTrack?: boolean;
+  order: number;
+  spotifyButton?: TrackRowServiceButton;
+  testIDPrefix: string;
+  title: string;
+  youtubeMusicButton?: TrackRowServiceButton;
+}
+
+function TrackRowComponent({
+  isTitleTrack = false,
+  order,
+  spotifyButton,
+  testIDPrefix,
+  title,
+  youtubeMusicButton,
+}: TrackRowProps) {
   const theme = useAppTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
+  const buttons: ServiceButtonGroupItem[] = [];
+
+  if (spotifyButton) {
+    buttons.push({
+      ...spotifyButton,
+      key: 'spotify',
+      service: 'spotify',
+    });
+  }
+
+  if (youtubeMusicButton) {
+    buttons.push({
+      ...youtubeMusicButton,
+      key: 'youtubeMusic',
+      service: 'youtubeMusic',
+    });
+  }
 
   return (
     <View
       accessible
       accessibilityLabel={[
-        `${track.order}번 트랙`,
-        track.title,
-        track.isTitleTrack ? '타이틀곡' : null,
+        `${order}번 트랙`,
+        title,
+        isTitleTrack ? '타이틀곡' : null,
       ]
         .filter(Boolean)
         .join(', ')}
       style={styles.trackRow}
-      testID={`${testIDPrefix}-${track.order}`}
+      testID={`${testIDPrefix}-${order}`}
     >
       <Text allowFontScaling style={styles.trackOrder}>
-        {track.order}
+        {order}
       </Text>
       <View style={styles.trackCopy}>
         <View style={styles.trackTitleRow}>
           <Text allowFontScaling style={styles.trackTitle}>
-            {track.title}
+            {title}
           </Text>
-          {track.isTitleTrack ? (
-            <View style={styles.titleTrackBadge} testID={`${testIDPrefix}-title-badge-${track.order}`}>
-              <Text allowFontScaling style={styles.titleTrackBadgeLabel}>
-                타이틀
-              </Text>
-            </View>
+          {isTitleTrack ? (
+            <InfoChip
+              label="타이틀"
+              testID={`${testIDPrefix}-title-badge-${order}`}
+              tone="title"
+            />
           ) : null}
         </View>
         {buttons.length ? (
-          <ServiceButtonGroup buttons={buttons} testID={`${testIDPrefix}-actions-${track.order}`} />
+          <ServiceButtonGroup buttons={buttons} testID={`${testIDPrefix}-actions-${order}`} />
         ) : null}
       </View>
     </View>
@@ -92,16 +129,6 @@ function createStyles(theme: MobileTheme) {
       ...theme.typography.cardTitle,
       color: theme.colors.text.primary,
       flexShrink: 1,
-    },
-    titleTrackBadge: {
-      paddingHorizontal: theme.space[8],
-      paddingVertical: theme.space[4],
-      borderRadius: theme.radius.chip,
-      backgroundColor: theme.colors.status.title.bg,
-    },
-    titleTrackBadgeLabel: {
-      ...theme.typography.chip,
-      color: theme.colors.status.title.text,
     },
   });
 }

--- a/mobile/src/components/upcoming/UpcomingEventRow.tsx
+++ b/mobile/src/components/upcoming/UpcomingEventRow.tsx
@@ -1,0 +1,93 @@
+import React, { memo, useMemo } from 'react';
+import {
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+
+import { ActionButton } from '../actions/ActionButton';
+import { TeamIdentityRow, type TeamIdentityRowProps } from '../identity/TeamIdentityRow';
+import { InfoChip } from '../meta/InfoChip';
+import { SourceLinkRow, type SourceLinkRowItem } from '../meta/SourceLinkRow';
+import { useAppTheme } from '../../tokens/theme';
+import type { MobileTheme } from '../../tokens/theme';
+
+export interface UpcomingEventRowProps {
+  confidenceChip?: string;
+  headline: string;
+  primaryAction: { label: string; onPress: () => void };
+  scheduledDate?: string;
+  sourceLinks?: SourceLinkRowItem[];
+  statusChip?: string;
+  team: TeamIdentityRowProps;
+  testID?: string;
+}
+
+function UpcomingEventRowComponent({
+  confidenceChip,
+  headline,
+  primaryAction,
+  scheduledDate,
+  sourceLinks = [],
+  statusChip,
+  team,
+  testID,
+}: UpcomingEventRowProps) {
+  const theme = useAppTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+
+  return (
+    <View style={styles.card} testID={testID}>
+      <TeamIdentityRow {...team} />
+      <View style={styles.copy}>
+        <Text allowFontScaling style={styles.title}>
+          {headline}
+        </Text>
+        {scheduledDate ? (
+          <Text allowFontScaling style={styles.meta}>
+            {scheduledDate}
+          </Text>
+        ) : null}
+        {statusChip || confidenceChip ? (
+          <View style={styles.chips}>
+            {statusChip ? <InfoChip label={statusChip} /> : null}
+            {confidenceChip ? <InfoChip label={confidenceChip} /> : null}
+          </View>
+        ) : null}
+      </View>
+      <ActionButton {...primaryAction} tone="primary" />
+      {sourceLinks.length ? <SourceLinkRow links={sourceLinks} /> : null}
+    </View>
+  );
+}
+
+function createStyles(theme: MobileTheme) {
+  return StyleSheet.create({
+    card: {
+      gap: theme.space[12],
+      padding: theme.space[16],
+      borderRadius: theme.radius.card,
+      backgroundColor: theme.colors.surface.elevated,
+      borderWidth: 1,
+      borderColor: theme.colors.border.subtle,
+    },
+    copy: {
+      gap: theme.space[4],
+    },
+    title: {
+      ...theme.typography.cardTitle,
+      color: theme.colors.text.primary,
+    },
+    meta: {
+      ...theme.typography.meta,
+      color: theme.colors.text.secondary,
+    },
+    chips: {
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+      gap: theme.space[4],
+    },
+  });
+}
+
+export const UpcomingEventRow = memo(UpcomingEventRowComponent);


### PR DESCRIPTION
## Summary
- add shared RN action, layout, identity, meta, calendar, release, and upcoming primitives
- refactor calendar, search, radar, and release detail screens to use the shared component contracts
- update mobile tests to lock the shared primitive API and screen integrations

## Verification
- cd mobile && npm run lint
- cd mobile && npm run typecheck
- cd mobile && npm run test -- --runInBand
- cd mobile && CI=1 npx expo export --platform web --output-dir /tmp/idol-song-app-mobile-shared-primitives-export
- git diff --check

Closes #428
Closes #429