### PR TITLE
Align mobile release detail screen to spec

### DIFF
--- a/mobile/app/releases/[id].tsx
+++ b/mobile/app/releases/[id].tsx
@@ -2,21 +2,24 @@ import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
 import React, { useEffect, useMemo, useState } from 'react';
 import {
   Image,
-  Pressable,
   ScrollView,
   StyleSheet,
   Text,
   View,
+  Linking,
 } from 'react-native';
 
 import {
   InlineFeedbackNotice,
   ScreenFeedbackState,
 } from '../../src/components/feedback/FeedbackState';
+import { AppBar } from '../../src/components/layout/AppBar';
 import {
   ServiceButtonGroup,
   type ServiceButtonGroupItem,
 } from '../../src/components/actions/ServiceButtonGroup';
+import { SourceLinkRow } from '../../src/components/meta/SourceLinkRow';
+import { TeamIdentityRow } from '../../src/components/identity/TeamIdentityRow';
 import { TrackRow } from '../../src/components/release/TrackRow';
 import {
   buildDatasetRiskDisclosure,
@@ -24,6 +27,7 @@ import {
 } from '../../src/features/surfaceDisclosures';
 import { useActiveDatasetScreen } from '../../src/features/useActiveDatasetScreen';
 import { selectReleaseDetailById } from '../../src/selectors';
+import { getFeatureGateState } from '../../src/config/featureGates';
 import {
   openServiceHandoff,
   resolveServiceHandoff,
@@ -163,7 +167,7 @@ function buildTrackServiceButtons(detail: ReleaseDetailModel, track: TrackModel)
     {
       accessibilityLabel: `YouTube Music에서 ${track.title} 트랙 열기`,
       key: 'youtubeMusic',
-      label: 'YT Music',
+      label: 'YouTube Music',
       handoff: resolveServiceHandoff({
         service: 'youtubeMusic',
         query,
@@ -194,6 +198,14 @@ function ReleaseCover({
   );
 }
 
+async function openExternalUrl(url: string) {
+  try {
+    await Linking.openURL(url);
+  } catch {
+    // Keep the current route stack stable when external handoff fails.
+  }
+}
+
 export default function ReleaseDetailScreen() {
   const router = useRouter();
   const params = useLocalSearchParams<{ id?: string | string[] }>();
@@ -211,6 +223,10 @@ export default function ReleaseDetailScreen() {
     () => (datasetState.kind === 'ready' && releaseId ? selectReleaseDetailById(datasetState.source.dataset, releaseId) : null),
     [datasetState, releaseId],
   );
+  const teamProfile =
+    datasetState.kind === 'ready' && detail
+      ? datasetState.source.dataset.artistProfiles.find((profile) => profile.group === detail.group) ?? null
+      : null;
 
   useEffect(() => {
     setHandoffFeedback(null);
@@ -323,6 +339,23 @@ export default function ReleaseDetailScreen() {
   const albumServiceButtons = buildAlbumServiceButtons(detail);
   const mvUrl = resolveYoutubeMvUrl(detail);
   const mvStatusCopy = getMvStatusCopy(detail.youtubeVideoStatus);
+  const mvEmbedGate = getFeatureGateState('mvEmbed');
+  const supportingLinks = [
+    detail.sourceUrl
+      ? {
+          key: 'release-source',
+          label: '출처 보기',
+          onPress: () => void openExternalUrl(detail.sourceUrl!),
+          type: 'source' as const,
+          url: detail.sourceUrl,
+        }
+      : null,
+  ].filter((link): link is NonNullable<typeof link> => link !== null);
+  const hasSupportingInfo = Boolean(detail.notes) || supportingLinks.length > 0;
+  const mvDisclosure =
+    mvUrl && !mvEmbedGate.enabled
+      ? '이 빌드에서는 앱 내 MV 임베드를 끄고 외부 YouTube 재생만 제공합니다.'
+      : mvStatusCopy ?? '공식 MV를 외부 YouTube에서 바로 열 수 있습니다.';
 
   return (
     <ScrollView
@@ -332,15 +365,31 @@ export default function ReleaseDetailScreen() {
     >
       <Stack.Screen options={{ title: detail.releaseTitle }} />
 
-      <Pressable
-        accessibilityHint="이전 화면으로 돌아갑니다."
-        accessibilityLabel="뒤로 가기"
-        accessibilityRole="button"
-        style={styles.backButton}
-        onPress={() => router.back()}
-      >
-        <Text style={styles.backButtonLabel}>뒤로</Text>
-      </Pressable>
+      <AppBar
+        leadingAction={{
+          accessibilityHint: '이전 화면으로 돌아갑니다.',
+          accessibilityLabel: '이전으로',
+          label: '이전으로',
+          onPress: () => router.back(),
+          testID: 'release-appbar-back',
+        }}
+        testID="release-appbar"
+        title={detail.releaseTitle}
+        titleTestID="release-detail-appbar-title"
+        trailingActions={
+          teamProfile
+            ? [
+                {
+                  key: 'team-page',
+                  accessibilityLabel: `${detail.displayGroup} 팀 페이지 열기`,
+                  label: '팀 페이지',
+                  onPress: () => router.push(`/artists/${teamProfile.slug}`),
+                  testID: 'release-appbar-team-page',
+                },
+              ]
+            : []
+        }
+      />
 
       <Text style={styles.eyebrow}>{datasetState.source.sourceLabel}</Text>
 
@@ -363,12 +412,17 @@ export default function ReleaseDetailScreen() {
             <View style={styles.kindChip}>
               <Text style={styles.kindChipLabel}>{getReleaseKindLabel(detail)}</Text>
             </View>
-            <Text style={styles.groupLabel}>{detail.displayGroup}</Text>
           </View>
+          <TeamIdentityRow
+            badgeImageUrl={teamProfile?.badge_image_url ?? teamProfile?.representative_image_url ?? undefined}
+            monogram={detail.displayGroup.slice(0, 2).toUpperCase()}
+            name={detail.displayGroup}
+            testID="release-team-identity"
+          />
         </View>
       </View>
 
-      <View style={styles.section}>
+      <View style={styles.section} testID="release-album-actions-section">
         <Text accessibilityRole="header" style={styles.sectionTitle}>앨범 액션</Text>
         <ServiceButtonGroup
           buttons={albumServiceButtons.map((button) => ({
@@ -396,59 +450,87 @@ export default function ReleaseDetailScreen() {
         {detail.tracks.length > 0 ? (
           <View style={styles.trackList}>
             {detail.tracks.map((track) => (
-              <TrackRow
-                key={`${detail.id}-${track.order}`}
-                isTitleTrack={track.isTitleTrack}
-                order={track.order}
-                spotifyButton={buildTrackServiceButtons(detail, track)
-                  .filter((button) => button.service === 'spotify')
-                  .map((button) => ({
-                    accessibilityHint: button.accessibilityHint,
-                    accessibilityLabel: button.accessibilityLabel,
-                    disabled: button.disabled,
-                    label: button.label,
-                    mode: button.mode,
-                    onPress: () => void handleHandoff(button.handoff),
-                    testID: button.testID,
-                  }))[0]}
-                testIDPrefix="release-track-row"
-                title={track.title}
-                youtubeMusicButton={buildTrackServiceButtons(detail, track)
-                  .filter((button) => button.service === 'youtubeMusic')
-                  .map((button) => ({
-                    accessibilityHint: button.accessibilityHint,
-                    accessibilityLabel: button.accessibilityLabel,
-                    disabled: button.disabled,
-                    label: button.label,
-                    mode: button.mode,
-                    onPress: () => void handleHandoff(button.handoff),
-                    testID: button.testID,
-                  }))[0]}
-              />
+              (() => {
+                const trackButtons = buildTrackServiceButtons(detail, track);
+                const spotifyButton = trackButtons.find((button) => button.service === 'spotify');
+                const youtubeMusicButton = trackButtons.find((button) => button.service === 'youtubeMusic');
+
+                return (
+                  <TrackRow
+                    key={`${detail.id}-${track.order}`}
+                    isTitleTrack={track.isTitleTrack}
+                    order={track.order}
+                    spotifyButton={
+                      spotifyButton
+                        ? {
+                            accessibilityHint: spotifyButton.accessibilityHint,
+                            accessibilityLabel: spotifyButton.accessibilityLabel,
+                            disabled: spotifyButton.disabled,
+                            label: spotifyButton.label,
+                            mode: spotifyButton.mode,
+                            onPress: () => void handleHandoff(spotifyButton.handoff),
+                            testID: spotifyButton.testID,
+                          }
+                        : undefined
+                    }
+                    testIDPrefix="release-track-row"
+                    title={track.title}
+                    youtubeMusicButton={
+                      youtubeMusicButton
+                        ? {
+                            accessibilityHint: youtubeMusicButton.accessibilityHint,
+                            accessibilityLabel: youtubeMusicButton.accessibilityLabel,
+                            disabled: youtubeMusicButton.disabled,
+                            label: youtubeMusicButton.label,
+                            mode: youtubeMusicButton.mode,
+                            onPress: () => void handleHandoff(youtubeMusicButton.handoff),
+                            testID: youtubeMusicButton.testID,
+                          }
+                        : undefined
+                    }
+                  />
+                );
+              })()
             ))}
           </View>
         ) : (
           <InlineFeedbackNotice
-            body="트랙 정보가 아직 정리되지 않았습니다."
+            body="이 릴리즈에는 신뢰 가능한 canonical tracklist가 아직 연결되지 않았습니다. placeholder 트랙은 표시하지 않습니다."
             testID="release-empty-tracks"
           />
         )}
       </View>
 
-      {detail.notes ? (
-        <View style={styles.section}>
-          <Text accessibilityRole="header" style={styles.sectionTitle}>메모</Text>
-          <View style={styles.metaCard}>
-            <Text style={styles.metaBody}>{detail.notes}</Text>
-          </View>
-        </View>
-      ) : null}
+      <View style={styles.section} testID="release-supporting-info">
+        <Text accessibilityRole="header" style={styles.sectionTitle}>추가 정보</Text>
+        {hasSupportingInfo ? (
+          <>
+            {detail.notes ? (
+              <View style={styles.metaCard}>
+                <Text style={styles.metaLabel}>메모</Text>
+                <Text style={styles.metaBody}>{detail.notes}</Text>
+              </View>
+            ) : null}
+            {supportingLinks.length > 0 ? (
+              <View style={styles.metaCard}>
+                <Text style={styles.metaLabel}>출처</Text>
+                <SourceLinkRow links={supportingLinks} testID="release-supporting-links" />
+              </View>
+            ) : null}
+          </>
+        ) : (
+          <InlineFeedbackNotice
+            body="추가 메타데이터와 출처 링크는 아직 정리되지 않았습니다."
+            testID="release-supporting-info-empty"
+          />
+        )}
+      </View>
 
       {mvUrl ? (
         <View style={styles.section} testID="release-mv-card">
           <Text accessibilityRole="header" style={styles.sectionTitle}>공식 MV</Text>
           <View style={styles.metaCard}>
-            {mvStatusCopy ? <Text style={styles.metaBody}>{mvStatusCopy}</Text> : null}
+            <Text style={styles.metaBody}>{mvDisclosure}</Text>
             <ServiceButtonGroup
               buttons={[
                 {
@@ -470,14 +552,6 @@ export default function ReleaseDetailScreen() {
               testID="release-mv-button-group"
             />
           </View>
-        </View>
-      ) : detail.youtubeVideoStatus ? (
-        <View style={styles.section} testID="release-mv-state">
-          <Text accessibilityRole="header" style={styles.sectionTitle}>MV 상태</Text>
-          <InlineFeedbackNotice
-            body={mvStatusCopy ?? '공식 MV 정보가 아직 정리되지 않았습니다.'}
-            title={detail.youtubeVideoProvenance}
-          />
         </View>
       ) : null}
     </ScrollView>
@@ -528,20 +602,6 @@ function createStyles(theme: MobileTheme) {
     retryButtonLabel: {
       ...theme.typography.buttonPrimary,
       color: theme.colors.text.primary,
-    },
-    backButton: {
-      alignSelf: 'flex-start',
-      minHeight: 44,
-      paddingHorizontal: theme.space[12],
-      paddingVertical: theme.space[8],
-      borderRadius: theme.radius.button,
-      backgroundColor: theme.colors.surface.interactive,
-    },
-    backButtonLabel: {
-      ...theme.typography.buttonService,
-      color: theme.colors.text.primary,
-      flexShrink: 1,
-      textAlign: 'center',
     },
     heroCard: {
       flexDirection: 'row',
@@ -602,10 +662,6 @@ function createStyles(theme: MobileTheme) {
       ...theme.typography.chip,
       color: theme.colors.text.brand,
     },
-    groupLabel: {
-      ...theme.typography.meta,
-      color: theme.colors.text.secondary,
-    },
     section: {
       gap: theme.space[12],
     },
@@ -649,6 +705,11 @@ function createStyles(theme: MobileTheme) {
     metaBody: {
       ...theme.typography.body,
       color: theme.colors.text.secondary,
+    },
+    metaLabel: {
+      ...theme.typography.meta,
+      color: theme.colors.text.tertiary,
+      textTransform: 'uppercase',
     },
     metaSubtle: {
       ...theme.typography.meta,

--- a/mobile/src/components/release/TrackRow.tsx
+++ b/mobile/src/components/release/TrackRow.tsx
@@ -90,7 +90,9 @@ function TrackRowComponent({
           ) : null}
         </View>
         {buttons.length ? (
-          <ServiceButtonGroup buttons={buttons} testID={`${testIDPrefix}-actions-${order}`} />
+          <View style={styles.trackActions}>
+            <ServiceButtonGroup buttons={buttons} testID={`${testIDPrefix}-actions-${order}`} />
+          </View>
         ) : null}
       </View>
     </View>
@@ -129,6 +131,9 @@ function createStyles(theme: MobileTheme) {
       ...theme.typography.cardTitle,
       color: theme.colors.text.primary,
       flexShrink: 1,
+    },
+    trackActions: {
+      alignSelf: 'flex-end',
     },
   });
 }

--- a/mobile/src/features/releaseDetailScreen.test.tsx
+++ b/mobile/src/features/releaseDetailScreen.test.tsx
@@ -3,6 +3,7 @@ import renderer, { act } from 'react-test-renderer';
 import { Text } from 'react-native';
 
 import ReleaseDetailScreen from '../../app/releases/[id]';
+import { getFeatureGateState } from '../config/featureGates';
 import { trackAnalyticsEvent } from '../services/analytics';
 import {
   openServiceHandoff,
@@ -63,6 +64,21 @@ jest.mock('../services/analytics', () => ({
   trackDatasetLoadFailed: jest.fn(),
 }));
 
+jest.mock('../config/featureGates', () => {
+  const actual = jest.requireActual('../config/featureGates');
+
+  return {
+    ...actual,
+    getFeatureGateState: jest.fn(() => ({
+      id: 'mv_embed_enabled',
+      key: 'mvEmbed',
+      label: 'MV embed',
+      offFallback: 'Hide the embed and keep the external watch CTA.',
+      enabled: true,
+    })),
+  };
+});
+
 const { __mock } = jest.requireMock('expo-router') as {
   __mock: {
     useLocalSearchParams: jest.Mock;
@@ -72,6 +88,7 @@ const { __mock } = jest.requireMock('expo-router') as {
 
 const mockOpenServiceHandoff = openServiceHandoff as jest.MockedFunction<typeof openServiceHandoff>;
 const mockTrackAnalyticsEvent = jest.mocked(trackAnalyticsEvent);
+const mockGetFeatureGateState = jest.mocked(getFeatureGateState);
 
 async function renderReleaseDetail() {
   let tree: renderer.ReactTestRenderer;
@@ -91,6 +108,13 @@ function hasText(tree: renderer.ReactTestRenderer, value: string): boolean {
 
 describe('mobile release detail screen', () => {
   beforeEach(() => {
+    mockGetFeatureGateState.mockReturnValue({
+      id: 'mv_embed_enabled',
+      key: 'mvEmbed',
+      label: 'MV embed',
+      offFallback: 'Hide the embed and keep the external watch CTA.',
+      enabled: true,
+    });
     __mock.useRouter.mockReturnValue({
       back: jest.fn(),
       push: jest.fn(),
@@ -100,30 +124,45 @@ describe('mobile release detail screen', () => {
   });
 
   test('renders populated release detail sections for a canonical release', async () => {
+    const push = jest.fn();
+    __mock.useRouter.mockReturnValue({
+      back: jest.fn(),
+      push,
+    });
     __mock.useLocalSearchParams.mockReturnValue({ id: 'yena--love-catcher--2026-03-11--album' });
     const tree = await renderReleaseDetail();
 
+    expect(tree.root.findByProps({ testID: 'release-appbar' })).toBeDefined();
+    expect(tree.root.findByProps({ testID: 'release-appbar-team-page' })).toBeDefined();
     expect(tree.root.findByProps({ testID: 'release-detail-title' }).props.children).toBe('LOVE CATCHER');
+    expect(tree.root.findByProps({ testID: 'release-team-identity' })).toBeDefined();
     expect(tree.root.findByProps({ testID: 'release-service-spotify' }).props.accessibilityLabel).toBe(
       'Spotify에서 LOVE CATCHER 열기',
     );
     expect(tree.root.findByProps({ testID: 'release-service-spotify' })).toBeDefined();
     expect(tree.root.findByProps({ testID: 'release-service-youtube-music' })).toBeDefined();
     expect(tree.root.findByProps({ testID: 'release-service-youtube-mv' })).toBeDefined();
+    expect(tree.root.findByProps({ testID: 'release-supporting-links' })).toBeDefined();
     expect(tree.root.findByProps({ testID: 'release-track-row-1' })).toBeDefined();
     expect(tree.root.findByProps({ testID: 'release-track-row-title-badge-1' })).toBeDefined();
     expect(tree.root.findByProps({ testID: 'release-mv-card' })).toBeDefined();
+
+    await act(async () => {
+      tree.root.findByProps({ testID: 'release-appbar-team-page' }).props.onPress();
+    });
+
+    expect(push).toHaveBeenCalledWith('/artists/yena');
   });
 
-  test('renders safe partial states for releases without track or mv links', async () => {
+  test('renders safe partial states for releases without track links and hides unavailable mv blocks', async () => {
     __mock.useLocalSearchParams.mockReturnValue({ id: 'atheart--glow-up--2025-11-18--song' });
     const tree = await renderReleaseDetail();
 
     expect(tree.root.findByProps({ testID: 'release-detail-title' }).props.children).toBe('Glow Up');
     expect(tree.root.findByProps({ testID: 'release-empty-tracks' })).toBeDefined();
-    expect(tree.root.findByProps({ testID: 'release-mv-state' })).toBeDefined();
     expect(tree.root.findByProps({ testID: 'release-detail-quality-notice' })).toBeDefined();
-    expect(hasText(tree, '현재는 공식 MV가 등록되지 않았습니다.')).toBe(true);
+    expect(tree.root.findAllByProps({ testID: 'release-mv-card' })).toHaveLength(0);
+    expect(tree.root.findAllByProps({ testID: 'release-mv-state' })).toHaveLength(0);
   });
 
   test('renders a safe recovery state for missing release ids', async () => {
@@ -208,5 +247,31 @@ describe('mobile release detail screen', () => {
         failureCode: 'handoff_open_failed',
       }),
     );
+  });
+
+  test('marks double title tracks consistently when a release has multiple title songs', async () => {
+    __mock.useLocalSearchParams.mockReturnValue({ id: 'p1harmony--duh--2026-04-02--album' });
+    const tree = await renderReleaseDetail();
+
+    expect(tree.root.findByProps({ testID: 'release-track-row-title-badge-1' })).toBeDefined();
+    expect(tree.root.findByProps({ testID: 'release-track-row-title-badge-2' })).toBeDefined();
+    expect(tree.root.findAllByProps({ testID: 'release-track-row-title-badge-3' })).toHaveLength(0);
+  });
+
+  test('keeps the mv CTA visible and adds disclosure when mv embed is disabled', async () => {
+    mockGetFeatureGateState.mockReturnValue({
+      id: 'mv_embed_enabled',
+      key: 'mvEmbed',
+      label: 'MV embed',
+      offFallback: 'Hide the embed and keep the external watch CTA.',
+      enabled: false,
+    });
+    __mock.useLocalSearchParams.mockReturnValue({ id: 'yena--love-catcher--2026-03-11--album' });
+
+    const tree = await renderReleaseDetail();
+
+    expect(tree.root.findByProps({ testID: 'release-mv-card' })).toBeDefined();
+    expect(hasText(tree, '이 빌드에서는 앱 내 MV 임베드를 끄고 외부 YouTube 재생만 제공합니다.')).toBe(true);
+    expect(tree.root.findByProps({ testID: 'release-mv-button' })).toBeDefined();
   });
 });

--- a/mobile/src/selectors/adapters.ts
+++ b/mobile/src/selectors/adapters.ts
@@ -253,6 +253,7 @@ export function adaptReleaseDetail(
   group: string,
   displayGroup: string,
   detail: ReleaseDetailRaw,
+  sourceUrl?: string,
   artwork?: ReleaseArtworkRaw,
 ): ReleaseDetailModel {
   const stream = normalizeReleaseStream(detail.stream);
@@ -267,6 +268,7 @@ export function adaptReleaseDetail(
     stream,
     coverImageUrl: artwork?.cover_image_url ?? undefined,
     spotifyUrl: detail.spotify_url ?? undefined,
+    sourceUrl,
     youtubeMusicUrl: detail.youtube_music_url ?? undefined,
     youtubeVideoId: detail.youtube_video_id ?? undefined,
     youtubeVideoUrl: detail.youtube_video_url ?? undefined,

--- a/mobile/src/selectors/index.ts
+++ b/mobile/src/selectors/index.ts
@@ -508,8 +508,21 @@ export function selectReleaseDetailById(
 
   const team = context.profilesByGroup.get(detail.group);
   const displayGroup = team?.display_name?.trim() || detail.group;
+  const sourceUrl =
+    context.releaseHistoryByGroup
+      .get(detail.group)
+      ?.releases.find(
+        (release) =>
+          buildReleaseId(detail.group, release.title, release.date, release.stream ?? detail.stream) === releaseId,
+      )?.source ?? undefined;
 
-  return adaptReleaseDetail(detail.group, displayGroup, detail, context.artworkByReleaseId.get(releaseId));
+  return adaptReleaseDetail(
+    detail.group,
+    displayGroup,
+    detail,
+    sourceUrl,
+    context.artworkByReleaseId.get(releaseId),
+  );
 }
 
 function resolveTimelineSortKey(item: EntityTimelineItemModel): string {

--- a/mobile/src/services/bundledDatasetFixture.ts
+++ b/mobile/src/services/bundledDatasetFixture.ts
@@ -138,6 +138,23 @@ const bundledDatasetFixture: MobileRawDataset = {
       },
       latest_album: null,
     },
+    {
+      group: 'P1Harmony',
+      latest_song: {
+        title: 'DUH!',
+        date: '2026-04-02',
+        source: 'https://musicbrainz.org/release-group/example-duh',
+        release_kind: 'single',
+        context_tags: ['title_track'],
+      },
+      latest_album: {
+        title: 'DUH!',
+        date: '2026-04-02',
+        source: 'https://musicbrainz.org/release-group/example-duh',
+        release_kind: 'ep',
+        context_tags: ['title_track'],
+      },
+    },
   ],
   upcomingCandidates: [
     {
@@ -244,6 +261,13 @@ const bundledDatasetFixture: MobileRawDataset = {
       stream: 'song',
       cover_image_url: 'https://example.com/glow-up.jpg',
     },
+    {
+      group: 'P1Harmony',
+      release_title: 'DUH!',
+      release_date: '2026-04-02',
+      stream: 'album',
+      cover_image_url: 'https://example.com/duh.jpg',
+    },
   ],
   releaseDetails: [
     {
@@ -318,6 +342,35 @@ const bundledDatasetFixture: MobileRawDataset = {
       notes: 'Representative rookie detail with incomplete catalog metadata.',
       tracks: [],
     },
+    {
+      group: 'P1Harmony',
+      release_title: 'DUH!',
+      release_date: '2026-04-02',
+      stream: 'album',
+      release_kind: 'ep',
+      spotify_url: 'https://open.spotify.com/album/example-duh',
+      youtube_music_url: 'https://music.youtube.com/playlist?list=example-duh',
+      notes: 'Representative double-title detail.',
+      tracks: [
+        {
+          order: 1,
+          title: 'DUH!',
+          is_title_track: true,
+          spotify_url: 'https://open.spotify.com/track/example-duh-title-track',
+        },
+        {
+          order: 2,
+          title: 'Back Again',
+          is_title_track: true,
+        },
+        {
+          order: 3,
+          title: 'Encore',
+          is_title_track: false,
+          youtube_music_url: 'https://music.youtube.com/watch?v=example-encore',
+        },
+      ],
+    },
   ],
   releaseHistory: [
     {
@@ -376,6 +429,19 @@ const bundledDatasetFixture: MobileRawDataset = {
           source: 'https://musicbrainz.org/release-group/example-glow-up',
           release_kind: 'single',
           stream: 'song',
+          context_tags: ['title_track'],
+        },
+      ],
+    },
+    {
+      group: 'P1Harmony',
+      releases: [
+        {
+          title: 'DUH!',
+          date: '2026-04-02',
+          source: 'https://musicbrainz.org/release-group/example-duh',
+          release_kind: 'ep',
+          stream: 'album',
           context_tags: ['title_track'],
         },
       ],

--- a/mobile/src/types/displayModels.ts
+++ b/mobile/src/types/displayModels.ts
@@ -80,6 +80,7 @@ export interface ReleaseDetailModel {
   stream?: ReleaseStream;
   coverImageUrl?: string;
   spotifyUrl?: string;
+  sourceUrl?: string;
   youtubeMusicUrl?: string;
   youtubeVideoId?: string;
   youtubeVideoUrl?: string;


### PR DESCRIPTION
## Summary
- align the mobile release detail screen with the release-detail spec for header, album actions, supporting info, track rows, and MV handling
- wire source URLs into the shared release detail display model and add a double-title fixture for regression coverage
- expand release detail tests for app bar navigation, partial states, double-title badges, and MV embed gate behavior

## Verification
- cd mobile && npm run lint
- cd mobile && npm run typecheck
- cd mobile && npm run test
- cd mobile && CI=1 npx expo export --platform web --output-dir /tmp/idol-song-app-mobile-release-detail-spec-export
- git diff --check

Closes #448
Closes #449
Closes #450