### PR TITLE
[RN] Make runtime backend-primary after mobile cutover

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ python3 sync_release_pipeline_to_neon.py
 - debug metadata helper/surface: `mobile/src/config/debugMetadata.ts`, `mobile/app/debug/metadata.tsx`
 - feature-gate layer: `mobile/src/config/featureGates.ts`
 - dataset-source layer: `mobile/src/services/datasetSource.ts`, `mobile/assets/datasets/README.md`
+  - preview / production은 backend-api primary, bundled static은 explicit fallback로만 유지
 - storage/cache layer: `mobile/src/services/storage.ts`, `mobile/src/services/datasetCache.ts`, `mobile/src/services/recentQueries.ts`
 - external handoff layer: `mobile/src/services/handoff.ts`
 - token/theme layer: `mobile/src/tokens/`, `mobile/src/tokens/theme.tsx`

--- a/mobile/app/README.md
+++ b/mobile/app/README.md
@@ -11,13 +11,13 @@
 - `(tabs)/_layout.tsx`
   - `calendar`, `radar`, `search` 탭 shell
 - `(tabs)/calendar.tsx`
-  - active dataset source + shared selector 기반 current-month container
+  - backend-first + cached snapshot + bundled fallback current-month container
 - `(tabs)/radar.tsx`
 - `(tabs)/search.tsx`
-  - 탭 placeholder screen
+  - backend-first search tab
 - `artists/[slug].tsx`
 - `releases/[id].tsx`
-  - push detail placeholder screen
+  - backend-first push detail screen
 - `debug/metadata.tsx`
   - internal build/dataset/commit metadata inspection route
 

