### PR TITLE
feat(mobile): cut over shared backend data path

### DIFF
--- a/mobile/app.config.ts
+++ b/mobile/app.config.ts
@@ -2,7 +2,7 @@ import type { ExpoConfig, ConfigContext } from 'expo/config';
 
 type MobileProfile = 'development' | 'preview' | 'production';
 type LoggingLevel = 'verbose' | 'debug' | 'error';
-type DataSourceMode = 'bundled-static' | 'preview-static' | 'production-static';
+type DataSourceMode = 'bundled-static' | 'backend-api';
 
 type ProfileConfig = {
   name: string;
@@ -23,7 +23,6 @@ type RuntimeConfig = {
   profile: MobileProfile;
   dataSource: {
     mode: DataSourceMode;
-    remoteDatasetUrl: string | null;
     datasetVersion: string | null;
   };
   services: {
@@ -67,7 +66,7 @@ const PROFILE_CONFIG: Record<MobileProfile, ProfileConfig> = {
     name: 'Idol Song App (Preview)',
     slug: 'idol-song-app-mobile-preview',
     scheme: 'idolsongapp-preview',
-    dataSourceMode: 'preview-static',
+    dataSourceMode: 'backend-api',
     loggingLevel: 'debug',
     featureGates: {
       radar: true,
@@ -81,7 +80,7 @@ const PROFILE_CONFIG: Record<MobileProfile, ProfileConfig> = {
     name: 'Idol Song App',
     slug: 'idol-song-app-mobile',
     scheme: 'idolsongapp',
-    dataSourceMode: 'production-static',
+    dataSourceMode: 'backend-api',
     loggingLevel: 'error',
     featureGates: {
       radar: true,
@@ -151,7 +150,6 @@ function assertHttpUrl(value: string | null, envName: string): string | null {
 
 function buildRuntimeConfig(profile: MobileProfile, profileConfig: ProfileConfig, env: EnvMap): RuntimeConfig {
   const apiBaseUrl = assertHttpUrl(optionalString(env.EXPO_PUBLIC_API_BASE_URL), 'EXPO_PUBLIC_API_BASE_URL');
-  const remoteDatasetUrl = assertHttpUrl(optionalString(env.EXPO_PUBLIC_REMOTE_DATASET_URL), 'EXPO_PUBLIC_REMOTE_DATASET_URL');
   const analyticsWriteKey = optionalString(env.EXPO_PUBLIC_ANALYTICS_WRITE_KEY);
   const datasetVersion = optionalString(env.EXPO_PUBLIC_DATASET_VERSION);
   const buildVersion = optionalString(env.EXPO_PUBLIC_BUILD_VERSION) ?? '0.1.0';
@@ -165,16 +163,12 @@ function buildRuntimeConfig(profile: MobileProfile, profileConfig: ProfileConfig
     shareActions: parseBooleanOverride(env.EXPO_PUBLIC_ENABLE_SHARE_ACTIONS, profileConfig.featureGates.shareActions),
   };
 
-  if (featureGates.remoteRefresh && !remoteDatasetUrl) {
-    throw new Error('EXPO_PUBLIC_REMOTE_DATASET_URL is required when EXPO_PUBLIC_ENABLE_REMOTE_REFRESH is enabled.');
+  if (featureGates.remoteRefresh) {
+    throw new Error('EXPO_PUBLIC_ENABLE_REMOTE_REFRESH is no longer supported.');
   }
 
-  if (profile !== 'preview' && featureGates.remoteRefresh) {
-    throw new Error('EXPO_PUBLIC_ENABLE_REMOTE_REFRESH is only supported for APP_ENV=preview.');
-  }
-
-  if (profile !== 'preview' && remoteDatasetUrl) {
-    throw new Error('EXPO_PUBLIC_REMOTE_DATASET_URL is only supported for APP_ENV=preview.');
+  if (profile !== 'development' && profileConfig.dataSourceMode === 'backend-api' && !apiBaseUrl) {
+    throw new Error('EXPO_PUBLIC_API_BASE_URL is required for preview/production mobile builds.');
   }
 
   if (featureGates.analytics && !analyticsWriteKey) {
@@ -185,7 +179,6 @@ function buildRuntimeConfig(profile: MobileProfile, profileConfig: ProfileConfig
     profile,
     dataSource: {
       mode: profileConfig.dataSourceMode,
-      remoteDatasetUrl,
       datasetVersion,
     },
     services: {

--- a/mobile/app/(tabs)/calendar.tsx
+++ b/mobile/app/(tabs)/calendar.tsx
@@ -1,5 +1,5 @@
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   Linking,
   Pressable,
@@ -38,6 +38,12 @@ import {
 } from '../../src/features/routeState';
 import { useActiveDatasetScreen } from '../../src/features/useActiveDatasetScreen';
 import { selectCalendarMonthSnapshot } from '../../src/selectors';
+import { loadActiveMobileDataset } from '../../src/services/activeDataset';
+import {
+  adaptBackendCalendarMonth,
+} from '../../src/services/backendDisplayAdapters';
+import type { BackendReadClient } from '../../src/services/backendReadClient';
+import { cloneBundledDatasetFixture } from '../../src/services/bundledDatasetFixture';
 import {
   openServiceHandoff,
   resolveServiceHandoff,
@@ -228,10 +234,28 @@ export default function CalendarTabScreen() {
   const [viewMode, setViewMode] = useState<CalendarViewMode>(routeState.viewMode);
   const [reloadCount, setReloadCount] = useState(0);
   const [handoffFeedback, setHandoffFeedback] = useState<string | null>(null);
+  const bundledProfiles = useMemo(() => cloneBundledDatasetFixture().artistProfiles, []);
+  const loadBundledSnapshot = useCallback(async () => {
+    const activeDataset = await loadActiveMobileDataset();
+    return selectCalendarMonthSnapshot(activeDataset.dataset, activeMonth, todayIsoDate);
+  }, [activeMonth, todayIsoDate]);
+  const loadBackendSnapshot = useCallback(
+    async (client: BackendReadClient) => {
+      const response = await client.getCalendarMonth(activeMonth);
+      return {
+        data: adaptBackendCalendarMonth(activeMonth, response.data),
+        generatedAt: response.meta?.generatedAt ?? null,
+      };
+    },
+    [activeMonth],
+  );
   const datasetState = useActiveDatasetScreen({
     surface: 'calendar',
     reloadKey: reloadCount,
+    cacheKey: `calendar:${activeMonth}:${todayIsoDate}`,
     fallbackErrorMessage: 'Calendar dataset could not be loaded right now.',
+    loadBundled: loadBundledSnapshot,
+    loadBackend: loadBackendSnapshot,
   });
 
   useEffect(() => {
@@ -250,10 +274,7 @@ export default function CalendarTabScreen() {
   ]);
 
   const source = datasetState.kind === 'ready' ? datasetState.source : null;
-  const snapshot = useMemo(
-    () => (source ? selectCalendarMonthSnapshot(source.dataset, activeMonth, todayIsoDate) : null),
-    [activeMonth, source, todayIsoDate],
-  );
+  const snapshot = source?.data ?? null;
   const filteredSnapshot = useMemo(
     () => (snapshot ? applyCalendarFilter(snapshot, filterMode) : null),
     [filterMode, snapshot],
@@ -272,16 +293,13 @@ export default function CalendarTabScreen() {
   const groupSlugByGroup = useMemo(() => {
     const entries = new Map<string, string>();
 
-    if (!source) {
-      return entries;
-    }
-
-    for (const profile of source.dataset.artistProfiles) {
+    for (const profile of bundledProfiles) {
       entries.set(profile.group, profile.slug);
+      entries.set(profile.slug, profile.slug);
     }
 
     return entries;
-  }, [source]);
+  }, [bundledProfiles]);
 
   useEffect(() => {
     if (!filteredSnapshot) {

--- a/mobile/app/(tabs)/radar.tsx
+++ b/mobile/app/(tabs)/radar.tsx
@@ -1,5 +1,5 @@
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   Linking,
   Modal,
@@ -26,9 +26,12 @@ import {
   type RadarFilterStatus,
   type RadarSectionKey,
 } from '../../src/features/routeState';
+import type { ScreenDataSource } from '../../src/features/screenDataSource';
 import { useActiveDatasetScreen } from '../../src/features/useActiveDatasetScreen';
 import { selectRadarSnapshot } from '../../src/selectors';
-import { type ActiveMobileDataset } from '../../src/services/activeDataset';
+import { loadActiveMobileDataset } from '../../src/services/activeDataset';
+import { adaptBackendRadarSnapshot } from '../../src/services/backendDisplayAdapters';
+import type { BackendReadClient } from '../../src/services/backendReadClient';
 import { useAppTheme } from '../../src/tokens/theme';
 import type {
   RadarChangeFeedItemModel,
@@ -158,7 +161,7 @@ function buildRadarPartialSections(snapshot: RadarSnapshotModel): string[] {
 }
 
 function resolveRadarDataState(
-  source: ActiveMobileDataset,
+  source: Pick<ScreenDataSource<unknown>, 'activeSource' | 'issues' | 'runtimeState'>,
   partialSections: string[],
 ): 'default' | 'partial' | 'degraded' {
   if (source.runtimeState.mode === 'degraded' || source.issues.length > 0) {
@@ -263,13 +266,30 @@ export default function RadarTabScreen() {
   const [actTypeFilter, setActTypeFilter] = useState(routeState.actTypeFilter);
   const [enabledSections, setEnabledSections] = useState(routeState.enabledSections);
   const [isFilterSheetOpen, setIsFilterSheetOpen] = useState(false);
+  const today = useMemo(() => new Date(), []);
+  const todayIsoDate = useMemo(() => today.toISOString().slice(0, 10), [today]);
+  const loadBundledSnapshot = useCallback(async () => {
+    const activeDataset = await loadActiveMobileDataset();
+    return selectRadarSnapshot(activeDataset.dataset, todayIsoDate);
+  }, [todayIsoDate]);
+  const loadBackendSnapshot = useCallback(
+    async (client: BackendReadClient) => {
+      const response = await client.getRadar();
+      return {
+        data: adaptBackendRadarSnapshot(response.data),
+        generatedAt: response.meta?.generatedAt ?? null,
+      };
+    },
+    [],
+  );
   const datasetState = useActiveDatasetScreen({
     surface: 'radar',
     reloadKey: reloadCount,
+    cacheKey: `radar:${todayIsoDate}`,
     fallbackErrorMessage: 'Radar dataset could not be loaded right now.',
+    loadBundled: loadBundledSnapshot,
+    loadBackend: loadBackendSnapshot,
   });
-  const today = useMemo(() => new Date(), []);
-  const todayIsoDate = useMemo(() => today.toISOString().slice(0, 10), [today]);
 
   useEffect(() => {
     setStatusFilter(routeState.statusFilter);
@@ -278,10 +298,7 @@ export default function RadarTabScreen() {
   }, [routeState]);
 
   const source = datasetState.kind === 'ready' ? datasetState.source : null;
-  const snapshot = useMemo(
-    () => (source ? selectRadarSnapshot(source.dataset, todayIsoDate) : null),
-    [source, todayIsoDate],
-  );
+  const snapshot = source?.data ?? null;
   const partialSections = useMemo(
     () => (snapshot ? buildRadarPartialSections(snapshot) : []),
     [snapshot],

--- a/mobile/app/(tabs)/search.tsx
+++ b/mobile/app/(tabs)/search.tsx
@@ -1,5 +1,5 @@
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import React, { useDeferredValue, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Keyboard,
   Linking,
@@ -34,6 +34,10 @@ import {
   selectSearchResults,
   selectTeamSummaryBySlug,
 } from '../../src/selectors';
+import { loadActiveMobileDataset } from '../../src/services/activeDataset';
+import { adaptBackendSearchResults } from '../../src/services/backendDisplayAdapters';
+import type { BackendReadClient } from '../../src/services/backendReadClient';
+import { cloneBundledDatasetFixture } from '../../src/services/bundledDatasetFixture';
 import {
   trackAnalyticsEvent,
   type SearchSubmitSource,
@@ -194,17 +198,61 @@ export default function SearchTabScreen() {
   const routeState = useMemo(() => resolveSearchRouteState(params), [params]);
 
   const [reloadCount, setReloadCount] = useState(0);
-  const datasetState = useActiveDatasetScreen({
-    surface: 'search',
-    reloadKey: reloadCount,
-    fallbackErrorMessage: 'Search dataset could not be loaded right now.',
-  });
   const [query, setQuery] = useState(routeState.query);
   const [activeSegment, setActiveSegment] = useState<SearchSegment>(routeState.activeSegment);
   const [isInputFocused, setIsInputFocused] = useState(false);
   const [handoffFeedback, setHandoffFeedback] = useState<string | null>(null);
   const [recentQueries, setRecentQueries] = useState<string[]>([]);
   const deferredQuery = useDeferredValue(query);
+  const bundledSelectorContext = useMemo(
+    () => createSelectorContext(cloneBundledDatasetFixture()),
+    [],
+  );
+  const loadBundledResults = useCallback(async () => {
+    const normalizedQuery = deferredQuery.trim();
+    if (!normalizedQuery) {
+      return {
+        query: '',
+        entities: [],
+        releases: [],
+        upcoming: [],
+      };
+    }
+
+    const activeDataset = await loadActiveMobileDataset();
+    return selectSearchResults(createSelectorContext(activeDataset.dataset), normalizedQuery);
+  }, [deferredQuery]);
+  const loadBackendResults = useCallback(
+    async (client: BackendReadClient) => {
+      const normalizedQuery = deferredQuery.trim();
+      if (!normalizedQuery) {
+        return {
+          data: {
+            query: '',
+            entities: [],
+            releases: [],
+            upcoming: [],
+          },
+          generatedAt: null,
+        };
+      }
+
+      const response = await client.getSearch(normalizedQuery);
+      return {
+        data: adaptBackendSearchResults(normalizedQuery, response.data),
+        generatedAt: response.meta?.generatedAt ?? null,
+      };
+    },
+    [deferredQuery],
+  );
+  const datasetState = useActiveDatasetScreen({
+    surface: 'search',
+    reloadKey: reloadCount,
+    cacheKey: `search:${deferredQuery.trim().toLowerCase() || 'empty'}`,
+    fallbackErrorMessage: 'Search dataset could not be loaded right now.',
+    loadBundled: loadBundledResults,
+    loadBackend: loadBackendResults,
+  });
 
   useEffect(() => {
     setQuery(routeState.query);
@@ -227,68 +275,44 @@ export default function SearchTabScreen() {
     };
   }, [reloadCount]);
 
-  const selectorContext = useMemo(() => {
-    if (datasetState.kind !== 'ready') {
-      return null;
-    }
-
-    return createSelectorContext(datasetState.source.dataset);
-  }, [datasetState]);
   const datasetRiskDisclosure =
     datasetState.kind === 'ready'
       ? buildDatasetRiskDisclosure(datasetState.source, '검색', 'search-dataset-risk-notice')
       : null;
-
-  const results = useMemo(() => {
-    if (!selectorContext) {
-      return null;
-    }
-
-    return selectSearchResults(selectorContext, deferredQuery);
-  }, [deferredQuery, selectorContext]);
+  const results = datasetState.kind === 'ready' ? datasetState.source.data : null;
 
   const suggestedTeams = useMemo(() => {
-    if (!selectorContext) {
-      return [];
-    }
-
-    return selectorContext.dataset.artistProfiles
-      .map((profile) => selectTeamSummaryBySlug(selectorContext, profile.slug))
+    return bundledSelectorContext.dataset.artistProfiles
+      .map((profile) => selectTeamSummaryBySlug(bundledSelectorContext, profile.slug))
       .filter((team): team is TeamSummaryModel => team !== null)
       .sort((left, right) => left.displayName.localeCompare(right.displayName))
       .slice(0, 4);
-  }, [selectorContext]);
+  }, [bundledSelectorContext]);
 
   const teamSlugByGroup = useMemo(() => {
     const entries = new Map<string, string>();
 
-    if (!selectorContext) {
-      return entries;
-    }
-
-    for (const profile of selectorContext.dataset.artistProfiles) {
+    for (const profile of bundledSelectorContext.dataset.artistProfiles) {
       entries.set(profile.group, profile.slug);
+      entries.set(profile.slug, profile.slug);
     }
 
     return entries;
-  }, [selectorContext]);
+  }, [bundledSelectorContext]);
 
   const teamSummaryByGroup = useMemo(() => {
     const entries = new Map<string, TeamSummaryModel>();
 
-    if (!selectorContext) {
-      return entries;
-    }
-
-    for (const profile of selectorContext.dataset.artistProfiles) {
-      const team = selectTeamSummaryBySlug(selectorContext, profile.slug);
+    for (const profile of bundledSelectorContext.dataset.artistProfiles) {
+      const team = selectTeamSummaryBySlug(bundledSelectorContext, profile.slug);
       if (team) {
         entries.set(profile.group, team);
+        entries.set(profile.slug, team);
       }
     }
 
     return entries;
-  }, [selectorContext]);
+  }, [bundledSelectorContext]);
 
   useEffect(() => {
     const currentRouteParams = buildSearchRouteParams({
@@ -320,7 +344,8 @@ export default function SearchTabScreen() {
       upcoming: number;
     };
   } {
-    if (!selectorContext) {
+    const normalized = nextQuery.trim();
+    if (!normalized) {
       return {
         hadResults: false,
         resultCounts: {
@@ -331,11 +356,14 @@ export default function SearchTabScreen() {
       };
     }
 
-    const nextResults = selectSearchResults(selectorContext, nextQuery);
+    const nextResults =
+      normalized === results?.query
+        ? results
+        : selectSearchResults(bundledSelectorContext, normalized);
     const resultCounts = {
-      entities: nextResults.entities.length,
-      releases: nextResults.releases.length,
-      upcoming: nextResults.upcoming.length,
+      entities: nextResults?.entities.length ?? 0,
+      releases: nextResults?.releases.length ?? 0,
+      upcoming: nextResults?.upcoming.length ?? 0,
     };
 
     return {

--- a/mobile/app/artists/[slug].tsx
+++ b/mobile/app/artists/[slug].tsx
@@ -1,5 +1,5 @@
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   Image,
   Linking,
@@ -25,6 +25,9 @@ import {
 } from '../../src/features/surfaceDisclosures';
 import { useActiveDatasetScreen } from '../../src/features/useActiveDatasetScreen';
 import { selectEntityDetailSnapshot } from '../../src/selectors';
+import { loadActiveMobileDataset } from '../../src/services/activeDataset';
+import { adaptBackendEntityDetail } from '../../src/services/backendDisplayAdapters';
+import { BackendReadError, type BackendReadClient } from '../../src/services/backendReadClient';
 import {
   openServiceHandoff,
   resolveServiceHandoff,
@@ -234,15 +237,47 @@ export default function ArtistDetailScreen() {
   const [reloadCount, setReloadCount] = useState(0);
   const [handoffFeedback, setHandoffFeedback] = useState<string | null>(null);
   const [showAdditionalInfo, setShowAdditionalInfo] = useState(false);
+  const loadBundledSnapshot = useCallback(async () => {
+    const activeDataset = await loadActiveMobileDataset();
+    return slug ? selectEntityDetailSnapshot(activeDataset.dataset, slug) : null;
+  }, [slug]);
+  const loadBackendSnapshot = useCallback(
+    async (client: BackendReadClient) => {
+      if (!slug) {
+        return {
+          data: null,
+          generatedAt: null,
+        };
+      }
+
+      try {
+        const response = await client.getEntityDetail(slug);
+        return {
+          data: adaptBackendEntityDetail(response.data),
+          generatedAt: response.meta?.generatedAt ?? null,
+        };
+      } catch (error) {
+        if (error instanceof BackendReadError && error.status === 404) {
+          return {
+            data: null,
+            generatedAt: null,
+          };
+        }
+
+        throw error;
+      }
+    },
+    [slug],
+  );
   const datasetState = useActiveDatasetScreen({
     surface: 'entity_detail',
     reloadKey: reloadCount,
+    cacheKey: `entity:${slug || 'missing'}`,
     fallbackErrorMessage: '팀 상세 데이터를 불러오지 못했습니다.',
+    loadBundled: loadBundledSnapshot,
+    loadBackend: loadBackendSnapshot,
   });
-  const snapshot = useMemo(
-    () => (datasetState.kind === 'ready' && slug ? selectEntityDetailSnapshot(datasetState.source.dataset, slug) : null),
-    [datasetState, slug],
-  );
+  const snapshot = datasetState.kind === 'ready' ? datasetState.source.data : null;
 
   useEffect(() => {
     setHandoffFeedback(null);

--- a/mobile/app/debug/metadata.tsx
+++ b/mobile/app/debug/metadata.tsx
@@ -14,7 +14,7 @@ export default function DebugMetadataScreen() {
     ['Dataset version', metadata.datasetVersion ?? 'Unavailable'],
     ['Commit hash', metadata.commitSha ?? 'Unavailable'],
     ['Data source mode', metadata.dataSourceMode],
-    ['Remote dataset URL', metadata.remoteDatasetUrl ?? 'Bundled-only'],
+    ['API base URL', metadata.apiBaseUrl ?? 'Bundled-only'],
     ['Analytics enabled', metadata.analyticsEnabled ? 'Yes' : 'No'],
     ['Analytics event count', `${metadata.analyticsEventCount}`],
     ['Latest analytics event', metadata.latestAnalyticsEvent ?? 'None'],

--- a/mobile/app/releases/[id].tsx
+++ b/mobile/app/releases/[id].tsx
@@ -1,5 +1,5 @@
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   Image,
   ScrollView,
@@ -28,6 +28,13 @@ import {
 import { useActiveDatasetScreen } from '../../src/features/useActiveDatasetScreen';
 import { selectReleaseDetailById } from '../../src/selectors';
 import { getFeatureGateState } from '../../src/config/featureGates';
+import { loadActiveMobileDataset } from '../../src/services/activeDataset';
+import { adaptBackendReleaseDetail } from '../../src/services/backendDisplayAdapters';
+import {
+  BackendReadError,
+  type BackendReadClient,
+} from '../../src/services/backendReadClient';
+import { cloneBundledDatasetFixture } from '../../src/services/bundledDatasetFixture';
 import {
   openServiceHandoff,
   resolveServiceHandoff,
@@ -214,18 +221,51 @@ export default function ReleaseDetailScreen() {
   const releaseId = getSingleParam(params.id)?.trim() ?? '';
   const [reloadCount, setReloadCount] = useState(0);
   const [handoffFeedback, setHandoffFeedback] = useState<string | null>(null);
+  const bundledProfiles = useMemo(() => cloneBundledDatasetFixture().artistProfiles, []);
+  const loadBundledDetail = useCallback(async () => {
+    const activeDataset = await loadActiveMobileDataset();
+    return releaseId ? selectReleaseDetailById(activeDataset.dataset, releaseId) : null;
+  }, [releaseId]);
+  const loadBackendDetail = useCallback(
+    async (client: BackendReadClient) => {
+      if (!releaseId) {
+        return {
+          data: null,
+          generatedAt: null,
+        };
+      }
+
+      try {
+        const resolved = await client.getReleaseDetailByLegacyId(releaseId);
+        return {
+          data: adaptBackendReleaseDetail(resolved.detail.data),
+          generatedAt: resolved.detail.meta?.generatedAt ?? resolved.lookup.meta?.generatedAt ?? null,
+        };
+      } catch (error) {
+        if (error instanceof BackendReadError && error.status === 404) {
+          return {
+            data: null,
+            generatedAt: null,
+          };
+        }
+
+        throw error;
+      }
+    },
+    [releaseId],
+  );
   const datasetState = useActiveDatasetScreen({
     surface: 'release_detail',
     reloadKey: reloadCount,
+    cacheKey: `release:${releaseId || 'missing'}`,
     fallbackErrorMessage: '릴리즈 상세 데이터를 불러오지 못했습니다.',
+    loadBundled: loadBundledDetail,
+    loadBackend: loadBackendDetail,
   });
-  const detail = useMemo(
-    () => (datasetState.kind === 'ready' && releaseId ? selectReleaseDetailById(datasetState.source.dataset, releaseId) : null),
-    [datasetState, releaseId],
-  );
+  const detail = datasetState.kind === 'ready' ? datasetState.source.data : null;
   const teamProfile =
-    datasetState.kind === 'ready' && detail
-      ? datasetState.source.dataset.artistProfiles.find((profile) => profile.group === detail.group) ?? null
+    detail
+      ? bundledProfiles.find((profile) => profile.slug === detail.group || profile.group === detail.group) ?? null
       : null;
 
   useEffect(() => {

--- a/mobile/src/config/debugMetadata.test.ts
+++ b/mobile/src/config/debugMetadata.test.ts
@@ -5,8 +5,7 @@ import { resetAnalyticsEvents, trackAnalyticsEvent } from '../services/analytics
 const previewRuntimeConfig: MobileRuntimeConfig = {
   profile: 'preview',
   dataSource: {
-    mode: 'preview-static',
-    remoteDatasetUrl: 'https://example.com/dataset.json',
+    mode: 'backend-api',
     datasetVersion: 'preview-v1',
   },
   services: {
@@ -19,7 +18,7 @@ const previewRuntimeConfig: MobileRuntimeConfig = {
   featureGates: {
     radar: true,
     analytics: false,
-    remoteRefresh: true,
+    remoteRefresh: false,
     mvEmbed: true,
     shareActions: true,
   },
@@ -80,8 +79,8 @@ describe('debug metadata helpers', () => {
       buildVersion: '0.1.0',
       datasetVersion: 'preview-v1',
       commitSha: 'abc123',
-      dataSourceMode: 'preview-static',
-      remoteDatasetUrl: 'https://example.com/dataset.json',
+      dataSourceMode: 'backend-api',
+      apiBaseUrl: 'https://example.com/api',
       analyticsEnabled: false,
       radarEnabled: true,
       analyticsEventCount: 1,
@@ -95,11 +94,6 @@ describe('debug metadata helpers', () => {
       isDebugMetadataAvailable({
         ...previewRuntimeConfig,
         profile: 'production',
-        dataSource: {
-          ...previewRuntimeConfig.dataSource,
-          mode: 'production-static',
-          remoteDatasetUrl: null,
-        },
       }),
     ).toBe(false);
   });

--- a/mobile/src/config/debugMetadata.ts
+++ b/mobile/src/config/debugMetadata.ts
@@ -14,7 +14,7 @@ export type MobileDebugMetadata = {
   datasetVersion: string | null;
   commitSha: string | null;
   dataSourceMode: MobileRuntimeConfig['dataSource']['mode'];
-  remoteDatasetUrl: string | null;
+  apiBaseUrl: string | null;
   analyticsEnabled: boolean;
   radarEnabled: boolean;
   analyticsEventCount: number;
@@ -40,7 +40,7 @@ export function getDebugMetadata(
     datasetVersion: runtimeConfig.dataSource.datasetVersion,
     commitSha: runtimeConfig.build.commitSha,
     dataSourceMode: runtimeConfig.dataSource.mode,
-    remoteDatasetUrl: runtimeConfig.dataSource.remoteDatasetUrl,
+    apiBaseUrl: runtimeConfig.services.apiBaseUrl,
     analyticsEnabled: runtimeConfig.featureGates.analytics,
     radarEnabled: runtimeConfig.featureGates.radar,
     analyticsEventCount: recentAnalyticsEvents.length,

--- a/mobile/src/config/featureGates.test.ts
+++ b/mobile/src/config/featureGates.test.ts
@@ -9,8 +9,7 @@ import {
 const runtimeConfig: MobileRuntimeConfig = {
   profile: 'preview',
   dataSource: {
-    mode: 'preview-static',
-    remoteDatasetUrl: 'https://example.com/dataset.json',
+    mode: 'backend-api',
     datasetVersion: 'preview-v1',
   },
   services: {
@@ -23,7 +22,7 @@ const runtimeConfig: MobileRuntimeConfig = {
   featureGates: {
     radar: true,
     analytics: false,
-    remoteRefresh: true,
+    remoteRefresh: false,
     mvEmbed: false,
     shareActions: true,
   },

--- a/mobile/src/config/runtime.test.ts
+++ b/mobile/src/config/runtime.test.ts
@@ -14,12 +14,11 @@ describe('parseRuntimeConfig', () => {
     const parsed = parseRuntimeConfig({
       profile: 'preview',
       dataSource: {
-        mode: 'preview-static',
-        remoteDatasetUrl: {},
+        mode: 'backend-api',
         datasetVersion: {},
       },
       services: {
-        apiBaseUrl: {},
+        apiBaseUrl: 'https://example.com/api',
         analyticsWriteKey: {},
       },
       logging: {
@@ -38,9 +37,7 @@ describe('parseRuntimeConfig', () => {
       },
     });
 
-    expect(parsed.dataSource.remoteDatasetUrl).toBeNull();
     expect(parsed.dataSource.datasetVersion).toBeNull();
-    expect(parsed.services.apiBaseUrl).toBeNull();
     expect(parsed.services.analyticsWriteKey).toBeNull();
     expect(parsed.build.version).toBe('0.1.0');
     expect(parsed.build.commitSha).toBeNull();
@@ -51,12 +48,11 @@ describe('parseRuntimeConfig', () => {
       parseRuntimeConfig({
         profile: 'production',
         dataSource: {
-          mode: 'production-static',
-          remoteDatasetUrl: null,
+          mode: 'backend-api',
           datasetVersion: null,
         },
         services: {
-          apiBaseUrl: null,
+          apiBaseUrl: 'https://example.com/api',
           analyticsWriteKey: null,
         },
         logging: {
@@ -77,17 +73,16 @@ describe('parseRuntimeConfig', () => {
     ).toThrow('analyticsWriteKey');
   });
 
-  test('rejects remote refresh without remote dataset url', () => {
+  test('rejects remote refresh gate outright', () => {
     expect(() =>
       parseRuntimeConfig({
         profile: 'preview',
         dataSource: {
-          mode: 'preview-static',
-          remoteDatasetUrl: null,
+          mode: 'backend-api',
           datasetVersion: null,
         },
         services: {
-          apiBaseUrl: null,
+          apiBaseUrl: 'https://example.com/api',
           analyticsWriteKey: null,
         },
         logging: {
@@ -105,24 +100,23 @@ describe('parseRuntimeConfig', () => {
           commitSha: null,
         },
       }),
-    ).toThrow('remoteDatasetUrl');
+    ).toThrow('remoteRefresh');
   });
 
-  test('rejects remote dataset settings outside preview profile', () => {
+  test('requires api base url for preview backend mode', () => {
     expect(() =>
       parseRuntimeConfig({
-        profile: 'production',
+        profile: 'preview',
         dataSource: {
-          mode: 'production-static',
-          remoteDatasetUrl: 'https://example.com/dataset.json',
-          datasetVersion: 'preview-v1',
+          mode: 'backend-api',
+          datasetVersion: null,
         },
         services: {
           apiBaseUrl: null,
           analyticsWriteKey: null,
         },
         logging: {
-          level: 'error',
+          level: 'debug',
         },
         featureGates: {
           radar: true,
@@ -136,7 +130,7 @@ describe('parseRuntimeConfig', () => {
           commitSha: null,
         },
       }),
-    ).toThrow('remoteDatasetUrl');
+    ).toThrow('services.apiBaseUrl');
   });
 
   test('requires build version to be present', () => {
@@ -145,7 +139,6 @@ describe('parseRuntimeConfig', () => {
         profile: 'development',
         dataSource: {
           mode: 'bundled-static',
-          remoteDatasetUrl: null,
           datasetVersion: null,
         },
         services: {
@@ -174,7 +167,7 @@ describe('parseRuntimeConfig', () => {
 
     expect(state.mode).toBe('degraded');
     expect(state.config.profile).toBe('preview');
-    expect(state.config.dataSource.mode).toBe('preview-static');
+    expect(state.config.dataSource.mode).toBe('backend-api');
     expect(state.config.featureGates.remoteRefresh).toBe(false);
     expect(state.config.services.analyticsWriteKey).toBeNull();
     expect(state.config.build.version).toBe('0.3.0');
@@ -190,8 +183,7 @@ describe('parseRuntimeConfig', () => {
       {
         profile: 'preview',
         dataSource: {
-          mode: 'preview-static',
-          remoteDatasetUrl: null,
+          mode: 'backend-api',
           datasetVersion: null,
         },
         services: {
@@ -203,7 +195,7 @@ describe('parseRuntimeConfig', () => {
         },
         featureGates: {
           radar: true,
-          analytics: true,
+          analytics: false,
           remoteRefresh: true,
           mvEmbed: true,
           shareActions: true,
@@ -219,13 +211,13 @@ describe('parseRuntimeConfig', () => {
 
     expect(state.mode).toBe('degraded');
     expect(state.config.profile).toBe('preview');
-    expect(state.config.dataSource.remoteDatasetUrl).toBeNull();
+    expect(state.config.dataSource.mode).toBe('backend-api');
     expect(state.config.featureGates.analytics).toBe(false);
     expect(state.config.featureGates.remoteRefresh).toBe(false);
     expect(state.issues).toEqual([
       expect.objectContaining({
         kind: 'invalid_runtime_config',
-        message: expect.stringContaining('remoteDatasetUrl'),
+        message: expect.stringContaining('remoteRefresh'),
       }),
     ]);
   });

--- a/mobile/src/config/runtime.ts
+++ b/mobile/src/config/runtime.ts
@@ -2,19 +2,18 @@ import Constants from 'expo-constants';
 
 export type MobileProfile = 'development' | 'preview' | 'production';
 export type LoggingLevel = 'verbose' | 'debug' | 'error';
-export type DataSourceMode = 'bundled-static' | 'preview-static' | 'production-static';
+export type DataSourceMode = 'bundled-static' | 'backend-api';
 
 const EXPECTED_MODE_BY_PROFILE: Record<MobileProfile, DataSourceMode> = {
   development: 'bundled-static',
-  preview: 'preview-static',
-  production: 'production-static',
+  preview: 'backend-api',
+  production: 'backend-api',
 };
 
 export type MobileRuntimeConfig = {
   profile: MobileProfile;
   dataSource: {
     mode: DataSourceMode;
-    remoteDatasetUrl: string | null;
     datasetVersion: string | null;
   };
   services: {
@@ -108,7 +107,7 @@ function readLoggingLevel(value: unknown): LoggingLevel {
 function readDataSourceMode(value: unknown): DataSourceMode {
   const fieldValue = readString(value, 'dataSource.mode');
 
-  if (fieldValue === 'bundled-static' || fieldValue === 'preview-static' || fieldValue === 'production-static') {
+  if (fieldValue === 'bundled-static' || fieldValue === 'backend-api') {
     return fieldValue;
   }
 
@@ -163,7 +162,6 @@ export function parseRuntimeConfig(input: unknown): MobileRuntimeConfig {
     profile: readProfile(input.profile),
     dataSource: {
       mode: readDataSourceMode(dataSource.mode),
-      remoteDatasetUrl: readOptionalUrl(dataSource.remoteDatasetUrl, 'dataSource.remoteDatasetUrl'),
       datasetVersion: readString(dataSource.datasetVersion, 'dataSource.datasetVersion', false),
     },
     services: {
@@ -186,20 +184,16 @@ export function parseRuntimeConfig(input: unknown): MobileRuntimeConfig {
     },
   };
 
-  if (config.featureGates.remoteRefresh && !config.dataSource.remoteDatasetUrl) {
-    throw new Error('Runtime config requires dataSource.remoteDatasetUrl when remoteRefresh is enabled.');
-  }
-
   if (config.dataSource.mode !== EXPECTED_MODE_BY_PROFILE[config.profile]) {
     throw new Error('Runtime config dataSource.mode does not match the active mobile profile.');
   }
 
-  if (config.profile !== 'preview' && config.featureGates.remoteRefresh) {
-    throw new Error('Runtime config only allows remoteRefresh in the preview profile.');
+  if (config.featureGates.remoteRefresh) {
+    throw new Error('Runtime config no longer supports featureGates.remoteRefresh.');
   }
 
-  if (config.profile !== 'preview' && config.dataSource.remoteDatasetUrl) {
-    throw new Error('Runtime config only allows dataSource.remoteDatasetUrl in the preview profile.');
+  if (config.profile !== 'development' && config.dataSource.mode === 'backend-api' && !config.services.apiBaseUrl) {
+    throw new Error('Runtime config requires services.apiBaseUrl when backend-api mode is enabled.');
   }
 
   if (config.featureGates.analytics && !config.services.analyticsWriteKey) {
@@ -225,7 +219,6 @@ function buildDegradedRuntimeConfig(
     profile,
     dataSource: {
       mode: EXPECTED_MODE_BY_PROFILE[profile],
-      remoteDatasetUrl: null,
       datasetVersion: null,
     },
     services: {

--- a/mobile/src/features/radarTab.test.tsx
+++ b/mobile/src/features/radarTab.test.tsx
@@ -13,6 +13,16 @@ import { trackDatasetDegraded, trackDatasetLoadFailed } from '../services/analyt
 import { cloneBundledDatasetFixture } from '../services/bundledDatasetFixture';
 import { createBundledDatasetSelection } from '../services/datasetSource';
 
+jest.mock('../config/runtime', () => {
+  const actual = jest.requireActual('../config/runtime');
+
+  return {
+    ...actual,
+    getRuntimeConfigState: jest.fn(),
+    getRuntimeConfig: jest.fn(),
+  };
+});
+
 jest.mock('expo-router', () => {
   const useLocalSearchParams = jest.fn(() => ({}));
   const push = jest.fn();
@@ -67,6 +77,10 @@ const mockLoadActiveMobileDataset = jest.mocked(loadActiveMobileDataset);
 const mockSelectRadarSnapshot = jest.mocked(selectRadarSnapshot);
 const mockTrackDatasetDegraded = jest.mocked(trackDatasetDegraded);
 const mockTrackDatasetLoadFailed = jest.mocked(trackDatasetLoadFailed);
+const runtimeModule = jest.requireMock('../config/runtime') as {
+  getRuntimeConfigState: jest.Mock;
+  getRuntimeConfig: jest.Mock;
+};
 
 function createRuntimeState(
   overrides: Partial<RuntimeConfigState> = {},
@@ -78,7 +92,6 @@ function createRuntimeState(
       profile: 'development',
       dataSource: {
         mode: 'bundled-static',
-        remoteDatasetUrl: null,
         datasetVersion: 'fixture-v1',
       },
       services: {
@@ -107,7 +120,6 @@ function createRuntimeState(
 function createSource(overrides: Partial<ActiveMobileDataset> = {}): ActiveMobileDataset {
   return {
     activeSource: 'bundled-static',
-    cachedArtifactIds: [],
     dataset: cloneBundledDatasetFixture(),
     freshness: {
       rollingReferenceAt: null,
@@ -142,6 +154,8 @@ describe('mobile radar tab', () => {
     __mock.useLocalSearchParams.mockReturnValue({});
     __mock.push.mockClear();
     __mock.setParams.mockClear();
+    runtimeModule.getRuntimeConfigState.mockReturnValue(createRuntimeState());
+    runtimeModule.getRuntimeConfig.mockReturnValue(createRuntimeState().config);
     mockLoadActiveMobileDataset.mockClear();
     mockSelectRadarSnapshot.mockClear();
     mockTrackDatasetDegraded.mockClear();
@@ -173,6 +187,17 @@ describe('mobile radar tab', () => {
         runtimeState: createRuntimeState({ mode: 'degraded' }),
         issues: ['Preview remote dataset is unavailable.'],
         sourceLabel: 'Bundled static dataset',
+      }),
+    );
+    runtimeModule.getRuntimeConfigState.mockReturnValue(
+      createRuntimeState({
+        mode: 'degraded',
+        issues: [
+          {
+            kind: 'invalid_runtime_config',
+            message: 'Preview remote dataset is unavailable.',
+          },
+        ],
       }),
     );
 

--- a/mobile/src/features/screenDataSource.ts
+++ b/mobile/src/features/screenDataSource.ts
@@ -1,0 +1,23 @@
+import type { RuntimeConfigState } from '../config/runtime';
+
+export type ScreenDataSourceActiveSource =
+  | 'bundled-static'
+  | 'backend-api'
+  | 'backend-cache'
+  | 'bundled-static-fallback';
+
+export type ScreenDataFreshness = {
+  rollingReferenceAt: string | null;
+  staleFreshnessClasses: string[];
+  cachedAt?: string | null;
+  generatedAt?: string | null;
+};
+
+export type ScreenDataSource<T = unknown> = {
+  activeSource: ScreenDataSourceActiveSource;
+  sourceLabel: string;
+  issues: string[];
+  freshness: ScreenDataFreshness;
+  runtimeState: RuntimeConfigState;
+  data: T;
+};

--- a/mobile/src/features/surfaceDisclosures.test.ts
+++ b/mobile/src/features/surfaceDisclosures.test.ts
@@ -26,7 +26,7 @@ describe('surface disclosure helpers', () => {
     expect(
       buildDatasetRiskDisclosure(
         {
-          activeSource: 'preview-remote-cache',
+          activeSource: 'backend-cache',
           freshness: {
             rollingReferenceAt: '2026-03-10T00:00:00.000Z',
             staleFreshnessClasses: ['rolling-release', 'rolling-upcoming'],

--- a/mobile/src/features/surfaceDisclosures.ts
+++ b/mobile/src/features/surfaceDisclosures.ts
@@ -1,4 +1,4 @@
-import type { ActiveMobileDataset } from '../services/activeDataset';
+import type { ScreenDataSource } from './screenDataSource';
 import type { EntityDetailSnapshotModel, ReleaseDetailModel } from '../types';
 
 export type SurfaceDisclosure = {
@@ -29,11 +29,8 @@ function summarizeIssues(issues: string[]): string {
 }
 
 export function buildDatasetRiskDisclosure(
-  source: Pick<
-    ActiveMobileDataset,
-    'activeSource' | 'freshness' | 'issues' | 'sourceLabel'
-  > & {
-    runtimeState: Pick<ActiveMobileDataset['runtimeState'], 'mode'>;
+  source: Pick<ScreenDataSource, 'activeSource' | 'freshness' | 'issues' | 'sourceLabel'> & {
+    runtimeState: Pick<ScreenDataSource['runtimeState'], 'mode'>;
   },
   surfaceLabel: string,
   testID: string,
@@ -43,11 +40,11 @@ export function buildDatasetRiskDisclosure(
   }
 
   const freshnessNote =
-    source.activeSource === 'preview-remote-cache'
+    source.activeSource.includes('cache')
       ? source.freshness.rollingReferenceAt
         ? `발매/예정 데이터는 ${formatCachedAt(source.freshness.rollingReferenceAt)}에 저장된 캐시 기준입니다.`
         : '발매/예정 데이터는 마지막으로 저장된 캐시 기준입니다.'
-      : '프로필/아트워크보다 발매·예정 데이터가 더 빨리 오래될 수 있습니다.';
+      : '발매·예정 데이터는 네트워크 상태에 따라 일부 지연되거나 최소 정보로 축소될 수 있습니다.';
 
   return {
     title: '데이터 최신화 유의',

--- a/mobile/src/features/useActiveDatasetScreen.test.tsx
+++ b/mobile/src/features/useActiveDatasetScreen.test.tsx
@@ -1,0 +1,215 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import { Text } from 'react-native';
+
+import { useActiveDatasetScreen } from './useActiveDatasetScreen';
+import {
+  resetStorageAdapter,
+  setStorageAdapter,
+  type KeyValueStorageAdapter,
+} from '../services/storage';
+import { readScreenSnapshotCacheEntry } from '../services/screenSnapshotCache';
+
+const mockGetRuntimeConfigState = jest.fn();
+const mockGetRuntimeConfig = jest.fn();
+const mockCreateBackendReadClient = jest.fn();
+const mockTrackDatasetDegraded = jest.fn();
+const mockTrackDatasetLoadFailed = jest.fn();
+
+jest.mock('../config/runtime', () => ({
+  getRuntimeConfigState: () => mockGetRuntimeConfigState(),
+  getRuntimeConfig: () => mockGetRuntimeConfig(),
+}));
+
+jest.mock('../services/backendReadClient', () => ({
+  createBackendReadClient: (...args: unknown[]) => mockCreateBackendReadClient(...args),
+}));
+
+jest.mock('../services/analytics', () => ({
+  trackDatasetDegraded: (...args: unknown[]) => mockTrackDatasetDegraded(...args),
+  trackDatasetLoadFailed: (...args: unknown[]) => mockTrackDatasetLoadFailed(...args),
+}));
+
+function createMemoryStorage(): KeyValueStorageAdapter {
+  const values = new Map<string, string>();
+
+  return {
+    async getItem(key) {
+      return values.has(key) ? values.get(key) ?? null : null;
+    },
+    async setItem(key, value) {
+      values.set(key, value);
+    },
+    async removeItem(key) {
+      values.delete(key);
+    },
+  };
+}
+
+function buildRuntimeState(mode: 'normal' | 'degraded' = 'normal') {
+  return {
+    mode,
+    config: {
+      profile: 'preview',
+      dataSource: {
+        mode: 'backend-api',
+        datasetVersion: 'preview-v1',
+      },
+      services: {
+        apiBaseUrl: 'https://example.com/api',
+        analyticsWriteKey: null,
+      },
+      logging: {
+        level: 'debug',
+      },
+      featureGates: {
+        radar: true,
+        analytics: false,
+        remoteRefresh: false,
+        mvEmbed: true,
+        shareActions: true,
+      },
+      build: {
+        version: '0.1.0',
+        commitSha: 'test-sha',
+      },
+    },
+    issues:
+      mode === 'degraded'
+        ? [
+            {
+              kind: 'invalid_runtime_config',
+              message: 'Runtime config is degraded.',
+            },
+          ]
+        : [],
+  };
+}
+
+function Harness(props: {
+  reloadKey?: number;
+  loadBundled: () => Promise<{ value: string }>;
+  loadBackend?: (client: unknown) => Promise<{ data: { value: string }; generatedAt?: string | null }>;
+}) {
+  const state = useActiveDatasetScreen({
+    surface: 'search',
+    reloadKey: props.reloadKey ?? 0,
+    cacheKey: 'search:test',
+    fallbackErrorMessage: 'Search failed.',
+    loadBundled: props.loadBundled,
+    loadBackend: props.loadBackend,
+  });
+
+  if (state.kind !== 'ready') {
+    return <Text testID="hook-state">{state.kind}</Text>;
+  }
+
+  return (
+    <>
+      <Text testID="hook-state">{state.kind}</Text>
+      <Text testID="hook-source">{state.source.activeSource}</Text>
+      <Text testID="hook-label">{state.source.sourceLabel}</Text>
+      <Text testID="hook-value">{state.source.data.value}</Text>
+      <Text testID="hook-issues">{state.source.issues.join('|')}</Text>
+    </>
+  );
+}
+
+async function renderHarness(props: React.ComponentProps<typeof Harness>) {
+  let tree: renderer.ReactTestRenderer;
+
+  await act(async () => {
+    tree = renderer.create(<Harness {...props} />);
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+
+  return tree!;
+}
+
+describe('useActiveDatasetScreen', () => {
+  beforeEach(() => {
+    setStorageAdapter(createMemoryStorage());
+    mockCreateBackendReadClient.mockReset();
+    mockTrackDatasetDegraded.mockReset();
+    mockTrackDatasetLoadFailed.mockReset();
+    mockGetRuntimeConfig.mockReturnValue(buildRuntimeState('normal').config);
+  });
+
+  afterEach(() => {
+    resetStorageAdapter();
+  });
+
+  test('prefers backend data and writes a persisted snapshot in backend-api mode', async () => {
+    mockGetRuntimeConfigState.mockReturnValue(buildRuntimeState('normal'));
+    const client = { name: 'backend-client' };
+    mockCreateBackendReadClient.mockReturnValue(client);
+    const loadBundled = jest.fn(async () => ({ value: 'bundled' }));
+    const loadBackend = jest.fn(async (receivedClient: unknown) => {
+      expect(receivedClient).toBe(client);
+      return {
+        data: { value: 'backend' },
+        generatedAt: '2026-03-10T00:00:00.000Z',
+      };
+    });
+
+    const tree = await renderHarness({
+      loadBundled,
+      loadBackend,
+    });
+
+    expect(tree.root.findByProps({ testID: 'hook-source' }).props.children).toBe('backend-api');
+    expect(tree.root.findByProps({ testID: 'hook-value' }).props.children).toBe('backend');
+    expect(loadBundled).not.toHaveBeenCalled();
+    await expect(readScreenSnapshotCacheEntry<{ value: string }>('search', 'search:test')).resolves.toEqual(
+      expect.objectContaining({
+        generatedAt: '2026-03-10T00:00:00.000Z',
+        value: { value: 'backend' },
+      }),
+    );
+  });
+
+  test('reuses cached backend data when the backend request fails', async () => {
+    mockGetRuntimeConfigState.mockReturnValue(buildRuntimeState('normal'));
+    mockCreateBackendReadClient.mockReturnValue({ name: 'backend-client' });
+
+    const firstTree = await renderHarness({
+      loadBundled: async () => ({ value: 'bundled' }),
+      loadBackend: async () => ({
+        data: { value: 'fresh-backend' },
+        generatedAt: '2026-03-10T00:00:00.000Z',
+      }),
+    });
+
+    expect(firstTree.root.findByProps({ testID: 'hook-source' }).props.children).toBe('backend-api');
+
+    const secondTree = await renderHarness({
+      loadBundled: async () => ({ value: 'bundled' }),
+      loadBackend: async () => {
+        throw new Error('Backend timed out.');
+      },
+    });
+
+    expect(secondTree.root.findByProps({ testID: 'hook-source' }).props.children).toBe('backend-cache');
+    expect(secondTree.root.findByProps({ testID: 'hook-value' }).props.children).toBe('fresh-backend');
+    expect(secondTree.root.findByProps({ testID: 'hook-issues' }).props.children).toContain('Backend timed out.');
+  });
+
+  test('falls back to bundled data when runtime is degraded and cache is unavailable', async () => {
+    mockGetRuntimeConfigState.mockReturnValue(buildRuntimeState('degraded'));
+    mockCreateBackendReadClient.mockReturnValue({ name: 'backend-client' });
+    const loadBundled = jest.fn(async () => ({ value: 'bundled-fallback' }));
+
+    const tree = await renderHarness({
+      loadBundled,
+      loadBackend: async () => ({
+        data: { value: 'backend' },
+      }),
+    });
+
+    expect(tree.root.findByProps({ testID: 'hook-source' }).props.children).toBe('bundled-static');
+    expect(tree.root.findByProps({ testID: 'hook-value' }).props.children).toBe('bundled-fallback');
+    expect(tree.root.findByProps({ testID: 'hook-issues' }).props.children).toContain('Runtime config is degraded.');
+    expect(loadBundled).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mobile/src/features/useActiveDatasetScreen.ts
+++ b/mobile/src/features/useActiveDatasetScreen.ts
@@ -1,14 +1,27 @@
 import React from 'react';
 
-import type { ActiveMobileDataset } from '../services/activeDataset';
-import { loadActiveMobileDataset } from '../services/activeDataset';
+import { getRuntimeConfigState } from '../config/runtime';
 import {
   trackDatasetDegraded,
   trackDatasetLoadFailed,
   type AnalyticsSurface,
 } from '../services/analytics';
+import { createBackendReadClient } from '../services/backendReadClient';
+import {
+  readScreenSnapshotCacheEntry,
+  writeScreenSnapshotCacheEntry,
+} from '../services/screenSnapshotCache';
+import type { ScreenDataSource } from './screenDataSource';
 
-export type ActiveDatasetScreenState =
+type BackendLoadResult<T> = {
+  data: T;
+  generatedAt?: string | null;
+};
+
+export type ActiveDatasetScreenState<T> =
+  | {
+      kind: 'disabled';
+    }
   | {
       kind: 'loading';
     }
@@ -18,17 +31,21 @@ export type ActiveDatasetScreenState =
     }
   | {
       kind: 'ready';
-      source: ActiveMobileDataset;
+      source: ScreenDataSource<T>;
     };
 
-type UseActiveDatasetScreenOptions = {
+type UseActiveDatasetScreenOptions<T> = {
+  enabled?: boolean;
   surface: AnalyticsSurface;
-  reloadKey: number;
+  reloadKey: number | string;
+  cacheKey: string;
   fallbackErrorMessage: string;
+  loadBundled: () => Promise<T>;
+  loadBackend?: (client: ReturnType<typeof createBackendReadClient>) => Promise<BackendLoadResult<T>>;
 };
 
 export function buildActiveDatasetEventKey(
-  source: Pick<ActiveMobileDataset, 'activeSource' | 'issues' | 'runtimeState'>,
+  source: Pick<ScreenDataSource<unknown>, 'activeSource' | 'issues' | 'runtimeState'>,
 ): string {
   if (source.runtimeState.mode === 'degraded' || source.issues.length > 0) {
     return `degraded:${source.activeSource}:${source.runtimeState.mode}:${source.issues.join('|')}`;
@@ -37,19 +54,144 @@ export function buildActiveDatasetEventKey(
   return `ready:${source.activeSource}`;
 }
 
-export function useActiveDatasetScreen({
+function dedupeIssues(issues: string[]): string[] {
+  return [...new Set(issues.filter(Boolean))];
+}
+
+function buildReadySource<T>(args: {
+  activeSource: ScreenDataSource<T>['activeSource'];
+  sourceLabel: string;
+  data: T;
+  issues?: string[];
+  runtimeState: ScreenDataSource<T>['runtimeState'];
+  rollingReferenceAt?: string | null;
+  cachedAt?: string | null;
+  generatedAt?: string | null;
+}): ScreenDataSource<T> {
+  return {
+    activeSource: args.activeSource,
+    sourceLabel: args.sourceLabel,
+    data: args.data,
+    issues: dedupeIssues(args.issues ?? []),
+    freshness: {
+      rollingReferenceAt: args.rollingReferenceAt ?? null,
+      staleFreshnessClasses: ['rolling-release', 'rolling-upcoming'],
+      cachedAt: args.cachedAt ?? null,
+      generatedAt: args.generatedAt ?? null,
+    },
+    runtimeState: args.runtimeState,
+  };
+}
+
+export function useActiveDatasetScreen<T>({
+  enabled = true,
+  cacheKey,
   fallbackErrorMessage,
+  loadBackend,
+  loadBundled,
   reloadKey,
   surface,
-}: UseActiveDatasetScreenOptions): ActiveDatasetScreenState {
-  const [state, setState] = React.useState<ActiveDatasetScreenState>({ kind: 'loading' });
+}: UseActiveDatasetScreenOptions<T>): ActiveDatasetScreenState<T> {
+  const [state, setState] = React.useState<ActiveDatasetScreenState<T>>(
+    enabled ? { kind: 'loading' } : { kind: 'disabled' },
+  );
   const datasetEventKeyRef = React.useRef<string | null>(null);
 
   React.useEffect(() => {
     let cancelled = false;
+
+    if (!enabled) {
+      setState({ kind: 'disabled' });
+      datasetEventKeyRef.current = null;
+      return () => {
+        cancelled = true;
+      };
+    }
+
     setState({ kind: 'loading' });
 
-    void loadActiveMobileDataset()
+    const runtimeState = getRuntimeConfigState();
+    const runtimeIssues = runtimeState.issues.map((issue) => issue.message);
+    const backendEnabled =
+      runtimeState.mode === 'normal' &&
+      runtimeState.config.dataSource.mode === 'backend-api' &&
+      Boolean(runtimeState.config.services.apiBaseUrl) &&
+      typeof loadBackend === 'function';
+
+    async function loadScreenSource(): Promise<ScreenDataSource<T>> {
+      if (backendEnabled) {
+        try {
+          const client = createBackendReadClient(runtimeState.config);
+          const backendResult = await loadBackend!(client);
+          await writeScreenSnapshotCacheEntry(surface, cacheKey, backendResult.data, {
+            generatedAt: backendResult.generatedAt ?? null,
+          });
+
+          return buildReadySource({
+            activeSource: 'backend-api',
+            sourceLabel: 'Backend API',
+            data: backendResult.data,
+            issues: runtimeIssues,
+            runtimeState,
+            rollingReferenceAt: backendResult.generatedAt ?? null,
+            generatedAt: backendResult.generatedAt ?? null,
+          });
+        } catch (error) {
+          const backendMessage =
+            error instanceof Error ? error.message : fallbackErrorMessage;
+          const cached = await readScreenSnapshotCacheEntry<T>(surface, cacheKey);
+
+          if (cached) {
+            return buildReadySource({
+              activeSource: 'backend-cache',
+              sourceLabel: 'Cached backend snapshot',
+              data: cached.value,
+              issues: [...runtimeIssues, backendMessage],
+              runtimeState,
+              rollingReferenceAt: cached.generatedAt ?? cached.cachedAt,
+              cachedAt: cached.cachedAt,
+              generatedAt: cached.generatedAt,
+            });
+          }
+
+          const bundledData = await loadBundled();
+          return buildReadySource({
+            activeSource: 'bundled-static-fallback',
+            sourceLabel: 'Bundled static fallback',
+            data: bundledData,
+            issues: [...runtimeIssues, backendMessage],
+            runtimeState,
+          });
+        }
+      }
+
+      if (runtimeState.mode === 'degraded') {
+        const cached = await readScreenSnapshotCacheEntry<T>(surface, cacheKey);
+        if (cached) {
+          return buildReadySource({
+            activeSource: 'backend-cache',
+            sourceLabel: 'Cached backend snapshot',
+            data: cached.value,
+            issues: runtimeIssues,
+            runtimeState,
+            rollingReferenceAt: cached.generatedAt ?? cached.cachedAt,
+            cachedAt: cached.cachedAt,
+            generatedAt: cached.generatedAt,
+          });
+        }
+      }
+
+      const bundledData = await loadBundled();
+      return buildReadySource({
+        activeSource: 'bundled-static',
+        sourceLabel: 'Bundled static dataset',
+        data: bundledData,
+        issues: runtimeIssues,
+        runtimeState,
+      });
+    }
+
+    void loadScreenSource()
       .then((source) => {
         if (cancelled) {
           return;
@@ -89,7 +231,7 @@ export function useActiveDatasetScreen({
     return () => {
       cancelled = true;
     };
-  }, [fallbackErrorMessage, reloadKey, surface]);
+  }, [cacheKey, enabled, fallbackErrorMessage, loadBackend, loadBundled, reloadKey, surface]);
 
   return state;
 }

--- a/mobile/src/services/activeDataset.test.ts
+++ b/mobile/src/services/activeDataset.test.ts
@@ -1,14 +1,11 @@
 import type { RuntimeConfigState } from '../config/runtime';
 
 import { loadActiveMobileDataset } from './activeDataset';
-import { writeDatasetCacheEntry } from './datasetCache';
 import {
   resetStorageAdapter,
   setStorageAdapter,
   type KeyValueStorageAdapter,
 } from './storage';
-import { selectDatasetSource } from './datasetSource';
-import { cloneBundledDatasetFixture } from './bundledDatasetFixture';
 
 function buildRuntimeState(overrides: Partial<RuntimeConfigState> = {}): RuntimeConfigState {
   return {
@@ -17,7 +14,6 @@ function buildRuntimeState(overrides: Partial<RuntimeConfigState> = {}): Runtime
       profile: 'development',
       dataSource: {
         mode: 'bundled-static',
-        remoteDatasetUrl: null,
         datasetVersion: 'fixture-v1',
       },
       services: {
@@ -70,151 +66,56 @@ describe('loadActiveMobileDataset', () => {
     });
 
     expect(result.activeSource).toBe('bundled-static');
-    expect(result.cachedArtifactIds).toEqual([]);
     expect(result.selection.kind).toBe('bundled-static');
     expect(result.sourceLabel).toBe('Bundled static dataset');
     expect(result.dataset.artistProfiles.length).toBeGreaterThan(0);
+    expect(result.issues).toEqual([]);
   });
 
-  test('loads a remote dataset when preview-remote is active', async () => {
+  test('falls back to bundled degraded mode when runtime config is degraded', async () => {
     const result = await loadActiveMobileDataset({
       runtimeState: buildRuntimeState({
-        config: {
-          ...buildRuntimeState().config,
-          profile: 'preview',
-          dataSource: {
-            mode: 'preview-static',
-            remoteDatasetUrl: 'https://example.com/mobile-dataset.json',
-            datasetVersion: 'preview-v1',
+        mode: 'degraded',
+        issues: [
+          {
+            kind: 'invalid_runtime_config',
+            message: 'Runtime config is degraded.',
           },
-          featureGates: {
-            ...buildRuntimeState().config.featureGates,
-            remoteRefresh: true,
-          },
-        },
+        ],
       }),
-      fetchImpl: jest.fn(async () => ({
-        ok: true,
-        json: async () => ({
-          artistProfiles: [],
-          releases: [],
-          upcomingCandidates: [],
-          releaseArtwork: [],
-          releaseDetails: [],
-          releaseHistory: [],
-          youtubeChannelAllowlists: [],
-        }),
-      })) as unknown as typeof fetch,
-    });
-
-    expect(result.activeSource).toBe('preview-remote');
-    expect(result.cachedArtifactIds.length).toBeGreaterThan(0);
-    expect(result.selection.kind).toBe('preview-remote');
-    expect(result.sourceLabel).toBe('Preview remote dataset');
-    expect(result.dataset.artistProfiles).toEqual([]);
-  });
-
-  test('falls back to bundled degraded mode when the remote payload is invalid', async () => {
-    const runtimeState = buildRuntimeState({
-      config: {
-        ...buildRuntimeState().config,
-        profile: 'preview',
-        dataSource: {
-          mode: 'preview-static',
-          remoteDatasetUrl: 'https://example.com/mobile-dataset.json',
-          datasetVersion: 'preview-v1',
-        },
-        featureGates: {
-          ...buildRuntimeState().config.featureGates,
-          remoteRefresh: true,
-        },
-      },
-    });
-
-    const result = await loadActiveMobileDataset({
-      runtimeState,
-      fetchImpl: jest.fn(async () => ({
-        ok: true,
-        json: async () => ({ nope: true }),
-      })) as unknown as typeof fetch,
     });
 
     expect(result.activeSource).toBe('bundled-static');
     expect(result.selection.kind).toBe('bundled-static');
-    expect(result.issues).toContain(
-      'Remote dataset payload does not match the expected contract.',
-    );
+    expect(result.selection.reason).toBe('runtime_degraded');
+    expect(result.issues).toContain('Runtime config is degraded.');
   });
 
-  test('restores the preview remote cache when the remote dataset is unavailable', async () => {
-    const runtimeState = buildRuntimeState({
-      config: {
-        ...buildRuntimeState().config,
-        profile: 'preview',
-        dataSource: {
-          mode: 'preview-static',
-          remoteDatasetUrl: 'https://example.com/mobile-dataset.json',
-          datasetVersion: 'preview-v1',
-        },
-        featureGates: {
-          ...buildRuntimeState().config.featureGates,
-          remoteRefresh: true,
+  test('uses bundled selection even when runtime prefers backend api', async () => {
+    const base = buildRuntimeState();
+    const result = await loadActiveMobileDataset({
+      runtimeState: {
+        ...base,
+        config: {
+          ...base.config,
+          profile: 'preview',
+          dataSource: {
+            mode: 'backend-api',
+            datasetVersion: 'preview-v1',
+          },
+          services: {
+            apiBaseUrl: 'https://example.com/api',
+            analyticsWriteKey: null,
+          },
+          logging: {
+            level: 'debug',
+          },
         },
       },
     });
-    const selection = selectDatasetSource(runtimeState.config);
-    const fixture = cloneBundledDatasetFixture();
 
-    if (selection.kind !== 'preview-remote') {
-      throw new Error('Expected preview-remote selection for cache test.');
-    }
-
-    await Promise.all(
-      selection.artifacts.map((artifact) =>
-        writeDatasetCacheEntry(
-          artifact.id,
-          (() => {
-            switch (artifact.id) {
-              case 'artistProfiles':
-                return fixture.artistProfiles;
-              case 'releases':
-                return fixture.releases;
-              case 'releaseArtwork':
-                return fixture.releaseArtwork;
-              case 'releaseDetails':
-                return fixture.releaseDetails;
-              case 'releaseHistory':
-                return fixture.releaseHistory;
-              case 'watchlist':
-                return fixture.watchlist ?? [];
-              case 'upcomingCandidates':
-                return fixture.upcomingCandidates;
-              case 'teamBadgeAssets':
-                return fixture.teamBadgeAssets ?? [];
-              case 'youtubeChannelAllowlists':
-                return fixture.youtubeChannelAllowlists;
-              case 'radarChangeFeed':
-                return fixture.radarChangeFeed ?? [];
-            }
-          })(),
-          selection,
-          '2026-03-10T00:00:00.000Z',
-        ),
-      ),
-    );
-
-    const result = await loadActiveMobileDataset({
-      runtimeState,
-      fetchImpl: jest.fn(async () => ({
-        ok: false,
-        status: 503,
-      })) as unknown as typeof fetch,
-    });
-
-    expect(result.activeSource).toBe('preview-remote-cache');
-    expect(result.sourceLabel).toBe('Preview remote cached dataset');
-    expect(result.cachedArtifactIds).toHaveLength(selection.artifacts.length);
-    expect(result.freshness.rollingReferenceAt).toBe('2026-03-10T00:00:00.000Z');
-    expect(result.dataset.artistProfiles.length).toBe(fixture.artistProfiles.length);
+    expect(result.activeSource).toBe('bundled-static');
+    expect(result.selection.reason).toBe('backend_api_mode');
+    expect(result.sourceLabel).toBe('Bundled static dataset');
   });
 });

--- a/mobile/src/services/activeDataset.ts
+++ b/mobile/src/services/activeDataset.ts
@@ -2,91 +2,22 @@ import type { RuntimeConfigState } from '../config/runtime';
 import { getRuntimeConfigState } from '../config/runtime';
 import type { MobileRawDataset } from '../types';
 
-import {
-  resolveDatasetFailurePolicy,
-  type DatasetFailurePolicy,
-} from './datasetFailurePolicy';
-import {
-  readDatasetCacheEntry,
-  writeDatasetCacheEntry,
-} from './datasetCache';
-import {
-  isRemoteDatasetSelection,
-  selectDatasetSource,
-  type DatasetArtifactDescriptor,
-  type DatasetArtifactId,
-  type DatasetFreshnessClass,
-  type DatasetSelection,
-  type PreviewRemoteDatasetSelection,
-} from './datasetSource';
+import { resolveDatasetFailurePolicy } from './datasetFailurePolicy';
+import { selectDatasetSource, type DatasetSelection } from './datasetSource';
 import { cloneBundledDatasetFixture } from './bundledDatasetFixture';
 
-type DatasetArtifactValues = {
-  artistProfiles: MobileRawDataset['artistProfiles'];
-  releases: MobileRawDataset['releases'];
-  releaseArtwork: MobileRawDataset['releaseArtwork'];
-  releaseDetails: MobileRawDataset['releaseDetails'];
-  releaseHistory: MobileRawDataset['releaseHistory'];
-  watchlist: NonNullable<MobileRawDataset['watchlist']>;
-  upcomingCandidates: MobileRawDataset['upcomingCandidates'];
-  teamBadgeAssets: NonNullable<MobileRawDataset['teamBadgeAssets']>;
-  youtubeChannelAllowlists: MobileRawDataset['youtubeChannelAllowlists'];
-  radarChangeFeed: NonNullable<MobileRawDataset['radarChangeFeed']>;
-};
-
 export type ActiveMobileDataset = {
-  activeSource: DatasetFailurePolicy['activeSource'];
-  cachedArtifactIds: DatasetArtifactId[];
+  activeSource: 'bundled-static';
   dataset: MobileRawDataset;
   freshness: {
     rollingReferenceAt: string | null;
-    staleFreshnessClasses: DatasetFreshnessClass[];
+    staleFreshnessClasses: string[];
   };
   issues: string[];
   runtimeState: RuntimeConfigState;
   selection: DatasetSelection;
   sourceLabel: string;
 };
-
-export class ActiveDatasetLoadError extends Error {
-  constructor(
-    public readonly code:
-      | 'remote_unavailable'
-      | 'invalid_dataset'
-      | 'invalid_cache',
-    message: string,
-  ) {
-    super(message);
-    this.name = 'ActiveDatasetLoadError';
-  }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
-}
-
-function isOptionalArray(value: unknown): boolean {
-  return value == null || Array.isArray(value);
-}
-
-function isMobileRawDataset(value: unknown): value is MobileRawDataset {
-  if (!isRecord(value)) {
-    return false;
-  }
-
-  return (
-    Array.isArray(value.artistProfiles) &&
-    Array.isArray(value.releases) &&
-    Array.isArray(value.upcomingCandidates) &&
-    Array.isArray(value.releaseArtwork) &&
-    Array.isArray(value.releaseDetails) &&
-    Array.isArray(value.releaseHistory) &&
-    Array.isArray(value.youtubeChannelAllowlists) &&
-    isOptionalArray(value.watchlist) &&
-    isOptionalArray(value.teamBadgeAssets) &&
-    isOptionalArray(value.radarChangeFeed)
-  );
-}
 
 function normalizeMobileRawDataset(dataset: MobileRawDataset): MobileRawDataset {
   return {
@@ -101,142 +32,23 @@ function normalizeMobileRawDataset(dataset: MobileRawDataset): MobileRawDataset 
   };
 }
 
-function getDatasetSourceLabel(
-  activeSource: DatasetFailurePolicy['activeSource'],
-): string {
-  switch (activeSource) {
-    case 'preview-remote':
-      return 'Preview remote dataset';
-    case 'preview-remote-cache':
-      return 'Preview remote cached dataset';
-    case 'bundled-static':
-    default:
-      return 'Bundled static dataset';
-  }
+function getDatasetSourceLabel(): string {
+  return 'Bundled static dataset';
 }
 
 function dedupeIssueMessages(messages: string[]): string[] {
   return [...new Set(messages.filter(Boolean))];
 }
 
-function getArtifactValue(
-  dataset: MobileRawDataset,
-  descriptor: DatasetArtifactDescriptor,
-): DatasetArtifactValues[typeof descriptor.id] {
-  switch (descriptor.id) {
-    case 'artistProfiles':
-      return dataset.artistProfiles;
-    case 'releases':
-      return dataset.releases;
-    case 'releaseArtwork':
-      return dataset.releaseArtwork;
-    case 'releaseDetails':
-      return dataset.releaseDetails;
-    case 'releaseHistory':
-      return dataset.releaseHistory;
-    case 'watchlist':
-      return Array.isArray(dataset.watchlist) ? dataset.watchlist : [];
-    case 'upcomingCandidates':
-      return dataset.upcomingCandidates;
-    case 'teamBadgeAssets':
-      return Array.isArray(dataset.teamBadgeAssets) ? dataset.teamBadgeAssets : [];
-    case 'youtubeChannelAllowlists':
-      return dataset.youtubeChannelAllowlists;
-    case 'radarChangeFeed':
-      return Array.isArray(dataset.radarChangeFeed) ? dataset.radarChangeFeed : [];
-  }
-}
-
-async function writeDatasetCaches(
-  dataset: MobileRawDataset,
-  selection: PreviewRemoteDatasetSelection,
-  cachedAt = new Date().toISOString(),
-): Promise<DatasetArtifactId[]> {
-  await Promise.all(
-    selection.artifacts.map((descriptor) =>
-      writeDatasetCacheEntry(
-        descriptor.id,
-        getArtifactValue(dataset, descriptor),
-        selection,
-        cachedAt,
-      ),
-    ),
-  );
-
-  return selection.artifacts.map((descriptor) => descriptor.id);
-}
-
-async function buildDatasetFromCache(
-  selection: PreviewRemoteDatasetSelection,
-): Promise<{
-  cachedArtifactIds: DatasetArtifactId[];
-  dataset: MobileRawDataset;
-  rollingReferenceAt: string | null;
-}> {
-  const entries = await Promise.all(
-    selection.artifacts.map(async (descriptor) => {
-      const entry = await readDatasetCacheEntry<DatasetArtifactValues[typeof descriptor.id]>(
-        descriptor.id,
-        selection,
-      );
-
-      return {
-        descriptor,
-        entry,
-      };
-    }),
-  );
-
-  const missing = entries.find(({ entry }) => entry === null);
-  if (missing) {
-    throw new ActiveDatasetLoadError(
-      'invalid_cache',
-      `Preview remote cache is missing ${missing.descriptor.id}.`,
-    );
-  }
-
-  const values = new Map<DatasetArtifactId, DatasetArtifactValues[DatasetArtifactId]>();
-  for (const { descriptor, entry } of entries) {
-    values.set(descriptor.id, entry!.value);
-  }
-
-  const rollingReferenceAt =
-    entries
-      .filter(({ descriptor }) => descriptor.freshnessClass !== 'stable-profile')
-      .map(({ entry }) => entry!.cachedAt)
-      .sort()[0] ?? null;
-
-  return {
-    cachedArtifactIds: selection.artifacts.map((descriptor) => descriptor.id),
-    dataset: normalizeMobileRawDataset({
-      artistProfiles: values.get('artistProfiles') as MobileRawDataset['artistProfiles'],
-      releases: values.get('releases') as MobileRawDataset['releases'],
-      releaseArtwork: values.get('releaseArtwork') as MobileRawDataset['releaseArtwork'],
-      releaseDetails: values.get('releaseDetails') as MobileRawDataset['releaseDetails'],
-      releaseHistory: values.get('releaseHistory') as MobileRawDataset['releaseHistory'],
-      watchlist: values.get('watchlist') as NonNullable<MobileRawDataset['watchlist']>,
-      upcomingCandidates: values.get('upcomingCandidates') as MobileRawDataset['upcomingCandidates'],
-      teamBadgeAssets: values.get('teamBadgeAssets') as NonNullable<MobileRawDataset['teamBadgeAssets']>,
-      youtubeChannelAllowlists: values.get(
-        'youtubeChannelAllowlists',
-      ) as MobileRawDataset['youtubeChannelAllowlists'],
-      radarChangeFeed: values.get('radarChangeFeed') as NonNullable<MobileRawDataset['radarChangeFeed']>,
-    }),
-    rollingReferenceAt,
-  };
-}
-
 function buildBundledDatasetResponse(args: {
-  cachedArtifactIds: DatasetArtifactId[];
   extraIssues?: string[];
-  policy: DatasetFailurePolicy;
+  selection: DatasetSelection;
   runtimeState: RuntimeConfigState;
 }): ActiveMobileDataset {
   const dataset = normalizeMobileRawDataset(cloneBundledDatasetFixture());
 
   return {
-    activeSource: args.policy.activeSource,
-    cachedArtifactIds: args.cachedArtifactIds,
+    activeSource: 'bundled-static',
     dataset,
     freshness: {
       rollingReferenceAt: null,
@@ -244,18 +56,16 @@ function buildBundledDatasetResponse(args: {
     },
     issues: dedupeIssueMessages([
       ...args.runtimeState.issues.map((issue) => issue.message),
-      ...args.policy.issues.map((issue) => issue.message),
       ...(args.extraIssues ?? []),
     ]),
     runtimeState: args.runtimeState,
-    selection: args.policy.selection,
-    sourceLabel: getDatasetSourceLabel(args.policy.activeSource),
+    selection: args.selection,
+    sourceLabel: getDatasetSourceLabel(),
   };
 }
 
 export async function loadActiveMobileDataset(
   options: {
-    fetchImpl?: typeof fetch;
     runtimeState?: RuntimeConfigState;
   } = {},
 ): Promise<ActiveMobileDataset> {
@@ -265,112 +75,9 @@ export async function loadActiveMobileDataset(
     runtimeState,
     selection,
   });
-
-  if (!isRemoteDatasetSelection(selection) || basePolicy.activeSource === 'bundled-static') {
-    return buildBundledDatasetResponse({
-      cachedArtifactIds: basePolicy.cachedArtifactIds,
-      policy: basePolicy,
-      runtimeState,
-    });
-  }
-
-  const fetchImpl = options.fetchImpl ?? fetch;
-
-  try {
-    const response = await fetchImpl(selection.remoteDatasetUrl);
-    if (!response.ok) {
-      throw new ActiveDatasetLoadError(
-        'remote_unavailable',
-        `Remote dataset request failed with status ${response.status}.`,
-      );
-    }
-
-    const payload = await response.json();
-    if (!isMobileRawDataset(payload)) {
-      throw new ActiveDatasetLoadError(
-        'invalid_dataset',
-        'Remote dataset payload does not match the expected contract.',
-      );
-    }
-
-    const dataset = normalizeMobileRawDataset(payload);
-    const cachedArtifactIds = await writeDatasetCaches(dataset, selection);
-
-    return {
-      activeSource: 'preview-remote',
-      cachedArtifactIds,
-      dataset,
-      freshness: {
-        rollingReferenceAt: null,
-        staleFreshnessClasses: [],
-      },
-      issues: dedupeIssueMessages(runtimeState.issues.map((issue) => issue.message)),
-      runtimeState,
-      selection,
-      sourceLabel: getDatasetSourceLabel('preview-remote'),
-    };
-  } catch (error: unknown) {
-    const remoteAvailability =
-      error instanceof ActiveDatasetLoadError && error.code === 'invalid_dataset'
-        ? {
-            message: error.message,
-            status: 'invalid' as const,
-          }
-        : {
-            message:
-              error instanceof Error
-                ? error.message
-                : 'Preview remote dataset is unavailable.',
-            status: 'unavailable' as const,
-          };
-
-    const fallbackPolicy = await resolveDatasetFailurePolicy({
-      runtimeState,
-      selection,
-      remoteAvailability,
-    });
-
-    if (fallbackPolicy.activeSource === 'preview-remote-cache') {
-      try {
-        const cached = await buildDatasetFromCache(selection);
-
-        return {
-          activeSource: 'preview-remote-cache',
-          cachedArtifactIds: cached.cachedArtifactIds,
-          dataset: cached.dataset,
-          freshness: {
-            rollingReferenceAt: cached.rollingReferenceAt,
-            staleFreshnessClasses: ['rolling-release', 'rolling-upcoming'],
-          },
-          issues: dedupeIssueMessages([
-            ...runtimeState.issues.map((issue) => issue.message),
-            ...fallbackPolicy.issues.map((issue) => issue.message),
-          ]),
-          runtimeState,
-          selection: fallbackPolicy.selection,
-          sourceLabel: getDatasetSourceLabel('preview-remote-cache'),
-        };
-      } catch (cacheError: unknown) {
-        return buildBundledDatasetResponse({
-          cachedArtifactIds: fallbackPolicy.cachedArtifactIds,
-          extraIssues: [
-            cacheError instanceof Error
-              ? cacheError.message
-              : 'Preview remote cache could not be restored.',
-          ],
-          policy: {
-            ...fallbackPolicy,
-            activeSource: 'bundled-static',
-          },
-          runtimeState,
-        });
-      }
-    }
-
-    return buildBundledDatasetResponse({
-      cachedArtifactIds: fallbackPolicy.cachedArtifactIds,
-      policy: fallbackPolicy,
-      runtimeState,
-    });
-  }
+  return buildBundledDatasetResponse({
+    extraIssues: basePolicy.issues.map((issue) => issue.message),
+    selection: basePolicy.selection,
+    runtimeState,
+  });
 }

--- a/mobile/src/services/analytics.test.ts
+++ b/mobile/src/services/analytics.test.ts
@@ -12,8 +12,7 @@ import {
 const analyticsEnabledRuntime: MobileRuntimeConfig = {
   profile: 'preview',
   dataSource: {
-    mode: 'preview-static',
-    remoteDatasetUrl: null,
+    mode: 'backend-api',
     datasetVersion: 'preview-v1',
   },
   services: {
@@ -100,7 +99,7 @@ describe('mobile analytics service', () => {
       },
       occurredAt: '2026-03-09T00:00:00.000Z',
       profile: 'preview',
-      dataSourceMode: 'preview-static',
+      dataSourceMode: 'backend-api',
       buildVersion: '0.1.0',
     });
   });

--- a/mobile/src/services/analytics.ts
+++ b/mobile/src/services/analytics.ts
@@ -1,6 +1,6 @@
 import type { MobileRuntimeConfig } from '../config/runtime';
 import { getRuntimeConfig } from '../config/runtime';
-import type { ActiveMobileDataset } from './activeDataset';
+import type { ScreenDataSource } from '../features/screenDataSource';
 
 import type {
   MusicService,
@@ -141,7 +141,7 @@ export function resetAnalyticsEvents(): void {
 
 export function trackDatasetDegraded(
   surface: AnalyticsSurface,
-  source: Pick<ActiveMobileDataset, 'activeSource' | 'issues' | 'runtimeState'>,
+  source: Pick<ScreenDataSource, 'activeSource' | 'issues' | 'runtimeState'>,
   runtimeConfig: MobileRuntimeConfig = getRuntimeConfig(),
   now?: () => string,
 ): boolean {

--- a/mobile/src/services/backendDisplayAdapters.ts
+++ b/mobile/src/services/backendDisplayAdapters.ts
@@ -1,0 +1,443 @@
+import type {
+  CalendarMonthSnapshotModel,
+  EntityDetailSnapshotModel,
+  EntityTimelineItemModel,
+  RadarChangeFeedItemModel,
+  RadarLongGapItemModel,
+  RadarRookieItemModel,
+  RadarSnapshotModel,
+  RadarUpcomingCardModel,
+  ReleaseDetailModel,
+  ReleaseSummaryModel,
+  SearchReleaseResultModel,
+  SearchResultsModel,
+  SearchTeamResultModel,
+  SearchUpcomingResultModel,
+  TeamSummaryModel,
+  TrackModel,
+  UpcomingEventModel,
+} from '../types';
+import type {
+  BackendCalendarMonthData,
+  BackendCalendarRelease,
+  BackendCalendarUpcoming,
+  BackendEntityDetailData,
+  BackendEntityReleaseSummary,
+  BackendEntityUpcomingSummary,
+  BackendRadarChangeFeedItem,
+  BackendRadarData,
+  BackendRadarGapOrRookieItem,
+  BackendRadarUpcoming,
+  BackendReleaseDetailData,
+  BackendSearchData,
+  BackendSearchEntity,
+  BackendSearchRelease,
+  BackendSearchUpcoming,
+} from './backendReadClient';
+import {
+  buildMonogram,
+  normalizeReleaseKind,
+  normalizeReleaseStream,
+  normalizeUpcomingConfidence,
+  normalizeUpcomingDatePrecision,
+  normalizeUpcomingSourceType,
+  normalizeUpcomingStatus,
+} from '../selectors/normalize';
+
+function resolveActType(value?: string | null): TeamSummaryModel['actType'] {
+  if (value === 'solo' || value === 'unit' || value === 'project' || value === 'group') {
+    return value;
+  }
+
+  return 'group';
+}
+
+function buildTeamSummary(input: {
+  slug: string;
+  displayName: string;
+  canonicalName?: string | null;
+  entityType?: string | null;
+  agencyName?: string | null;
+  debutYear?: number | null;
+  badgeImageUrl?: string | null;
+  representativeImageUrl?: string | null;
+  officialYoutubeUrl?: string | null;
+  officialXUrl?: string | null;
+  officialInstagramUrl?: string | null;
+  youtubeChannelUrls?: string[];
+  artistSourceUrl?: string | null;
+  aliases?: string[];
+}): TeamSummaryModel {
+  const displayName = input.displayName;
+
+  return {
+    slug: input.slug,
+    group: input.canonicalName?.trim() || displayName,
+    displayName,
+    actType: resolveActType(input.entityType),
+    debutYear: input.debutYear ?? undefined,
+    agency: input.agencyName ?? undefined,
+    badge: input.badgeImageUrl || input.representativeImageUrl
+      ? {
+          imageUrl: input.badgeImageUrl ?? input.representativeImageUrl ?? undefined,
+          label: displayName,
+        }
+      : {
+          monogram: buildMonogram(displayName),
+          label: displayName,
+        },
+    representativeImageUrl: input.representativeImageUrl ?? undefined,
+    officialYoutubeUrl: input.officialYoutubeUrl ?? undefined,
+    officialXUrl: input.officialXUrl ?? undefined,
+    officialInstagramUrl: input.officialInstagramUrl ?? undefined,
+    youtubeChannelUrls: input.youtubeChannelUrls ?? [],
+    artistSourceUrl: input.artistSourceUrl ?? undefined,
+    searchTokens: [
+      displayName,
+      input.canonicalName,
+      ...(input.aliases ?? []),
+    ].filter((value): value is string => typeof value === 'string' && value.length > 0),
+  };
+}
+
+function adaptReleaseSummary(
+  input: BackendCalendarRelease | BackendSearchRelease | BackendEntityReleaseSummary,
+  entitySlug: string,
+  displayName: string,
+): ReleaseSummaryModel {
+  return {
+    id: input.release_id,
+    group: entitySlug,
+    displayGroup: displayName,
+    releaseTitle: input.release_title,
+    releaseDate: input.release_date ?? '',
+    releaseKind: normalizeReleaseKind(input.release_kind ?? null),
+    stream: normalizeReleaseStream(input.stream),
+    coverImageUrl:
+      'artwork' in input
+        ? input.artwork?.cover_image_url ?? input.artwork?.thumbnail_image_url ?? undefined
+        : undefined,
+    contextTags:
+      'release_format' in input && typeof input.release_format === 'string' && input.release_format.length > 0
+        ? [input.release_format]
+        : [],
+  };
+}
+
+function adaptUpcomingEvent(
+  input: BackendCalendarUpcoming | BackendSearchUpcoming | BackendEntityUpcomingSummary | BackendRadarUpcoming,
+  entitySlug: string,
+  displayName: string,
+): UpcomingEventModel {
+  return {
+    id: input.upcoming_signal_id,
+    group: entitySlug,
+    displayGroup: displayName,
+    scheduledDate: input.scheduled_date ?? undefined,
+    scheduledMonth: input.scheduled_month ?? undefined,
+    datePrecision: normalizeUpcomingDatePrecision(input.date_precision),
+    headline: input.headline,
+    status: normalizeUpcomingStatus(input.date_status),
+    confidence: normalizeUpcomingConfidence(input.confidence_score ?? null),
+    sourceType: normalizeUpcomingSourceType(('source_type' in input ? input.source_type : null) ?? null),
+    sourceUrl: ('source_url' in input ? input.source_url : null) ?? undefined,
+  };
+}
+
+function adaptRadarUpcomingCard(input: BackendRadarUpcoming): RadarUpcomingCardModel {
+  const upcoming = adaptUpcomingEvent(input, input.entity_slug, input.display_name);
+
+  return {
+    id: input.upcoming_signal_id,
+    team: buildTeamSummary({
+      slug: input.entity_slug,
+      displayName: input.display_name,
+    }),
+    upcoming,
+    dayLabel: upcoming.scheduledDate ?? upcoming.scheduledMonth ?? '날짜 미정',
+    sourceLabel: input.release_format ?? input.date_status ?? '예정',
+    sourceUrl: input.source_url ?? undefined,
+  };
+}
+
+function adaptRadarChangeFeedItem(input: BackendRadarChangeFeedItem): RadarChangeFeedItemModel {
+  if (input.kind === 'verified_release') {
+    return {
+      id: input.release_id ?? `${input.entity_slug}-verified`,
+      team: buildTeamSummary({
+        slug: input.entity_slug,
+        displayName: input.display_name,
+      }),
+      changeTypeLabel: '검증된 발매',
+      previousScheduleLabel: '이전 일정 없음',
+      nextScheduleLabel: [input.release_title, input.release_date].filter(Boolean).join(' · '),
+      occurredAtLabel: input.occurred_at ?? undefined,
+      releaseLabel: input.release_title ?? undefined,
+      headline: input.release_title ?? undefined,
+      sourceLabel: 'Verified release',
+    };
+  }
+
+  return {
+    id: input.upcoming_signal_id ?? `${input.entity_slug}-upcoming`,
+    team: buildTeamSummary({
+      slug: input.entity_slug,
+      displayName: input.display_name,
+    }),
+    changeTypeLabel: '예정 신호',
+    previousScheduleLabel: input.scheduled_month && !input.scheduled_date ? `${input.scheduled_month} · 날짜 미정` : '일정 조정',
+    nextScheduleLabel:
+      input.scheduled_date ?? input.scheduled_month ?? input.headline ?? '날짜 미정',
+    occurredAtLabel: input.occurred_at ?? undefined,
+    releaseLabel: input.headline ?? undefined,
+    headline: input.headline ?? undefined,
+    sourceLabel: 'Upcoming signal',
+  };
+}
+
+function adaptRadarGapItem(input: BackendRadarGapOrRookieItem): RadarLongGapItemModel {
+  return {
+    id: input.entity_slug,
+    team: buildTeamSummary({
+      slug: input.entity_slug,
+      displayName: input.display_name,
+    }),
+    latestRelease: input.latest_release
+      ? adaptReleaseSummary(input.latest_release, input.entity_slug, input.display_name)
+      : null,
+    gapDays: input.gap_days ?? 0,
+    gapLabel: input.gap_days ? `${input.gap_days}일 공백` : '장기 공백',
+    hasUpcomingSignal: input.has_upcoming_signal,
+  };
+}
+
+function adaptRadarRookieItem(input: BackendRadarGapOrRookieItem): RadarRookieItemModel {
+  return {
+    id: input.entity_slug,
+    team: buildTeamSummary({
+      slug: input.entity_slug,
+      displayName: input.display_name,
+    }),
+    debutYear: input.debut_year ?? new Date().getFullYear(),
+    latestRelease: input.latest_release
+      ? adaptReleaseSummary(input.latest_release, input.entity_slug, input.display_name)
+      : null,
+    hasUpcomingSignal: input.has_upcoming_signal,
+  };
+}
+
+function resolveEntityTimelineKind(eventType?: string | null): EntityTimelineItemModel['kind'] {
+  if (eventType === 'release_verified') {
+    return 'release_source';
+  }
+
+  if (eventType === 'artist_source') {
+    return 'artist_source';
+  }
+
+  return 'upcoming_source';
+}
+
+function resolveEntityTimelineMeta(item: BackendEntityDetailData['source_timeline'][number]): string {
+  return (
+    item.summary ??
+    [
+      item.release_format,
+      item.date_status,
+      item.scheduled_date ?? item.scheduled_month ?? item.published_at ?? item.occurred_at,
+    ]
+      .filter((value): value is string => typeof value === 'string' && value.length > 0)
+      .join(' · ')
+  );
+}
+
+function resolveMatchKind(value: string): SearchTeamResultModel['matchKind'] {
+  if (value === 'display_name_exact' || value === 'alias_exact' || value === 'alias_partial' || value === 'partial') {
+    return value;
+  }
+
+  return 'partial';
+}
+
+function resolveReleaseMatchKind(value: string): SearchReleaseResultModel['matchKind'] {
+  if (value === 'release_title_exact' || value === 'entity_exact_latest_release' || value === 'partial') {
+    return value;
+  }
+
+  return 'partial';
+}
+
+function resolveUpcomingMatchKind(value: string): SearchUpcomingResultModel['matchKind'] {
+  if (value === 'entity_exact' || value === 'headline_exact' || value === 'partial') {
+    return value;
+  }
+
+  return 'partial';
+}
+
+function stringifyNote(value: unknown): string | undefined {
+  if (typeof value === 'string' && value.trim().length > 0) {
+    return value;
+  }
+
+  if (typeof value === 'object' && value !== null && 'summary' in value && typeof value.summary === 'string') {
+    return value.summary;
+  }
+
+  return undefined;
+}
+
+export function adaptBackendCalendarMonth(
+  month: string,
+  data: BackendCalendarMonthData,
+): CalendarMonthSnapshotModel {
+  const releases = data.verified_list.map((release) =>
+    adaptReleaseSummary(release, release.entity_slug, release.display_name),
+  );
+  const exactUpcoming = data.scheduled_list
+    .filter((item) => item.date_precision === 'exact')
+    .map((item) => adaptUpcomingEvent(item, item.entity_slug, item.display_name));
+  const monthOnlyUpcoming = data.month_only_upcoming.map((item) =>
+    adaptUpcomingEvent(item, item.entity_slug, item.display_name),
+  );
+
+  return {
+    month,
+    releaseCount: releases.length,
+    upcomingCount: exactUpcoming.length + monthOnlyUpcoming.length,
+    nearestUpcoming: data.nearest_upcoming
+      ? adaptUpcomingEvent(
+          data.nearest_upcoming,
+          data.nearest_upcoming.entity_slug,
+          data.nearest_upcoming.display_name,
+        )
+      : null,
+    releases,
+    exactUpcoming,
+    monthOnlyUpcoming,
+  };
+}
+
+export function adaptBackendSearchResults(query: string, data: BackendSearchData): SearchResultsModel {
+  return {
+    query,
+    entities: data.entities.map((entity: BackendSearchEntity): SearchTeamResultModel => ({
+      team: buildTeamSummary({
+        slug: entity.entity_slug,
+        displayName: entity.display_name,
+        canonicalName: entity.canonical_name,
+        entityType: entity.entity_type,
+        agencyName: entity.agency_name ?? null,
+        aliases: entity.aliases ?? [],
+      }),
+      latestRelease: entity.latest_release
+        ? adaptReleaseSummary(entity.latest_release, entity.entity_slug, entity.display_name)
+        : null,
+      matchKind: resolveMatchKind(entity.match_reason),
+    })),
+    releases: data.releases.map((release: BackendSearchRelease): SearchReleaseResultModel => ({
+      release: adaptReleaseSummary(release, release.entity_slug, release.display_name),
+      matchKind: resolveReleaseMatchKind(release.match_reason),
+    })),
+    upcoming: data.upcoming.map((upcoming: BackendSearchUpcoming): SearchUpcomingResultModel => ({
+      upcoming: adaptUpcomingEvent(upcoming, upcoming.entity_slug, upcoming.display_name),
+      matchKind: resolveUpcomingMatchKind(upcoming.match_reason),
+    })),
+  };
+}
+
+export function adaptBackendRadarSnapshot(data: BackendRadarData): RadarSnapshotModel {
+  const futureUpcoming = data.featured_upcoming ? [adaptRadarUpcomingCard(data.featured_upcoming)] : [];
+
+  return {
+    futureUpcoming,
+    featuredUpcoming: futureUpcoming[0] ?? null,
+    weeklyUpcoming: data.weekly_upcoming.map(adaptRadarUpcomingCard),
+    changeFeed: data.change_feed.map(adaptRadarChangeFeedItem),
+    longGap: data.long_gap.map(adaptRadarGapItem),
+    rookie: data.rookie.map(adaptRadarRookieItem),
+  };
+}
+
+export function adaptBackendEntityDetail(data: BackendEntityDetailData): EntityDetailSnapshotModel {
+  const team = buildTeamSummary({
+    slug: data.identity.entity_slug,
+    displayName: data.identity.display_name,
+    canonicalName: data.identity.canonical_name ?? data.identity.display_name,
+    entityType: data.identity.entity_type,
+    agencyName: data.identity.agency_name ?? null,
+    debutYear: data.identity.debut_year ?? null,
+    badgeImageUrl: data.identity.badge_image_url ?? null,
+    representativeImageUrl: data.identity.representative_image_url ?? null,
+    officialYoutubeUrl: data.official_links.youtube ?? data.youtube_channels.primary_team_channel_url ?? null,
+    officialXUrl: data.official_links.x ?? null,
+    officialInstagramUrl: data.official_links.instagram ?? null,
+    youtubeChannelUrls: [
+      data.youtube_channels.primary_team_channel_url,
+      ...(data.youtube_channels.mv_allowlist_urls ?? []),
+    ].filter((value): value is string => typeof value === 'string' && value.length > 0),
+    artistSourceUrl: data.artist_source_url ?? null,
+  });
+
+  return {
+    team,
+    nextUpcoming: data.next_upcoming
+      ? adaptUpcomingEvent(data.next_upcoming, data.identity.entity_slug, data.identity.display_name)
+      : null,
+    latestRelease: data.latest_release
+      ? adaptReleaseSummary(data.latest_release, data.identity.entity_slug, data.identity.display_name)
+      : null,
+    recentAlbums: data.recent_albums.map((release) =>
+      adaptReleaseSummary(release, data.identity.entity_slug, data.identity.display_name),
+    ),
+    sourceTimeline: data.source_timeline.map(
+      (item): EntityTimelineItemModel => ({
+        id: `${item.event_type ?? 'source'}-${item.occurred_at ?? item.headline}`,
+        kind: resolveEntityTimelineKind(item.event_type),
+        title: item.headline,
+        meta: resolveEntityTimelineMeta(item),
+        sourceUrl: item.source_url ?? undefined,
+      }),
+    ),
+  };
+}
+
+export function adaptBackendReleaseDetail(data: BackendReleaseDetailData): ReleaseDetailModel {
+  const tracks: TrackModel[] = (data.tracks ?? []).map((track) => ({
+    order: track.order,
+    title: track.title,
+    isTitleTrack: track.is_title_track ?? undefined,
+    spotifyUrl: track.spotify?.url ?? undefined,
+    youtubeMusicUrl: track.youtube_music?.url ?? undefined,
+  }));
+
+  return {
+    id: data.release.release_id,
+    group: data.release.entity_slug,
+    displayGroup: data.release.display_name,
+    releaseTitle: data.release.release_title,
+    releaseDate: data.release.release_date,
+    releaseKind: data.release.release_kind ?? undefined,
+    stream: normalizeReleaseStream(data.release.stream),
+    coverImageUrl:
+      data.artwork?.image_url ??
+      data.artwork?.cover_image_url ??
+      data.artwork?.thumbnail_image_url ??
+      undefined,
+    spotifyUrl: data.service_links?.spotify?.url ?? undefined,
+    youtubeMusicUrl: data.service_links?.youtube_music?.url ?? undefined,
+    youtubeVideoId: data.mv?.video_id ?? undefined,
+    youtubeVideoUrl: data.mv?.url ?? undefined,
+    youtubeVideoStatus:
+      data.mv?.status === 'relation_match' ||
+      data.mv?.status === 'manual_override' ||
+      data.mv?.status === 'needs_review' ||
+      data.mv?.status === 'no_mv' ||
+      data.mv?.status === 'unresolved'
+        ? data.mv.status
+        : undefined,
+    youtubeVideoProvenance: data.mv?.provenance ?? undefined,
+    notes: stringifyNote(data.notes),
+    tracks,
+  };
+}

--- a/mobile/src/services/backendReadClient.test.ts
+++ b/mobile/src/services/backendReadClient.test.ts
@@ -1,0 +1,163 @@
+import {
+  createBackendReadClient,
+} from './backendReadClient';
+import type { MobileRuntimeConfig } from '../config/runtime';
+
+function buildRuntimeConfig(): MobileRuntimeConfig {
+  return {
+    profile: 'preview',
+    dataSource: {
+      mode: 'backend-api',
+      datasetVersion: 'preview-v1',
+    },
+    services: {
+      apiBaseUrl: 'https://example.com/api',
+      analyticsWriteKey: null,
+    },
+    logging: {
+      level: 'debug',
+    },
+    featureGates: {
+      radar: true,
+      analytics: false,
+      remoteRefresh: false,
+      mvEmbed: true,
+      shareActions: true,
+    },
+    build: {
+      version: '0.1.0',
+      commitSha: 'test-sha',
+    },
+  };
+}
+
+function createJsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    async json() {
+      return body;
+    },
+  } as Response;
+}
+
+describe('mobile backend read client', () => {
+  test('requests calendar month envelope from the shared backend contract', async () => {
+    const fetchMock = jest.fn(async () =>
+      createJsonResponse({
+        meta: {
+          generatedAt: '2026-03-10T00:00:00.000Z',
+        },
+        data: {
+          summary: {
+            verified_count: 1,
+            exact_upcoming_count: 1,
+            month_only_upcoming_count: 0,
+          },
+          nearest_upcoming: null,
+          days: [],
+          month_only_upcoming: [],
+          verified_list: [],
+          scheduled_list: [],
+        },
+      }),
+    );
+
+    const client = createBackendReadClient(buildRuntimeConfig(), fetchMock as unknown as typeof fetch);
+    const response = await client.getCalendarMonth('2026-03');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://example.com/api/v1/calendar/month?month=2026-03',
+      expect.objectContaining({
+        method: 'GET',
+      }),
+    );
+    expect(response.meta?.generatedAt).toBe('2026-03-10T00:00:00.000Z');
+    expect(response.data.summary.verified_count).toBe(1);
+  });
+
+  test('resolves release detail through legacy lookup and then canonical release id', async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce(
+        createJsonResponse({
+          meta: {
+            generatedAt: '2026-03-10T00:00:00.000Z',
+          },
+          data: {
+            release_id: 'release-uuid-1',
+            canonical_path: '/v1/releases/release-uuid-1',
+            release: {
+              release_id: 'release-uuid-1',
+              entity_slug: 'yena',
+              display_name: 'YENA',
+              release_title: 'LOVE CATCHER',
+              release_date: '2026-03-11',
+              stream: 'album',
+              release_kind: 'ep',
+            },
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        createJsonResponse({
+          meta: {
+            generatedAt: '2026-03-10T00:00:01.000Z',
+          },
+          data: {
+            release: {
+              release_id: 'release-uuid-1',
+              entity_slug: 'yena',
+              display_name: 'YENA',
+              release_title: 'LOVE CATCHER',
+              release_date: '2026-03-11',
+              stream: 'album',
+              release_kind: 'ep',
+            },
+            tracks: [],
+            mv: {
+              status: 'unresolved',
+            },
+          },
+        }),
+      );
+
+    const client = createBackendReadClient(buildRuntimeConfig(), fetchMock as unknown as typeof fetch);
+    const response = await client.getReleaseDetailByLegacyId('yena--love-catcher--2026-03-11--album');
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      'https://example.com/api/v1/releases/lookup?entity_slug=yena&title=love-catcher&date=2026-03-11&stream=album',
+    );
+    expect(fetchMock.mock.calls[1]?.[0]).toBe('https://example.com/api/v1/releases/release-uuid-1');
+    expect(response.lookup.data.release.release_title).toBe('LOVE CATCHER');
+    expect(response.detail.data.release.release_id).toBe('release-uuid-1');
+  });
+
+  test('throws a typed error when the backend returns an error envelope', async () => {
+    const fetchMock = jest.fn(async () =>
+      createJsonResponse(
+        {
+          error: {
+            code: 'not_found',
+            message: 'No release matched the supplied legacy lookup key.',
+          },
+        },
+        404,
+      ),
+    );
+
+    const client = createBackendReadClient(buildRuntimeConfig(), fetchMock as unknown as typeof fetch);
+
+    await expect(client.getReleaseDetailByLegacyId('no-such-release')).rejects.toMatchObject({
+      name: 'BackendReadError',
+      status: null,
+      code: 'invalid_release_lookup',
+    });
+
+    await expect(client.getCalendarMonth('2026-03')).rejects.toMatchObject({
+      name: 'BackendReadError',
+      status: 404,
+      code: 'not_found',
+    });
+  });
+});

--- a/mobile/src/services/backendReadClient.ts
+++ b/mobile/src/services/backendReadClient.ts
@@ -1,0 +1,535 @@
+import { getRuntimeConfig, type MobileRuntimeConfig } from '../config/runtime';
+
+export type BackendReadEnvelope<T> = {
+  meta?: {
+    generatedAt?: string | null;
+    [key: string]: unknown;
+  };
+  data: T;
+};
+
+export type BackendCalendarRelease = {
+  release_id: string;
+  entity_slug: string;
+  display_name: string;
+  release_title: string;
+  release_date?: string;
+  stream: string;
+  release_kind?: string | null;
+};
+
+export type BackendCalendarUpcoming = {
+  upcoming_signal_id: string;
+  entity_slug: string;
+  display_name: string;
+  headline: string;
+  scheduled_date?: string | null;
+  scheduled_month?: string | null;
+  date_precision: string;
+  date_status: string;
+  confidence_score?: number | null;
+  release_format?: string | null;
+  source_url?: string | null;
+  source_type?: string | null;
+  source_domain?: string | null;
+  evidence_summary?: string | null;
+  source_count?: number | null;
+};
+
+export type BackendCalendarMonthData = {
+  summary: {
+    verified_count: number;
+    exact_upcoming_count: number;
+    month_only_upcoming_count: number;
+  };
+  nearest_upcoming: BackendCalendarUpcoming | null;
+  days: {
+    date: string;
+    verified_releases: BackendCalendarRelease[];
+    exact_upcoming: BackendCalendarUpcoming[];
+  }[];
+  month_only_upcoming: BackendCalendarUpcoming[];
+  verified_list: BackendCalendarRelease[];
+  scheduled_list: BackendCalendarUpcoming[];
+};
+
+export type BackendSearchEntity = {
+  entity_slug: string;
+  display_name: string;
+  canonical_name: string;
+  entity_type: string;
+  agency_name?: string | null;
+  aliases?: string[];
+  latest_release?: {
+    release_id: string;
+    release_title: string;
+    release_date: string;
+    stream: string;
+    release_kind?: string | null;
+  } | null;
+  next_upcoming?: {
+    headline: string;
+    scheduled_date?: string | null;
+    scheduled_month?: string | null;
+    date_precision: string;
+    date_status: string;
+    release_format?: string | null;
+    confidence_score?: number | null;
+  } | null;
+  match_reason: string;
+  matched_alias?: string | null;
+};
+
+export type BackendSearchRelease = {
+  release_id: string;
+  entity_slug: string;
+  display_name: string;
+  release_title: string;
+  release_date: string;
+  stream: string;
+  release_kind?: string | null;
+  release_format?: string | null;
+  match_reason: string;
+  matched_alias?: string | null;
+};
+
+export type BackendSearchUpcoming = {
+  upcoming_signal_id: string;
+  entity_slug: string;
+  display_name: string;
+  headline: string;
+  scheduled_date?: string | null;
+  scheduled_month?: string | null;
+  date_precision: string;
+  date_status: string;
+  release_format?: string | null;
+  confidence_score?: number | null;
+  source_type?: string | null;
+  source_url?: string | null;
+  evidence_summary?: string | null;
+  match_reason: string;
+  matched_alias?: string | null;
+};
+
+export type BackendSearchData = {
+  query: string;
+  entities: BackendSearchEntity[];
+  releases: BackendSearchRelease[];
+  upcoming: BackendSearchUpcoming[];
+};
+
+export type BackendRadarUpcoming = {
+  upcoming_signal_id: string;
+  entity_slug: string;
+  display_name: string;
+  headline: string;
+  scheduled_date?: string | null;
+  scheduled_month?: string | null;
+  date_precision: string;
+  date_status: string;
+  confidence_score?: number | null;
+  release_format?: string | null;
+  source_url?: string | null;
+};
+
+export type BackendRadarChangeFeedItem = {
+  kind: 'verified_release' | 'upcoming_signal' | string;
+  entity_slug: string;
+  display_name: string;
+  occurred_at?: string | null;
+  release_id?: string | null;
+  release_title?: string | null;
+  release_date?: string | null;
+  stream?: string | null;
+  release_kind?: string | null;
+  upcoming_signal_id?: string | null;
+  headline?: string | null;
+  scheduled_date?: string | null;
+  scheduled_month?: string | null;
+  date_precision?: string | null;
+  date_status?: string | null;
+  confidence_score?: number | null;
+};
+
+export type BackendRadarReleaseSummary = {
+  release_id: string;
+  release_title: string;
+  release_date: string;
+  stream: string;
+  release_kind?: string | null;
+};
+
+export type BackendRadarGapOrRookieItem = {
+  entity_slug: string;
+  display_name: string;
+  watch_reason?: string | null;
+  latest_release?: BackendRadarReleaseSummary | null;
+  gap_days?: number | null;
+  has_upcoming_signal: boolean;
+  debut_year?: number | null;
+  latest_signal?: BackendRadarUpcoming | null;
+};
+
+export type BackendRadarData = {
+  featured_upcoming: BackendRadarUpcoming | null;
+  weekly_upcoming: BackendRadarUpcoming[];
+  change_feed: BackendRadarChangeFeedItem[];
+  long_gap: BackendRadarGapOrRookieItem[];
+  rookie: BackendRadarGapOrRookieItem[];
+};
+
+export type BackendEntityReleaseSummary = {
+  release_id: string;
+  release_title: string;
+  release_date: string;
+  stream: string;
+  release_kind?: string | null;
+  release_format?: string | null;
+  artwork?: {
+    cover_image_url?: string | null;
+    thumbnail_image_url?: string | null;
+  } | null;
+};
+
+export type BackendEntityUpcomingSummary = {
+  upcoming_signal_id: string;
+  headline: string;
+  scheduled_date?: string | null;
+  scheduled_month?: string | null;
+  date_precision: string;
+  date_status: string;
+  release_format?: string | null;
+  confidence_score?: number | null;
+  latest_seen_at?: string | null;
+  source_type?: string | null;
+  source_url?: string | null;
+  source_domain?: string | null;
+  evidence_summary?: string | null;
+  source_count?: number | null;
+};
+
+export type BackendEntityDetailData = {
+  identity: {
+    entity_slug: string;
+    display_name: string;
+    canonical_name?: string | null;
+    entity_type: string;
+    agency_name?: string | null;
+    debut_year?: number | null;
+    badge_image_url?: string | null;
+    badge_source_url?: string | null;
+    badge_source_label?: string | null;
+    badge_kind?: string | null;
+    representative_image_url?: string | null;
+    representative_image_source?: string | null;
+  };
+  official_links: {
+    youtube?: string | null;
+    x?: string | null;
+    instagram?: string | null;
+  };
+  youtube_channels: {
+    primary_team_channel_url?: string | null;
+    mv_allowlist_urls?: string[];
+  };
+  tracking_state: {
+    tier?: string | null;
+    watch_reason?: string | null;
+    tracking_status?: string | null;
+  };
+  next_upcoming: BackendEntityUpcomingSummary | null;
+  latest_release: BackendEntityReleaseSummary | null;
+  recent_albums: BackendEntityReleaseSummary[];
+  source_timeline: {
+    event_type?: string | null;
+    headline: string;
+    occurred_at?: string | null;
+    summary?: string | null;
+    source_url?: string | null;
+    source_type?: string | null;
+    source_domain?: string | null;
+    published_at?: string | null;
+    scheduled_date?: string | null;
+    scheduled_month?: string | null;
+    date_precision?: string | null;
+    date_status?: string | null;
+    release_format?: string | null;
+    confidence_score?: number | null;
+    evidence_summary?: string | null;
+    source_count?: number | null;
+  }[];
+  artist_source_url?: string | null;
+};
+
+export type BackendReleaseLookupData = {
+  release_id: string;
+  canonical_path: string;
+  release: {
+    release_id: string;
+    entity_slug: string;
+    display_name: string;
+    release_title: string;
+    release_date: string;
+    stream: string;
+    release_kind?: string | null;
+  };
+};
+
+export type BackendReleaseDetailData = {
+  release: {
+    release_id: string;
+    entity_slug: string;
+    display_name: string;
+    release_title: string;
+    release_date: string;
+    stream: string;
+    release_kind?: string | null;
+  };
+  detail_metadata?: {
+    status?: string | null;
+    provenance?: string | null;
+  } | null;
+  title_track_metadata?: {
+    status?: string | null;
+    provenance?: string | null;
+  } | null;
+  artwork?: {
+    image_url?: string | null;
+    cover_image_url?: string | null;
+    thumbnail_image_url?: string | null;
+    source_url?: string | null;
+    is_placeholder?: boolean | null;
+  } | null;
+  service_links?: {
+    spotify?: {
+      url?: string | null;
+      status?: string | null;
+      provenance?: string | null;
+    } | null;
+    youtube_music?: {
+      url?: string | null;
+      status?: string | null;
+      provenance?: string | null;
+    } | null;
+  } | null;
+  tracks?: {
+    track_id: string;
+    order: number;
+    title: string;
+    is_title_track?: boolean;
+    spotify?: {
+      url?: string | null;
+    } | null;
+    youtube_music?: {
+      url?: string | null;
+    } | null;
+  }[] | null;
+  mv?: {
+    url?: string | null;
+    video_id?: string | null;
+    status?: string | null;
+    provenance?: string | null;
+  } | null;
+  notes?: unknown;
+};
+
+export type BackendResolvedReleaseDetail = {
+  lookup: BackendReadEnvelope<BackendReleaseLookupData>;
+  detail: BackendReadEnvelope<BackendReleaseDetailData>;
+};
+
+export class BackendReadError extends Error {
+  status: number | null;
+  code: string | null;
+
+  constructor(message: string, options: { status?: number | null; code?: string | null } = {}) {
+    super(message);
+    this.name = 'BackendReadError';
+    this.status = options.status ?? null;
+    this.code = options.code ?? null;
+  }
+}
+
+function buildUrl(baseUrl: string, pathname: string, searchParams?: Record<string, string | number | undefined>): string {
+  const trimmedBaseUrl = baseUrl.replace(/\/+$/, '');
+  const query = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(searchParams ?? {})) {
+    if (value === undefined) {
+      continue;
+    }
+    query.set(key, String(value));
+  }
+
+  const queryString = query.toString();
+  return `${trimmedBaseUrl}${pathname}${queryString ? `?${queryString}` : ''}`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function parseLegacyReleaseId(legacyReleaseId: string): {
+  entitySlug: string;
+  releaseTitle: string;
+  releaseDate: string;
+  stream: string;
+} | null {
+  const parts = legacyReleaseId
+    .split('--')
+    .map((part) => part.trim())
+    .filter(Boolean);
+
+  if (parts.length < 4) {
+    return null;
+  }
+
+  const stream = parts.at(-1)?.toLowerCase() ?? '';
+  const releaseDate = parts.at(-2) ?? '';
+  const entitySlug = parts[0] ?? '';
+  const releaseTitle = parts.slice(1, -2).join(' ');
+
+  if (!entitySlug || !releaseTitle || !/^\d{4}-\d{2}-\d{2}$/.test(releaseDate)) {
+    return null;
+  }
+
+  if (stream !== 'album' && stream !== 'song') {
+    return null;
+  }
+
+  return {
+    entitySlug,
+    releaseTitle,
+    releaseDate,
+    stream,
+  };
+}
+
+async function readJsonResponse<T>(response: Response): Promise<BackendReadEnvelope<T>> {
+  let payload: unknown = null;
+
+  try {
+    payload = await response.json();
+  } catch {
+    throw new BackendReadError('Backend response was not valid JSON.', {
+      status: response.status,
+    });
+  }
+
+  if (!response.ok) {
+    const message =
+      isRecord(payload) && isRecord(payload.error) && typeof payload.error.message === 'string'
+        ? payload.error.message
+        : `Backend request failed with status ${response.status}.`;
+    const code =
+      isRecord(payload) && isRecord(payload.error) && typeof payload.error.code === 'string'
+        ? payload.error.code
+        : null;
+    throw new BackendReadError(message, {
+      status: response.status,
+      code,
+    });
+  }
+
+  if (!isRecord(payload) || !('data' in payload)) {
+    throw new BackendReadError('Backend response envelope was missing data.');
+  }
+
+  return payload as BackendReadEnvelope<T>;
+}
+
+export type BackendReadClient = {
+  getCalendarMonth(month: string): Promise<BackendReadEnvelope<BackendCalendarMonthData>>;
+  getSearch(query: string, limit?: number): Promise<BackendReadEnvelope<BackendSearchData>>;
+  getRadar(): Promise<BackendReadEnvelope<BackendRadarData>>;
+  getEntityDetail(slug: string): Promise<BackendReadEnvelope<BackendEntityDetailData>>;
+  lookupRelease(params: {
+    entitySlug: string;
+    releaseTitle: string;
+    releaseDate: string;
+    stream: string;
+  }): Promise<BackendReadEnvelope<BackendReleaseLookupData>>;
+  getReleaseDetail(releaseId: string): Promise<BackendReadEnvelope<BackendReleaseDetailData>>;
+  getReleaseDetailByLegacyId(legacyReleaseId: string): Promise<BackendResolvedReleaseDetail>;
+};
+
+export function createBackendReadClient(
+  runtimeConfig: MobileRuntimeConfig = getRuntimeConfig(),
+  fetchImpl: typeof fetch = fetch,
+): BackendReadClient {
+  const baseUrl = runtimeConfig.services.apiBaseUrl;
+
+  if (!baseUrl) {
+    throw new BackendReadError('Backend API base URL is not configured.');
+  }
+
+  const resolvedBaseUrl = baseUrl;
+
+  async function get<T>(pathname: string, searchParams?: Record<string, string | number | undefined>) {
+    const url = buildUrl(resolvedBaseUrl, pathname, searchParams);
+    let response: Response;
+
+    try {
+      response = await fetchImpl(url, {
+        method: 'GET',
+        headers: {
+          Accept: 'application/json',
+        },
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Backend request failed.';
+      throw new BackendReadError(message);
+    }
+
+    return readJsonResponse<T>(response);
+  }
+
+  return {
+    getCalendarMonth(month) {
+      return get<BackendCalendarMonthData>('/v1/calendar/month', { month });
+    },
+    getSearch(query, limit = 8) {
+      return get<BackendSearchData>('/v1/search', { q: query, limit });
+    },
+    getRadar() {
+      return get<BackendRadarData>('/v1/radar');
+    },
+    getEntityDetail(slug) {
+      return get<BackendEntityDetailData>(`/v1/entities/${encodeURIComponent(slug)}`);
+    },
+    lookupRelease({ entitySlug, releaseTitle, releaseDate, stream }) {
+      return get<BackendReleaseLookupData>('/v1/releases/lookup', {
+        entity_slug: entitySlug,
+        title: releaseTitle,
+        date: releaseDate,
+        stream,
+      });
+    },
+    getReleaseDetail(releaseId) {
+      return get<BackendReleaseDetailData>(`/v1/releases/${encodeURIComponent(releaseId)}`);
+    },
+    async getReleaseDetailByLegacyId(legacyReleaseId) {
+      const parsed = parseLegacyReleaseId(legacyReleaseId);
+      if (!parsed) {
+        throw new BackendReadError('Release detail route could not resolve the legacy release identifier.', {
+          code: 'invalid_release_lookup',
+        });
+      }
+
+      const lookup = await get<BackendReleaseLookupData>('/v1/releases/lookup', {
+        entity_slug: parsed.entitySlug,
+        title: parsed.releaseTitle,
+        date: parsed.releaseDate,
+        stream: parsed.stream,
+      });
+      const detail = await get<BackendReleaseDetailData>(
+        `/v1/releases/${encodeURIComponent(lookup.data.release_id)}`,
+      );
+
+      return {
+        lookup,
+        detail,
+      };
+    },
+  };
+}

--- a/mobile/src/services/datasetFailurePolicy.test.ts
+++ b/mobile/src/services/datasetFailurePolicy.test.ts
@@ -1,28 +1,7 @@
 import type { RuntimeConfigState } from '../config/runtime';
-import {
-  resetStorageAdapter,
-  setStorageAdapter,
-  type KeyValueStorageAdapter,
-} from './storage';
-import type { PreviewRemoteDatasetSelection } from './datasetSource';
-import { writeDatasetCacheEntry } from './datasetCache';
+
 import { resolveDatasetFailurePolicy } from './datasetFailurePolicy';
-
-function createMemoryStorage(): KeyValueStorageAdapter {
-  const values = new Map<string, string>();
-
-  return {
-    async getItem(key) {
-      return values.has(key) ? values.get(key) ?? null : null;
-    },
-    async setItem(key, value) {
-      values.set(key, value);
-    },
-    async removeItem(key) {
-      values.delete(key);
-    },
-  };
-}
+import { createBundledDatasetSelection } from './datasetSource';
 
 function createRuntimeState(mode: RuntimeConfigState['mode'] = 'normal'): RuntimeConfigState {
   return {
@@ -30,12 +9,11 @@ function createRuntimeState(mode: RuntimeConfigState['mode'] = 'normal'): Runtim
     config: {
       profile: 'preview',
       dataSource: {
-        mode: 'preview-static',
-        remoteDatasetUrl: mode === 'normal' ? 'https://example.com/dataset.json' : null,
+        mode: 'backend-api',
         datasetVersion: 'preview-v2',
       },
       services: {
-        apiBaseUrl: null,
+        apiBaseUrl: 'https://example.com/api',
         analyticsWriteKey: null,
       },
       logging: {
@@ -44,7 +22,7 @@ function createRuntimeState(mode: RuntimeConfigState['mode'] = 'normal'): Runtim
       featureGates: {
         radar: true,
         analytics: false,
-        remoteRefresh: mode === 'normal',
+        remoteRefresh: false,
         mvEmbed: true,
         shareActions: true,
       },
@@ -58,45 +36,14 @@ function createRuntimeState(mode: RuntimeConfigState['mode'] = 'normal'): Runtim
         ? [
             {
               kind: 'invalid_runtime_config',
-              message: 'Runtime config only allows remoteRefresh in the preview profile.',
+              message: 'Runtime config is degraded.',
             },
           ]
         : [],
   };
 }
 
-function createPreviewSelection(): PreviewRemoteDatasetSelection {
-  return {
-    kind: 'preview-remote',
-    reason: 'preview_remote_enabled',
-    contractId: 'idol-song-mobile-static-v1',
-    datasetVersion: 'preview-v2',
-    mixingAllowed: false,
-    remoteDatasetUrl: 'https://example.com/dataset.json',
-    artifacts: [
-      {
-        id: 'artistProfiles',
-        freshnessClass: 'stable-profile',
-        relativePath: 'artistProfiles.json',
-      },
-      {
-        id: 'releases',
-        freshnessClass: 'rolling-release',
-        relativePath: 'releases.json',
-      },
-    ],
-  };
-}
-
 describe('dataset failure policy', () => {
-  beforeEach(() => {
-    setStorageAdapter(createMemoryStorage());
-  });
-
-  afterEach(() => {
-    resetStorageAdapter();
-  });
-
   test('falls back to bundled degraded mode when runtime config is already degraded', async () => {
     const policy = await resolveDatasetFailurePolicy({
       runtimeState: createRuntimeState('degraded'),
@@ -113,70 +60,16 @@ describe('dataset failure policy', () => {
     ]);
   });
 
-  test('stays in normal mode when preview remote dataset is available', async () => {
-    const selection = createPreviewSelection();
+  test('stays in normal mode when runtime config is healthy', async () => {
+    const selection = createBundledDatasetSelection('preview-v2', 'backend_api_mode');
     const policy = await resolveDatasetFailurePolicy({
       runtimeState: createRuntimeState('normal'),
       selection,
-      remoteAvailability: {
-        status: 'available',
-      },
     });
 
     expect(policy.mode).toBe('normal');
-    expect(policy.activeSource).toBe('preview-remote');
+    expect(policy.activeSource).toBe('bundled-static');
     expect(policy.selection).toEqual(selection);
     expect(policy.issues).toEqual([]);
-  });
-
-  test('falls back to last-known-good remote cache when remote dataset is unavailable', async () => {
-    const selection = createPreviewSelection();
-    await writeDatasetCacheEntry('artistProfiles', { rows: 1 }, selection, '2026-03-08T00:00:00.000Z');
-    await writeDatasetCacheEntry('releases', { rows: 2 }, selection, '2026-03-08T00:00:00.000Z');
-
-    const policy = await resolveDatasetFailurePolicy({
-      runtimeState: createRuntimeState('normal'),
-      selection,
-      remoteAvailability: {
-        status: 'unavailable',
-        message: 'Fetch failed with 503.',
-      },
-    });
-
-    expect(policy.mode).toBe('degraded');
-    expect(policy.activeSource).toBe('preview-remote-cache');
-    expect(policy.selection).toEqual(selection);
-    expect(policy.cachedArtifactIds).toEqual(['artistProfiles', 'releases']);
-    expect(policy.issues).toEqual([
-      {
-        kind: 'remote_dataset_unavailable',
-        message: 'Fetch failed with 503.',
-      },
-    ]);
-  });
-
-  test('falls back to bundled dataset when remote dataset is invalid and cache is incomplete', async () => {
-    const selection = createPreviewSelection();
-    await writeDatasetCacheEntry('artistProfiles', { rows: 1 }, selection, '2026-03-08T00:00:00.000Z');
-
-    const policy = await resolveDatasetFailurePolicy({
-      runtimeState: createRuntimeState('normal'),
-      selection,
-      remoteAvailability: {
-        status: 'invalid',
-      },
-    });
-
-    expect(policy.mode).toBe('degraded');
-    expect(policy.activeSource).toBe('bundled-static');
-    expect(policy.selection.kind).toBe('bundled-static');
-    expect(policy.selection.reason).toBe('remote_unavailable');
-    expect(policy.cachedArtifactIds).toEqual(['artistProfiles']);
-    expect(policy.issues).toEqual([
-      {
-        kind: 'remote_dataset_invalid',
-        message: 'Preview remote dataset payload is invalid.',
-      },
-    ]);
   });
 });

--- a/mobile/src/services/datasetFailurePolicy.ts
+++ b/mobile/src/services/datasetFailurePolicy.ts
@@ -5,27 +5,12 @@ import {
 } from '../config/runtime';
 import {
   createBundledDatasetSelection,
-  isRemoteDatasetSelection,
   selectDatasetSource,
-  type DatasetArtifactId,
   type DatasetSelection,
-  type PreviewRemoteDatasetSelection,
 } from './datasetSource';
-import { readDatasetCacheEntry } from './datasetCache';
-
-export type RemoteDatasetAvailability =
-  | {
-      status: 'available';
-    }
-  | {
-      status: 'unavailable' | 'invalid';
-      message?: string;
-    };
 
 export type DatasetFailurePolicyIssueKind =
-  | RuntimeConfigIssue['kind']
-  | 'remote_dataset_unavailable'
-  | 'remote_dataset_invalid';
+  | RuntimeConfigIssue['kind'];
 
 export type DatasetFailurePolicyIssue = {
   kind: DatasetFailurePolicyIssueKind;
@@ -34,9 +19,8 @@ export type DatasetFailurePolicyIssue = {
 
 export type DatasetFailurePolicy = {
   mode: 'normal' | 'degraded';
-  activeSource: 'bundled-static' | 'preview-remote' | 'preview-remote-cache';
+  activeSource: 'bundled-static';
   selection: DatasetSelection;
-  cachedArtifactIds: DatasetArtifactId[];
   issues: DatasetFailurePolicyIssue[];
 };
 
@@ -47,33 +31,9 @@ function toFailurePolicyIssues(issues: RuntimeConfigIssue[]): DatasetFailurePoli
   }));
 }
 
-async function readCachedArtifactIds(
-  selection: PreviewRemoteDatasetSelection,
-): Promise<DatasetArtifactId[]> {
-  const cachedArtifactIds = await Promise.all(
-    selection.artifacts.map(async (artifact) => {
-      const entry = await readDatasetCacheEntry(artifact.id, selection);
-      return entry ? artifact.id : null;
-    }),
-  );
-
-  return cachedArtifactIds.filter((artifactId): artifactId is DatasetArtifactId => artifactId !== null);
-}
-
-function hasCompleteCachedDataset(
-  selection: PreviewRemoteDatasetSelection,
-  cachedArtifactIds: DatasetArtifactId[],
-): boolean {
-  return (
-    selection.artifacts.length > 0 &&
-    cachedArtifactIds.length === selection.artifacts.length
-  );
-}
-
 export async function resolveDatasetFailurePolicy(options: {
   runtimeState?: RuntimeConfigState;
   selection?: DatasetSelection;
-  remoteAvailability?: RemoteDatasetAvailability;
 } = {}): Promise<DatasetFailurePolicy> {
   const runtimeState = options.runtimeState ?? getRuntimeConfigState();
 
@@ -85,68 +45,15 @@ export async function resolveDatasetFailurePolicy(options: {
         runtimeState.config.dataSource.datasetVersion,
         'runtime_degraded',
       ),
-      cachedArtifactIds: [],
       issues: toFailurePolicyIssues(runtimeState.issues),
     };
   }
 
   const selection = options.selection ?? selectDatasetSource(runtimeState.config);
-  const remoteAvailability = options.remoteAvailability ?? { status: 'available' as const };
-
-  if (!isRemoteDatasetSelection(selection)) {
-    return {
-      mode: 'normal',
-      activeSource: 'bundled-static',
-      selection,
-      cachedArtifactIds: [],
-      issues: [],
-    };
-  }
-
-  if (remoteAvailability.status === 'available') {
-    return {
-      mode: 'normal',
-      activeSource: 'preview-remote',
-      selection,
-      cachedArtifactIds: [],
-      issues: [],
-    };
-  }
-
-  const cachedArtifactIds = await readCachedArtifactIds(selection);
-  const issueKind =
-    remoteAvailability.status === 'invalid' ? 'remote_dataset_invalid' : 'remote_dataset_unavailable';
-  const issueMessage =
-    remoteAvailability.message ??
-    (remoteAvailability.status === 'invalid'
-      ? 'Preview remote dataset payload is invalid.'
-      : 'Preview remote dataset is unavailable.');
-
-  if (hasCompleteCachedDataset(selection, cachedArtifactIds)) {
-    return {
-      mode: 'degraded',
-      activeSource: 'preview-remote-cache',
-      selection,
-      cachedArtifactIds,
-      issues: [
-        {
-          kind: issueKind,
-          message: issueMessage,
-        },
-      ],
-    };
-  }
-
   return {
-    mode: 'degraded',
+    mode: 'normal',
     activeSource: 'bundled-static',
-    selection: createBundledDatasetSelection(selection.datasetVersion, 'remote_unavailable'),
-    cachedArtifactIds,
-    issues: [
-      {
-        kind: issueKind,
-        message: issueMessage,
-      },
-    ],
+    selection,
+    issues: [],
   };
 }

--- a/mobile/src/services/datasetSource.test.ts
+++ b/mobile/src/services/datasetSource.test.ts
@@ -1,33 +1,33 @@
 import type { MobileRuntimeConfig } from '../config/runtime';
+
 import {
   BUNDLED_DATASET_BASE_PATH,
   DATASET_ARTIFACTS,
   DATASET_CONTRACT_ID,
   isBundledDatasetSelection,
-  isRemoteDatasetSelection,
   selectDatasetSource,
 } from './datasetSource';
 
 function buildRuntimeConfig(
   overrides: Partial<MobileRuntimeConfig> = {},
   dataSourceOverrides: Partial<MobileRuntimeConfig['dataSource']> = {},
-  featureGateOverrides: Partial<MobileRuntimeConfig['featureGates']> = {},
 ): MobileRuntimeConfig {
+  const profile = overrides.profile ?? 'development';
+
   return {
-    profile: overrides.profile ?? 'development',
+    profile,
     dataSource: {
-      mode: overrides.profile === 'production' ? 'production-static' : overrides.profile === 'preview' ? 'preview-static' : 'bundled-static',
-      remoteDatasetUrl: null,
+      mode: profile === 'development' ? 'bundled-static' : 'backend-api',
       datasetVersion: 'v1-test',
       ...dataSourceOverrides,
     },
     services: {
-      apiBaseUrl: null,
+      apiBaseUrl: profile === 'development' ? null : 'https://example.com/api',
       analyticsWriteKey: null,
       ...overrides.services,
     },
     logging: {
-      level: overrides.profile === 'production' ? 'error' : 'debug',
+      level: profile === 'production' ? 'error' : 'debug',
       ...overrides.logging,
     },
     featureGates: {
@@ -36,7 +36,6 @@ function buildRuntimeConfig(
       remoteRefresh: false,
       mvEmbed: true,
       shareActions: true,
-      ...featureGateOverrides,
     },
     build: {
       version: '0.1.0',
@@ -51,10 +50,6 @@ describe('selectDatasetSource', () => {
     const selection = selectDatasetSource(buildRuntimeConfig());
 
     expect(isBundledDatasetSelection(selection)).toBe(true);
-    if (!isBundledDatasetSelection(selection)) {
-      throw new Error('Expected bundled dataset selection.');
-    }
-
     expect(selection.kind).toBe('bundled-static');
     expect(selection.reason).toBe('profile_default');
     expect(selection.bundledBasePath).toBe(BUNDLED_DATASET_BASE_PATH);
@@ -62,66 +57,23 @@ describe('selectDatasetSource', () => {
     expect(selection.mixingAllowed).toBe(false);
   });
 
-  test('keeps preview on bundled data when remote refresh is disabled', () => {
+  test('uses bundled selection as a bridge when runtime prefers backend api', () => {
     const selection = selectDatasetSource(
-      buildRuntimeConfig(
-        { profile: 'preview' },
-        {
-          mode: 'preview-static',
-          remoteDatasetUrl: 'https://example.com/dataset.json',
-        },
-      ),
+      buildRuntimeConfig({ profile: 'preview' }, { mode: 'backend-api', datasetVersion: 'preview-v2' }),
     );
 
     expect(isBundledDatasetSelection(selection)).toBe(true);
-    expect(selection.reason).toBe('preview_remote_disabled');
-  });
-
-  test('switches preview builds to the remote dataset when explicitly enabled', () => {
-    const selection = selectDatasetSource(
-      buildRuntimeConfig(
-        { profile: 'preview' },
-        {
-          mode: 'preview-static',
-          remoteDatasetUrl: 'https://example.com/dataset.json',
-          datasetVersion: 'preview-v2',
-        },
-        {
-          remoteRefresh: true,
-        },
-      ),
-    );
-
-    expect(isRemoteDatasetSelection(selection)).toBe(true);
-    if (!isRemoteDatasetSelection(selection)) {
-      throw new Error('Expected preview remote dataset selection.');
-    }
-
-    expect(selection.kind).toBe('preview-remote');
-    expect(selection.reason).toBe('preview_remote_enabled');
-    expect(selection.remoteDatasetUrl).toBe('https://example.com/dataset.json');
+    expect(selection.reason).toBe('backend_api_mode');
     expect(selection.datasetVersion).toBe('preview-v2');
-    expect(selection.mixingAllowed).toBe(false);
   });
 
-  test('preserves the same artifact contract between bundled and remote selections', () => {
-    const bundled = selectDatasetSource(buildRuntimeConfig());
-    const remote = selectDatasetSource(
-      buildRuntimeConfig(
-        { profile: 'preview' },
-        {
-          mode: 'preview-static',
-          remoteDatasetUrl: 'https://example.com/dataset.json',
-        },
-        {
-          remoteRefresh: true,
-        },
-      ),
-    );
+  test('preserves artifact contract for all bundled selections', () => {
+    const development = selectDatasetSource(buildRuntimeConfig());
+    const preview = selectDatasetSource(buildRuntimeConfig({ profile: 'preview' }));
 
-    expect(bundled.contractId).toBe(DATASET_CONTRACT_ID);
-    expect(remote.contractId).toBe(DATASET_CONTRACT_ID);
-    expect(bundled.artifacts.map((artifact) => artifact.id)).toEqual(DATASET_ARTIFACTS.map((artifact) => artifact.id));
-    expect(remote.artifacts.map((artifact) => artifact.id)).toEqual(DATASET_ARTIFACTS.map((artifact) => artifact.id));
+    expect(development.contractId).toBe(DATASET_CONTRACT_ID);
+    expect(preview.contractId).toBe(DATASET_CONTRACT_ID);
+    expect(development.artifacts.map((artifact) => artifact.id)).toEqual(DATASET_ARTIFACTS.map((artifact) => artifact.id));
+    expect(preview.artifacts.map((artifact) => artifact.id)).toEqual(DATASET_ARTIFACTS.map((artifact) => artifact.id));
   });
 });

--- a/mobile/src/services/datasetSource.ts
+++ b/mobile/src/services/datasetSource.ts
@@ -1,7 +1,7 @@
 import { getRuntimeConfig, type MobileRuntimeConfig } from '../config/runtime';
 
 export type DatasetContractId = 'idol-song-mobile-static-v1';
-export type DatasetSourceKind = 'bundled-static' | 'preview-remote';
+export type DatasetSourceKind = 'bundled-static';
 export type DatasetArtifactId =
   | 'artistProfiles'
   | 'releases'
@@ -31,17 +31,10 @@ type DatasetSelectionBase = {
 
 export type BundledDatasetSelection = DatasetSelectionBase & {
   kind: 'bundled-static';
-  reason: 'profile_default' | 'preview_remote_disabled' | 'runtime_degraded' | 'remote_unavailable';
+  reason: 'profile_default' | 'backend_api_mode' | 'runtime_degraded';
   bundledBasePath: string;
 };
-
-export type PreviewRemoteDatasetSelection = DatasetSelectionBase & {
-  kind: 'preview-remote';
-  reason: 'preview_remote_enabled';
-  remoteDatasetUrl: string;
-};
-
-export type DatasetSelection = BundledDatasetSelection | PreviewRemoteDatasetSelection;
+export type DatasetSelection = BundledDatasetSelection;
 
 export const DATASET_CONTRACT_ID: DatasetContractId = 'idol-song-mobile-static-v1';
 export const BUNDLED_DATASET_BASE_PATH = 'mobile/assets/datasets/v1';
@@ -114,40 +107,13 @@ export function createBundledDatasetSelection(
   };
 }
 
-function canUsePreviewRemote(config: MobileRuntimeConfig): config is MobileRuntimeConfig & {
-  profile: 'preview';
-  dataSource: MobileRuntimeConfig['dataSource'] & { remoteDatasetUrl: string };
-} {
-  return (
-    config.profile === 'preview' &&
-    config.featureGates.remoteRefresh &&
-    typeof config.dataSource.remoteDatasetUrl === 'string'
-  );
-}
-
 export function selectDatasetSource(
   runtimeConfig: MobileRuntimeConfig = getRuntimeConfig(),
 ): DatasetSelection {
-  if (canUsePreviewRemote(runtimeConfig)) {
-    return {
-      kind: 'preview-remote',
-      reason: 'preview_remote_enabled',
-      contractId: DATASET_CONTRACT_ID,
-      datasetVersion: runtimeConfig.dataSource.datasetVersion,
-      mixingAllowed: false,
-      remoteDatasetUrl: runtimeConfig.dataSource.remoteDatasetUrl,
-      artifacts: DATASET_ARTIFACTS,
-    };
-  }
-
   return createBundledDatasetSelection(
     runtimeConfig.dataSource.datasetVersion,
-    runtimeConfig.profile === 'preview' ? 'preview_remote_disabled' : 'profile_default',
+    runtimeConfig.dataSource.mode === 'backend-api' ? 'backend_api_mode' : 'profile_default',
   );
-}
-
-export function isRemoteDatasetSelection(selection: DatasetSelection): selection is PreviewRemoteDatasetSelection {
-  return selection.kind === 'preview-remote';
 }
 
 export function isBundledDatasetSelection(selection: DatasetSelection): selection is BundledDatasetSelection {

--- a/mobile/src/services/screenSnapshotCache.test.ts
+++ b/mobile/src/services/screenSnapshotCache.test.ts
@@ -1,0 +1,72 @@
+import {
+  clearScreenSnapshotCacheEntry,
+  readScreenSnapshotCacheEntry,
+  writeScreenSnapshotCacheEntry,
+} from './screenSnapshotCache';
+import {
+  resetStorageAdapter,
+  setStorageAdapter,
+  type KeyValueStorageAdapter,
+} from './storage';
+
+function createMemoryStorage(): KeyValueStorageAdapter {
+  const values = new Map<string, string>();
+
+  return {
+    async getItem(key) {
+      return values.has(key) ? values.get(key) ?? null : null;
+    },
+    async setItem(key, value) {
+      values.set(key, value);
+    },
+    async removeItem(key) {
+      values.delete(key);
+    },
+  };
+}
+
+describe('screen snapshot cache', () => {
+  beforeEach(() => {
+    setStorageAdapter(createMemoryStorage());
+  });
+
+  afterEach(() => {
+    resetStorageAdapter();
+  });
+
+  test('round-trips serializable screen payloads with cache metadata', async () => {
+    await writeScreenSnapshotCacheEntry(
+      'calendar',
+      'calendar:2026-03:2026-03-10',
+      {
+        month: '2026-03',
+        releaseCount: 1,
+      },
+      {
+        cachedAt: '2026-03-10T00:01:00.000Z',
+        generatedAt: '2026-03-10T00:00:00.000Z',
+      },
+    );
+
+    await expect(
+      readScreenSnapshotCacheEntry<{ month: string; releaseCount: number }>(
+        'calendar',
+        'calendar:2026-03:2026-03-10',
+      ),
+    ).resolves.toEqual({
+      surface: 'calendar',
+      cacheKey: 'calendar:2026-03:2026-03-10',
+      cachedAt: '2026-03-10T00:01:00.000Z',
+      generatedAt: '2026-03-10T00:00:00.000Z',
+      value: {
+        month: '2026-03',
+        releaseCount: 1,
+      },
+    });
+
+    await clearScreenSnapshotCacheEntry('calendar', 'calendar:2026-03:2026-03-10');
+    await expect(
+      readScreenSnapshotCacheEntry('calendar', 'calendar:2026-03:2026-03-10'),
+    ).resolves.toBeNull();
+  });
+});

--- a/mobile/src/services/screenSnapshotCache.ts
+++ b/mobile/src/services/screenSnapshotCache.ts
@@ -1,0 +1,50 @@
+import {
+  buildScreenSnapshotCacheKey,
+  readStoredJson,
+  removeStoredJson,
+  writeStoredJson,
+} from './storage';
+
+export type ScreenSnapshotCacheEntry<T> = {
+  surface: string;
+  cacheKey: string;
+  cachedAt: string;
+  generatedAt: string | null;
+  value: T;
+};
+
+export function getScreenSnapshotCacheStorageKey(surface: string, cacheKey: string): string {
+  return buildScreenSnapshotCacheKey(surface, cacheKey);
+}
+
+export async function readScreenSnapshotCacheEntry<T>(
+  surface: string,
+  cacheKey: string,
+): Promise<ScreenSnapshotCacheEntry<T> | null> {
+  return readStoredJson<ScreenSnapshotCacheEntry<T>>(getScreenSnapshotCacheStorageKey(surface, cacheKey));
+}
+
+export async function writeScreenSnapshotCacheEntry<T>(
+  surface: string,
+  cacheKey: string,
+  value: T,
+  options: {
+    cachedAt?: string;
+    generatedAt?: string | null;
+  } = {},
+): Promise<ScreenSnapshotCacheEntry<T>> {
+  const entry: ScreenSnapshotCacheEntry<T> = {
+    surface,
+    cacheKey,
+    cachedAt: options.cachedAt ?? new Date().toISOString(),
+    generatedAt: options.generatedAt ?? null,
+    value,
+  };
+
+  await writeStoredJson(getScreenSnapshotCacheStorageKey(surface, cacheKey), entry);
+  return entry;
+}
+
+export async function clearScreenSnapshotCacheEntry(surface: string, cacheKey: string): Promise<void> {
+  await removeStoredJson(getScreenSnapshotCacheStorageKey(surface, cacheKey));
+}

--- a/mobile/src/services/storage.test.ts
+++ b/mobile/src/services/storage.test.ts
@@ -42,12 +42,12 @@ const bundledSelection: DatasetSelection = {
 };
 
 const previewSelection: DatasetSelection = {
-  kind: 'preview-remote',
-  reason: 'preview_remote_enabled',
+  kind: 'bundled-static',
+  reason: 'backend_api_mode',
   contractId: 'idol-song-mobile-static-v1',
   datasetVersion: 'preview-v2',
   mixingAllowed: false,
-  remoteDatasetUrl: 'https://example.com/dataset.json',
+  bundledBasePath: 'mobile/assets/datasets/v1',
   artifacts: [],
 };
 
@@ -69,7 +69,7 @@ describe('mobile storage foundations', () => {
     );
   });
 
-  test('round-trips dataset cache entries and isolates source selections', async () => {
+  test('round-trips dataset cache entries and isolates dataset versions', async () => {
     await writeDatasetCacheEntry('releases', { rows: 10 }, bundledSelection, '2026-03-08T00:00:00.000Z');
     await writeDatasetCacheEntry('releases', { rows: 12 }, previewSelection, '2026-03-08T01:00:00.000Z');
 

--- a/mobile/src/services/storage.ts
+++ b/mobile/src/services/storage.ts
@@ -39,6 +39,10 @@ export function buildDatasetCacheKey(
   );
 }
 
+export function buildScreenSnapshotCacheKey(surface: string, cacheKey: string): string {
+  return buildNamespacedKey('screen-cache', `${surface}/${cacheKey}`);
+}
+
 export async function readStoredJson<T>(storageKey: string): Promise<T | null> {
   const raw = await storageAdapter.getItem(storageKey);
 


### PR DESCRIPTION
## Summary
- add a shared mobile backend read client plus persisted screen snapshot cache
- cut calendar, search, radar, entity detail, and release detail over to backend-first reads with cache/bundled fallback semantics
- update runtime/data-source helpers, disclosures, and mobile tests for backend-api preview/production behavior

## Verification
- cd mobile && npm run lint
- cd mobile && npm run typecheck
- cd mobile && npm test -- --runInBand
- git diff --check

Closes #404
Closes #405
Closes #415
Closes #416
