### PR TITLE
[RN] Add mobile spec traceability and contract parity audits

### DIFF
--- a/docs/specs/mobile/README.md
+++ b/docs/specs/mobile/README.md
@@ -102,12 +102,16 @@
    - RN 핵심 user journey walkthrough 결과
 48. `rn-freshness-review-2026-03-10.md`
    - RN freshness/stale disclosure 리뷰 기록
+49. `rn-traceability-matrix.md`
+   - 전체 mobile spec 문서와 RN issue 매핑
+50. `rn-selector-contract-audit.md`
+   - selector/adaptor/display-model naming 및 contract parity audit
 ### Screen Specs
-49. `calendar-screen.md`
-50. `radar-screen.md`
-51. `search-screen.md`
-52. `team-detail-screen.md`
-53. `release-detail-screen.md`
+51. `calendar-screen.md`
+52. `radar-screen.md`
+53. `search-screen.md`
+54. `team-detail-screen.md`
+55. `release-detail-screen.md`
 
 ## 읽는 순서
 1. `master-spec.md`
@@ -155,9 +159,11 @@
 43. `rn-screen-structure-validation-2026-03-10.md`
 44. `rn-journey-walkthrough-2026-03-10.md`
 45. `rn-freshness-review-2026-03-10.md`
-46. 각 화면 스펙
-47. `edge-case-catalog.md`
-48. `qa-acceptance-spec.md`
+46. `rn-traceability-matrix.md`
+47. `rn-selector-contract-audit.md`
+48. 각 화면 스펙
+49. `edge-case-catalog.md`
+50. `qa-acceptance-spec.md`
 
 ## 구현 원칙
 - 모바일은 웹과 다른 레이아웃을 사용한다.

--- a/docs/specs/mobile/github-issue-breakdown-plan.md
+++ b/docs/specs/mobile/github-issue-breakdown-plan.md
@@ -105,3 +105,37 @@
 - relevant QA acceptance 항목 충족
 - selector fallback 테스트 존재
 - external handoff smoke 확인
+
+## 7. Live RN Umbrella and Execution Order
+
+### 7.1 Landed foundation / cutover work
+- `#404` shared mobile backend read client
+- `#405` parent mobile surface cutover
+- `#415` persisted screen snapshot cache
+- `#416` shared mobile screen-source hook
+- `#417` calendar/search backend cutover
+- `#418` radar/entity detail/release detail backend cutover
+- `#419` preview/production backend-primary runtime policy
+
+### 7.2 Remaining system / shared work
+1. `#425` RN executable implementation umbrella
+2. `#456` document-to-issue traceability matrix
+3. `#457` naming alignment with glossary/TS examples
+4. `#458` selector output + binding parity validation
+5. `#455` content-governance and fallback parity checks
+6. `#426` route-param/deep-link/back-navigation contracts
+7. `#427` shared sheet + snap behavior
+8. `#430` layout constraints, density, token sizing
+9. `#431` copy/localization rules
+10. `#432` analytics and observability taxonomy
+11. `#433` privacy/security/external handoff guards
+12. `#434` feature-gate, environment, failure-policy enforcement
+13. `#435` state restoration across tabs/sheets/detail/search/radar
+
+### 7.3 QA / polish gate
+1. `#459` interaction matrix compliance across all screens
+2. `#454` release-readiness gate + device QA matrix
+
+### 7.4 Working rule
+- 새 RN 작업은 위 순서를 기본으로 집행하되, dependency가 강한 항목은 한 PR에서 묶을 수 있다.
+- `#425`는 umbrella, `#456`은 traceability anchor, `#454`는 최종 gate로 유지한다.

