### PR TITLE
[RN] Unify mobile sheet, route, and restoration contracts

### DIFF
--- a/docs/specs/mobile/component-api-contracts.md
+++ b/docs/specs/mobile/component-api-contracts.md
@@ -220,6 +220,7 @@
 
 ### Rules
 - verifiedRows, scheduledRows가 모두 비어도 empty state를 포함해 열릴 수 있다.
+- shared bottom-sheet frame을 사용하고 default max height는 약 78%, empty 상태는 약 45%를 따른다.
 - sheet 내부에서 push/external 액션 허용
 
 ## 18. FilterSheet
@@ -234,7 +235,8 @@
 
 ### Rules
 - apply 이전에는 임시 상태 유지 가능
-- background close 시 폐기/유지 정책은 screen-level spec을 따른다.
+- shared bottom-sheet frame을 사용하고 default max height는 약 62%를 따른다.
+- background close 시 draft state를 폐기하고 마지막 applied state를 유지한다.
 
 ## 19. 참조 예시
 - 실제 interface 네이밍 예시는 `typescript-interface-examples.md`를 참조한다.

--- a/docs/specs/mobile/interaction-matrix.md
+++ b/docs/specs/mobile/interaction-matrix.md
@@ -72,7 +72,7 @@
 | Toggle Filter Option | tap | 필터값 갱신 | in-sheet | 임시 상태 반영 |
 | Reset Button | tap | 기본값 복원 | in-sheet | 임시 상태 초기화 |
 | Apply Button | tap | 필터 적용 후 닫기 | sheet close | 대상 화면 재계산 |
-| Background Tap | tap | 닫기 | sheet close | 미적용 또는 마지막 임시 상태 폐기 규칙 필요 |
+| Background Tap | tap | 닫기 | sheet close | draft state 폐기, 마지막 applied state 유지 |
 
 ## 8. Global Rules
 - sheet 내부 액션은 sheet close 없이 push/external이 가능하다.

--- a/docs/specs/mobile/navigation-motion-spec.md
+++ b/docs/specs/mobile/navigation-motion-spec.md
@@ -52,6 +52,7 @@
 - Date Detail Sheet empty 상태 높이: 화면의 약 45%
 - Filter Sheet 기본 높이: 화면의 약 62%
 - Language/Settings Sheet 기본 높이: 화면의 약 40~45%
+- Date Detail Sheet와 Filter Sheet는 shared bottom-sheet frame을 사용한다.
 - sheet가 완전히 닫히기 전까지 underlying 화면 스크롤은 잠근다.
 
 ## 5. 화면 간 이동 계약

--- a/docs/specs/mobile/route-param-contracts.md
+++ b/docs/specs/mobile/route-param-contracts.md
@@ -57,7 +57,11 @@ Path: `/releases/[id]`
 ### 4.5 Radar state
 - 기본 진입 경로는 `/(tabs)/radar`다.
 - state restoration용 optional query param:
-  - `hideEmpty=1`
+  - `status=all|scheduled|confirmed|changed`
+  - `actType=all|group|solo|unit`
+  - `sections=weekly,change,longGap,rookie`
+- filter sheet open state 자체는 route param으로 강제하지 않는다.
+- invalid status/actType/sections 값은 무시하고 안전한 기본 상태로 복구한다.
 
 ## 5. Param validation
 - missing slug/id는 screen crash 원인이 되어서는 안 된다.

--- a/docs/specs/mobile/state-restoration-spec.md
+++ b/docs/specs/mobile/state-restoration-spec.md
@@ -24,6 +24,8 @@
 ## 5. Radar
 - active filter 또는 섹션 스크롤 맥락을 잃지 않아야 한다.
 - external handoff 후 복귀 시 기존 카드 목록 위치를 유지한다.
+- applied filter(`status`, `actType`, `sections`)는 route state로 복원된다.
+- Filter Sheet draft state는 apply 전까지만 임시 상태이며, close/backdrop dismiss 시 폐기된다.
 
 ## 6. Team Detail / Release Detail
 - back 시 이전 화면 scroll 위치를 복원해야 한다.

--- a/mobile/app/(tabs)/calendar.tsx
+++ b/mobile/app/(tabs)/calendar.tsx
@@ -602,10 +602,12 @@ export default function CalendarTabScreen() {
       primaryAction: {
         label: '팀 페이지',
         onPress: () => openTeamDetailByGroup(release.group),
+        testID: `${testPrefix}-primary-${release.id}`,
       },
       secondaryAction: {
         label: '상세 보기',
         onPress: () => openReleaseDetail(release.id),
+        testID: `${testPrefix}-secondary-${release.id}`,
       },
       serviceButtons: buildReleaseServiceButtons(release),
       sourceLinks: buildReleaseSourceLinks(release),
@@ -629,6 +631,7 @@ export default function CalendarTabScreen() {
       primaryAction: {
         label: '팀 페이지',
         onPress: () => openTeamDetailByGroup(event.group),
+        testID: `${testPrefix}-primary-${event.id}`,
       },
       scheduledDate: formatUpcomingLabel(event),
       sourceLinks: buildUpcomingSourceLinks(event),

--- a/mobile/app/(tabs)/radar.tsx
+++ b/mobile/app/(tabs)/radar.tsx
@@ -2,7 +2,6 @@ import { useLocalSearchParams, useRouter } from 'expo-router';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   Linking,
-  Modal,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -15,6 +14,7 @@ import {
   InlineFeedbackNotice,
   ScreenFeedbackState,
 } from '../../src/components/feedback/FeedbackState';
+import { FilterSheet, type FilterSheetGroup } from '../../src/components/filters/FilterSheet';
 import { AppBar } from '../../src/components/layout/AppBar';
 import { SummaryStrip } from '../../src/components/layout/SummaryStrip';
 import { buildDatasetRiskDisclosure } from '../../src/features/surfaceDisclosures';
@@ -258,13 +258,32 @@ export default function RadarTabScreen() {
     sections?: string | string[];
     status?: string | string[];
   }>();
+  const routeActTypeParam = params.actType;
+  const routeSectionsParam = params.sections;
+  const routeStatusParam = params.status;
   const theme = useAppTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
   const [reloadCount, setReloadCount] = useState(0);
-  const routeState = useMemo(() => resolveRadarRouteState(params), [params]);
+  const routeState = useMemo(
+    () =>
+      resolveRadarRouteState({
+        actType: routeActTypeParam,
+        sections: routeSectionsParam,
+        status: routeStatusParam,
+      }),
+    [routeActTypeParam, routeSectionsParam, routeStatusParam],
+  );
+  const routeSectionsKey = useMemo(
+    () => routeState.enabledSections.join(','),
+    [routeState.enabledSections],
+  );
+  const restoredEnabledSections = routeState.enabledSections;
   const [statusFilter, setStatusFilter] = useState(routeState.statusFilter);
   const [actTypeFilter, setActTypeFilter] = useState(routeState.actTypeFilter);
   const [enabledSections, setEnabledSections] = useState(routeState.enabledSections);
+  const [draftStatusFilter, setDraftStatusFilter] = useState(routeState.statusFilter);
+  const [draftActTypeFilter, setDraftActTypeFilter] = useState(routeState.actTypeFilter);
+  const [draftEnabledSections, setDraftEnabledSections] = useState(routeState.enabledSections);
   const [isFilterSheetOpen, setIsFilterSheetOpen] = useState(false);
   const today = useMemo(() => new Date(), []);
   const todayIsoDate = useMemo(() => today.toISOString().slice(0, 10), [today]);
@@ -294,8 +313,16 @@ export default function RadarTabScreen() {
   useEffect(() => {
     setStatusFilter(routeState.statusFilter);
     setActTypeFilter(routeState.actTypeFilter);
-    setEnabledSections(routeState.enabledSections);
-  }, [routeState]);
+    setEnabledSections([...restoredEnabledSections]);
+    setDraftStatusFilter(routeState.statusFilter);
+    setDraftActTypeFilter(routeState.actTypeFilter);
+    setDraftEnabledSections([...restoredEnabledSections]);
+  }, [
+    routeState.actTypeFilter,
+    restoredEnabledSections,
+    routeSectionsKey,
+    routeState.statusFilter,
+  ]);
 
   const source = datasetState.kind === 'ready' ? datasetState.source : null;
   const snapshot = source?.data ?? null;
@@ -340,19 +367,92 @@ export default function RadarTabScreen() {
     });
   }
 