--- a/mobile/app/debug/metadata.tsx
+++ b/mobile/app/debug/metadata.tsx
@@ -14,6 +14,7 @@ export default function DebugMetadataScreen() {
     ['Dataset version', metadata.datasetVersion ?? 'Unavailable'],
     ['Commit hash', metadata.commitSha ?? 'Unavailable'],
     ['Data source mode', metadata.dataSourceMode],
+    ['Data source policy', metadata.dataSourcePolicy],
     ['API base URL', metadata.apiBaseUrl ?? 'Bundled-only'],
     ['Analytics enabled', metadata.analyticsEnabled ? 'Yes' : 'No'],
     ['Analytics event count', `${metadata.analyticsEventCount}`],

--- a/mobile/src/README.md
+++ b/mobile/src/README.md
@@ -20,9 +20,9 @@
   - `index.ts`: shared selectors entrypoint
     - team / entity detail / release detail selector 외에 calendar month snapshot / radar snapshot / search result selector 포함
 - `services/`: data source / external handoff / helper
-  - `datasetSource.ts`: bundled-static vs preview-remote source selector
-  - `activeDataset.ts`: runtime selection을 실제 dataset payload로 로드하는 entrypoint
-  - `datasetFailurePolicy.ts`: remote unavailable / misconfig degraded-mode fallback policy
+  - `datasetSource.ts`: backend-primary runtime selection + bundled fallback descriptor
+  - `activeDataset.ts`: selector fallback용 bundled dataset payload loader
+  - `datasetFailurePolicy.ts`: backend-primary runtime / degraded fallback policy
   - `storage.ts`: `AsyncStorage` adapter + namespaced key/value helper
   - `datasetCache.ts`: static dataset artifact cache entry helper
   - `recentQueries.ts`: recent-query persistence helper
@@ -66,5 +66,6 @@ feedback state 관련 규칙:
 failure-policy 관련 규칙:
 
 - runtime config parse failure는 crash 대신 degraded state로 내려간다.
-- preview remote dataset failure는 `datasetFailurePolicy.ts`에서 `preview-remote-cache` 또는 `bundled-static` fallback으로 resolve한다.
+- preview / production은 `backend-api`를 primary runtime source로 간주한다.
+- bundled static dataset은 development 기본값이거나, backend failure/degraded state에서만 explicit fallback으로 사용한다.
 - later UI는 `mode = normal | degraded`와 issue list를 직접 소비할 수 있어야 한다.

--- a/mobile/src/config/debugMetadata.test.ts
+++ b/mobile/src/config/debugMetadata.test.ts
@@ -80,6 +80,7 @@ describe('debug metadata helpers', () => {
       datasetVersion: 'preview-v1',
       commitSha: 'abc123',
       dataSourceMode: 'backend-api',
+      dataSourcePolicy: 'Backend API primary + bundled fallback',
       apiBaseUrl: 'https://example.com/api',
       analyticsEnabled: false,
       radarEnabled: true,

--- a/mobile/src/config/debugMetadata.ts
+++ b/mobile/src/config/debugMetadata.ts
@@ -14,6 +14,7 @@ export type MobileDebugMetadata = {
   datasetVersion: string | null;
   commitSha: string | null;
   dataSourceMode: MobileRuntimeConfig['dataSource']['mode'];
+  dataSourcePolicy: string;
   apiBaseUrl: string | null;
   analyticsEnabled: boolean;
   radarEnabled: boolean;
@@ -40,6 +41,10 @@ export function getDebugMetadata(
     datasetVersion: runtimeConfig.dataSource.datasetVersion,
     commitSha: runtimeConfig.build.commitSha,
     dataSourceMode: runtimeConfig.dataSource.mode,
+    dataSourcePolicy:
+      runtimeConfig.dataSource.mode === 'backend-api'
+        ? 'Backend API primary + bundled fallback'
+        : 'Bundled static primary',
     apiBaseUrl: runtimeConfig.services.apiBaseUrl,
     analyticsEnabled: runtimeConfig.featureGates.analytics,
     radarEnabled: runtimeConfig.featureGates.radar,

--- a/mobile/src/services/activeDataset.test.ts
+++ b/mobile/src/services/activeDataset.test.ts
@@ -67,7 +67,7 @@ describe('loadActiveMobileDataset', () => {
 
     expect(result.activeSource).toBe('bundled-static');
     expect(result.selection.kind).toBe('bundled-static');
-    expect(result.sourceLabel).toBe('Bundled static dataset');
+    expect(result.sourceLabel).toBe('Bundled fallback dataset');
     expect(result.dataset.artistProfiles.length).toBeGreaterThan(0);
     expect(result.issues).toEqual([]);
   });
@@ -115,7 +115,7 @@ describe('loadActiveMobileDataset', () => {
     });
 
     expect(result.activeSource).toBe('bundled-static');
-    expect(result.selection.reason).toBe('backend_api_mode');
-    expect(result.sourceLabel).toBe('Bundled static dataset');
+    expect(result.selection.reason).toBe('backend_primary_fallback');
+    expect(result.sourceLabel).toBe('Bundled fallback dataset');
   });
 });

--- a/mobile/src/services/activeDataset.ts
+++ b/mobile/src/services/activeDataset.ts
@@ -2,8 +2,7 @@ import type { RuntimeConfigState } from '../config/runtime';
 import { getRuntimeConfigState } from '../config/runtime';
 import type { MobileRawDataset } from '../types';
 
-import { resolveDatasetFailurePolicy } from './datasetFailurePolicy';
-import { selectDatasetSource, type DatasetSelection } from './datasetSource';
+import { createBundledDatasetSelection, type BundledDatasetSelection } from './datasetSource';
 import { cloneBundledDatasetFixture } from './bundledDatasetFixture';
 
 export type ActiveMobileDataset = {
@@ -15,7 +14,7 @@ export type ActiveMobileDataset = {
   };
   issues: string[];
   runtimeState: RuntimeConfigState;
-  selection: DatasetSelection;
+  selection: BundledDatasetSelection;
   sourceLabel: string;
 };
 
@@ -33,7 +32,7 @@ function normalizeMobileRawDataset(dataset: MobileRawDataset): MobileRawDataset 
 }
 
 function getDatasetSourceLabel(): string {
-  return 'Bundled static dataset';
+  return 'Bundled fallback dataset';
 }
 
 function dedupeIssueMessages(messages: string[]): string[] {
@@ -42,7 +41,7 @@ function dedupeIssueMessages(messages: string[]): string[] {
 
 function buildBundledDatasetResponse(args: {
   extraIssues?: string[];
-  selection: DatasetSelection;
+  selection: BundledDatasetSelection;
   runtimeState: RuntimeConfigState;
 }): ActiveMobileDataset {
   const dataset = normalizeMobileRawDataset(cloneBundledDatasetFixture());
@@ -70,14 +69,17 @@ export async function loadActiveMobileDataset(
   } = {},
 ): Promise<ActiveMobileDataset> {
   const runtimeState = options.runtimeState ?? getRuntimeConfigState();
-  const selection = selectDatasetSource(runtimeState.config);
-  const basePolicy = await resolveDatasetFailurePolicy({
-    runtimeState,
-    selection,
-  });
+  const selection = createBundledDatasetSelection(
+    runtimeState.config.dataSource.datasetVersion,
+    runtimeState.mode === 'degraded'
+      ? 'runtime_degraded'
+      : runtimeState.config.dataSource.mode === 'backend-api'
+        ? 'backend_primary_fallback'
+        : 'profile_default',
+  );
+
   return buildBundledDatasetResponse({
-    extraIssues: basePolicy.issues.map((issue) => issue.message),
-    selection: basePolicy.selection,
+    selection,
     runtimeState,
   });
 }

--- a/mobile/src/services/datasetFailurePolicy.test.ts
+++ b/mobile/src/services/datasetFailurePolicy.test.ts
@@ -1,7 +1,7 @@
 import type { RuntimeConfigState } from '../config/runtime';
 
 import { resolveDatasetFailurePolicy } from './datasetFailurePolicy';
-import { createBundledDatasetSelection } from './datasetSource';
+import { createBackendDatasetSelection } from './datasetSource';
 
 function createRuntimeState(mode: RuntimeConfigState['mode'] = 'normal'): RuntimeConfigState {
   return {
@@ -61,14 +61,14 @@ describe('dataset failure policy', () => {
   });
 
   test('stays in normal mode when runtime config is healthy', async () => {
-    const selection = createBundledDatasetSelection('preview-v2', 'backend_api_mode');
+    const selection = createBackendDatasetSelection('preview-v2', 'https://example.com/api');
     const policy = await resolveDatasetFailurePolicy({
       runtimeState: createRuntimeState('normal'),
       selection,
     });
 
     expect(policy.mode).toBe('normal');
-    expect(policy.activeSource).toBe('bundled-static');
+    expect(policy.activeSource).toBe('backend-api');
     expect(policy.selection).toEqual(selection);
     expect(policy.issues).toEqual([]);
   });

--- a/mobile/src/services/datasetFailurePolicy.ts
+++ b/mobile/src/services/datasetFailurePolicy.ts
@@ -19,7 +19,7 @@ export type DatasetFailurePolicyIssue = {
 
 export type DatasetFailurePolicy = {
   mode: 'normal' | 'degraded';
-  activeSource: 'bundled-static';
+  activeSource: DatasetSelection['kind'];
   selection: DatasetSelection;
   issues: DatasetFailurePolicyIssue[];
 };
@@ -52,7 +52,7 @@ export async function resolveDatasetFailurePolicy(options: {
   const selection = options.selection ?? selectDatasetSource(runtimeState.config);
   return {
     mode: 'normal',
-    activeSource: 'bundled-static',
+    activeSource: selection.kind,
     selection,
     issues: [],
   };

--- a/mobile/src/services/datasetSource.test.ts
+++ b/mobile/src/services/datasetSource.test.ts
@@ -4,6 +4,7 @@ import {
   BUNDLED_DATASET_BASE_PATH,
   DATASET_ARTIFACTS,
   DATASET_CONTRACT_ID,
+  isBackendDatasetSelection,
   isBundledDatasetSelection,
   selectDatasetSource,
 } from './datasetSource';
@@ -50,6 +51,10 @@ describe('selectDatasetSource', () => {
     const selection = selectDatasetSource(buildRuntimeConfig());
 
     expect(isBundledDatasetSelection(selection)).toBe(true);
+    if (!isBundledDatasetSelection(selection)) {
+      throw new Error('Expected development selection to use bundled-static.');
+    }
+
     expect(selection.kind).toBe('bundled-static');
     expect(selection.reason).toBe('profile_default');
     expect(selection.bundledBasePath).toBe(BUNDLED_DATASET_BASE_PATH);
@@ -57,17 +62,24 @@ describe('selectDatasetSource', () => {
     expect(selection.mixingAllowed).toBe(false);
   });
 
-  test('uses bundled selection as a bridge when runtime prefers backend api', () => {
+  test('uses backend selection as the primary source when runtime prefers backend api', () => {
     const selection = selectDatasetSource(
       buildRuntimeConfig({ profile: 'preview' }, { mode: 'backend-api', datasetVersion: 'preview-v2' }),
     );
 
-    expect(isBundledDatasetSelection(selection)).toBe(true);
-    expect(selection.reason).toBe('backend_api_mode');
+    expect(isBackendDatasetSelection(selection)).toBe(true);
+    if (!isBackendDatasetSelection(selection)) {
+      throw new Error('Expected preview selection to use backend-api.');
+    }
+
+    expect(selection.kind).toBe('backend-api');
+    expect(selection.reason).toBe('profile_default');
     expect(selection.datasetVersion).toBe('preview-v2');
+    expect(selection.apiBaseUrl).toBe('https://example.com/api');
+    expect(selection.bundledFallbackBasePath).toBe(BUNDLED_DATASET_BASE_PATH);
   });
 
-  test('preserves artifact contract for all bundled selections', () => {
+  test('preserves artifact contract across development and backend-primary selections', () => {
     const development = selectDatasetSource(buildRuntimeConfig());
     const preview = selectDatasetSource(buildRuntimeConfig({ profile: 'preview' }));
 

--- a/mobile/src/services/datasetSource.ts
+++ b/mobile/src/services/datasetSource.ts
@@ -1,7 +1,7 @@
 import { getRuntimeConfig, type MobileRuntimeConfig } from '../config/runtime';
 
 export type DatasetContractId = 'idol-song-mobile-static-v1';
-export type DatasetSourceKind = 'bundled-static';
+export type DatasetSourceKind = 'bundled-static' | 'backend-api';
 export type DatasetArtifactId =
   | 'artistProfiles'
   | 'releases'
@@ -31,10 +31,18 @@ type DatasetSelectionBase = {
 
 export type BundledDatasetSelection = DatasetSelectionBase & {
   kind: 'bundled-static';
-  reason: 'profile_default' | 'backend_api_mode' | 'runtime_degraded';
+  reason: 'profile_default' | 'backend_primary_fallback' | 'runtime_degraded';
   bundledBasePath: string;
 };
-export type DatasetSelection = BundledDatasetSelection;
+
+export type BackendDatasetSelection = DatasetSelectionBase & {
+  kind: 'backend-api';
+  reason: 'profile_default';
+  apiBaseUrl: string;
+  bundledFallbackBasePath: string;
+};
+
+export type DatasetSelection = BundledDatasetSelection | BackendDatasetSelection;
 
 export const DATASET_CONTRACT_ID: DatasetContractId = 'idol-song-mobile-static-v1';
 export const BUNDLED_DATASET_BASE_PATH = 'mobile/assets/datasets/v1';
@@ -107,15 +115,39 @@ export function createBundledDatasetSelection(
   };
 }
 
+export function createBackendDatasetSelection(
+  datasetVersion: string | null,
+  apiBaseUrl: string,
+): BackendDatasetSelection {
+  return {
+    kind: 'backend-api',
+    reason: 'profile_default',
+    contractId: DATASET_CONTRACT_ID,
+    datasetVersion,
+    mixingAllowed: false,
+    apiBaseUrl,
+    bundledFallbackBasePath: BUNDLED_DATASET_BASE_PATH,
+    artifacts: DATASET_ARTIFACTS,
+  };
+}
+
 export function selectDatasetSource(
   runtimeConfig: MobileRuntimeConfig = getRuntimeConfig(),
 ): DatasetSelection {
-  return createBundledDatasetSelection(
-    runtimeConfig.dataSource.datasetVersion,
-    runtimeConfig.dataSource.mode === 'backend-api' ? 'backend_api_mode' : 'profile_default',
-  );
+  if (runtimeConfig.dataSource.mode === 'backend-api' && runtimeConfig.services.apiBaseUrl) {
+    return createBackendDatasetSelection(
+      runtimeConfig.dataSource.datasetVersion,
+      runtimeConfig.services.apiBaseUrl,
+    );
+  }
+
+  return createBundledDatasetSelection(runtimeConfig.dataSource.datasetVersion, 'profile_default');
 }
 
 export function isBundledDatasetSelection(selection: DatasetSelection): selection is BundledDatasetSelection {
   return selection.kind === 'bundled-static';
+}
+
+export function isBackendDatasetSelection(selection: DatasetSelection): selection is BackendDatasetSelection {
+  return selection.kind === 'backend-api';
 }

--- a/mobile/src/services/storage.test.ts
+++ b/mobile/src/services/storage.test.ts
@@ -42,12 +42,13 @@ const bundledSelection: DatasetSelection = {
 };
 
 const previewSelection: DatasetSelection = {
-  kind: 'bundled-static',
-  reason: 'backend_api_mode',
+  kind: 'backend-api',
+  reason: 'profile_default',
   contractId: 'idol-song-mobile-static-v1',
   datasetVersion: 'preview-v2',
   mixingAllowed: false,
-  bundledBasePath: 'mobile/assets/datasets/v1',
+  apiBaseUrl: 'https://example.com/api',
+  bundledFallbackBasePath: 'mobile/assets/datasets/v1',
   artifacts: [],
 };
 


### PR DESCRIPTION
## Summary\n- model preview/production mobile runtime as backend-api primary and keep bundled static only as explicit fallback\n- align bundled fallback loader, dataset failure policy, debug metadata, and storage tests with the new source-selection rules\n- refresh mobile docs/readmes so calendar/search/radar/entity detail/release detail are described as backend-first surfaces\n\n## Verification\n- cd mobile && npm run lint\n- cd mobile && npm run typecheck\n- cd mobile && npm test -- --runInBand mobile/src/services/datasetSource.test.ts mobile/src/services/datasetFailurePolicy.test.ts mobile/src/services/activeDataset.test.ts mobile/src/config/debugMetadata.test.ts mobile/src/services/storage.test.ts\n- cd mobile && npm test -- --runInBand mobile/src/features/useActiveDatasetScreen.test.tsx mobile/src/features/route-shell.smoke.test.tsx\n- git diff --check\n\nCloses #417\nCloses #418\nCloses #419