--- a/docs/specs/mobile/rn-selector-contract-audit.md
+++ b/docs/specs/mobile/rn-selector-contract-audit.md
@@ -1,0 +1,55 @@
+# RN Selector and Contract Audit
+
+## 목적
+- RN selector, backend adapter, display-model naming이 모바일 glossary와 TS examples에서 벗어나지 않도록 고정한다.
+- sample-data contract와 content-governance/data-binding rules가 테스트 가능한 체크리스트가 되게 만든다.
+
+## 1. Naming Alignment Decisions
+
+### 1.1 유지하는 이름
+- `TeamSummaryModel`
+  - glossary에서 `Team`은 그룹/솔로/유닛/프로젝트를 모두 포함하는 추적 단위다.
+  - RN 코드에서는 `entity`보다 `team`을 화면 모델 이름으로 우선 사용한다.
+- `ReleaseSummaryModel`, `ReleaseDetailModel`, `UpcomingEventModel`
+  - `typescript-interface-examples.md`와 일치한다.
+- `datePrecision`, `status`, `confidence`, `sourceType`
+  - raw JSON 필드가 `date_precision`, `date_status`, `confidence`, `source_type`여도 selector/adaptor 단계에서 camelCase display model로 정규화한다.
+
+### 1.2 의도적으로 남겨둔 bridge 이름
+- raw payload 쪽의 `group`, `display_name`, `scheduled_date`, `source_type`
+  - dataset/backend contract와의 1:1 매핑을 위해 raw layer에만 유지한다.
+- backend route/result segment의 `entities`
+  - shared read API contract를 따르기 위한 이름이며, RN display layer에서는 `team` 모델로 변환한다.
+
+### 1.3 drift 방지 규칙
+- UI 컴포넌트 prop은 raw snake_case를 직접 받지 않는다.
+- selector/adaptor가 `display model` 경계다.
+- 새 surface model을 추가할 때는 `domain-glossary.md`, `typescript-interface-examples.md`, `view-state-models.md` 3개 문서를 같이 대조한다.
+
+## 2. Sample/Data-Binding Parity Checklist
+
+| Surface | Contract anchor | Current parity check |
+| --- | --- | --- |
+| Calendar | `sample-data-contracts.md`, `data-binding-spec.md` 5.1 | `CalendarMonthSnapshotModel`이 `exactUpcoming`, `monthOnlyUpcoming`, `nearestUpcoming`를 분리하고 `nearestUpcoming`은 exact만 허용 |
+| Search | `sample-data-contracts.md`, `data-binding-spec.md` 5.3 | `SearchResultsModel`이 `entities`, `releases`, `upcoming` 세그먼트를 유지하고 alias/partial 이유를 display model로 노출 |
+| Team Detail | `data-binding-spec.md` 5.4 | `EntityDetailSnapshotModel`이 공식 링크/다음 예정/최근 앨범/source timeline을 raw JSON 없이 파생 |
+| Release Detail | `sample-data-contracts.md`, `data-binding-spec.md` 5.5 | `ReleaseDetailModel`이 title-track, service links, MV state를 explicit field로 유지 |
+| Fallback/Disclosure | `content-governance-spec.md`, `edge-case-catalog.md`, `state-feedback-spec.md` | missing image/link/detail/MV를 가짜 값으로 채우지 않고 disclosure/helper 경로로 드러냄 |
+
+## 3. Content-Governance Decisions Confirmed
+- official link가 없으면 버튼을 숨긴다.
+- representative image가 없으면 placeholder/monogram fallback으로 내려가되, fake image URL을 만들지 않는다.
+- release detail service link가 비면 검색 fallback 또는 quality disclosure로만 노출한다.
+- `needs_review`, `unresolved`, `no_mv` 같은 MV 상태는 숨기지 않고 명시 상태로 유지한다.
+- partial data는 전체 화면을 막지 않고 disclosure + usable subset을 우선 렌더링한다.
+
+## 4. Test Evidence
+- selector parity: [mobile/src/selectors/specParity.test.ts](/Users/gimtaehun/Desktop/idol-song-app/mobile/src/selectors/specParity.test.ts)
+- backend adapter parity: [mobile/src/services/backendDisplayAdapters.test.ts](/Users/gimtaehun/Desktop/idol-song-app/mobile/src/services/backendDisplayAdapters.test.ts)
+- screen source fallback: [mobile/src/features/useActiveDatasetScreen.test.tsx](/Users/gimtaehun/Desktop/idol-song-app/mobile/src/features/useActiveDatasetScreen.test.tsx)
+- runtime/source selection: [mobile/src/services/datasetSource.test.ts](/Users/gimtaehun/Desktop/idol-song-app/mobile/src/services/datasetSource.test.ts), [mobile/src/services/datasetFailurePolicy.test.ts](/Users/gimtaehun/Desktop/idol-song-app/mobile/src/services/datasetFailurePolicy.test.ts)
+
+## 5. Follow-up Triggers
+- `SearchScreenState.selectedSegment`처럼 doc example과 runtime route/query naming이 다르면 next polish issue에서 일괄 정리한다.
+- backend payload contract가 바뀌면 이 문서와 parity tests를 같이 업데이트한다.
+- 새로운 screen model이 추가되면 traceability matrix에도 primary issue를 연결한다.

