### PR TITLE
Validate RN structure, journey, and freshness

### DIFF
--- a/docs/specs/mobile/README.md
+++ b/docs/specs/mobile/README.md
@@ -96,12 +96,18 @@
    - RN 구현 중복/신뢰도 경로 감사 기록
 45. `rn-quality-coverage-matrix.md`
    - 공용 컴포넌트 / screen smoke / manual QA coverage matrix
+46. `rn-screen-structure-validation-2026-03-10.md`
+   - RN 주요 화면의 wireframe/checklist 구조 검증 기록
+47. `rn-journey-walkthrough-2026-03-10.md`
+   - RN 핵심 user journey walkthrough 결과
+48. `rn-freshness-review-2026-03-10.md`
+   - RN freshness/stale disclosure 리뷰 기록
 ### Screen Specs
-46. `calendar-screen.md`
-47. `radar-screen.md`
-48. `search-screen.md`
-49. `team-detail-screen.md`
-50. `release-detail-screen.md`
+49. `calendar-screen.md`
+50. `radar-screen.md`
+51. `search-screen.md`
+52. `team-detail-screen.md`
+53. `release-detail-screen.md`
 
 ## 읽는 순서
 1. `master-spec.md`
@@ -146,9 +152,12 @@
 40. `decision-log-review-checklist.md`
 41. `rn-implementation-audit-2026-03-10.md`
 42. `rn-quality-coverage-matrix.md`
-43. 각 화면 스펙
-44. `edge-case-catalog.md`
-45. `qa-acceptance-spec.md`
+43. `rn-screen-structure-validation-2026-03-10.md`
+44. `rn-journey-walkthrough-2026-03-10.md`
+45. `rn-freshness-review-2026-03-10.md`
+46. 각 화면 스펙
+47. `edge-case-catalog.md`
+48. `qa-acceptance-spec.md`
 
 ## 구현 원칙
 - 모바일은 웹과 다른 레이아웃을 사용한다.

--- a/docs/specs/mobile/rn-freshness-review-2026-03-10.md
+++ b/docs/specs/mobile/rn-freshness-review-2026-03-10.md
@@ -1,0 +1,54 @@
+# RN Freshness Review 2026-03-10
+
+기준 문서:
+- `data-sync-freshness-spec.md`
+- `state-feedback-spec.md`
+- `configuration-environment-spec.md`
+
+## Summary
+- Result: `PASS`
+- Focus:
+  - rolling release/upcoming freshness disclosure
+  - degraded runtime handling
+  - cache-vs-bundled distinction
+
+## Current Behavior
+- `useActiveDatasetScreen` routes all five primary surfaces through the same dataset loading contract.
+- `activeDataset.ts` now distinguishes:
+  - `bundled-static`
+  - `preview-remote`
+  - `preview-remote-cache`
+- `surfaceDisclosures.ts` exposes different copy for:
+  - bundled degraded fallback
+  - preview cached dataset with cached-at timestamp
+
+## Review Notes
+- `bundled-static`
+  - profile/artwork can remain usable
+  - rolling release/upcoming may stale faster
+  - disclosure warns about this difference
+- `preview-remote-cache`
+  - disclosure includes cached timestamp when available
+  - still treated as usable but not current
+- `error`
+  - surfaces use blocking feedback state with retry
+- `partial/degraded`
+  - surfaces keep minimum viable content and show inline notice
+
+## Surface Outcome
+- Calendar: `PASS`
+  - stale/degraded notice present
+  - month-only and exact-date semantics preserved
+- Radar: `PASS`
+  - degraded and partial notices separated
+  - sections remain usable under partial data
+- Search: `PASS`
+  - dataset load failure and empty results are separated
+- Team Detail: `PASS`
+  - dataset risk disclosure visible when needed
+- Release Detail: `PASS`
+  - dependency quality disclosure visible when data is incomplete
+
+## Residual Risks
+- Actual remote-cache age simulation on device was not run here.
+- Validation is based on fixture/test path and shared disclosure logic.

--- a/docs/specs/mobile/rn-journey-walkthrough-2026-03-10.md
+++ b/docs/specs/mobile/rn-journey-walkthrough-2026-03-10.md
@@ -1,0 +1,72 @@
+# RN Journey Walkthrough 2026-03-10
+
+기준 문서:
+- `user-journey-sequences.md`
+- `qa-acceptance-spec.md`
+
+## Summary
+- Result: `PASS`
+- Coverage: Journey `A` to `E`
+- Validation mode: selector-backed screen walkthrough + regression tests + web export smoke
+
+## Journey A: 날짜에서 바로 듣기
+- Result: `PASS`
+- Flow:
+  1. Calendar tab open
+  2. day cell tap
+  3. Date Detail Sheet open
+  4. verified release row visible
+  5. service action exposed
+- Alternate flow:
+  - same drill-in works from list view row
+  - month-only signal stays outside day cell and does not create false drill rows
+
+## Journey B: 예정 컴백에서 팀 허브로 이동
+- Result: `PASS`
+- Flow:
+  1. Radar tab open
+  2. featured/weekly card available
+  3. Team Detail open
+  4. next upcoming section visible
+  5. latest release section visible
+- Alternate flow:
+  - degraded radar still keeps usable cards
+  - sparse team keeps safe empty disclosures
+
+## Journey C: 별칭 검색 후 릴리즈 상세 진입
+- Result: `PASS`
+- Flow:
+  1. Search tab open
+  2. alias query submit
+  3. release segment select
+  4. release row open
+  5. Release Detail render
+- Alternate flow:
+  - no-result stays in safe empty state
+  - entity-only result still navigates cleanly
+
+## Journey D: 팀 상세에서 수록곡 단위 이동
+- Result: `PASS`
+- Flow:
+  1. Team Detail open
+  2. latest release or album card open
+  3. Release Detail open
+  4. Track row render
+  5. per-track handoff available
+- Alternate flow:
+  - search fallback handoff path is preserved
+  - missing track metadata shows explicit incomplete notice instead of fake rows
+
+## Journey E: 필터 적용 후 결과 재탐색
+- Result: `PASS`
+- Flow:
+  1. Calendar filter or radar filter change
+  2. result list/grid recomputed
+  3. selected route params restored
+- Alternate flow:
+  - switching calendar grid/list keeps drill-down contract
+  - radar degraded/partial states do not dead-end the flow
+
+## Follow-up
+- No new flow-gap follow-up issue was required from this pass.
+- Device-only motion/gesture QA remains manual follow-up territory.

--- a/docs/specs/mobile/rn-screen-structure-validation-2026-03-10.md
+++ b/docs/specs/mobile/rn-screen-structure-validation-2026-03-10.md
@@ -1,0 +1,97 @@
+# RN Screen Structure Validation 2026-03-10
+
+## Scope
+- Calendar
+- Radar
+- Search
+- Team Detail
+- Release Detail
+
+기준 문서:
+- `wireframe-block-diagrams.md`
+- `screen-delivery-checklists.md`
+
+## Summary
+- Result: `PASS`
+- Structural mismatches closed in this pass:
+  - Calendar `Calendar | List` view toggle restored
+  - Team Detail custom back row replaced with shared `AppBar`
+  - Dataset/degraded disclosure path aligned with shared feedback contract
+
+## Calendar
+- Result: `PASS`
+- Implemented blocks:
+  - `AppBar`
+  - quick jump row
+  - `View` segmented control
+  - `Filters` segmented control
+  - summary strip
+  - `Calendar grid` block
+  - `List view` block
+  - `Month-only signals` bucket
+  - selected-day bottom sheet
+- Overlay check:
+  - bottom sheet opens from both grid cell and list row
+  - same selected day state is restored via route params
+
+## Radar
+- Result: `PASS`
+- Implemented blocks:
+  - app bar/header
+  - dataset risk notice
+  - featured upcoming
+  - weekly upcoming
+  - change feed
+  - long-gap section
+  - rookie section
+  - section/status/act-type filter controls
+- Overlay check:
+  - filter disclosure and degraded notice are inline, not blocking
+
+## Search
+- Result: `PASS`
+- Implemented blocks:
+  - app bar/header
+  - search input
+  - recent query row
+  - segmented results
+  - entity/release/upcoming result groups
+  - empty/error feedback
+- Overlay check:
+  - no required sheet in current spec
+
+## Team Detail
+- Result: `PASS`
+- Implemented blocks:
+  - shared `AppBar`
+  - hero identity card
+  - official links row
+  - artist source meta link
+  - next upcoming section
+  - latest release section with primary/service/meta hierarchy
+  - recent albums single-card or carousel branch
+  - optional source timeline expansion
+- Overlay check:
+  - source timeline is collapsed by default and expands inline
+
+## Release Detail
+- Result: `PASS`
+- Implemented blocks:
+  - app bar/header
+  - hero/meta block
+  - supporting info
+  - service action row
+  - track list
+  - MV/status block
+  - empty/error/quality notices
+- Overlay check:
+  - no unsupported placeholder track rows remain
+
+## Checklist Trace Notes
+- Calendar delivery checklist item `Calendar/List segment 전환`: satisfied
+- Team Detail delivery checklist item `App Bar: Back / Title`: satisfied
+- Release Detail delivery checklist item `canonical tracklist만 표시`: satisfied
+
+## Residual Risks
+- Manual device QA for actual gesture feel and dynamic type overflow was not executed in this environment.
+- Current validation is code/test/export based.

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -11,6 +11,9 @@
 - decision-log 구현 점검 기준은 `docs/specs/mobile/decision-log-review-checklist.md`를 따른다.
 - RN 구현 감사 메모는 `docs/specs/mobile/rn-implementation-audit-2026-03-10.md`를 따른다.
 - RN 품질 커버리지 매트릭스는 `docs/specs/mobile/rn-quality-coverage-matrix.md`를 따른다.