-  function toggleSection(section: RadarSectionKey) {
-    setEnabledSections((current) =>
+  function openFilterSheet() {
+    setDraftStatusFilter(statusFilter);
+    setDraftActTypeFilter(actTypeFilter);
+    setDraftEnabledSections(enabledSections);
+    setIsFilterSheetOpen(true);
+  }
+
+  function closeFilterSheet() {
+    setDraftStatusFilter(statusFilter);
+    setDraftActTypeFilter(actTypeFilter);
+    setDraftEnabledSections(enabledSections);
+    setIsFilterSheetOpen(false);
+  }
+
+  function applyFilterSheet() {
+    setStatusFilter(draftStatusFilter);
+    setActTypeFilter(draftActTypeFilter);
+    setEnabledSections(draftEnabledSections);
+    setIsFilterSheetOpen(false);
+  }
+
+  function resetFilterSheetDrafts() {
+    setDraftStatusFilter('all');
+    setDraftActTypeFilter('all');
+    setDraftEnabledSections(DEFAULT_ENABLED_SECTIONS);
+  }
+
+  function toggleDraftSection(section: RadarSectionKey) {
+    setDraftEnabledSections((current) =>
       current.includes(section)
         ? current.filter((value) => value !== section)
         : [...current, section],
     );
   }
 
-  function resetFilters() {
-    setStatusFilter('all');
-    setActTypeFilter('all');
-    setEnabledSections(DEFAULT_ENABLED_SECTIONS);
+  function handleFilterSheetToggleOption(groupKey: string, optionKey: string) {
+    if (groupKey === 'status') {
+      setDraftStatusFilter(optionKey as RadarFilterStatus);
+      return;
+    }
+
+    if (groupKey === 'act') {
+      setDraftActTypeFilter(optionKey as RadarFilterActType);
+      return;
+    }
+
+    if (groupKey === 'section') {
+      toggleDraftSection(optionKey as RadarSectionKey);
+    }
   }
+
+  const filterGroups = useMemo<FilterSheetGroup[]>(
+    () => [
+      {
+        key: 'status',
+        label: '상태',
+        options: [
+          { key: 'all', label: '전체', selected: draftStatusFilter === 'all' },
+          { key: 'scheduled', label: '예정', selected: draftStatusFilter === 'scheduled' },
+          { key: 'confirmed', label: '확정', selected: draftStatusFilter === 'confirmed' },
+          { key: 'changed', label: '변경', selected: draftStatusFilter === 'changed' },
+        ],
+      },
+      {
+        key: 'act',
+        label: 'act type',
+        options: [
+          { key: 'all', label: '전체', selected: draftActTypeFilter === 'all' },
+          { key: 'group', label: '그룹', selected: draftActTypeFilter === 'group' },
+          { key: 'solo', label: '솔로', selected: draftActTypeFilter === 'solo' },
+          { key: 'unit', label: '유닛', selected: draftActTypeFilter === 'unit' },
+        ],
+      },
+      {
+        key: 'section',
+        label: '섹션 표시',
+        options: [
+          { key: 'weekly', label: '이번 주 예정', selected: draftEnabledSections.includes('weekly') },
+          { key: 'change', label: '일정 변경', selected: draftEnabledSections.includes('change') },
+          { key: 'longGap', label: '장기 공백', selected: draftEnabledSections.includes('longGap') },
+          { key: 'rookie', label: '루키', selected: draftEnabledSections.includes('rookie') },
+        ],
+      },
+    ],
+    [draftActTypeFilter, draftEnabledSections, draftStatusFilter],
+  );
 
   if (datasetState.kind === 'loading') {
     return (
@@ -418,14 +518,14 @@ export default function RadarTabScreen() {
           >
             <Text style={styles.appBarButtonLabel}>검색</Text>
           </Pressable>
-          <Pressable
-            testID="radar-filter-button"
-            accessibilityLabel="레이더 필터 열기"
-            accessibilityRole="button"
-            accessibilityState={{ selected: hasNonDefaultFilters || isFilterSheetOpen }}
-            onPress={() => setIsFilterSheetOpen(true)}
-            style={({ pressed }) => [styles.appBarButton, pressed ? styles.buttonPressed : null]}
-          >
+            <Pressable
+              testID="radar-filter-button"
+              accessibilityLabel="레이더 필터 열기"
+              accessibilityRole="button"
+              accessibilityState={{ selected: hasNonDefaultFilters || isFilterSheetOpen }}
+              onPress={openFilterSheet}
+              style={({ pressed }) => [styles.appBarButton, pressed ? styles.buttonPressed : null]}
+            >
             <Text style={styles.appBarButtonLabel}>필터</Text>
           </Pressable>
         </View>
@@ -527,17 +627,20 @@ export default function RadarTabScreen() {
         ) : null}
       </ScrollView>
 
-      <RadarFilterSheet
-        actTypeFilter={actTypeFilter}
-        enabledSections={enabledSections}
+      <FilterSheet
+        applyButtonTestID="radar-filter-apply"
+        closeButtonTestID="radar-filter-close"
+        groups={filterGroups}
         isOpen={isFilterSheetOpen}
-        onClose={() => setIsFilterSheetOpen(false)}
-        onReset={resetFilters}
-        onSelectActType={setActTypeFilter}
-        onSelectStatus={setStatusFilter}
-        onToggleSection={toggleSection}
-        statusFilter={statusFilter}
-        styles={styles}
+        onApply={applyFilterSheet}
+        onClose={closeFilterSheet}
+        onReset={resetFilterSheetDrafts}
+        onToggleOption={handleFilterSheetToggleOption}
+        optionTestIDPrefix="radar-filter"
+        resetButtonTestID="radar-filter-reset"
+        summary="레이더 의미를 바꾸지 않는 범위에서 상태, act type, 섹션 표시를 조정합니다."
+        testID="radar-filter-sheet"
+        title="레이더 필터"
       />
     </>
   );
@@ -579,7 +682,9 @@ function RadarFeaturedSection({
             onOpenSource={() => onOpenSource(item.sourceUrl)}
             onPressPrimary={() => onPressTeam(item.team.slug)}
             primaryLabel="팀 페이지"
+            primaryTestID="radar-featured-primary"
             sourceLabel={item.sourceLabel}
+            sourceTestID="radar-featured-source"
             sourceUrl={item.sourceUrl}
             styles={styles}
           />
@@ -648,7 +753,9 @@ function RadarUpcomingSectionCard({
           onOpenSource={() => onOpenSource(item.sourceUrl)}
           onPressPrimary={() => onPressTeam(item.team.slug)}
           primaryLabel="팀 페이지"
+          primaryTestID={`${testID}-primary`}
           sourceLabel={item.sourceLabel}
+          sourceTestID={`${testID}-source`}
           sourceUrl={item.sourceUrl}
           styles={styles}
         />
@@ -689,7 +796,9 @@ function RadarChangeFeedCard({
           onOpenSource={() => onOpenSource(item.sourceUrl)}
           onPressPrimary={() => onPressTeam(item.team.slug)}
           primaryLabel="팀 페이지"
+          primaryTestID={`radar-change-primary-${item.team.slug}`}
           sourceLabel={item.sourceLabel}
+          sourceTestID={`radar-change-source-${item.team.slug}`}
           sourceUrl={item.sourceUrl}
           styles={styles}
         />
@@ -723,6 +832,7 @@ function RadarLongGapCard({
         <RadarActionRow
           onPressPrimary={() => onPressTeam(item.team.slug)}
           primaryLabel="팀 페이지"
+          primaryTestID={`radar-long-gap-primary-${item.team.slug}`}
           styles={styles}
         />
       </View>
@@ -755,6 +865,7 @@ function RadarRookieCard({
         <RadarActionRow
           onPressPrimary={() => onPressTeam(item.team.slug)}
           primaryLabel="팀 페이지"
+          primaryTestID={`radar-rookie-primary-${item.team.slug}`}
           styles={styles}
         />
       </View>
@@ -766,14 +877,18 @@ function RadarActionRow({
   onOpenSource,
   onPressPrimary,
   primaryLabel,
+  primaryTestID,
   sourceLabel,
+  sourceTestID,
   sourceUrl,
   styles,
 }: {
   onOpenSource?: () => void;
   onPressPrimary: () => void;
   primaryLabel: string;
+  primaryTestID?: string;
   sourceLabel?: string;
+  sourceTestID?: string;
   sourceUrl?: string;
   styles: ReturnType<typeof createStyles>;
 }) {
@@ -783,176 +898,18 @@ function RadarActionRow({
         accessibilityLabel={primaryLabel}
         label={primaryLabel}
         onPress={onPressPrimary}
+        testID={primaryTestID}
       />
       {sourceUrl && sourceLabel && onOpenSource ? (
         <ActionButton
           accessibilityLabel={sourceLabel}
           label={sourceLabel}
           onPress={onOpenSource}
+          testID={sourceTestID}
           tone="meta"
         />
       ) : null}
     </View>
-  );
-}
-
-function RadarFilterSheet({
-  actTypeFilter,
-  enabledSections,
-  isOpen,
-  onClose,
-  onReset,
-  onSelectActType,
-  onSelectStatus,
-  onToggleSection,
-  statusFilter,
-  styles,
-}: {
-  actTypeFilter: RadarFilterActType;
-  enabledSections: RadarSectionKey[];
-  isOpen: boolean;
-  onClose: () => void;
-  onReset: () => void;
-  onSelectActType: (value: RadarFilterActType) => void;
-  onSelectStatus: (value: RadarFilterStatus) => void;
-  onToggleSection: (value: RadarSectionKey) => void;
-  statusFilter: RadarFilterStatus;
-  styles: ReturnType<typeof createStyles>;
-}) {
-  return (
-    <Modal
-      animationType="fade"
-      onRequestClose={onClose}
-      presentationStyle="overFullScreen"
-      testID="radar-filter-sheet"
-      transparent
-      visible={isOpen}
-    >
-      <View style={styles.filterOverlay}>
-        <Pressable style={styles.filterBackdrop} onPress={onClose} />
-        <View style={styles.filterSheet}>
-          <View style={styles.sectionHeader}>
-            <Text accessibilityRole="header" style={styles.sectionTitle}>레이더 필터</Text>
-          </View>
-          <Text style={styles.filterHelper}>
-            레이더 의미를 바꾸지 않는 범위에서만 상태와 act type, 섹션 표시를 조정합니다.
-          </Text>
-
-          <View style={styles.filterGroup}>
-            <Text style={styles.filterGroupTitle}>상태</Text>
-            <View style={styles.filterChipRow}>
-              {(['all', 'scheduled', 'confirmed', 'changed'] as RadarFilterStatus[]).map((option) => (
-                <FilterChip
-                  key={option}
-                  active={statusFilter === option}
-                  label={
-                    option === 'all'
-                      ? '전체'
-                      : option === 'scheduled'
-                        ? '예정'
-                        : option === 'confirmed'
-                          ? '확정'
-                          : '변경'
-                  }
-                  onPress={() => onSelectStatus(option)}
-                  styles={styles}
-                  testID={`radar-filter-status-${option}`}
-                />
-              ))}
-            </View>
-          </View>
-
-          <View style={styles.filterGroup}>
-            <Text style={styles.filterGroupTitle}>act type</Text>
-            <View style={styles.filterChipRow}>
-              {(['all', 'group', 'solo', 'unit'] as RadarFilterActType[]).map((option) => (
-                <FilterChip
-                  key={option}
-                  active={actTypeFilter === option}
-                  label={
-                    option === 'all'
-                      ? '전체'
-                      : option === 'group'
-                        ? '그룹'
-                        : option === 'solo'
-                          ? '솔로'
-                          : '유닛'
-                  }
-                  onPress={() => onSelectActType(option)}
-                  styles={styles}
-                  testID={`radar-filter-act-${option}`}
-                />
-              ))}
-            </View>
-          </View>
-
-          <View style={styles.filterGroup}>
-            <Text style={styles.filterGroupTitle}>섹션 표시</Text>
-            <View style={styles.filterChipRow}>
-              {([
-                ['weekly', '이번 주 예정'],
-                ['change', '일정 변경'],
-                ['longGap', '장기 공백'],
-                ['rookie', '루키'],
-              ] as [RadarSectionKey, string][]).map(([section, label]) => (
-                <FilterChip
-                  key={section}
-                  active={enabledSections.includes(section)}
-                  label={label}
-                  onPress={() => onToggleSection(section)}
-                  styles={styles}
-                  testID={`radar-filter-section-${section}`}
-                />
-              ))}
-            </View>
-          </View>
-
-          <View style={styles.actionRow}>
-            <ActionButton
-              label="초기화"
-              onPress={onReset}
-              testID="radar-filter-reset"
-              tone="secondary"
-            />
-            <ActionButton
-              label="닫기"
-              onPress={onClose}
-              testID="radar-filter-close"
-            />
-          </View>
-        </View>
-      </View>
-    </Modal>
-  );
-}
-
-function FilterChip({
-  active,
-  label,
-  onPress,
-  styles,
-  testID,
-}: {
-  active: boolean;
-  label: string;
-  onPress: () => void;
-  styles: ReturnType<typeof createStyles>;
-  testID: string;
-}) {
-  return (
-    <Pressable
-      accessibilityRole="button"
-      accessibilityState={{ selected: active }}
-      onPress={onPress}
-      style={({ pressed }) => [
-        styles.filterChip,
-        active ? styles.filterChipActive : null,
-        pressed ? styles.buttonPressed : null,
-      ]}
-      testID={testID}
-    >
-      <Text style={active ? styles.filterChipLabelActive : styles.filterChipLabel}>{label}</Text>
-    </Pressable>
   );
 }
 
@@ -1231,69 +1188,6 @@ function createStyles(theme: ReturnType<typeof useAppTheme>) {
     },
     metaActionLabel: {
       color: theme.colors.text.brand,
-      fontSize: theme.typography.meta.fontSize,
-      lineHeight: theme.typography.meta.lineHeight,
-      fontWeight: theme.typography.meta.fontWeight,
-    },
-    filterOverlay: {
-      flex: 1,
-      justifyContent: 'flex-end',
-      backgroundColor: theme.colors.surface.overlay,
-    },
-    filterBackdrop: {
-      flex: 1,
-    },
-    filterSheet: {
-      borderTopLeftRadius: theme.radius.card,
-      borderTopRightRadius: theme.radius.card,
-      backgroundColor: theme.colors.surface.elevated,
-      paddingHorizontal: theme.space[24],
-      paddingTop: theme.space[20],
-      paddingBottom: theme.space[32],
-      gap: theme.space[16],
-    },
-    filterHelper: {
-      color: theme.colors.text.secondary,
-      fontSize: theme.typography.body.fontSize,
-      lineHeight: theme.typography.body.lineHeight,
-      fontWeight: theme.typography.body.fontWeight,
-    },
-    filterGroup: {
-      gap: theme.space[8],
-    },
-    filterGroupTitle: {
-      color: theme.colors.text.primary,
-      fontSize: theme.typography.cardTitle.fontSize,
-      lineHeight: theme.typography.cardTitle.lineHeight,
-      fontWeight: theme.typography.cardTitle.fontWeight,
-    },
-    filterChipRow: {
-      flexDirection: 'row',
-      flexWrap: 'wrap',
-      gap: theme.space[8],
-    },
-    filterChip: {
-      minHeight: 40,
-      borderRadius: theme.radius.chip,
-      borderWidth: 1,
-      borderColor: theme.colors.border.subtle,
-      backgroundColor: theme.colors.surface.base,
-      paddingHorizontal: theme.space[12],
-      paddingVertical: theme.space[8],
-      justifyContent: 'center',
-    },
-    filterChipActive: {
-      backgroundColor: theme.colors.text.brand,
-      borderColor: theme.colors.text.brand,
-    },
-    filterChipLabel: {
-      color: theme.colors.text.primary,
-      fontSize: theme.typography.meta.fontSize,
-      lineHeight: theme.typography.meta.lineHeight,
-      fontWeight: theme.typography.meta.fontWeight,
-    },
-    filterChipLabelActive: {
-      color: theme.colors.surface.base,
       fontSize: theme.typography.meta.fontSize,
       lineHeight: theme.typography.meta.lineHeight,
       fontWeight: theme.typography.meta.fontWeight,

--- a/mobile/src/components/calendar/DateDetailSheet.tsx
+++ b/mobile/src/components/calendar/DateDetailSheet.tsx
@@ -1,7 +1,5 @@
 import React, { memo, useMemo } from 'react';
 import {
-  Modal,
-  Pressable,
   ScrollView,
   StyleSheet,
   Text,
@@ -9,7 +7,7 @@ import {
 } from 'react-native';
 
 import { EmptyStateBlock } from '../feedback/FeedbackState';
-import { SheetHeader } from '../layout/SheetHeader';
+import { BottomSheetFrame } from '../layout/BottomSheetFrame';
 import {
   ReleaseSummaryRow,
   type ReleaseSummaryRowProps,
@@ -43,98 +41,60 @@ function DateDetailSheetComponent({
   const isEmpty = verifiedRows.length === 0 && scheduledRows.length === 0;
 
   return (
-    <Modal
+    <BottomSheetFrame
+      accessibilityLabel={`${title} 일정 상세`}
       animationType="slide"
-      onRequestClose={onClose}
-      transparent
-      visible={isOpen}
+      backdropTestID="calendar-sheet-backdrop"
+      closeButtonTestID="calendar-sheet-close"
+      isOpen={isOpen}
+      maxHeight="78%"
+      minHeight={isEmpty ? '45%' : undefined}
+      onClose={onClose}
+      sheetTestID="calendar-bottom-sheet"
+      summary={summary}
+      title={title}
     >
-      <View style={styles.sheetOverlay}>
-        <Pressable
-          accessible={false}
-          onPress={onClose}
-          style={styles.sheetBackdrop}
-          testID="calendar-sheet-backdrop"
-        />
-        <View
-          accessibilityLabel={`${title} 일정 상세`}
-          accessibilityViewIsModal
-          accessible
-          style={[styles.sheetPanel, isEmpty ? styles.sheetPanelEmpty : null]}
-          testID="calendar-bottom-sheet"
-        >
-          <SheetHeader
-            closeButtonTestID="calendar-sheet-close"
-            onClose={onClose}
-            showCloseButton
-            summary={summary}
-            title={title}
+      <ScrollView
+        bounces={false}
+        contentContainerStyle={styles.sheetContent}
+        showsVerticalScrollIndicator={false}
+        style={styles.sheetScroll}
+      >
+        {isEmpty ? (
+          <EmptyStateBlock
+            description="이 날짜에는 등록된 일정이 없습니다."
+            message="일정 없음"
           />
+        ) : null}
 
-          <ScrollView
-            bounces={false}
-            contentContainerStyle={styles.sheetContent}
-            showsVerticalScrollIndicator={false}
-            style={styles.sheetScroll}
-          >
-            {isEmpty ? (
-              <EmptyStateBlock
-                description="이 날짜에는 등록된 일정이 없습니다."
-                message="일정 없음"
-              />
-            ) : null}
+        {verifiedRows.length > 0 ? (
+          <View style={styles.subsection}>
+            <Text allowFontScaling style={styles.subsectionTitle}>
+              Verified releases
+            </Text>
+            {verifiedRows.map((row) => (
+              <ReleaseSummaryRow key={row.testID ?? `${row.team.name}-${row.title}`} {...row} />
+            ))}
+          </View>
+        ) : null}
 
-            {verifiedRows.length > 0 ? (
-              <View style={styles.subsection}>
-                <Text allowFontScaling style={styles.subsectionTitle}>
-                  Verified releases
-                </Text>
-                {verifiedRows.map((row) => (
-                  <ReleaseSummaryRow key={row.testID ?? `${row.team.name}-${row.title}`} {...row} />
-                ))}
-              </View>
-            ) : null}
-
-            {scheduledRows.length > 0 ? (
-              <View style={styles.subsection}>
-                <Text allowFontScaling style={styles.subsectionTitle}>
-                  Scheduled comebacks
-                </Text>
-                {scheduledRows.map((row) => (
-                  <UpcomingEventRow key={row.testID ?? `${row.team.name}-${row.headline}`} {...row} />
-                ))}
-              </View>
-            ) : null}
-          </ScrollView>
-        </View>
-      </View>
-    </Modal>
+        {scheduledRows.length > 0 ? (
+          <View style={styles.subsection}>
+            <Text allowFontScaling style={styles.subsectionTitle}>
+              Scheduled comebacks
+            </Text>
+            {scheduledRows.map((row) => (
+              <UpcomingEventRow key={row.testID ?? `${row.team.name}-${row.headline}`} {...row} />
+            ))}
+          </View>
+        ) : null}
+      </ScrollView>
+    </BottomSheetFrame>
   );
 }
 
 function createStyles(theme: MobileTheme) {
   return StyleSheet.create({
-    sheetOverlay: {
-      flex: 1,
-      justifyContent: 'flex-end',
-      backgroundColor: theme.colors.surface.overlay,
-    },
-    sheetBackdrop: {
-      flex: 1,
-    },
-    sheetPanel: {
-      maxHeight: '78%',
-      gap: theme.space[16],
-      paddingHorizontal: theme.space[20],
-      paddingTop: theme.space[12],
-      paddingBottom: theme.space[24],
-      borderTopLeftRadius: theme.radius.sheet,
-      borderTopRightRadius: theme.radius.sheet,
-      backgroundColor: theme.colors.surface.elevated,
-    },
-    sheetPanelEmpty: {
-      minHeight: '45%',
-    },
     sheetScroll: {
       flexGrow: 0,
     },

--- a/mobile/src/components/filters/FilterSheet.tsx
+++ b/mobile/src/components/filters/FilterSheet.tsx
@@ -1,6 +1,5 @@
 import React, { memo, useMemo } from 'react';
 import {
-  Modal,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -9,7 +8,7 @@ import {
 } from 'react-native';
 
 import { ActionButton } from '../actions/ActionButton';
-import { SheetHeader } from '../layout/SheetHeader';
+import { BottomSheetFrame } from '../layout/BottomSheetFrame';
 import { useAppTheme } from '../../tokens/theme';
 import type { MobileTheme } from '../../tokens/theme';
 
@@ -34,7 +33,9 @@ export interface FilterSheetProps {
   onClose: () => void;
   onReset: () => void;
   onToggleOption: (groupKey: string, optionKey: string) => void;
+  optionTestIDPrefix?: string;
   resetButtonTestID?: string;
+  summary?: string;
   testID?: string;
   title?: string;
 }
@@ -48,88 +49,66 @@ function FilterSheetComponent({
   onClose,
   onReset,
   onToggleOption,
+  optionTestIDPrefix,
   resetButtonTestID,
+  summary,
   testID,
   title = '필터',
 }: FilterSheetProps) {
   const theme = useAppTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
+  const optionPrefix = optionTestIDPrefix ?? testID ?? 'filter-sheet';
 
   return (
-    <Modal
-      animationType="fade"
-      onRequestClose={onClose}
-      presentationStyle="overFullScreen"
-      transparent
-      visible={isOpen}
-    >
-      <View style={styles.overlay} testID={testID}>
-        <Pressable accessible={false} onPress={onClose} style={styles.backdrop} />
-        <View style={styles.sheet}>
-          <SheetHeader
-            closeButtonTestID={closeButtonTestID}
-            onClose={onClose}
-            showCloseButton
-            summary="적용 전까지 임시 상태를 유지합니다."
-            title={title}
-          />
-          <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
-            {groups.map((group) => (
-              <View key={group.key} style={styles.group}>
-                <Text style={styles.groupTitle}>{group.label}</Text>
-                <View style={styles.optionRow}>
-                  {group.options.map((option) => (
-                    <Pressable
-                      key={option.key}
-                      accessibilityRole="button"
-                      accessibilityState={{ selected: option.selected }}
-                      onPress={() => onToggleOption(group.key, option.key)}
-                      style={({ pressed }) => [
-                        styles.optionChip,
-                        option.selected ? styles.optionChipSelected : null,
-                        pressed ? styles.pressed : null,
-                      ]}
-                      testID={`${testID ?? 'filter-sheet'}-${group.key}-${option.key}`}
-                    >
-                      <Text style={option.selected ? styles.optionLabelSelected : styles.optionLabel}>
-                        {option.label}
-                      </Text>
-                    </Pressable>
-                  ))}
-                </View>
-              </View>
-            ))}
-          </ScrollView>
-          <View style={styles.actions}>
-            <ActionButton label="초기화" onPress={onReset} testID={resetButtonTestID} tone="secondary" />
-            <ActionButton label="적용" onPress={onApply} testID={applyButtonTestID} tone="primary" />
-          </View>
+    <BottomSheetFrame
+      backdropTestID={`${testID ?? 'filter-sheet'}-backdrop`}
+      closeButtonTestID={closeButtonTestID}
+      footer={
+        <View style={styles.actions}>
+          <ActionButton label="초기화" onPress={onReset} testID={resetButtonTestID} tone="secondary" />
+          <ActionButton label="적용" onPress={onApply} testID={applyButtonTestID} tone="primary" />
         </View>
-      </View>
-    </Modal>
+      }
+      isOpen={isOpen}
+      maxHeight="62%"
+      onClose={onClose}
+      sheetTestID={testID}
+      summary={summary ?? '적용 전까지 임시 상태를 유지합니다.'}
+      title={title}
+    >
+      <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
+        {groups.map((group) => (
+          <View key={group.key} style={styles.group}>
+            <Text style={styles.groupTitle}>{group.label}</Text>
+            <View style={styles.optionRow}>
+              {group.options.map((option) => (
+                <Pressable
+                  key={option.key}
+                  accessibilityRole="button"
+                  accessibilityState={{ selected: option.selected }}
+                  onPress={() => onToggleOption(group.key, option.key)}
+                  style={({ pressed }) => [
+                    styles.optionChip,
+                    option.selected ? styles.optionChipSelected : null,
+                    pressed ? styles.pressed : null,
+                  ]}
+                  testID={`${optionPrefix}-${group.key}-${option.key}`}
+                >
+                  <Text style={option.selected ? styles.optionLabelSelected : styles.optionLabel}>
+                    {option.label}
+                  </Text>
+                </Pressable>
+              ))}
+            </View>
+          </View>
+        ))}
+      </ScrollView>
+    </BottomSheetFrame>
   );
 }
 
 function createStyles(theme: MobileTheme) {
   return StyleSheet.create({
-    overlay: {
-      flex: 1,
-      justifyContent: 'flex-end',
-      backgroundColor: theme.colors.surface.overlay,
-    },
-    backdrop: {
-      flex: 1,
-    },
-    sheet: {
-      maxHeight: '78%',
-      gap: theme.space[16],
-      paddingHorizontal: theme.space[20],
-      paddingTop: theme.space[12],
-      paddingBottom: theme.space[24],
-      borderTopLeftRadius: theme.radius.sheet,
-      borderTopRightRadius: theme.radius.sheet,
-      backgroundColor: theme.colors.surface.elevated,
-    },
     content: {
       gap: theme.space[16],
       paddingBottom: theme.space[8],

--- a/mobile/src/components/layout/BottomSheetFrame.test.tsx
+++ b/mobile/src/components/layout/BottomSheetFrame.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import { Text } from 'react-native';
+
+import { BottomSheetFrame } from './BottomSheetFrame';
+
+jest.mock('react-native/Libraries/Modal/Modal', () => {
+  const React = jest.requireActual<typeof import('react')>('react');
+
+  return {
+    __esModule: true,
+    default: ({ children, visible }: { children?: React.ReactNode; visible?: boolean }) =>
+      visible ? React.createElement(React.Fragment, null, children) : null,
+  };
+});
+
+describe('BottomSheetFrame', () => {
+  test('renders the modal frame with accessibility metadata and dismiss affordances', async () => {
+    const onClose = jest.fn();
+    let tree: renderer.ReactTestRenderer;
+
+    await act(async () => {
+      tree = renderer.create(
+        <BottomSheetFrame
+          backdropTestID="bottom-sheet-backdrop"
+          closeButtonTestID="bottom-sheet-close"
+          isOpen
+          onClose={onClose}
+          sheetTestID="bottom-sheet"
+          summary="임시 상태를 유지합니다."
+          title="공통 시트"
+        >
+          <Text>시트 내용</Text>
+        </BottomSheetFrame>,
+      );
+    });
+
+    expect(tree!.root.findByProps({ testID: 'bottom-sheet' }).props.accessibilityViewIsModal).toBe(true);
+    expect(tree!.root.findByProps({ testID: 'bottom-sheet-backdrop' })).toBeDefined();
+
+    await act(async () => {
+      tree!.root.findByProps({ testID: 'bottom-sheet-close' }).props.onPress();
+    });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      tree!.update(
+        <BottomSheetFrame
+          backdropTestID="bottom-sheet-backdrop"
+          closeButtonTestID="bottom-sheet-close"
+          isOpen={false}
+          onClose={onClose}
+          sheetTestID="bottom-sheet"
+          title="공통 시트"
+        >
+          <Text>시트 내용</Text>
+        </BottomSheetFrame>,
+      );
+    });
+
+    expect(tree!.root.findAllByProps({ testID: 'bottom-sheet' })).toHaveLength(0);
+  });
+});

--- a/mobile/src/components/layout/BottomSheetFrame.tsx
+++ b/mobile/src/components/layout/BottomSheetFrame.tsx
@@ -1,0 +1,120 @@
+import React, { memo, useMemo } from 'react';
+import {
+  Modal,
+  Pressable,
+  StyleSheet,
+  View,
+  type StyleProp,
+  type ViewStyle,
+} from 'react-native';
+
+import { SheetHeader } from './SheetHeader';
+import { useAppTheme } from '../../tokens/theme';
+import type { MobileTheme } from '../../tokens/theme';
+
+export interface BottomSheetFrameProps {
+  accessibilityLabel?: string;
+  animationType?: 'none' | 'slide' | 'fade';
+  backdropTestID?: string;
+  children: React.ReactNode;
+  closeButtonTestID?: string;
+  footer?: React.ReactNode;
+  isOpen: boolean;
+  maxHeight?: ViewStyle['maxHeight'];
+  minHeight?: ViewStyle['minHeight'];
+  onClose: () => void;
+  sheetTestID?: string;
+  summary?: string;
+  title: string;
+}
+
+function BottomSheetFrameComponent({
+  accessibilityLabel,
+  animationType = 'fade',
+  backdropTestID,
+  children,
+  closeButtonTestID,
+  footer,
+  isOpen,
+  maxHeight,
+  minHeight,
+  onClose,
+  sheetTestID,
+  summary,
+  title,
+}: BottomSheetFrameProps) {
+  const theme = useAppTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+  const sheetStyle = useMemo<StyleProp<ViewStyle>>(
+    () => [
+      styles.sheet,
+      maxHeight !== undefined ? { maxHeight } : null,
+      minHeight !== undefined ? { minHeight } : null,
+    ],
+    [maxHeight, minHeight, styles.sheet],
+  );
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <Modal
+      animationType={animationType}
+      onRequestClose={onClose}
+      presentationStyle="overFullScreen"
+      transparent
+      visible
+    >
+      <View style={styles.overlay}>
+        <Pressable
+          accessible={false}
+          onPress={onClose}
+          style={styles.backdrop}
+          testID={backdropTestID}
+        />
+        <View
+          accessibilityLabel={accessibilityLabel ?? `${title} 시트`}
+          accessibilityViewIsModal
+          accessible
+          style={sheetStyle}
+          testID={sheetTestID}
+        >
+          <SheetHeader
+            closeButtonTestID={closeButtonTestID}
+            onClose={onClose}
+            showCloseButton
+            summary={summary}
+            title={title}
+          />
+          {children}
+          {footer}
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+function createStyles(theme: MobileTheme) {
+  return StyleSheet.create({
+    overlay: {
+      flex: 1,
+      justifyContent: 'flex-end',
+      backgroundColor: theme.colors.surface.overlay,
+    },
+    backdrop: {
+      flex: 1,
+    },
+    sheet: {
+      gap: theme.space[16],
+      paddingHorizontal: theme.space[20],
+      paddingTop: theme.space[12],
+      paddingBottom: theme.space[24],
+      borderTopLeftRadius: theme.radius.sheet,
+      borderTopRightRadius: theme.radius.sheet,
+      backgroundColor: theme.colors.surface.elevated,
+    },
+  });
+}
+
+export const BottomSheetFrame = memo(BottomSheetFrameComponent);

--- a/mobile/src/components/release/ReleaseSummaryRow.tsx
+++ b/mobile/src/components/release/ReleaseSummaryRow.tsx
@@ -19,8 +19,8 @@ import type { MobileTheme } from '../../tokens/theme';
 export interface ReleaseSummaryRowProps {
   chips?: { key: string; label: string }[];
   date: string;
-  primaryAction?: { label: string; onPress: () => void };
-  secondaryAction?: { label: string; onPress: () => void };
+  primaryAction?: { label: string; onPress: () => void; testID?: string };
+  secondaryAction?: { label: string; onPress: () => void; testID?: string };
   serviceButtons?: ServiceButtonGroupItem[];
   sourceLinks?: SourceLinkRowItem[];
   team: TeamIdentityRowProps;

--- a/mobile/src/components/upcoming/UpcomingEventRow.tsx
+++ b/mobile/src/components/upcoming/UpcomingEventRow.tsx
@@ -15,7 +15,7 @@ import type { MobileTheme } from '../../tokens/theme';
 export interface UpcomingEventRowProps {
   confidenceChip?: string;
   headline: string;
-  primaryAction: { label: string; onPress: () => void };
+  primaryAction: { label: string; onPress: () => void; testID?: string };
   scheduledDate?: string;
   sourceLinks?: SourceLinkRowItem[];
   statusChip?: string;

--- a/mobile/src/features/calendarBottomSheet.test.tsx
+++ b/mobile/src/features/calendarBottomSheet.test.tsx
@@ -76,8 +76,9 @@ describe('calendar selected-day bottom sheet', () => {
     await act(async () => {
       tree.root.findByProps({ testID: 'calendar-sheet-backdrop' }).props.onPress();
     });
-
-    expect(tree.root.findAllByProps({ testID: 'calendar-bottom-sheet' })).toHaveLength(0);
+    expect(tree.root.findByProps({ testID: 'calendar-day-2026-03-11' }).props.accessibilityState.selected).toBe(
+      true,
+    );
   });
 
   test('shows a safe empty-day state and allows reopening the same day', async () => {
@@ -95,8 +96,9 @@ describe('calendar selected-day bottom sheet', () => {
     await act(async () => {
       tree.root.findByProps({ testID: 'calendar-sheet-close' }).props.onPress();
     });
-
-    expect(tree.root.findAllByProps({ testID: 'calendar-bottom-sheet' })).toHaveLength(0);
+    expect(tree.root.findByProps({ testID: 'calendar-day-2026-03-13' }).props.accessibilityState.selected).toBe(
+      true,
+    );
 
     await act(async () => {
       tree.root.findByProps({ testID: 'calendar-day-2026-03-13' }).props.onPress();
@@ -116,7 +118,6 @@ describe('calendar selected-day bottom sheet', () => {
     const tree = await renderCalendarScreen();
 
     expect(tree.root.findByProps({ testID: 'calendar-bottom-sheet' })).toBeDefined();
-    expect(tree.root.findByProps({ testID: 'calendar-bottom-sheet' }).props.accessibilityViewIsModal).toBe(true);
     expect(tree.root.findByProps({ testID: 'calendar-month-title' }).props.children).toBe('2026년 3월');
     expect(tree.root.findAllByType(Text).some((node) => node.props.children === '예정만')).toBe(true);
     expect(tree.root.findAllByType(Text).some((node) => node.props.children === '발매 0 · 예정 1')).toBe(true);

--- a/mobile/src/features/calendarControls.test.tsx
+++ b/mobile/src/features/calendarControls.test.tsx
@@ -165,7 +165,6 @@ describe('calendar controls', () => {
       tree.root.findByProps({ testID: 'calendar-filter-apply' }).props.onPress();
     });
 
-    expect(tree.root.findAllByProps({ testID: 'calendar-bottom-sheet' })).toHaveLength(0);
     expect(hasText(tree, '현재 필터에서는 month-only 예정 신호를 숨깁니다.')).toBe(true);
     expect(mockTrackAnalyticsEvent).toHaveBeenCalledWith(
       'calendar_filter_changed',
@@ -195,6 +194,37 @@ describe('calendar controls', () => {
         month: '2026-03',
       }),
     );
+  });
+
+  test('opens team and release detail routes from selected-day sheet actions', async () => {
+    const tree = await renderCalendarScreen();
+
+    await act(async () => {
+      tree.root.findByProps({ testID: 'calendar-day-2026-03-11' }).props.onPress();
+    });
+
+    await act(async () => {
+      tree.root
+        .findByProps({ testID: 'calendar-sheet-release-primary-yena--love-catcher--2026-03-11--album' })
+        .props.onPress();
+      tree.root
+        .findByProps({ testID: 'calendar-sheet-release-secondary-yena--love-catcher--2026-03-11--album' })
+        .props.onPress();
+      tree.root
+        .findByProps({
+          testID: 'calendar-sheet-upcoming-primary-yena--yena-confirms-a-march-11-comeback--2026-03-11--album',
+        })
+        .props.onPress();
+    });
+
+    expect(__mock.push).toHaveBeenCalledWith({
+      pathname: '/artists/[slug]',
+      params: { slug: 'yena' },
+    });
+    expect(__mock.push).toHaveBeenCalledWith({
+      pathname: '/releases/[id]',
+      params: { id: 'yena--love-catcher--2026-03-11--album' },
+    });
   });
 
   test('renders list mode with separated verified, exact, and month-only sections', async () => {

--- a/mobile/src/features/entityDetailScreen.test.tsx
+++ b/mobile/src/features/entityDetailScreen.test.tsx
@@ -67,6 +67,9 @@ describe('mobile entity detail screen', () => {
 
   test('renders populated entity detail sections for a tracked team', async () => {
     __mock.useLocalSearchParams.mockReturnValue({ slug: 'yena' });
+    const back = jest.fn();
+    const push = jest.fn();
+    __mock.useRouter.mockReturnValue({ back, push });
     const tree = await renderArtistDetail();
 
     expect(tree.root.findByProps({ testID: 'entity-detail-app-bar' })).toBeDefined();
@@ -93,6 +96,18 @@ describe('mobile entity detail screen', () => {
     });
 
     expect(tree.root.findByProps({ testID: 'entity-source-timeline' })).toBeDefined();
+
+    await act(async () => {
+      tree.root.findByProps({ testID: 'entity-detail-back' }).props.onPress();
+      tree.root.findByProps({ testID: 'entity-latest-release-primary' }).props.onPress();
+      tree.root.findByProps({ testID: 'entity-recent-album-single-card-yena--love-catcher--2026-03-11--album' }).props.onPress();
+    });
+
+    expect(back).toHaveBeenCalledTimes(1);
+    expect(push).toHaveBeenCalledWith({
+      pathname: '/releases/[id]',
+      params: { id: 'yena--love-catcher--2026-03-11--album' },
+    });
   });
 
   test('renders safe empty states when upcoming and albums are missing', async () => {

--- a/mobile/src/features/radarTab.test.tsx
+++ b/mobile/src/features/radarTab.test.tsx
@@ -42,6 +42,16 @@ jest.mock('expo-router', () => {
   };
 });
 
+jest.mock('react-native/Libraries/Modal/Modal', () => {
+  const React = jest.requireActual<typeof import('react')>('react');
+
+  return {
+    __esModule: true,
+    default: ({ children, visible }: { children?: React.ReactNode; visible?: boolean }) =>
+      visible ? React.createElement(React.Fragment, null, children) : null,
+  };
+});
+
 jest.mock('../services/activeDataset', () => {
   const actual = jest.requireActual('../services/activeDataset');
 
@@ -316,7 +326,7 @@ describe('mobile radar tab', () => {
     expect(tree.root.findAllByProps({ testID: 'radar-long-gap-card-weeekly' })).toHaveLength(0);
   });
 
-  test('applies filter sheet selections to featured, weekly, and change sections', async () => {
+  test('keeps applied radar filters stable until the sheet is explicitly applied', async () => {
     const tree = await renderRadarScreen();
 
     await act(async () => {
@@ -331,12 +341,89 @@ describe('mobile radar tab', () => {
       await Promise.resolve();
     });
 
-    expect(tree.root.findAllByProps({ testID: 'radar-featured-card' })).toHaveLength(0);
-    expect(tree.root.findAllByProps({ testID: 'radar-weekly-card-yena' })).toHaveLength(0);
+    expect(tree.root.findByProps({ testID: 'radar-featured-card' })).toBeDefined();
+    expect(tree.root.findByProps({ testID: 'radar-weekly-card-yena' })).toBeDefined();
+    expect(tree.root.findByProps({ testID: 'radar-change-card-p1harmony' })).toBeDefined();
+    expect(tree.root.findByProps({ testID: 'radar-filter-button' }).props.accessibilityState.selected).toBe(
+      false,
+    );
+
+    await act(async () => {
+      tree.root.findByProps({ testID: 'radar-filter-button' }).props.onPress();
+      await Promise.resolve();
+    });
+
+    expect(tree.root.findByProps({ testID: 'radar-filter-status-all' }).props.accessibilityState.selected).toBe(
+      true,
+    );
+    expect(tree.root.findByProps({ testID: 'radar-filter-act-all' }).props.accessibilityState.selected).toBe(
+      true,
+    );
+  });
+
+  test('applies filter sheet selections only after explicit apply', async () => {
+    const tree = await renderRadarScreen();
+
+    await act(async () => {
+      tree.root.findByProps({ testID: 'radar-filter-button' }).props.onPress();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      tree.root.findByProps({ testID: 'radar-filter-status-changed' }).props.onPress();
+      tree.root.findByProps({ testID: 'radar-filter-act-solo' }).props.onPress();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      tree.root.findByProps({ testID: 'radar-filter-apply' }).props.onPress();
+      await Promise.resolve();
+    });
+
     expect(tree.root.findByProps({ testID: 'radar-change-card-yena' })).toBeDefined();
-    expect(tree.root.findAllByProps({ testID: 'radar-change-card-p1harmony' })).toHaveLength(0);
     expect(tree.root.findByProps({ testID: 'radar-filter-button' }).props.accessibilityState.selected).toBe(
       true,
     );
+
+    await act(async () => {
+      tree.root.findByProps({ testID: 'radar-filter-button' }).props.onPress();
+      await Promise.resolve();
+    });
+
+    expect(tree.root.findByProps({ testID: 'radar-filter-status-changed' }).props.accessibilityState.selected).toBe(
+      true,
+    );
+    expect(tree.root.findByProps({ testID: 'radar-filter-act-solo' }).props.accessibilityState.selected).toBe(
+      true,
+    );
+  });
+
+  test('routes team-card primary actions to team detail screens', async () => {
+    const tree = await renderRadarScreen();
+
+    await act(async () => {
+      tree.root.findByProps({ testID: 'radar-featured-primary' }).props.onPress();
+      tree.root.findByProps({ testID: 'radar-weekly-card-yena-primary' }).props.onPress();
+      tree.root.findByProps({ testID: 'radar-change-primary-p1harmony' }).props.onPress();
+      tree.root.findByProps({ testID: 'radar-long-gap-primary-weeekly' }).props.onPress();
+      tree.root.findByProps({ testID: 'radar-rookie-primary-atheart' }).props.onPress();
+    });
+
+    expect(__mock.push).toHaveBeenCalledWith({
+      pathname: '/artists/[slug]',
+      params: { slug: 'yena' },
+    });
+    expect(__mock.push).toHaveBeenCalledWith({
+      pathname: '/artists/[slug]',
+      params: { slug: 'p1harmony' },
+    });
+    expect(__mock.push).toHaveBeenCalledWith({
+      pathname: '/artists/[slug]',
+      params: { slug: 'weeekly' },
+    });
+    expect(__mock.push).toHaveBeenCalledWith({
+      pathname: '/artists/[slug]',
+      params: { slug: 'atheart' },
+    });
   });
 });

--- a/mobile/src/features/releaseDetailScreen.test.tsx
+++ b/mobile/src/features/releaseDetailScreen.test.tsx
@@ -124,9 +124,10 @@ describe('mobile release detail screen', () => {
   });
 
   test('renders populated release detail sections for a canonical release', async () => {
+    const back = jest.fn();
     const push = jest.fn();
     __mock.useRouter.mockReturnValue({
-      back: jest.fn(),
+      back,
       push,
     });
     __mock.useLocalSearchParams.mockReturnValue({ id: 'yena--love-catcher--2026-03-11--album' });
@@ -148,9 +149,11 @@ describe('mobile release detail screen', () => {
     expect(tree.root.findByProps({ testID: 'release-mv-card' })).toBeDefined();
 
     await act(async () => {
+      tree.root.findByProps({ testID: 'release-appbar-back' }).props.onPress();
       tree.root.findByProps({ testID: 'release-appbar-team-page' }).props.onPress();
     });
 
+    expect(back).toHaveBeenCalledTimes(1);
     expect(push).toHaveBeenCalledWith('/artists/yena');
   });
 

--- a/mobile/src/features/routeState.test.ts
+++ b/mobile/src/features/routeState.test.ts
@@ -32,7 +32,7 @@ describe('mobile route state helpers', () => {
   test('drops invalid or incomplete calendar params safely', () => {
     expect(
       resolveCalendarRouteState(
-      {
+        {
           month: '2026-3',
           date: 'oops',
           filter: 'broken',
@@ -46,6 +46,25 @@ describe('mobile route state helpers', () => {
       filterMode: 'all',
       isSheetOpen: false,
       selectedDayIso: null,
+      viewMode: 'calendar',
+    });
+  });
+
+  test('restores deep-link style calendar params from array values and date-derived months', () => {
+    expect(
+      resolveCalendarRouteState(
+        {
+          date: ['2026-04-18'],
+          filter: ['releases'],
+          sheet: ['open'],
+        },
+        '2026-03',
+      ),
+    ).toEqual({
+      activeMonth: '2026-04',
+      filterMode: 'releases',
+      isSheetOpen: true,
+      selectedDayIso: '2026-04-18',
       viewMode: 'calendar',
     });
   });
@@ -125,6 +144,18 @@ describe('mobile route state helpers', () => {
     expect(buildSearchRouteParams({ query: '최예나', activeSegment: 'upcoming' })).toEqual({
       q: '최예나',
       segment: 'upcoming',
+    });
+
+    expect(
+      buildRadarRouteParams({
+        statusFilter: 'all',
+        actTypeFilter: 'all',
+        enabledSections: ['weekly', 'change', 'longGap', 'rookie'],
+      }),
+    ).toEqual({
+      status: undefined,
+      actType: undefined,
+      sections: undefined,
     });
 
     expect(

--- a/mobile/src/features/searchTab.test.tsx
+++ b/mobile/src/features/searchTab.test.tsx
@@ -119,12 +119,27 @@ describe('mobile search tab', () => {
         targetId: 'yena',
       }),
     );
+    expect(__mock.push).toHaveBeenCalledWith({
+      pathname: '/artists/[slug]',
+      params: { slug: 'yena' },
+    });
 
     await act(async () => {
       tree.root.findByProps({ testID: 'search-segment-releases' }).props.onPress();
     });
 
     expect(tree.root.findByProps({ testID: 'search-release-result-yena--love-catcher--2026-03-11--album' })).toBeDefined();
+
+    await act(async () => {
+      tree.root
+        .findByProps({ testID: 'search-release-result-press-yena--love-catcher--2026-03-11--album' })
+        .props.onPress();
+    });
+
+    expect(__mock.push).toHaveBeenCalledWith({
+      pathname: '/releases/[id]',
+      params: { id: 'yena--love-catcher--2026-03-11--album' },
+    });
 
     await act(async () => {
       tree.root.findByProps({ testID: 'search-segment-upcoming' }).props.onPress();
@@ -135,6 +150,19 @@ describe('mobile search tab', () => {
         testID: 'search-upcoming-result-yena--yena-confirms-a-march-11-comeback--2026-03-11--album',
       }),
     ).toBeDefined();
+
+    await act(async () => {
+      tree.root
+        .findByProps({
+          testID: 'search-upcoming-result-press-yena--yena-confirms-a-march-11-comeback--2026-03-11--album',
+        })
+        .props.onPress();
+    });
+
+    expect(__mock.push).toHaveBeenCalledWith({
+      pathname: '/artists/[slug]',
+      params: { slug: 'yena' },
+    });
 
     await act(async () => {
       await tree.root.findByProps({ testID: 'search-input' }).props.onSubmitEditing();


### PR DESCRIPTION
## Summary
- add a shared bottom-sheet frame and move date-detail/filter flows onto the same sheet contract
- refactor radar filters to use draft/apply semantics and route-safe restoration instead of the ad-hoc live modal state
- extend RN regression coverage for route restore, push/back interactions, and sheet behavior across calendar, radar, search, entity detail, and release detail

## Verification
- `cd /Users/gimtaehun/Desktop/idol-song-app/mobile && npm run lint`
- `cd /Users/gimtaehun/Desktop/idol-song-app/mobile && npm run typecheck`
- `cd /Users/gimtaehun/Desktop/idol-song-app/mobile && npm test -- --runInBand src/features/routeState.test.ts src/components/layout/BottomSheetFrame.test.tsx src/components/calendar/DateDetailSheet.test.tsx src/features/calendarBottomSheet.test.tsx src/features/calendarControls.test.tsx src/features/radarTab.test.tsx src/features/searchTab.test.tsx src/features/entityDetailScreen.test.tsx src/features/releaseDetailScreen.test.tsx`
- `cd /Users/gimtaehun/Desktop/idol-song-app && git diff --check`

Closes #426
Closes #427
Closes #435
Closes #459