--- a/docs/specs/mobile/rn-traceability-matrix.md
+++ b/docs/specs/mobile/rn-traceability-matrix.md
@@ -1,0 +1,91 @@
+# RN Traceability Matrix
+
+## 목적
+- `docs/specs/mobile/` 전체 문서를 RN 구현/QA/운영 이슈에 추적 가능하게 연결한다.
+- 구현자가 문서를 보고 바로 집행 이슈를 찾을 수 있게 한다.
+- sign-off 전 문서 누락 여부를 빠르게 판별한다.
+
+## 운영 규칙
+- 모든 모바일 문서는 최소 1개의 RN 이슈에 primary로 연결된다.
+- umbrella 성격 문서는 `#425`를 secondary anchor로 둔다.
+- 구현이 끝난 이슈는 `closed`, 남은 이슈는 `open`으로 기록한다.
+- 문서가 여러 축에 걸치면 `secondary issues`에만 확장하고 primary는 하나로 유지한다.
+
+## Core Spec Mapping
+
+| Document | Primary RN issue | Secondary issues | Status | Note |
+| --- | --- | --- | --- | --- |
+| `master-spec.md` | `#425` | `#430`, `#431`, `#434` | open | 전역 UX/구현 단계 umbrella |
+| `component-action-system.md` | `#459` | `#433` | open | 탭/푸시/외부 이동 액션 계층 |
+| `navigation-motion-spec.md` | `#426` | `#427`, `#435`, `#459` | open | route, sheet, 복귀 규칙 |
+| `data-binding-spec.md` | `#458` | `#455` | open | selector output과 fallback 계약 |
+| `visual-design-spec.md` | `#430` |  | open | spacing, density, sizing |
+| `component-catalog.md` | `#430` | `#427`, `#459` | open | shared component 구조/행동 |
+| `layout-constraint-spec.md` | `#430` |  | open | surface layout/density |
+| `state-feedback-spec.md` | `#455` | `#454` | open | loading/empty/error/partial states |
+| `copy-localization-spec.md` | `#431` | `#455` | open | copy/localization 규칙 |
+| `accessibility-platform-spec.md` | `#454` | `#459` | open | QA/platform acceptance |
+| `edge-case-catalog.md` | `#455` | `#458` | open | null/missing/partial edge cases |
+| `qa-acceptance-spec.md` | `#454` | `#459` | open | preview sign-off gate |
+| `interaction-matrix.md` | `#459` | `#426`, `#427`, `#433` | open | 탭/시트/push/external 행동 매트릭스 |
+| `sample-data-contracts.md` | `#458` | `#455` | open | fixture/sample parity 기준 |
+| `wireframe-block-diagrams.md` | `#430` | `#425` | open | 화면 구조 baseline |
+| `design-token-spec.md` | `#430` |  | open | token-driven sizing/bounds |
+| `implementation-work-breakdown.md` | `#425` | `#456` | open | RN executable backlog baseline |
+| `component-api-contracts.md` | `#430` | `#427`, `#459` | open | 공통 컴포넌트 props/행동 |
+| `view-state-models.md` | `#457` | `#435`, `#458` | open | state/model naming 기준 |
+| `user-journey-sequences.md` | `#459` | `#454` | open | interaction + QA path |
+| `expo-implementation-guide.md` | `#425` | `#426`, `#434` | open | runtime/router implementation baseline |
+| `screen-delivery-checklists.md` | `#454` | `#425` | open | release gate checklist |
+| `testing-strategy-spec.md` | `#454` | `#458` | open | selector/UI smoke/test scope |
+| `typescript-interface-examples.md` | `#457` | `#458` | open | display model/type naming 기준 |
+| `github-issue-breakdown-plan.md` | `#425` | `#456` | open | live issue umbrella/order |
+| `domain-glossary.md` | `#457` | `#456` | open | 용어 고정점 |
+| `non-functional-requirements-spec.md` | `#430` | `#434`, `#454` | open | perf/runtime/testability |
+| `decision-log.md` | `#425` | `#456` | open | 구현 판단 근거 |
+| `analytics-event-spec.md` | `#432` | `#459` | open | interaction/failure analytics |
+| `data-sync-freshness-spec.md` | `#455` | `#434` | open | stale/partial disclosure 기준 |
+| `privacy-security-spec.md` | `#433` | `#459` | open | external/handoff/privacy guard |
+| `accessibility-reading-order-spec.md` | `#454` | `#459` | open | reading order QA |
+| `release-readiness-gate.md` | `#454` | `#425` | open | preview sign-off barrier |
+| `route-param-contracts.md` | `#426` | `#435` | open | path/deep-link/back stack |
+| `configuration-environment-spec.md` | `#434` | `#419` | open | runtime/env/failure policy |
+| `observability-error-taxonomy.md` | `#432` | `#434` | open | analytics + runtime failures |
+| `content-governance-spec.md` | `#455` | `#458` | open | null/missing data handling |
+| `performance-budget-spec.md` | `#430` | `#454` | open | density/perf QA |
+| `state-restoration-spec.md` | `#435` | `#426`, `#427` | open | tabs/sheets/detail restore |
+| `feature-gate-matrix.md` | `#434` | `#432` | open | feature-gate/runtime rules |
+| `external-dependency-risk-spec.md` | `#433` | `#434` | open | service/dependency guardrails |
+
+## Audit and Review Record Mapping
+
+| Document | Primary RN issue | Secondary issues | Status | Note |
+| --- | --- | --- | --- | --- |
+| `accessibility-audit-2026-03-09.md` | `#454` |  | open | pre-sign-off accessibility evidence |
+| `decision-log-review-checklist.md` | `#456` | `#425` | open | doc review/traceability anchor |
+| `rn-implementation-audit-2026-03-10.md` | `#456` | `#457`, `#458` | open | implementation audit evidence |
+| `rn-quality-coverage-matrix.md` | `#454` | `#458` | open | QA/coverage matrix |
+| `rn-screen-structure-validation-2026-03-10.md` | `#430` | `#459` | open | structure/layout validation |
+| `rn-journey-walkthrough-2026-03-10.md` | `#459` | `#454` | open | journey execution evidence |
+| `rn-freshness-review-2026-03-10.md` | `#455` | `#434` | open | stale/fallback review evidence |
+
+## Screen Spec Mapping
+
+| Document | Primary RN issue | Secondary issues | Status | Note |
+| --- | --- | --- | --- | --- |
+| `calendar-screen.md` | `#417` | `#427`, `#435`, `#459` | closed | backend-first calendar landed, polish remains in child issues |
+| `radar-screen.md` | `#418` | `#455`, `#459` | closed | backend-backed radar landed, contract/polish remains |
+| `search-screen.md` | `#417` | `#458`, `#459` | closed | backend-backed search landed, contract/polish remains |
+| `team-detail-screen.md` | `#418` | `#455`, `#459` | closed | backend-backed entity detail landed |
+| `release-detail-screen.md` | `#418` | `#455`, `#459` | closed | backend-backed release detail landed |
+
+## Coverage Summary
+- `covered docs`: `53 / 53`
+- `closed primary anchors`: `5 / 53`
+- `open primary anchors`: `48 / 53`
+- `documents currently anchored to umbrella/backlog docs`: `master-spec.md`, `implementation-work-breakdown.md`, `github-issue-breakdown-plan.md`, `decision-log.md`
+
+## Review Notes
+- `#417`, `#418`, `#419`는 구현 완료됐지만, 해당 문서들의 polish/validation obligations는 `#454`, `#455`, `#459`에 남아 있다.
+- `#425`는 live umbrella와 execution order를 계속 유지하는 기준 문서 역할을 맡는다.
+- `#456`은 이 matrix 자체와 이후 audit artifacts의 유지 이슈다.