+- RN 구조 검증 기록은 `docs/specs/mobile/rn-screen-structure-validation-2026-03-10.md`를 따른다.
+- RN journey walkthrough 기록은 `docs/specs/mobile/rn-journey-walkthrough-2026-03-10.md`를 따른다.
+- RN freshness review 기록은 `docs/specs/mobile/rn-freshness-review-2026-03-10.md`를 따른다.
 
 ## 현재 포함 범위
 

--- a/mobile/app/(tabs)/calendar.tsx
+++ b/mobile/app/(tabs)/calendar.tsx
@@ -28,6 +28,7 @@ import {
   buildCalendarRouteParams,
   resolveCalendarRouteState,
   type CalendarFilterMode,
+  type CalendarViewMode,
 } from '../../src/features/routeState';
 import { useActiveDatasetScreen } from '../../src/features/useActiveDatasetScreen';
 import {
@@ -117,6 +118,60 @@ function getSelectedDayCounts(snapshot: CalendarMonthSnapshotModel, isoDate: str
   };
 }
 
+type CalendarListRowModel = {
+  isoDate: string;
+  label: string;
+  releaseCount: number;
+  releaseTitles: string[];
+  upcomingCount: number;
+  upcomingTitles: string[];
+};
+
+function formatDayLabel(isoDate: string): string {
+  const [, month, day] = isoDate.split('-');
+  return `${Number(month)}월 ${Number(day)}일`;
+}
+
+function buildCalendarListRows(snapshot: CalendarMonthSnapshotModel): CalendarListRowModel[] {
+  const rows = new Map<string, CalendarListRowModel>();
+
+  for (const release of snapshot.releases) {
+    const current = rows.get(release.releaseDate) ?? {
+      isoDate: release.releaseDate,
+      label: formatDayLabel(release.releaseDate),
+      releaseCount: 0,
+      releaseTitles: [],
+      upcomingCount: 0,
+      upcomingTitles: [],
+    };
+
+    current.releaseCount += 1;
+    current.releaseTitles.push(release.releaseTitle);
+    rows.set(release.releaseDate, current);
+  }
+
+  for (const event of snapshot.exactUpcoming) {
+    if (!event.scheduledDate) {
+      continue;
+    }
+
+    const current = rows.get(event.scheduledDate) ?? {
+      isoDate: event.scheduledDate,
+      label: formatDayLabel(event.scheduledDate),
+      releaseCount: 0,
+      releaseTitles: [],
+      upcomingCount: 0,
+      upcomingTitles: [],
+    };
+
+    current.upcomingCount += 1;
+    current.upcomingTitles.push(event.releaseLabel ?? event.headline);
+    rows.set(event.scheduledDate, current);
+  }
+
+  return Array.from(rows.values()).sort((left, right) => left.isoDate.localeCompare(right.isoDate));
+}
+
 export default function CalendarTabScreen() {
   const router = useRouter();
   const params = useLocalSearchParams<{
@@ -124,6 +179,7 @@ export default function CalendarTabScreen() {
     filter?: string | string[];
     month?: string | string[];
     sheet?: string | string[];
+    view?: string | string[];
   }>();
   const theme = useAppTheme();
   const [reloadCount, setReloadCount] = useState(0);
@@ -138,6 +194,7 @@ export default function CalendarTabScreen() {
   const [filterMode, setFilterMode] = useState<CalendarFilterMode>(routeState.filterMode);
   const [selectedDayIso, setSelectedDayIso] = useState<string | null>(routeState.selectedDayIso);
   const [isSheetOpen, setIsSheetOpen] = useState(routeState.isSheetOpen);
+  const [viewMode, setViewMode] = useState<CalendarViewMode>(routeState.viewMode);
   const datasetState = useActiveDatasetScreen({
     surface: 'calendar',
     reloadKey: reloadCount,
@@ -150,11 +207,13 @@ export default function CalendarTabScreen() {
     setFilterMode(routeState.filterMode);
     setSelectedDayIso(routeState.selectedDayIso);
     setIsSheetOpen(routeState.isSheetOpen);
+    setViewMode(routeState.viewMode);
   }, [
     routeState.activeMonth,
     routeState.filterMode,
     routeState.isSheetOpen,
     routeState.selectedDayIso,
+    routeState.viewMode,
   ]);
 
   const source = datasetState.kind === 'ready' ? datasetState.source : null;
@@ -213,6 +272,10 @@ export default function CalendarTabScreen() {
   }, [filteredSnapshot, selectedDayIso, todayIsoDate]);
 
   const selectedDay = monthGrid?.selectedDay ?? null;
+  const listRows = useMemo(
+    () => (filteredSnapshot ? buildCalendarListRows(filteredSnapshot) : []),
+    [filteredSnapshot],
+  );
 
   useEffect(() => {
     const currentRouteParams = buildCalendarRouteParams({
@@ -221,6 +284,7 @@ export default function CalendarTabScreen() {
       filterMode: routeState.filterMode,
       isSheetOpen: routeState.isSheetOpen,
       selectedDayIso: routeState.selectedDayIso,
+      viewMode: routeState.viewMode,
     });
     const nextRouteParams = buildCalendarRouteParams({
       activeMonth,
@@ -228,6 +292,7 @@ export default function CalendarTabScreen() {
       filterMode,
       isSheetOpen,
       selectedDayIso,
+      viewMode,
     });
 
     if (areRouteParamsEqual(currentRouteParams, nextRouteParams)) {
@@ -244,8 +309,10 @@ export default function CalendarTabScreen() {
     routeState.filterMode,
     routeState.isSheetOpen,
     routeState.selectedDayIso,
+    routeState.viewMode,
     router,
     selectedDayIso,
+    viewMode,
   ]);
 
   function jumpToMonth(month: string, isoDate: string) {
@@ -353,6 +420,14 @@ export default function CalendarTabScreen() {
       month: filteredSnapshot.month,
     });
     setFilterMode(nextFilterMode);
+  }
+
+  function handleViewChange(nextViewMode: CalendarViewMode) {
+    if (viewMode === nextViewMode) {
+      return;
+    }
+
+    setViewMode(nextViewMode);
   }
 
   if (datasetState.kind === 'loading') {
@@ -480,21 +555,41 @@ export default function CalendarTabScreen() {
         </View>
 
         <View style={styles.sectionCard}>
-          <View style={styles.calendarHeader}>
-            <Text accessibilityRole="header" style={styles.sectionTitle}>Filters</Text>
-            <Text style={styles.sectionMeta}>{formatFilterLabel(filterMode)}</Text>
-          </View>
+          <View style={styles.controlsBlock}>
+            <View style={styles.controlSection}>
+              <View style={styles.calendarHeader}>
+                <Text accessibilityRole="header" style={styles.sectionTitle}>View</Text>
+                <Text style={styles.sectionMeta}>{viewMode === 'calendar' ? 'Calendar' : 'List'}</Text>
+              </View>
+              <SegmentedControl
+                items={[
+                  { key: 'calendar', label: 'Calendar' },
+                  { key: 'list', label: 'List' },
+                ]}
+                onChange={(key) => handleViewChange(key as CalendarViewMode)}
+                selectedKey={viewMode}
+                testID="calendar-view"
+              />
+            </View>
 
-          <SegmentedControl
-            items={[
-              { key: 'all', label: '전체' },
-              { key: 'releases', label: '발매' },
-              { key: 'upcoming', label: '예정' },
-            ]}
-            onChange={(key) => handleFilterChange(key as CalendarFilterMode)}
-            selectedKey={filterMode}
-            testID="calendar-filter"
-          />
+            <View style={styles.controlSection}>
+              <View style={styles.calendarHeader}>
+                <Text accessibilityRole="header" style={styles.sectionTitle}>Filters</Text>
+                <Text style={styles.sectionMeta}>{formatFilterLabel(filterMode)}</Text>
+              </View>
+
+              <SegmentedControl
+                items={[
+                  { key: 'all', label: '전체' },
+                  { key: 'releases', label: '발매' },
+                  { key: 'upcoming', label: '예정' },
+                ]}
+                onChange={(key) => handleFilterChange(key as CalendarFilterMode)}
+                selectedKey={filterMode}
+                testID="calendar-filter"
+              />
+            </View>
+          </View>
         </View>
 
         <SummaryStrip
@@ -511,7 +606,7 @@ export default function CalendarTabScreen() {
           testID="calendar-summary-strip"
         />
 
-        {monthGrid ? (
+        {viewMode === 'calendar' && monthGrid ? (
           <View style={styles.sectionCard}>
             <View style={styles.calendarHeader}>
               <Text accessibilityRole="header" style={styles.sectionTitle}>Calendar grid</Text>
@@ -566,6 +661,56 @@ export default function CalendarTabScreen() {
                 body={`현재 dataset source에는 ${formatMonthLabel(filteredSnapshot.month)} 기준 발매나 예정 컴백이 없습니다.`}
               />
             ) : null}
+          </View>
+        ) : null}
+
+        {viewMode === 'list' ? (
+          <View style={styles.sectionCard}>
+            <View style={styles.calendarHeader}>
+              <Text accessibilityRole="header" style={styles.sectionTitle}>List view</Text>
+              <Text style={styles.sectionMeta}>{listRows.length}일</Text>
+            </View>
+            {listRows.length > 0 ? (
+              <View style={styles.listRows}>
+                {listRows.map((row) => (
+                  <Pressable
+                    key={row.isoDate}
+                    accessibilityHint="이 날짜의 발매와 예정 상세를 엽니다."
+                    accessibilityLabel={`${row.label} 상세 열기`}
+                    accessibilityRole="button"
+                    onPress={() => openDaySheet(row.isoDate)}
+                    style={({ pressed }) => [
+                      styles.listRowCard,
+                      pressed ? styles.buttonPressed : null,
+                    ]}
+                    testID={`calendar-list-row-${row.isoDate}`}
+                  >
+                    <View style={styles.listRowHeader}>
+                      <Text style={styles.listRowTitle}>{row.label}</Text>
+                      <Text style={styles.listRowMeta}>
+                        발매 {row.releaseCount} · 예정 {row.upcomingCount}
+                      </Text>
+                    </View>
+                    {row.releaseTitles.length > 0 ? (
+                      <Text style={styles.listRowBody}>
+                        발매: {row.releaseTitles.slice(0, 2).join(', ')}
+                        {row.releaseTitles.length > 2 ? ` 외 ${row.releaseTitles.length - 2}건` : ''}
+                      </Text>
+                    ) : null}
+                    {row.upcomingTitles.length > 0 ? (
+                      <Text style={styles.listRowBody}>
+                        예정: {row.upcomingTitles.slice(0, 2).join(', ')}
+                        {row.upcomingTitles.length > 2 ? ` 외 ${row.upcomingTitles.length - 2}건` : ''}
+                      </Text>
+                    ) : null}
+                  </Pressable>
+                ))}
+              </View>
+            ) : (
+              <InlineFeedbackNotice
+                body={`현재 dataset source에는 ${formatMonthLabel(filteredSnapshot.month)} 기준 발매나 예정 컴백이 없습니다.`}
+              />
+            )}
           </View>
         ) : null}
 
@@ -705,6 +850,44 @@ function createStyles(theme: ReturnType<typeof useAppTheme>) {
       lineHeight: theme.typography.meta.lineHeight,
       fontWeight: theme.typography.meta.fontWeight,
     },
+    listRows: {
+      gap: theme.space[12],
+    },
+    listRowCard: {
+      gap: theme.space[8],
+      padding: theme.space[12],
+      borderRadius: theme.radius.card,
+      borderWidth: 1,
+      borderColor: theme.colors.border.subtle,
+      backgroundColor: theme.colors.surface.elevated,
+      minHeight: 72,
+    },
+    listRowHeader: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'flex-start',
+      gap: theme.space[12],
+    },
+    listRowTitle: {
+      flex: 1,
+      color: theme.colors.text.primary,
+      fontSize: theme.typography.cardTitle.fontSize,
+      lineHeight: theme.typography.cardTitle.lineHeight,
+      fontWeight: theme.typography.cardTitle.fontWeight,
+    },
+    listRowMeta: {
+      color: theme.colors.text.tertiary,
+      fontSize: theme.typography.meta.fontSize,
+      lineHeight: theme.typography.meta.lineHeight,
+      fontWeight: theme.typography.meta.fontWeight,
+      textAlign: 'right',
+    },
+    listRowBody: {
+      color: theme.colors.text.secondary,
+      fontSize: theme.typography.body.fontSize,
+      lineHeight: theme.typography.body.lineHeight,
+      fontWeight: theme.typography.body.fontWeight,
+    },
     sourceCard: {
       borderRadius: theme.radius.card,
       borderWidth: 1,
@@ -734,6 +917,12 @@ function createStyles(theme: ReturnType<typeof useAppTheme>) {
     },
     summaryGrid: {
       gap: theme.space[12],
+    },
+    controlsBlock: {
+      gap: theme.space[16],
+    },
+    controlSection: {
+      gap: theme.space[8],
     },
     summaryCard: {
       borderRadius: theme.radius.card,
@@ -866,6 +1055,9 @@ function createStyles(theme: ReturnType<typeof useAppTheme>) {
     },
     buttonDisabled: {
       opacity: 0.4,
+    },
+    buttonPressed: {
+      opacity: 0.84,
     },
     retryButton: {
       alignSelf: 'flex-start',

--- a/mobile/app/artists/[slug].tsx
+++ b/mobile/app/artists/[slug].tsx
@@ -18,6 +18,7 @@ import {
   ServiceButtonGroup,
   type ServiceButtonGroupItem,
 } from '../../src/components/actions/ServiceButtonGroup';
+import { AppBar } from '../../src/components/layout/AppBar';
 import {
   buildDatasetRiskDisclosure,
   buildEntitySourceDisclosure,
@@ -347,17 +348,18 @@ export default function ArtistDetailScreen() {
     <ScrollView style={styles.screen} contentContainerStyle={styles.content}>
       <Stack.Screen options={{ title: snapshot.team.displayName }} />
 
-      <View style={styles.appBar}>
-        <Pressable
-          accessibilityHint="이전 화면으로 돌아갑니다."
-          accessibilityLabel="뒤로 가기"
-          accessibilityRole="button"
-          onPress={() => router.back()}
-          style={({ pressed }) => [styles.backButton, pressed ? styles.buttonPressed : null]}
-        >
-          <Text style={styles.backButtonLabel}>뒤로</Text>
-        </Pressable>
-      </View>
+      <AppBar
+        leadingAction={{
+          accessibilityHint: '이전 화면으로 돌아갑니다.',
+          accessibilityLabel: '뒤로 가기',
+          label: '뒤로',
+          onPress: () => router.back(),
+          testID: 'entity-detail-back',
+        }}
+        subtitle="팀 페이지"
+        testID="entity-detail-app-bar"
+        title={snapshot.team.displayName}
+      />
 
       <View style={styles.heroBlock}>
         <View style={styles.heroCard}>
@@ -671,28 +673,6 @@ function createStyles(theme: ReturnType<typeof useAppTheme>) {
       paddingTop: theme.space[16],
       paddingBottom: theme.space[32],
       gap: theme.space[16],
-    },
-    appBar: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      justifyContent: 'flex-start',
-    },
-    backButton: {
-      minHeight: 44,
-      paddingHorizontal: theme.space[12],
-      paddingVertical: theme.space[8],
-      borderRadius: theme.radius.button,
-      backgroundColor: theme.colors.surface.interactive,
-      borderWidth: StyleSheet.hairlineWidth,
-      borderColor: theme.colors.border.default,
-    },
-    backButtonLabel: {
-      fontSize: theme.typography.buttonService.fontSize,
-      lineHeight: theme.typography.buttonService.lineHeight,
-      fontWeight: '600',
-      color: theme.colors.text.primary,
-      flexShrink: 1,
-      textAlign: 'center',
     },
     heroBlock: {
       gap: theme.space[12],

--- a/mobile/src/features/calendarControls.test.tsx
+++ b/mobile/src/features/calendarControls.test.tsx
@@ -56,6 +56,22 @@ function hasText(tree: renderer.ReactTestRenderer, value: string): boolean {
   return tree.root.findAllByType(Text).some((node) => node.props.children === value);
 }
 
+function hasTextContaining(tree: renderer.ReactTestRenderer, value: string): boolean {
+  return tree.root.findAllByType(Text).some((node) => {
+    const children = node.props.children;
+
+    if (typeof children === 'string') {
+      return children.includes(value);
+    }
+
+    if (Array.isArray(children)) {
+      return children.join('').includes(value);
+    }
+
+    return false;
+  });
+}
+
 describe('calendar controls', () => {
   beforeEach(() => {
     jest.useFakeTimers();
@@ -161,5 +177,23 @@ describe('calendar controls', () => {
         filterMode: 'upcoming',
       }),
     );
+  });
+
+  test('switches to list view and keeps the same day drill-in contract', async () => {
+    const tree = await renderCalendarScreen();
+
+    await act(async () => {
+      tree.root.findByProps({ testID: 'calendar-view-list' }).props.onPress();
+    });
+
+    expect(tree.root.findByProps({ testID: 'calendar-list-row-2026-03-11' })).toBeDefined();
+    expect(hasTextContaining(tree, '발매 1 · 예정 0')).toBe(true);
+
+    await act(async () => {
+      tree.root.findByProps({ testID: 'calendar-list-row-2026-03-11' }).props.onPress();
+    });
+
+    expect(tree.root.findByProps({ testID: 'calendar-bottom-sheet' })).toBeDefined();
+    expect(hasText(tree, '2026년 3월 11일')).toBe(true);
   });
 });

--- a/mobile/src/features/entityDetailScreen.test.tsx
+++ b/mobile/src/features/entityDetailScreen.test.tsx
@@ -69,6 +69,8 @@ describe('mobile entity detail screen', () => {
     __mock.useLocalSearchParams.mockReturnValue({ slug: 'yena' });
     const tree = await renderArtistDetail();
 
+    expect(tree.root.findByProps({ testID: 'entity-detail-app-bar' })).toBeDefined();
+    expect(tree.root.findByProps({ testID: 'entity-detail-back' })).toBeDefined();
     expect(tree.root.findByProps({ testID: 'entity-detail-title' }).props.children).toBe('YENA');
     expect(tree.root.findByProps({ testID: 'entity-official-link-x' }).props.accessibilityLabel).toBe(
       'YENA 공식 X 열기',

--- a/mobile/src/features/radarTab.test.tsx
+++ b/mobile/src/features/radarTab.test.tsx
@@ -106,7 +106,13 @@ function createRuntimeState(
 
 function createSource(overrides: Partial<ActiveMobileDataset> = {}): ActiveMobileDataset {
   return {
+    activeSource: 'bundled-static',
+    cachedArtifactIds: [],
     dataset: cloneBundledDatasetFixture(),
+    freshness: {
+      rollingReferenceAt: null,
+      staleFreshnessClasses: [],
+    },
     selection: createBundledDatasetSelection('fixture-v1', 'profile_default'),
     runtimeState: createRuntimeState(),
     sourceLabel: 'Bundled static dataset',

--- a/mobile/src/features/route-shell.smoke.test.tsx
+++ b/mobile/src/features/route-shell.smoke.test.tsx
@@ -56,7 +56,13 @@ jest.mock('../features/useActiveDatasetScreen', () => {
     useActiveDatasetScreen: jest.fn(() => ({
       kind: 'ready',
       source: {
+        activeSource: 'bundled-static',
+        cachedArtifactIds: [],
         dataset: cloneBundledDatasetFixture(),
+        freshness: {
+          rollingReferenceAt: null,
+          staleFreshnessClasses: [],
+        },
         selection: createBundledDatasetSelection('fixture-v1', 'profile_default'),
         runtimeState: {
           mode: 'normal',

--- a/mobile/src/features/routeState.test.ts
+++ b/mobile/src/features/routeState.test.ts
@@ -11,11 +11,12 @@ describe('mobile route state helpers', () => {
   test('restores calendar route state safely from valid params', () => {
     expect(
       resolveCalendarRouteState(
-        {
+      {
           month: '2026-03',
           date: '2026-03-11',
           filter: 'upcoming',
           sheet: 'open',
+          view: 'list',
         },
         '2026-03',
       ),
@@ -24,17 +25,19 @@ describe('mobile route state helpers', () => {
       filterMode: 'upcoming',
       isSheetOpen: true,
       selectedDayIso: '2026-03-11',
+      viewMode: 'list',
     });
   });
 
   test('drops invalid or incomplete calendar params safely', () => {
     expect(
       resolveCalendarRouteState(
-        {
+      {
           month: '2026-3',
           date: 'oops',
           filter: 'broken',
           sheet: 'open',
+          view: 'broken',
         },
         '2026-03',
       ),
@@ -43,6 +46,7 @@ describe('mobile route state helpers', () => {
       filterMode: 'all',
       isSheetOpen: false,
       selectedDayIso: null,
+      viewMode: 'calendar',
     });
   });
 
@@ -91,12 +95,31 @@ describe('mobile route state helpers', () => {
         filterMode: 'all',
         isSheetOpen: false,
         selectedDayIso: '2026-03-11',
+        viewMode: 'calendar',
       }),
     ).toEqual({
       month: undefined,
       filter: undefined,
       date: undefined,
       sheet: undefined,
+      view: undefined,
+    });
+
+    expect(
+      buildCalendarRouteParams({
+        activeMonth: '2026-04',
+        currentMonth: '2026-03',
+        filterMode: 'upcoming',
+        isSheetOpen: false,
+        selectedDayIso: null,
+        viewMode: 'list',
+      }),
+    ).toEqual({
+      month: '2026-04',
+      filter: 'upcoming',
+      date: undefined,
+      sheet: undefined,
+      view: 'list',
     });
 
     expect(buildSearchRouteParams({ query: '최예나', activeSegment: 'upcoming' })).toEqual({

--- a/mobile/src/features/routeState.ts
+++ b/mobile/src/features/routeState.ts
@@ -1,4 +1,5 @@
 export type CalendarFilterMode = 'all' | 'releases' | 'upcoming';
+export type CalendarViewMode = 'calendar' | 'list';
 export type SearchSegment = 'entities' | 'releases' | 'upcoming';
 export type RadarFilterStatus = 'all' | 'scheduled' | 'confirmed' | 'changed';
 export type RadarFilterActType = 'all' | 'group' | 'solo' | 'unit';
@@ -11,6 +12,7 @@ type CalendarRouteParams = {
   filter?: RouteParamValue;
   month?: RouteParamValue;
   sheet?: RouteParamValue;
+  view?: RouteParamValue;
 };
 
 type SearchRouteParams = {
@@ -29,6 +31,7 @@ export type CalendarRouteState = {
   filterMode: CalendarFilterMode;
   isSheetOpen: boolean;
   selectedDayIso: string | null;
+  viewMode: CalendarViewMode;
 };
 
 export type SearchRouteState = {
@@ -60,6 +63,10 @@ function isIsoDate(value: string | null): value is string {
 
 function resolveFilterMode(value: string | null): CalendarFilterMode {
   return value === 'releases' || value === 'upcoming' ? value : 'all';
+}
+
+function resolveViewMode(value: string | null): CalendarViewMode {
+  return value === 'list' ? 'list' : 'calendar';
 }
 
 function resolveSearchSegment(value: string | null): SearchSegment {
@@ -109,6 +116,7 @@ export function resolveCalendarRouteState(
     filterMode: resolveFilterMode(getSingleRouteParam(params.filter)),
     isSheetOpen: getSingleRouteParam(params.sheet) === 'open' && selectedDayIso !== null,
     selectedDayIso,
+    viewMode: resolveViewMode(getSingleRouteParam(params.view)),
   };
 }
 
@@ -118,17 +126,20 @@ export function buildCalendarRouteParams(args: {
   filterMode: CalendarFilterMode;
   isSheetOpen: boolean;
   selectedDayIso: string | null;
+  viewMode: CalendarViewMode;
 }) {
   const includeMonth =
     args.activeMonth !== args.currentMonth ||
     args.filterMode !== 'all' ||
-    args.isSheetOpen;
+    args.isSheetOpen ||
+    args.viewMode !== 'calendar';
 
   return {
     month: includeMonth ? args.activeMonth : undefined,
     filter: args.filterMode !== 'all' ? args.filterMode : undefined,
     date: args.isSheetOpen && args.selectedDayIso ? args.selectedDayIso : undefined,
     sheet: args.isSheetOpen && args.selectedDayIso ? 'open' : undefined,
+    view: args.viewMode !== 'calendar' ? args.viewMode : undefined,
   };
 }
 

--- a/mobile/src/features/surfaceDisclosures.test.ts
+++ b/mobile/src/features/surfaceDisclosures.test.ts
@@ -9,6 +9,11 @@ describe('surface disclosure helpers', () => {
     expect(
       buildDatasetRiskDisclosure(
         {
+          activeSource: 'bundled-static',
+          freshness: {
+            rollingReferenceAt: null,
+            staleFreshnessClasses: [],
+          },
           sourceLabel: 'Bundled static dataset',
           runtimeState: { mode: 'normal' },
           issues: [],
@@ -21,6 +26,11 @@ describe('surface disclosure helpers', () => {
     expect(
       buildDatasetRiskDisclosure(
         {
+          activeSource: 'preview-remote-cache',
+          freshness: {
+            rollingReferenceAt: '2026-03-10T00:00:00.000Z',
+            staleFreshnessClasses: ['rolling-release', 'rolling-upcoming'],
+          },
           sourceLabel: 'Bundled static dataset',
           runtimeState: { mode: 'degraded' },
           issues: ['Preview remote dataset is unavailable.'],

--- a/mobile/src/features/surfaceDisclosures.ts
+++ b/mobile/src/features/surfaceDisclosures.ts
@@ -7,6 +7,19 @@ export type SurfaceDisclosure = {
   testID: string;
 };
 
+function formatCachedAt(value: string | null): string | null {
+  if (!value) {
+    return null;
+  }
+
+  const [date, time] = value.split('T');
+  if (!date || !time) {
+    return value;
+  }
+
+  return `${date} ${time.slice(0, 5)}`;
+}
+
 function summarizeIssues(issues: string[]): string {
   if (issues.length === 0) {
     return 'runtime 이슈는 없지만 최신 동기화 상태를 다시 확인해 주세요.';
@@ -16,7 +29,10 @@ function summarizeIssues(issues: string[]): string {
 }
 
 export function buildDatasetRiskDisclosure(
-  source: Pick<ActiveMobileDataset, 'issues' | 'sourceLabel'> & {
+  source: Pick<
+    ActiveMobileDataset,
+    'activeSource' | 'freshness' | 'issues' | 'sourceLabel'
+  > & {
     runtimeState: Pick<ActiveMobileDataset['runtimeState'], 'mode'>;
   },
   surfaceLabel: string,
@@ -26,9 +42,16 @@ export function buildDatasetRiskDisclosure(
     return null;
   }
 
+  const freshnessNote =
+    source.activeSource === 'preview-remote-cache'
+      ? source.freshness.rollingReferenceAt
+        ? `발매/예정 데이터는 ${formatCachedAt(source.freshness.rollingReferenceAt)}에 저장된 캐시 기준입니다.`
+        : '발매/예정 데이터는 마지막으로 저장된 캐시 기준입니다.'
+      : '프로필/아트워크보다 발매·예정 데이터가 더 빨리 오래될 수 있습니다.';
+
   return {
     title: '데이터 최신화 유의',
-    body: `${surfaceLabel} 화면은 현재 ${source.sourceLabel} 기준으로 유지되고 있습니다. ${summarizeIssues(source.issues)} 일부 정보는 늦게 채워지거나 최소 정보만 표시될 수 있습니다.`,
+    body: `${surfaceLabel} 화면은 현재 ${source.sourceLabel} 기준으로 유지되고 있습니다. ${freshnessNote} ${summarizeIssues(source.issues)} 일부 정보는 늦게 채워지거나 최소 정보만 표시될 수 있습니다.`,
     testID,
   };
 }

--- a/mobile/src/features/useActiveDatasetScreen.ts
+++ b/mobile/src/features/useActiveDatasetScreen.ts
@@ -27,12 +27,14 @@ type UseActiveDatasetScreenOptions = {
   fallbackErrorMessage: string;
 };
 
-export function buildActiveDatasetEventKey(source: Pick<ActiveMobileDataset, 'issues' | 'runtimeState' | 'selection'>): string {
+export function buildActiveDatasetEventKey(
+  source: Pick<ActiveMobileDataset, 'activeSource' | 'issues' | 'runtimeState'>,
+): string {
   if (source.runtimeState.mode === 'degraded' || source.issues.length > 0) {
-    return `degraded:${source.selection.kind}:${source.runtimeState.mode}:${source.issues.join('|')}`;
+    return `degraded:${source.activeSource}:${source.runtimeState.mode}:${source.issues.join('|')}`;
   }
 
-  return `ready:${source.selection.kind}`;
+  return `ready:${source.activeSource}`;
 }
 
 export function useActiveDatasetScreen({

--- a/mobile/src/services/activeDataset.test.ts
+++ b/mobile/src/services/activeDataset.test.ts
@@ -1,6 +1,14 @@
 import type { RuntimeConfigState } from '../config/runtime';
 
 import { loadActiveMobileDataset } from './activeDataset';
+import { writeDatasetCacheEntry } from './datasetCache';
+import {
+  resetStorageAdapter,
+  setStorageAdapter,
+  type KeyValueStorageAdapter,
+} from './storage';
+import { selectDatasetSource } from './datasetSource';
+import { cloneBundledDatasetFixture } from './bundledDatasetFixture';
 
 function buildRuntimeState(overrides: Partial<RuntimeConfigState> = {}): RuntimeConfigState {
   return {
@@ -37,11 +45,32 @@ function buildRuntimeState(overrides: Partial<RuntimeConfigState> = {}): Runtime
 }
 
 describe('loadActiveMobileDataset', () => {
+  beforeEach(() => {
+    const store = new Map<string, string>();
+    const adapter: KeyValueStorageAdapter = {
+      getItem: jest.fn(async (key: string) => store.get(key) ?? null),
+      removeItem: jest.fn(async (key: string) => {
+        store.delete(key);
+      }),
+      setItem: jest.fn(async (key: string, value: string) => {
+        store.set(key, value);
+      }),
+    };
+
+    setStorageAdapter(adapter);
+  });
+
+  afterEach(() => {
+    resetStorageAdapter();
+  });
+
   test('returns bundled fixture for bundled-static runtime selection', async () => {
     const result = await loadActiveMobileDataset({
       runtimeState: buildRuntimeState(),
     });
 
+    expect(result.activeSource).toBe('bundled-static');
+    expect(result.cachedArtifactIds).toEqual([]);
     expect(result.selection.kind).toBe('bundled-static');
     expect(result.sourceLabel).toBe('Bundled static dataset');
     expect(result.dataset.artistProfiles.length).toBeGreaterThan(0);
@@ -78,36 +107,114 @@ describe('loadActiveMobileDataset', () => {
       })) as unknown as typeof fetch,
     });
 
+    expect(result.activeSource).toBe('preview-remote');
+    expect(result.cachedArtifactIds.length).toBeGreaterThan(0);
     expect(result.selection.kind).toBe('preview-remote');
     expect(result.sourceLabel).toBe('Preview remote dataset');
     expect(result.dataset.artistProfiles).toEqual([]);
   });
 
-  test('throws a typed error when the remote dataset payload is invalid', async () => {
-    await expect(
-      loadActiveMobileDataset({
-        runtimeState: buildRuntimeState({
-          config: {
-            ...buildRuntimeState().config,
-            profile: 'preview',
-            dataSource: {
-              mode: 'preview-static',
-              remoteDatasetUrl: 'https://example.com/mobile-dataset.json',
-              datasetVersion: 'preview-v1',
-            },
-            featureGates: {
-              ...buildRuntimeState().config.featureGates,
-              remoteRefresh: true,
-            },
-          },
-        }),
-        fetchImpl: jest.fn(async () => ({
-          ok: true,
-          json: async () => ({ nope: true }),
-        })) as unknown as typeof fetch,
-      }),
-    ).rejects.toMatchObject({
-      code: 'invalid_dataset',
+  test('falls back to bundled degraded mode when the remote payload is invalid', async () => {
+    const runtimeState = buildRuntimeState({
+      config: {
+        ...buildRuntimeState().config,
+        profile: 'preview',
+        dataSource: {
+          mode: 'preview-static',
+          remoteDatasetUrl: 'https://example.com/mobile-dataset.json',
+          datasetVersion: 'preview-v1',
+        },
+        featureGates: {
+          ...buildRuntimeState().config.featureGates,
+          remoteRefresh: true,
+        },
+      },
     });
+
+    const result = await loadActiveMobileDataset({
+      runtimeState,
+      fetchImpl: jest.fn(async () => ({
+        ok: true,
+        json: async () => ({ nope: true }),
+      })) as unknown as typeof fetch,
+    });
+
+    expect(result.activeSource).toBe('bundled-static');
+    expect(result.selection.kind).toBe('bundled-static');
+    expect(result.issues).toContain(
+      'Remote dataset payload does not match the expected contract.',
+    );
+  });
+
+  test('restores the preview remote cache when the remote dataset is unavailable', async () => {
+    const runtimeState = buildRuntimeState({
+      config: {
+        ...buildRuntimeState().config,
+        profile: 'preview',
+        dataSource: {
+          mode: 'preview-static',
+          remoteDatasetUrl: 'https://example.com/mobile-dataset.json',
+          datasetVersion: 'preview-v1',
+        },
+        featureGates: {
+          ...buildRuntimeState().config.featureGates,
+          remoteRefresh: true,
+        },
+      },
+    });
+    const selection = selectDatasetSource(runtimeState.config);
+    const fixture = cloneBundledDatasetFixture();
+
+    if (selection.kind !== 'preview-remote') {
+      throw new Error('Expected preview-remote selection for cache test.');
+    }
+
+    await Promise.all(
+      selection.artifacts.map((artifact) =>
+        writeDatasetCacheEntry(
+          artifact.id,
+          (() => {
+            switch (artifact.id) {
+              case 'artistProfiles':
+                return fixture.artistProfiles;
+              case 'releases':
+                return fixture.releases;
+              case 'releaseArtwork':
+                return fixture.releaseArtwork;
+              case 'releaseDetails':
+                return fixture.releaseDetails;
+              case 'releaseHistory':
+                return fixture.releaseHistory;
+              case 'watchlist':
+                return fixture.watchlist ?? [];
+              case 'upcomingCandidates':
+                return fixture.upcomingCandidates;
+              case 'teamBadgeAssets':
+                return fixture.teamBadgeAssets ?? [];
+              case 'youtubeChannelAllowlists':
+                return fixture.youtubeChannelAllowlists;
+              case 'radarChangeFeed':
+                return fixture.radarChangeFeed ?? [];
+            }
+          })(),
+          selection,
+          '2026-03-10T00:00:00.000Z',
+        ),
+      ),
+    );
+
+    const result = await loadActiveMobileDataset({
+      runtimeState,
+      fetchImpl: jest.fn(async () => ({
+        ok: false,
+        status: 503,
+      })) as unknown as typeof fetch,
+    });
+
+    expect(result.activeSource).toBe('preview-remote-cache');
+    expect(result.sourceLabel).toBe('Preview remote cached dataset');
+    expect(result.cachedArtifactIds).toHaveLength(selection.artifacts.length);
+    expect(result.freshness.rollingReferenceAt).toBe('2026-03-10T00:00:00.000Z');
+    expect(result.dataset.artistProfiles.length).toBe(fixture.artistProfiles.length);
   });
 });

--- a/mobile/src/services/activeDataset.ts
+++ b/mobile/src/services/activeDataset.ts
@@ -1,24 +1,59 @@
-import { getRuntimeConfigState, type RuntimeConfigState } from '../config/runtime';
+import type { RuntimeConfigState } from '../config/runtime';
+import { getRuntimeConfigState } from '../config/runtime';
 import type { MobileRawDataset } from '../types';
 
 import {
+  resolveDatasetFailurePolicy,
+  type DatasetFailurePolicy,
+} from './datasetFailurePolicy';
+import {
+  readDatasetCacheEntry,
+  writeDatasetCacheEntry,
+} from './datasetCache';
+import {
   isRemoteDatasetSelection,
   selectDatasetSource,
+  type DatasetArtifactDescriptor,
+  type DatasetArtifactId,
+  type DatasetFreshnessClass,
   type DatasetSelection,
+  type PreviewRemoteDatasetSelection,
 } from './datasetSource';
 import { cloneBundledDatasetFixture } from './bundledDatasetFixture';
 
+type DatasetArtifactValues = {
+  artistProfiles: MobileRawDataset['artistProfiles'];
+  releases: MobileRawDataset['releases'];
+  releaseArtwork: MobileRawDataset['releaseArtwork'];
+  releaseDetails: MobileRawDataset['releaseDetails'];
+  releaseHistory: MobileRawDataset['releaseHistory'];
+  watchlist: NonNullable<MobileRawDataset['watchlist']>;
+  upcomingCandidates: MobileRawDataset['upcomingCandidates'];
+  teamBadgeAssets: NonNullable<MobileRawDataset['teamBadgeAssets']>;
+  youtubeChannelAllowlists: MobileRawDataset['youtubeChannelAllowlists'];
+  radarChangeFeed: NonNullable<MobileRawDataset['radarChangeFeed']>;
+};
+
 export type ActiveMobileDataset = {
+  activeSource: DatasetFailurePolicy['activeSource'];
+  cachedArtifactIds: DatasetArtifactId[];
   dataset: MobileRawDataset;
-  selection: DatasetSelection;
-  runtimeState: RuntimeConfigState;
-  sourceLabel: string;
+  freshness: {
+    rollingReferenceAt: string | null;
+    staleFreshnessClasses: DatasetFreshnessClass[];
+  };
   issues: string[];
+  runtimeState: RuntimeConfigState;
+  selection: DatasetSelection;
+  sourceLabel: string;
 };
 
 export class ActiveDatasetLoadError extends Error {
   constructor(
-    public readonly code: 'remote_unavailable' | 'invalid_dataset',
+    public readonly code:
+      | 'remote_unavailable'
+      | 'invalid_dataset'
+      | 'invalid_cache',
     message: string,
   ) {
     super(message);
@@ -28,6 +63,10 @@ export class ActiveDatasetLoadError extends Error {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
+}
+
+function isOptionalArray(value: unknown): boolean {
+  return value == null || Array.isArray(value);
 }
 
 function isMobileRawDataset(value: unknown): value is MobileRawDataset {
@@ -42,55 +81,296 @@ function isMobileRawDataset(value: unknown): value is MobileRawDataset {
     Array.isArray(value.releaseArtwork) &&
     Array.isArray(value.releaseDetails) &&
     Array.isArray(value.releaseHistory) &&
-    Array.isArray(value.youtubeChannelAllowlists)
+    Array.isArray(value.youtubeChannelAllowlists) &&
+    isOptionalArray(value.watchlist) &&
+    isOptionalArray(value.teamBadgeAssets) &&
+    isOptionalArray(value.radarChangeFeed)
   );
 }
 
-function getDatasetSourceLabel(selection: DatasetSelection): string {
-  return selection.kind === 'preview-remote' ? 'Preview remote dataset' : 'Bundled static dataset';
+function normalizeMobileRawDataset(dataset: MobileRawDataset): MobileRawDataset {
+  return {
+    ...dataset,
+    watchlist: Array.isArray(dataset.watchlist) ? dataset.watchlist : [],
+    teamBadgeAssets: Array.isArray(dataset.teamBadgeAssets)
+      ? dataset.teamBadgeAssets
+      : [],
+    radarChangeFeed: Array.isArray(dataset.radarChangeFeed)
+      ? dataset.radarChangeFeed
+      : [],
+  };
 }
 
-export async function loadActiveMobileDataset(options: {
-  runtimeState?: RuntimeConfigState;
-  fetchImpl?: typeof fetch;
-} = {}): Promise<ActiveMobileDataset> {
+function getDatasetSourceLabel(
+  activeSource: DatasetFailurePolicy['activeSource'],
+): string {
+  switch (activeSource) {
+    case 'preview-remote':
+      return 'Preview remote dataset';
+    case 'preview-remote-cache':
+      return 'Preview remote cached dataset';
+    case 'bundled-static':
+    default:
+      return 'Bundled static dataset';
+  }
+}
+
+function dedupeIssueMessages(messages: string[]): string[] {
+  return [...new Set(messages.filter(Boolean))];
+}
+
+function getArtifactValue(
+  dataset: MobileRawDataset,
+  descriptor: DatasetArtifactDescriptor,
+): DatasetArtifactValues[typeof descriptor.id] {
+  switch (descriptor.id) {
+    case 'artistProfiles':
+      return dataset.artistProfiles;
+    case 'releases':
+      return dataset.releases;
+    case 'releaseArtwork':
+      return dataset.releaseArtwork;
+    case 'releaseDetails':
+      return dataset.releaseDetails;
+    case 'releaseHistory':
+      return dataset.releaseHistory;
+    case 'watchlist':
+      return Array.isArray(dataset.watchlist) ? dataset.watchlist : [];
+    case 'upcomingCandidates':
+      return dataset.upcomingCandidates;
+    case 'teamBadgeAssets':
+      return Array.isArray(dataset.teamBadgeAssets) ? dataset.teamBadgeAssets : [];
+    case 'youtubeChannelAllowlists':
+      return dataset.youtubeChannelAllowlists;
+    case 'radarChangeFeed':
+      return Array.isArray(dataset.radarChangeFeed) ? dataset.radarChangeFeed : [];
+  }
+}
+
+async function writeDatasetCaches(
+  dataset: MobileRawDataset,
+  selection: PreviewRemoteDatasetSelection,
+  cachedAt = new Date().toISOString(),
+): Promise<DatasetArtifactId[]> {
+  await Promise.all(
+    selection.artifacts.map((descriptor) =>
+      writeDatasetCacheEntry(
+        descriptor.id,
+        getArtifactValue(dataset, descriptor),
+        selection,
+        cachedAt,
+      ),
+    ),
+  );
+
+  return selection.artifacts.map((descriptor) => descriptor.id);
+}
+
+async function buildDatasetFromCache(
+  selection: PreviewRemoteDatasetSelection,
+): Promise<{
+  cachedArtifactIds: DatasetArtifactId[];
+  dataset: MobileRawDataset;
+  rollingReferenceAt: string | null;
+}> {
+  const entries = await Promise.all(
+    selection.artifacts.map(async (descriptor) => {
+      const entry = await readDatasetCacheEntry<DatasetArtifactValues[typeof descriptor.id]>(
+        descriptor.id,
+        selection,
+      );
+
+      return {
+        descriptor,
+        entry,
+      };
+    }),
+  );
+
+  const missing = entries.find(({ entry }) => entry === null);
+  if (missing) {
+    throw new ActiveDatasetLoadError(
+      'invalid_cache',
+      `Preview remote cache is missing ${missing.descriptor.id}.`,
+    );
+  }
+
+  const values = new Map<DatasetArtifactId, DatasetArtifactValues[DatasetArtifactId]>();
+  for (const { descriptor, entry } of entries) {
+    values.set(descriptor.id, entry!.value);
+  }
+
+  const rollingReferenceAt =
+    entries
+      .filter(({ descriptor }) => descriptor.freshnessClass !== 'stable-profile')
+      .map(({ entry }) => entry!.cachedAt)
+      .sort()[0] ?? null;
+
+  return {
+    cachedArtifactIds: selection.artifacts.map((descriptor) => descriptor.id),
+    dataset: normalizeMobileRawDataset({
+      artistProfiles: values.get('artistProfiles') as MobileRawDataset['artistProfiles'],
+      releases: values.get('releases') as MobileRawDataset['releases'],
+      releaseArtwork: values.get('releaseArtwork') as MobileRawDataset['releaseArtwork'],
+      releaseDetails: values.get('releaseDetails') as MobileRawDataset['releaseDetails'],
+      releaseHistory: values.get('releaseHistory') as MobileRawDataset['releaseHistory'],
+      watchlist: values.get('watchlist') as NonNullable<MobileRawDataset['watchlist']>,
+      upcomingCandidates: values.get('upcomingCandidates') as MobileRawDataset['upcomingCandidates'],
+      teamBadgeAssets: values.get('teamBadgeAssets') as NonNullable<MobileRawDataset['teamBadgeAssets']>,
+      youtubeChannelAllowlists: values.get(
+        'youtubeChannelAllowlists',
+      ) as MobileRawDataset['youtubeChannelAllowlists'],
+      radarChangeFeed: values.get('radarChangeFeed') as NonNullable<MobileRawDataset['radarChangeFeed']>,
+    }),
+    rollingReferenceAt,
+  };
+}
+
+function buildBundledDatasetResponse(args: {
+  cachedArtifactIds: DatasetArtifactId[];
+  extraIssues?: string[];
+  policy: DatasetFailurePolicy;
+  runtimeState: RuntimeConfigState;
+}): ActiveMobileDataset {
+  const dataset = normalizeMobileRawDataset(cloneBundledDatasetFixture());
+
+  return {
+    activeSource: args.policy.activeSource,
+    cachedArtifactIds: args.cachedArtifactIds,
+    dataset,
+    freshness: {
+      rollingReferenceAt: null,
+      staleFreshnessClasses: ['rolling-release', 'rolling-upcoming'],
+    },
+    issues: dedupeIssueMessages([
+      ...args.runtimeState.issues.map((issue) => issue.message),
+      ...args.policy.issues.map((issue) => issue.message),
+      ...(args.extraIssues ?? []),
+    ]),
+    runtimeState: args.runtimeState,
+    selection: args.policy.selection,
+    sourceLabel: getDatasetSourceLabel(args.policy.activeSource),
+  };
+}
+
+export async function loadActiveMobileDataset(
+  options: {
+    fetchImpl?: typeof fetch;
+    runtimeState?: RuntimeConfigState;
+  } = {},
+): Promise<ActiveMobileDataset> {
   const runtimeState = options.runtimeState ?? getRuntimeConfigState();
   const selection = selectDatasetSource(runtimeState.config);
-  const issues = runtimeState.issues.map((issue) => issue.message);
+  const basePolicy = await resolveDatasetFailurePolicy({
+    runtimeState,
+    selection,
+  });
 
-  if (!isRemoteDatasetSelection(selection)) {
-    return {
-      dataset: cloneBundledDatasetFixture(),
-      selection,
+  if (!isRemoteDatasetSelection(selection) || basePolicy.activeSource === 'bundled-static') {
+    return buildBundledDatasetResponse({
+      cachedArtifactIds: basePolicy.cachedArtifactIds,
+      policy: basePolicy,
       runtimeState,
-      sourceLabel: getDatasetSourceLabel(selection),
-      issues,
-    };
+    });
   }
 
   const fetchImpl = options.fetchImpl ?? fetch;
-  const response = await fetchImpl(selection.remoteDatasetUrl);
 
-  if (!response.ok) {
-    throw new ActiveDatasetLoadError(
-      'remote_unavailable',
-      `Remote dataset request failed with status ${response.status}.`,
-    );
+  try {
+    const response = await fetchImpl(selection.remoteDatasetUrl);
+    if (!response.ok) {
+      throw new ActiveDatasetLoadError(
+        'remote_unavailable',
+        `Remote dataset request failed with status ${response.status}.`,
+      );
+    }
+
+    const payload = await response.json();
+    if (!isMobileRawDataset(payload)) {
+      throw new ActiveDatasetLoadError(
+        'invalid_dataset',
+        'Remote dataset payload does not match the expected contract.',
+      );
+    }
+
+    const dataset = normalizeMobileRawDataset(payload);
+    const cachedArtifactIds = await writeDatasetCaches(dataset, selection);
+
+    return {
+      activeSource: 'preview-remote',
+      cachedArtifactIds,
+      dataset,
+      freshness: {
+        rollingReferenceAt: null,
+        staleFreshnessClasses: [],
+      },
+      issues: dedupeIssueMessages(runtimeState.issues.map((issue) => issue.message)),
+      runtimeState,
+      selection,
+      sourceLabel: getDatasetSourceLabel('preview-remote'),
+    };
+  } catch (error: unknown) {
+    const remoteAvailability =
+      error instanceof ActiveDatasetLoadError && error.code === 'invalid_dataset'
+        ? {
+            message: error.message,
+            status: 'invalid' as const,
+          }
+        : {
+            message:
+              error instanceof Error
+                ? error.message
+                : 'Preview remote dataset is unavailable.',
+            status: 'unavailable' as const,
+          };
+
+    const fallbackPolicy = await resolveDatasetFailurePolicy({
+      runtimeState,
+      selection,
+      remoteAvailability,
+    });
+
+    if (fallbackPolicy.activeSource === 'preview-remote-cache') {
+      try {
+        const cached = await buildDatasetFromCache(selection);
+
+        return {
+          activeSource: 'preview-remote-cache',
+          cachedArtifactIds: cached.cachedArtifactIds,
+          dataset: cached.dataset,
+          freshness: {
+            rollingReferenceAt: cached.rollingReferenceAt,
+            staleFreshnessClasses: ['rolling-release', 'rolling-upcoming'],
+          },
+          issues: dedupeIssueMessages([
+            ...runtimeState.issues.map((issue) => issue.message),
+            ...fallbackPolicy.issues.map((issue) => issue.message),
+          ]),
+          runtimeState,
+          selection: fallbackPolicy.selection,
+          sourceLabel: getDatasetSourceLabel('preview-remote-cache'),
+        };
+      } catch (cacheError: unknown) {
+        return buildBundledDatasetResponse({
+          cachedArtifactIds: fallbackPolicy.cachedArtifactIds,
+          extraIssues: [
+            cacheError instanceof Error
+              ? cacheError.message
+              : 'Preview remote cache could not be restored.',
+          ],
+          policy: {
+            ...fallbackPolicy,
+            activeSource: 'bundled-static',
+          },
+          runtimeState,
+        });
+      }
+    }
+
+    return buildBundledDatasetResponse({
+      cachedArtifactIds: fallbackPolicy.cachedArtifactIds,
+      policy: fallbackPolicy,
+      runtimeState,
+    });
   }
-
-  const payload = await response.json();
-  if (!isMobileRawDataset(payload)) {
-    throw new ActiveDatasetLoadError(
-      'invalid_dataset',
-      'Remote dataset payload does not match the expected contract.',
-    );
-  }
-
-  return {
-    dataset: payload,
-    selection,
-    runtimeState,
-    sourceLabel: getDatasetSourceLabel(selection),
-    issues,
-  };
 }

--- a/mobile/src/services/analytics.test.ts
+++ b/mobile/src/services/analytics.test.ts
@@ -1,5 +1,4 @@
 import type { MobileRuntimeConfig } from '../config/runtime';
-import { createBundledDatasetSelection } from './datasetSource';
 
 import {
   getLatestAnalyticsEvent,
@@ -135,7 +134,7 @@ describe('mobile analytics service', () => {
     trackDatasetDegraded(
       'calendar',
       {
-        selection: createBundledDatasetSelection('preview-v1', 'runtime_degraded'),
+        activeSource: 'bundled-static',
         runtimeState: {
           mode: 'degraded',
           config: analyticsEnabledRuntime,

--- a/mobile/src/services/analytics.ts
+++ b/mobile/src/services/analytics.ts
@@ -141,7 +141,7 @@ export function resetAnalyticsEvents(): void {
 
 export function trackDatasetDegraded(
   surface: AnalyticsSurface,
-  source: Pick<ActiveMobileDataset, 'issues' | 'runtimeState' | 'selection'>,
+  source: Pick<ActiveMobileDataset, 'activeSource' | 'issues' | 'runtimeState'>,
   runtimeConfig: MobileRuntimeConfig = getRuntimeConfig(),
   now?: () => string,
 ): boolean {
@@ -149,7 +149,7 @@ export function trackDatasetDegraded(
     'dataset_degraded',
     {
       surface,
-      activeSource: source.selection.kind,
+      activeSource: source.activeSource,
       runtimeMode: source.runtimeState.mode,
       issueCount: source.issues.length,
     },

--- a/mobile/src/services/bundledDatasetFixture.ts
+++ b/mobile/src/services/bundledDatasetFixture.ts
@@ -156,6 +156,7 @@ const bundledDatasetFixture: MobileRawDataset = {
       },
     },
   ],
+  watchlist: [],
   upcomingCandidates: [
     {
       group: 'YENA',
@@ -489,6 +490,7 @@ const bundledDatasetFixture: MobileRawDataset = {
       ],
     },
   ],
+  teamBadgeAssets: [],
 };
 
 export const BUNDLED_DATASET_FIXTURE = bundledDatasetFixture;

--- a/mobile/src/services/datasetSource.ts
+++ b/mobile/src/services/datasetSource.ts
@@ -10,7 +10,9 @@ export type DatasetArtifactId =
   | 'releaseHistory'
   | 'watchlist'
   | 'upcomingCandidates'
-  | 'teamBadgeAssets';
+  | 'teamBadgeAssets'
+  | 'youtubeChannelAllowlists'
+  | 'radarChangeFeed';
 export type DatasetFreshnessClass = 'stable-profile' | 'rolling-release' | 'rolling-upcoming';
 
 export type DatasetArtifactDescriptor = {
@@ -84,6 +86,16 @@ export const DATASET_ARTIFACTS: DatasetArtifactDescriptor[] = [
     id: 'teamBadgeAssets',
     freshnessClass: 'stable-profile',
     relativePath: 'teamBadgeAssets.json',
+  },
+  {
+    id: 'youtubeChannelAllowlists',
+    freshnessClass: 'stable-profile',
+    relativePath: 'youtubeChannelAllowlists.json',
+  },
+  {
+    id: 'radarChangeFeed',
+    freshnessClass: 'rolling-upcoming',
+    relativePath: 'radarChangeFeed.json',
   },
 ];
 

--- a/mobile/src/types/rawData.ts
+++ b/mobile/src/types/rawData.ts
@@ -124,10 +124,12 @@ export type YoutubeChannelAllowlistRaw = {
 export type MobileRawDataset = {
   artistProfiles: ArtistProfileRaw[];
   releases: ReleaseStreamCollectionRaw[];
+  watchlist?: unknown[] | null;
   upcomingCandidates: UpcomingCandidateRaw[];
   radarChangeFeed?: RadarChangeFeedRaw[] | null;
   releaseArtwork: ReleaseArtworkRaw[];
   releaseDetails: ReleaseDetailRaw[];
   releaseHistory: ReleaseHistoryGroupRaw[];
   youtubeChannelAllowlists: YoutubeChannelAllowlistRaw[];
+  teamBadgeAssets?: unknown[] | null;
 };


### PR DESCRIPTION
## Summary
- restore calendar/list route state and UI contract for the RN calendar screen
- align entity detail with the shared app bar and degraded dataset disclosure flow
- add structure, journey, and freshness validation artifacts for RN surfaces

## Verification
- cd mobile && npm run lint
- cd mobile && npm run typecheck
- cd mobile && npm run test -- --runInBand
- cd mobile && CI=1 npx expo export --platform web --output-dir /tmp/idol-song-app-mobile-460-461-462-export
- git diff --check

Closes #460
Closes #461
Closes #462