--- a/docs/specs/mobile/typescript-interface-examples.md
+++ b/docs/specs/mobile/typescript-interface-examples.md
@@ -90,7 +90,7 @@ export interface CalendarScreenState {
 
 export interface SearchScreenState {
   query: string;
-  selectedSegment: 'team' | 'release' | 'upcoming';
+  selectedSegment: 'entities' | 'releases' | 'upcoming';
   recentQueries: string[];
   isFocused: boolean;
   loadingState: 'idle' | 'loading' | 'error';
@@ -148,3 +148,4 @@ export interface CalendarDerivedModel {
 - raw JSON type와 display model type를 분리한다.
 - nullable field는 selector 단계에서 최대한 축약한다.
 - UI 컴포넌트는 raw JSON shape를 직접 알면 안 된다.
+- search segment naming은 shared read contract와 맞춰 `entities / releases / upcoming`을 사용한다.

--- a/mobile/src/selectors/specParity.test.ts
+++ b/mobile/src/selectors/specParity.test.ts
@@ -1,0 +1,125 @@
+import {
+  buildEntitySourceDisclosure,
+  buildReleaseDependencyDisclosure,
+} from '../features/surfaceDisclosures';
+import { cloneBundledDatasetFixture } from '../services/bundledDatasetFixture';
+
+import {
+  selectCalendarMonthSnapshot,
+  selectEntityDetailSnapshot,
+  selectReleaseDetailById,
+  selectSearchResults,
+  selectTeamSummaryBySlug,
+} from './index';
+import { buildReleaseId } from './normalize';
+
+describe('RN selector spec parity', () => {
+  test('keeps exact upcoming, month-only upcoming, and nearest exact upcoming separate for calendar binding', () => {
+    const dataset = cloneBundledDatasetFixture();
+
+    const snapshot = selectCalendarMonthSnapshot(dataset, '2026-03', '2026-03-07');
+
+    expect(snapshot.month).toBe('2026-03');
+    expect(snapshot.exactUpcoming).toHaveLength(2);
+    expect(snapshot.monthOnlyUpcoming).toHaveLength(1);
+    expect(snapshot.exactUpcoming.every((item) => item.datePrecision === 'exact')).toBe(true);
+    expect(snapshot.monthOnlyUpcoming.every((item) => item.datePrecision === 'month_only')).toBe(true);
+    expect(snapshot.nearestUpcoming?.displayGroup).toBe('YENA');
+    expect(snapshot.nearestUpcoming?.datePrecision).toBe('exact');
+  });
+
+  test('matches Korean alias and release title queries into display-model search segments', () => {
+    const dataset = cloneBundledDatasetFixture();
+
+    const aliasResults = selectSearchResults(dataset, '최예나');
+    expect(aliasResults.query).toBe('최예나');
+    expect(aliasResults.entities[0]?.team.displayName).toBe('YENA');
+    expect(aliasResults.entities[0]?.matchKind).toBe('alias_exact');
+
+    const releaseResults = selectSearchResults(dataset, 'LOVE CATCHER');
+    expect(releaseResults.releases[0]?.release.releaseTitle).toBe('LOVE CATCHER');
+    expect(releaseResults.releases[0]?.matchKind).toBe('release_title_exact');
+
+    const upcomingResults = selectSearchResults(dataset, 'YENA confirms a March 11 comeback');
+    expect(upcomingResults.upcoming[0]?.upcoming.displayGroup).toBe('YENA');
+  });
+
+  test('uses monogram and hidden links when team metadata is missing instead of inventing placeholders', () => {
+    const dataset = cloneBundledDatasetFixture();
+    const yenaProfile = dataset.artistProfiles.find((profile) => profile.slug === 'yena');
+    const yenaUpcoming = dataset.upcomingCandidates.find((item) => item.group === 'YENA');
+    const yenaRelease = dataset.releases.find((item) => item.group === 'YENA');
+    const yenaAllowlist = dataset.youtubeChannelAllowlists.find((item) => item.group === 'YENA');
+    const yenaHistory = dataset.releaseHistory.find((item) => item.group === 'YENA');
+
+    if (!yenaProfile || !yenaUpcoming || !yenaRelease || !yenaAllowlist || !yenaHistory) {
+      throw new Error('Expected YENA fixture rows to exist.');
+    }
+
+    yenaProfile.official_youtube_url = null;
+    yenaProfile.official_x_url = null;
+    yenaProfile.official_instagram_url = null;
+    yenaProfile.artist_source_url = null;
+    yenaAllowlist.primary_team_channel_url = null;
+    yenaAllowlist.channels = [];
+    yenaUpcoming.source_url = null;
+    if (yenaRelease.latest_song) {
+      yenaRelease.latest_song.source = undefined;
+    }
+    if (yenaRelease.latest_album) {
+      yenaRelease.latest_album.source = undefined;
+    }
+    for (const release of yenaHistory.releases) {
+      release.source = undefined;
+    }
+
+    const team = selectTeamSummaryBySlug(dataset, 'yena');
+    const detail = selectEntityDetailSnapshot(dataset, 'yena');
+
+    expect(team?.officialYoutubeUrl).toBeUndefined();
+    expect(team?.officialXUrl).toBeUndefined();
+    expect(team?.officialInstagramUrl).toBeUndefined();
+    expect(team?.badge?.imageUrl).toBeUndefined();
+    expect(team?.badge?.monogram).toBe('YE');
+    expect(detail).not.toBeNull();
+    expect(detail?.sourceTimeline).toHaveLength(0);
+
+    const disclosure = buildEntitySourceDisclosure(detail!);
+    expect(disclosure?.body).toContain('아티스트 출처');
+    expect(disclosure?.body).toContain('다음 컴백 출처');
+    expect(disclosure?.body).toContain('최신 발매 출처');
+    expect(disclosure?.body).toContain('소스 타임라인');
+  });
+
+  test('keeps title-track and MV/service-link states explicit for release detail binding', () => {
+    const dataset = cloneBundledDatasetFixture();
+    const releaseId = buildReleaseId('YENA', 'LOVE CATCHER', '2026-03-11', 'album');
+    const sparseReleaseId = buildReleaseId('AtHeart', 'Glow Up', '2025-11-18', 'song');
+    const atHeartDetail = dataset.releaseDetails.find(
+      (detail) => detail.group === 'AtHeart' && detail.release_title === 'Glow Up',
+    );
+
+    if (!atHeartDetail) {
+      throw new Error('Expected AtHeart release detail fixture to exist.');
+    }
+
+    atHeartDetail.spotify_url = undefined;
+    atHeartDetail.youtube_music_url = undefined;
+
+    const resolved = selectReleaseDetailById(dataset, releaseId);
+    const sparse = selectReleaseDetailById(dataset, sparseReleaseId);
+
+    expect(resolved?.tracks.some((track) => track.isTitleTrack)).toBe(true);
+    expect(resolved?.youtubeMusicUrl).toContain('music.youtube.com');
+    expect(resolved?.youtubeVideoStatus).toBe('manual_override');
+
+    expect(sparse?.spotifyUrl).toBeUndefined();
+    expect(sparse?.youtubeMusicUrl).toBeUndefined();
+    expect(sparse?.youtubeVideoStatus).toBe('no_mv');
+
+    const disclosure = buildReleaseDependencyDisclosure(sparse!);
+    expect(disclosure?.body).toContain('트랙 메타데이터 미완료');
+    expect(disclosure?.body).toContain('음원 서비스 링크 일부 누락');
+    expect(disclosure?.body).toContain('공식 MV 미제공');
+  });
+});

--- a/mobile/src/services/backendDisplayAdapters.test.ts
+++ b/mobile/src/services/backendDisplayAdapters.test.ts
@@ -1,0 +1,235 @@
+import type {
+  BackendCalendarMonthData,
+  BackendEntityDetailData,
+  BackendReleaseDetailData,
+  BackendSearchData,
+} from './backendReadClient';
+import {
+  adaptBackendCalendarMonth,
+  adaptBackendEntityDetail,
+  adaptBackendReleaseDetail,
+  adaptBackendSearchResults,
+} from './backendDisplayAdapters';
+
+describe('backend display adapter parity', () => {
+  test('separates exact and month-only upcoming rows for calendar month responses', () => {
+    const data: BackendCalendarMonthData = {
+      summary: {
+        verified_count: 0,
+        exact_upcoming_count: 1,
+        month_only_upcoming_count: 1,
+      },
+      nearest_upcoming: {
+        upcoming_signal_id: 'upcoming-yena',
+        entity_slug: 'yena',
+        display_name: 'YENA',
+        headline: 'YENA confirms a March 11 comeback',
+        scheduled_date: '2026-03-11',
+        scheduled_month: '2026-03',
+        date_precision: 'exact',
+        date_status: 'confirmed',
+        source_type: 'news_rss',
+      },
+      days: [],
+      month_only_upcoming: [
+        {
+          upcoming_signal_id: 'upcoming-le-sserafim',
+          entity_slug: 'le-sserafim',
+          display_name: 'LE SSERAFIM',
+          headline: 'LE SSERAFIM is rumored to return later this month',
+          scheduled_month: '2026-03',
+          date_precision: 'month_only',
+          date_status: 'rumor',
+          source_type: 'news_rss',
+        },
+      ],
+      verified_list: [],
+      scheduled_list: [
+        {
+          upcoming_signal_id: 'upcoming-yena',
+          entity_slug: 'yena',
+          display_name: 'YENA',
+          headline: 'YENA confirms a March 11 comeback',
+          scheduled_date: '2026-03-11',
+          scheduled_month: '2026-03',
+          date_precision: 'exact',
+          date_status: 'confirmed',
+          source_type: 'news_rss',
+        },
+        {
+          upcoming_signal_id: 'upcoming-le-sserafim',
+          entity_slug: 'le-sserafim',
+          display_name: 'LE SSERAFIM',
+          headline: 'LE SSERAFIM is rumored to return later this month',
+          scheduled_month: '2026-03',
+          date_precision: 'month_only',
+          date_status: 'rumor',
+          source_type: 'news_rss',
+        },
+      ],
+    };
+
+    const snapshot = adaptBackendCalendarMonth('2026-03', data);
+
+    expect(snapshot.month).toBe('2026-03');
+    expect(snapshot.exactUpcoming).toHaveLength(1);
+    expect(snapshot.monthOnlyUpcoming).toHaveLength(1);
+    expect(snapshot.exactUpcoming[0]?.datePrecision).toBe('exact');
+    expect(snapshot.monthOnlyUpcoming[0]?.datePrecision).toBe('month_only');
+    expect(snapshot.nearestUpcoming?.displayGroup).toBe('YENA');
+  });
+
+  test('maps backend search segments into display models with explicit match kinds', () => {
+    const data: BackendSearchData = {
+      query: '최예나',
+      entities: [
+        {
+          entity_slug: 'yena',
+          display_name: 'YENA',
+          canonical_name: 'YENA',
+          entity_type: 'solo',
+          aliases: ['최예나'],
+          latest_release: {
+            release_id: 'release-yena',
+            release_title: 'LOVE CATCHER',
+            release_date: '2026-03-11',
+            stream: 'album',
+            release_kind: 'ep',
+          },
+          match_reason: 'alias_exact',
+        },
+      ],
+      releases: [
+        {
+          release_id: 'release-yena',
+          entity_slug: 'yena',
+          display_name: 'YENA',
+          release_title: 'LOVE CATCHER',
+          release_date: '2026-03-11',
+          stream: 'album',
+          release_kind: 'ep',
+          match_reason: 'release_title_exact',
+        },
+      ],
+      upcoming: [
+        {
+          upcoming_signal_id: 'upcoming-yena',
+          entity_slug: 'yena',
+          display_name: 'YENA',
+          headline: 'YENA confirms a March 11 comeback',
+          scheduled_date: '2026-03-11',
+          scheduled_month: '2026-03',
+          date_precision: 'exact',
+          date_status: 'confirmed',
+          release_format: 'LOVE CATCHER',
+          source_type: 'news_rss',
+          source_url: 'https://example.com/yena-news',
+          match_reason: 'entity_exact',
+        },
+      ],
+    };
+
+    const results = adaptBackendSearchResults('최예나', data);
+
+    expect(results.query).toBe('최예나');
+    expect(results.entities[0]?.team.displayName).toBe('YENA');
+    expect(results.entities[0]?.matchKind).toBe('alias_exact');
+    expect(results.releases[0]?.matchKind).toBe('release_title_exact');
+    expect(results.upcoming[0]?.matchKind).toBe('entity_exact');
+    expect(results.upcoming[0]?.upcoming.sourceUrl).toBe('https://example.com/yena-news');
+  });
+
+  test('keeps missing official/source links undefined for sparse entity detail payloads', () => {
+    const data: BackendEntityDetailData = {
+      identity: {
+        entity_slug: 'allday-project',
+        display_name: 'ALLDAY PROJECT',
+        canonical_name: 'ALLDAY PROJECT',
+        entity_type: 'project',
+      },
+      official_links: {
+        youtube: null,
+        x: null,
+        instagram: null,
+      },
+      youtube_channels: {
+        mv_allowlist_urls: [],
+      },
+      tracking_state: {},
+      next_upcoming: null,
+      latest_release: null,
+      recent_albums: [],
+      source_timeline: [
+        {
+          event_type: 'upcoming_signal',
+          headline: 'Sparse source timeline row',
+          summary: 'No explicit source URL yet',
+          source_url: null,
+        },
+      ],
+      artist_source_url: null,
+    };
+
+    const snapshot = adaptBackendEntityDetail(data);
+
+    expect(snapshot.team.actType).toBe('project');
+    expect(snapshot.team.officialYoutubeUrl).toBeUndefined();
+    expect(snapshot.team.officialXUrl).toBeUndefined();
+    expect(snapshot.team.officialInstagramUrl).toBeUndefined();
+    expect(snapshot.team.badge?.monogram).toBe('AP');
+    expect(snapshot.team.artistSourceUrl).toBeUndefined();
+    expect(snapshot.sourceTimeline[0]?.sourceUrl).toBeUndefined();
+  });
+
+  test('keeps release detail service links and MV state explicit without fake fallback values', () => {
+    const data: BackendReleaseDetailData = {
+      release: {
+        release_id: 'release-atheart',
+        entity_slug: 'atheart',
+        display_name: 'AtHeart',
+        release_title: 'Glow Up',
+        release_date: '2025-11-18',
+        stream: 'song',
+        release_kind: 'single',
+      },
+      artwork: null,
+      service_links: {
+        spotify: {
+          url: null,
+        },
+        youtube_music: {
+          url: null,
+        },
+      },
+      tracks: [
+        {
+          track_id: 'track-glow-up',
+          order: 1,
+          title: 'Glow Up',
+          is_title_track: true,
+          spotify: null,
+          youtube_music: null,
+        },
+      ],
+      mv: {
+        status: 'unresolved',
+        url: null,
+        video_id: null,
+      },
+      notes: {
+        summary: 'Backend detail remains sparse.',
+      },
+    };
+
+    const detail = adaptBackendReleaseDetail(data);
+
+    expect(detail.spotifyUrl).toBeUndefined();
+    expect(detail.youtubeMusicUrl).toBeUndefined();
+    expect(detail.youtubeVideoId).toBeUndefined();
+    expect(detail.youtubeVideoUrl).toBeUndefined();
+    expect(detail.youtubeVideoStatus).toBe('unresolved');
+    expect(detail.notes).toBe('Backend detail remains sparse.');
+    expect(detail.tracks[0]?.isTitleTrack).toBe(true);
+    expect(detail.tracks[0]?.spotifyUrl).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary\n- add a stable RN traceability matrix for the entire mobile spec set and document the live umbrella execution order\n- add an RN selector/contract audit that fixes search segment naming drift in the TS examples and records naming decisions\n- add selector/backend-adapter parity tests for sample-data, data-binding, and content-governance rules\n\n## Verification\n- cd mobile && npm run lint\n- cd mobile && npm run typecheck\n- cd mobile && npm test -- --runInBand src/selectors/specParity.test.ts src/services/backendDisplayAdapters.test.ts src/services/datasetSource.test.ts src/services/datasetFailurePolicy.test.ts src/features/useActiveDatasetScreen.test.tsx\n- git diff --check\n\nCloses #425\nCloses #455\nCloses #456\nCloses #457\nCloses #458