### PR TITLE
[RN] Align layout constraints and copy rules

### DIFF
--- a/mobile/app/(tabs)/calendar.tsx
+++ b/mobile/app/(tabs)/calendar.tsx
@@ -37,6 +37,12 @@ import {
 } from '../../src/features/routeState';
 import { useActiveDatasetScreen } from '../../src/features/useActiveDatasetScreen';
 import { selectCalendarMonthSnapshot } from '../../src/selectors';
+import {
+  MOBILE_COPY,
+  resolveSourceLinkLabel,
+  resolveUpcomingConfidenceLabel,
+  resolveUpcomingStatusLabel,
+} from '../../src/copy/mobileCopy';
 import { loadActiveMobileDataset } from '../../src/services/activeDataset';
 import {
   adaptBackendCalendarMonth,
@@ -65,9 +71,7 @@ import type { SourceLinkRowItem } from '../../src/components/meta/SourceLinkRow'
 import type {
   CalendarMonthSnapshotModel,
   ReleaseSummaryModel,
-  UpcomingConfidence,
   UpcomingEventModel,
-  UpcomingStatus,
 } from '../../src/types';
 
 function buildMonthKey(date: Date): string {
@@ -118,32 +122,6 @@ function formatReleaseKindChip(release: ReleaseSummaryModel): string | null {
   return value ? value.toUpperCase() : null;
 }
 
-function formatUpcomingStatus(status?: UpcomingStatus): string | undefined {
-  switch (status) {
-    case 'confirmed':
-      return '확정';
-    case 'rumor':
-      return '루머';
-    case 'scheduled':
-      return '예정';
-    default:
-      return undefined;
-  }
-}
-
-function formatUpcomingConfidence(confidence?: UpcomingConfidence): string | undefined {
-  switch (confidence) {
-    case 'high':
-      return '신뢰 높음';
-    case 'medium':
-      return '신뢰 중간';
-    case 'low':
-      return '신뢰 낮음';
-    default:
-      return undefined;
-  }
-}
-
 function formatUpcomingLabel(event: UpcomingEventModel): string {
   if (event.datePrecision === 'exact' && event.scheduledDate) {
     return formatExactDateLabel(event.scheduledDate);
@@ -153,7 +131,7 @@ function formatUpcomingLabel(event: UpcomingEventModel): string {
     return formatMonthOnlyLabel(event.scheduledMonth);
   }
 
-  return '날짜 미정';
+  return MOBILE_COPY.date.unknown;
 }
 
 function applyCalendarFilter(
@@ -262,7 +240,7 @@ export default function CalendarTabScreen() {
     surface: 'calendar',
     reloadKey: reloadCount,
     cacheKey: `calendar:${activeMonth}:${todayIsoDate}`,
-    fallbackErrorMessage: 'Calendar dataset could not be loaded right now.',
+    fallbackErrorMessage: '캘린더 데이터를 지금 불러오지 못했습니다.',
     loadBundled: loadBundledSnapshot,
     loadBackend: loadBackendSnapshot,
   });
@@ -616,7 +594,7 @@ export default function CalendarTabScreen() {
     return [
       {
         key: `${release.id}-source`,
-        label: '출처 보기',
+        label: MOBILE_COPY.action.sourceView,
         onPress: () => void openExternalUrl(release.sourceUrl),
         type: 'source',
         url: release.sourceUrl,
@@ -632,7 +610,7 @@ export default function CalendarTabScreen() {
     return [
       {
         key: `${event.id}-source`,
-        label: '기사/공식 공지',
+        label: resolveSourceLinkLabel(event.sourceType),
         onPress: () => void openExternalUrl(event.sourceUrl),
         type: 'source',
         url: event.sourceUrl,
@@ -650,12 +628,12 @@ export default function CalendarTabScreen() {
       chips: kindChip ? [{ key: `${release.id}-kind`, label: kindChip }] : [],
       date: formatExactDateLabel(release.releaseDate),
       primaryAction: {
-        label: '팀 페이지',
+        label: MOBILE_COPY.action.teamPage,
         onPress: () => openTeamDetailByGroup(release.group),
         testID: `${testPrefix}-primary-${release.id}`,
       },
       secondaryAction: {
-        label: '상세 보기',
+        label: MOBILE_COPY.action.detailView,
         onPress: () => openReleaseDetail(release.id),
         testID: `${testPrefix}-secondary-${release.id}`,
       },
@@ -676,16 +654,16 @@ export default function CalendarTabScreen() {
     testPrefix: string,
   ): UpcomingEventRowProps {
     return {
-      confidenceChip: formatUpcomingConfidence(event.confidence),
+      confidenceChip: resolveUpcomingConfidenceLabel(event.confidence),
       headline: event.releaseLabel ?? event.headline,
       primaryAction: {
-        label: '팀 페이지',
+        label: MOBILE_COPY.action.teamPage,
         onPress: () => openTeamDetailByGroup(event.group),
         testID: `${testPrefix}-primary-${event.id}`,
       },
       scheduledDate: formatUpcomingLabel(event),
       sourceLinks: buildUpcomingSourceLinks(event),
-      statusChip: formatUpcomingStatus(event.status),
+      statusChip: resolveUpcomingStatusLabel(event.status),
       team: {
         monogram: buildTeamMonogram(event.displayGroup),
         name: event.displayGroup,
@@ -764,7 +742,7 @@ export default function CalendarTabScreen() {
     return (
       <ScreenFeedbackState
         body="현재 월 데이터와 예정 신호를 불러오는 중입니다."
-        eyebrow="DATASET LOADING"
+        eyebrow="데이터 로딩"
         title="캘린더"
         variant="loading"
       />
@@ -775,11 +753,11 @@ export default function CalendarTabScreen() {
     return (
       <ScreenFeedbackState
         action={{
-          label: '다시 시도',
+          label: MOBILE_COPY.action.retry,
           onPress: () => setReloadCount((count) => count + 1),
         }}
         body={datasetState.message}
-        eyebrow="LOAD ERROR"
+        eyebrow="로드 오류"
         title="캘린더"
         variant="error"
       />
@@ -790,7 +768,7 @@ export default function CalendarTabScreen() {
     return (
       <ScreenFeedbackState
         body="현재 월 데이터를 찾지 못했습니다."
-        eyebrow="EMPTY MONTH"
+        eyebrow="빈 월"
         title="캘린더"
         variant="empty"
       />
@@ -970,12 +948,12 @@ export default function CalendarTabScreen() {
           <View style={styles.sectionCard}>
             <View style={styles.sectionHeader}>
               <Text accessibilityRole="header" style={styles.sectionTitle}>
-                Month-only signals
+                월 단위 예정 신호
               </Text>
               <Text style={styles.sectionMeta}>{filteredSnapshot.monthOnlyUpcoming.length}건</Text>
             </View>
             {filterMode === 'releases' ? (
-              <InlineFeedbackNotice body="현재 필터에서는 month-only 예정 신호를 숨깁니다." />
+              <InlineFeedbackNotice body="현재 필터에서는 월 단위 예정 신호를 숨깁니다." />
             ) : listMonthOnlyRows.length > 0 ? (
               <View style={styles.sectionStack}>
                 {listMonthOnlyRows.map((row) => (
@@ -983,7 +961,7 @@ export default function CalendarTabScreen() {
                 ))}
               </View>
             ) : (
-              <InlineFeedbackNotice body="현재 월에 month-only 예정 신호가 없습니다." />
+              <InlineFeedbackNotice body="현재 월에 월 단위 예정 신호가 없습니다." />
             )}
           </View>
         ) : null}
@@ -994,7 +972,7 @@ export default function CalendarTabScreen() {
               <View style={styles.sectionCard}>
                 <View style={styles.sectionHeader}>
                   <Text accessibilityRole="header" style={styles.sectionTitle}>
-                    Verified releases
+                    검증된 발매
                   </Text>
                   <Text style={styles.sectionMeta}>{listReleaseRows.length}건</Text>
                 </View>
@@ -1014,7 +992,7 @@ export default function CalendarTabScreen() {
               <View style={styles.sectionCard}>
                 <View style={styles.sectionHeader}>
                   <Text accessibilityRole="header" style={styles.sectionTitle}>
-                    Scheduled comebacks
+                    날짜가 잡힌 예정 컴백
                   </Text>
                   <Text style={styles.sectionMeta}>{listExactUpcomingRows.length}건</Text>
                 </View>
@@ -1025,7 +1003,7 @@ export default function CalendarTabScreen() {
                     ))}
                   </View>
                 ) : (
-                  <InlineFeedbackNotice body="현재 월에 exact 예정 컴백이 없습니다." />
+                  <InlineFeedbackNotice body="현재 월에 날짜가 잡힌 예정 컴백이 없습니다." />
                 )}
               </View>
             ) : null}
@@ -1033,12 +1011,12 @@ export default function CalendarTabScreen() {
             <View style={styles.sectionCard}>
               <View style={styles.sectionHeader}>
                 <Text accessibilityRole="header" style={styles.sectionTitle}>
-                  Month-only signals
+                  월 단위 예정 신호
                 </Text>
                 <Text style={styles.sectionMeta}>{listMonthOnlyRows.length}건</Text>
               </View>
               {filterMode === 'releases' ? (
-                <InlineFeedbackNotice body="현재 필터에서는 month-only 예정 신호를 숨깁니다." />
+                <InlineFeedbackNotice body="현재 필터에서는 월 단위 예정 신호를 숨깁니다." />
               ) : listMonthOnlyRows.length > 0 ? (
                 <View style={styles.sectionStack}>
                   {listMonthOnlyRows.map((row) => (
@@ -1046,7 +1024,7 @@ export default function CalendarTabScreen() {
                   ))}
                 </View>
               ) : (
-                <InlineFeedbackNotice body="현재 월에 month-only 예정 신호가 없습니다." />
+                <InlineFeedbackNotice body="현재 월에 월 단위 예정 신호가 없습니다." />
               )}
             </View>
           </View>
@@ -1119,7 +1097,7 @@ function createStyles(theme: ReturnType<typeof useAppTheme>) {
       justifyContent: 'flex-end',
     },
     headerButton: {
-      minHeight: 40,
+      minHeight: theme.size.button.heightSecondary,
       justifyContent: 'center',
       paddingHorizontal: theme.space[12],
       paddingVertical: theme.space[8],

--- a/mobile/app/(tabs)/radar.tsx
+++ b/mobile/app/(tabs)/radar.tsx
@@ -38,6 +38,12 @@ import {
 } from '../../src/services/analytics';
 import { openExternalLink, normalizeExternalLinkUrl } from '../../src/services/externalLinks';
 import { useAppTheme } from '../../src/tokens/theme';
+import {
+  MOBILE_COPY,
+  formatUpcomingDateLabel as formatUpcomingScheduleLabel,
+  resolveUpcomingConfidenceLabel,
+  resolveUpcomingStatusWithFallback,
+} from '../../src/copy/mobileCopy';
 import type {
   RadarChangeFeedItemModel,
   RadarLongGapItemModel,
@@ -56,43 +62,18 @@ function resolveBadgeLabel(team: TeamSummaryModel): string {
 }
 
 function resolveUpcomingStatusLabel(status?: UpcomingStatus): string {
-  if (status === 'confirmed') {
-    return '확정';
-  }
-
-  if (status === 'rumor') {
-    return '루머';
-  }
-
-  return '예정';
+  return resolveUpcomingStatusWithFallback(status);
 }
 
 function resolveConfidenceLabel(confidence?: UpcomingConfidence): string | null {
-  if (confidence === 'high') {
-    return '신뢰도 높음';
-  }
-
-  if (confidence === 'medium') {
-    return '신뢰도 보통';
-  }
-
-  if (confidence === 'low') {
-    return '신뢰도 낮음';
-  }
-
-  return null;
+  return resolveUpcomingConfidenceLabel(confidence) ?? null;
 }
 
 function formatUpcomingDateLabel(item: RadarUpcomingCardModel): string {
-  if (item.upcoming.scheduledDate) {
-    return item.upcoming.scheduledDate;
-  }
-
-  if (item.upcoming.scheduledMonth) {
-    return `${item.upcoming.scheduledMonth} · 날짜 미정`;
-  }
-
-  return '날짜 미정';
+  return formatUpcomingScheduleLabel({
+    scheduledDate: item.upcoming.scheduledDate,
+    scheduledMonth: item.upcoming.scheduledMonth,
+  });
 }
 
 function formatFeaturedBody(item: RadarUpcomingCardModel): string {
@@ -300,7 +281,7 @@ export default function RadarTabScreen() {
     surface: 'radar',
     reloadKey: reloadCount,
     cacheKey: `radar:${todayIsoDate}`,
-    fallbackErrorMessage: 'Radar dataset could not be loaded right now.',
+    fallbackErrorMessage: '레이더 데이터를 지금 불러오지 못했습니다.',
     loadBundled: loadBundledSnapshot,
     loadBackend: loadBackendSnapshot,
   });
@@ -500,7 +481,7 @@ export default function RadarTabScreen() {
     return (
       <ScreenFeedbackState
         body="가장 가까운 컴백과 레이더 요약을 불러오는 중입니다."
-        eyebrow="DATA-BACKED TAB"
+        eyebrow="데이터 로딩"
         title="레이더"
         variant="loading"
       />
@@ -511,12 +492,12 @@ export default function RadarTabScreen() {
     return (
       <ScreenFeedbackState
         action={{
-          label: '다시 시도',
+          label: MOBILE_COPY.action.retry,
           onPress: () => setReloadCount((count) => count + 1),
           testID: 'radar-error-retry',
         }}
         body={datasetState.message}
-        eyebrow="LOAD ERROR"
+        eyebrow="로드 오류"
         title="레이더"
         variant="error"
       />
@@ -527,7 +508,7 @@ export default function RadarTabScreen() {
     return (
       <ScreenFeedbackState
         body="레이더 스냅샷을 찾지 못했습니다."
-        eyebrow="EMPTY SNAPSHOT"
+        eyebrow="빈 스냅샷"
         title="레이더"
         variant="empty"
       />
@@ -575,7 +556,7 @@ export default function RadarTabScreen() {
         {dataState === 'degraded' && datasetRiskDisclosure ? (
           <InlineFeedbackNotice
             action={{
-              label: '다시 시도',
+              label: MOBILE_COPY.action.retry,
               onPress: () => setReloadCount((count) => count + 1),
               testID: 'radar-degraded-retry',
             }}
@@ -718,8 +699,8 @@ function RadarFeaturedSection({
           testID="radar-featured-card"
         >
           <Text style={styles.featuredEyebrow}>{item.dayLabel}</Text>
-          <Text style={styles.featuredTitle}>{item.team.displayName}</Text>
-          <Text style={styles.featuredBody}>{formatFeaturedBody(item)}</Text>
+          <Text numberOfLines={1} style={styles.featuredTitle}>{item.team.displayName}</Text>
+          <Text numberOfLines={2} style={styles.featuredBody}>{formatFeaturedBody(item)}</Text>
           <View style={styles.chipRow}>
             <StatusChip label={resolveUpcomingStatusLabel(item.upcoming.status)} styles={styles} />
             {resolveConfidenceLabel(item.upcoming.confidence) ? (
@@ -730,7 +711,7 @@ function RadarFeaturedSection({
         <RadarActionRow
           onOpenSource={() => onOpenSource(item.sourceUrl)}
           onPressPrimary={() => onPressTeam(item.team.slug, 'featured_upcoming')}
-          primaryLabel="팀 페이지"
+          primaryLabel={MOBILE_COPY.action.teamPage}
           primaryTestID="radar-featured-primary"
             sourceLabel={item.sourceLabel}
             sourceTestID="radar-featured-source"
@@ -790,8 +771,8 @@ function RadarUpcomingSectionCard({
         <Text style={styles.cardBadgeLabel}>{resolveBadgeLabel(item.team)}</Text>
       </View>
       <View style={styles.cardCopy}>
-        <Text style={styles.cardTitle}>{item.team.displayName}</Text>
-        <Text style={styles.cardBody}>{formatFeaturedBody(item)}</Text>
+        <Text numberOfLines={1} style={styles.cardTitle}>{item.team.displayName}</Text>
+        <Text numberOfLines={2} style={styles.cardBody}>{formatFeaturedBody(item)}</Text>
         <View style={styles.chipRow}>
           <StatusChip label={resolveUpcomingStatusLabel(item.upcoming.status)} styles={styles} />
           {resolveConfidenceLabel(item.upcoming.confidence) ? (
@@ -804,7 +785,7 @@ function RadarUpcomingSectionCard({
         <RadarActionRow
           onOpenSource={() => onOpenSource(item.sourceUrl)}
           onPressPrimary={() => onPressTeam(item.team.slug, 'weekly_upcoming')}
-          primaryLabel="팀 페이지"
+          primaryLabel={MOBILE_COPY.action.teamPage}
           primaryTestID={`${testID}-primary`}
           sourceLabel={item.sourceLabel}
           sourceTestID={`${testID}-source`}
@@ -840,8 +821,8 @@ function RadarChangeFeedCard({
         <Text style={styles.cardBadgeLabel}>{resolveBadgeLabel(item.team)}</Text>
       </View>
       <View style={styles.cardCopy}>
-        <Text style={styles.cardTitle}>{item.team.displayName}</Text>
-        <Text style={styles.cardBody}>{item.releaseLabel ?? item.headline ?? item.changeTypeLabel}</Text>
+        <Text numberOfLines={1} style={styles.cardTitle}>{item.team.displayName}</Text>
+        <Text numberOfLines={2} style={styles.cardBody}>{item.releaseLabel ?? item.headline ?? item.changeTypeLabel}</Text>
         <View style={styles.chipRow}>
           <StatusChip label={item.changeTypeLabel} styles={styles} tone="title" />
         </View>
@@ -850,7 +831,7 @@ function RadarChangeFeedCard({
         <RadarActionRow
           onOpenSource={() => onOpenSource(item.sourceUrl)}
           onPressPrimary={() => onPressTeam(item.team.slug, 'change_feed')}
-          primaryLabel="팀 페이지"
+          primaryLabel={MOBILE_COPY.action.teamPage}
           primaryTestID={`radar-change-primary-${item.team.slug}`}
           sourceLabel={item.sourceLabel}
           sourceTestID={`radar-change-source-${item.team.slug}`}
@@ -884,12 +865,12 @@ function RadarLongGapCard({
         <Text style={styles.cardBadgeLabel}>{resolveBadgeLabel(item.team)}</Text>
       </View>
       <View style={styles.cardCopy}>
-        <Text style={styles.cardTitle}>{item.team.displayName}</Text>
-        <Text style={styles.cardBody}>{formatLongGapBody(item)}</Text>
+        <Text numberOfLines={1} style={styles.cardTitle}>{item.team.displayName}</Text>
+        <Text numberOfLines={2} style={styles.cardBody}>{formatLongGapBody(item)}</Text>
         <Text style={styles.cardMeta}>{formatLongGapMeta(item)}</Text>
         <RadarActionRow
           onPressPrimary={() => onPressTeam(item.team.slug, 'long_gap')}
-          primaryLabel="팀 페이지"
+          primaryLabel={MOBILE_COPY.action.teamPage}
           primaryTestID={`radar-long-gap-primary-${item.team.slug}`}
           styles={styles}
         />
@@ -920,12 +901,12 @@ function RadarRookieCard({
         <Text style={styles.cardBadgeLabel}>{resolveBadgeLabel(item.team)}</Text>
       </View>
       <View style={styles.cardCopy}>
-        <Text style={styles.cardTitle}>{item.team.displayName}</Text>
-        <Text style={styles.cardBody}>{formatRookieBody(item)}</Text>
+        <Text numberOfLines={1} style={styles.cardTitle}>{item.team.displayName}</Text>
+        <Text numberOfLines={2} style={styles.cardBody}>{formatRookieBody(item)}</Text>
         <Text style={styles.cardMeta}>{formatRookieMeta(item)}</Text>
         <RadarActionRow
           onPressPrimary={() => onPressTeam(item.team.slug, 'rookie')}
-          primaryLabel="팀 페이지"
+          primaryLabel={MOBILE_COPY.action.teamPage}
           primaryTestID={`radar-rookie-primary-${item.team.slug}`}
           styles={styles}
         />
@@ -1019,7 +1000,7 @@ function createStyles(theme: ReturnType<typeof useAppTheme>) {
       borderWidth: 1,
       borderColor: theme.colors.border.subtle,
       backgroundColor: theme.colors.surface.elevated,
-      minHeight: 44,
+      minHeight: theme.size.button.heightSecondary,
       paddingHorizontal: theme.space[12],
       paddingVertical: theme.space[8],
       justifyContent: 'center',
@@ -1213,7 +1194,7 @@ function createStyles(theme: ReturnType<typeof useAppTheme>) {
       marginTop: theme.space[4],
     },
     primaryActionButton: {
-      minHeight: 44,
+      minHeight: theme.size.button.heightPrimary,
       borderRadius: theme.radius.button,
       backgroundColor: theme.colors.text.brand,
       paddingHorizontal: theme.space[16],
@@ -1227,7 +1208,7 @@ function createStyles(theme: ReturnType<typeof useAppTheme>) {
       fontWeight: theme.typography.buttonService.fontWeight,
     },
     secondaryActionButton: {
-      minHeight: 44,
+      minHeight: theme.size.button.heightSecondary,
       borderRadius: theme.radius.button,
       borderWidth: 1,
       borderColor: theme.colors.border.default,
@@ -1243,7 +1224,7 @@ function createStyles(theme: ReturnType<typeof useAppTheme>) {
       fontWeight: theme.typography.buttonService.fontWeight,
     },
     metaActionButton: {
-      minHeight: 44,
+      minHeight: theme.size.button.heightSecondary,
       justifyContent: 'center',
       paddingVertical: theme.space[8],
     },

--- a/mobile/app/(tabs)/search.tsx
+++ b/mobile/app/(tabs)/search.tsx
@@ -22,6 +22,12 @@ import { AppBar } from '../../src/components/layout/AppBar';
 import { SourceLinkRow } from '../../src/components/meta/SourceLinkRow';
 import { buildDatasetRiskDisclosure } from '../../src/features/surfaceDisclosures';
 import {
+  MOBILE_COPY,
+  formatUpcomingDateLabel,
+  resolveSourceLinkLabel,
+  resolveUpcomingStatusWithFallback,
+} from '../../src/copy/mobileCopy';
+import {
   areRouteParamsEqual,
   buildSearchRouteParams,
   resolveSearchRouteState,
@@ -88,13 +94,12 @@ function formatReleaseMeta(release: ReleaseSummaryModel): string {
 
 function formatUpcomingMeta(result: SearchUpcomingResultModel): string {
   const event = result.upcoming;
-  const dateLabel = event.scheduledDate
-    ? event.scheduledDate
-    : event.scheduledMonth
-      ? `${event.scheduledMonth} · 날짜 미정`
-      : '날짜 미정';
+  const dateLabel = formatUpcomingDateLabel({
+    scheduledDate: event.scheduledDate,
+    scheduledMonth: event.scheduledMonth,
+  });
 
-  return [dateLabel, event.status ?? '예정', event.sourceType].join(' · ');
+  return [dateLabel, resolveUpcomingStatusWithFallback(event.status), event.sourceType].join(' · ');
 }
 
 function formatTeamMeta(result: SearchTeamResultModel): string {
@@ -159,22 +164,6 @@ function resolveSearchSegmentLabel(segment: SearchSegment): string {
   }
 
   return '예정';
-}
-
-function resolveUpcomingSourceLabel(sourceType: SearchUpcomingResultModel['upcoming']['sourceType']): string {
-  if (
-    sourceType === 'agency_notice' ||
-    sourceType === 'weverse_notice' ||
-    sourceType === 'official_social'
-  ) {
-    return '공식 공지';
-  }
-
-  if (sourceType === 'news_rss') {
-    return '기사 원문';
-  }
-
-  return '출처 보기';
 }
 
 function buildTeamResultAccessibilityLabel(result: SearchTeamResultModel): string {
@@ -253,7 +242,7 @@ export default function SearchTabScreen() {
     surface: 'search',
     reloadKey: reloadCount,
     cacheKey: `search:${deferredQuery.trim().toLowerCase() || 'empty'}`,
-    fallbackErrorMessage: 'Search dataset could not be loaded right now.',
+    fallbackErrorMessage: '검색 데이터를 지금 불러오지 못했습니다.',
     loadBundled: loadBundledResults,
     loadBackend: loadBackendResults,
   });
@@ -577,8 +566,8 @@ export default function SearchTabScreen() {
     return (
       <ScreenFeedbackState
         body="검색 대상 팀, 발매, 예정 데이터를 불러오는 중입니다."
-        eyebrow="DATASET LOADING"
-        title="Search"
+        eyebrow="데이터 로딩"
+        title="검색"
         variant="loading"
       />
     );
@@ -588,12 +577,12 @@ export default function SearchTabScreen() {
     return (
       <ScreenFeedbackState
         action={{
-          label: '다시 시도',
+          label: MOBILE_COPY.action.retry,
           onPress: () => setReloadCount((count) => count + 1),
         }}
         body={datasetState.message}
-        eyebrow="LOAD ERROR"
-        title="Search"
+        eyebrow="로드 오류"
+        title="검색"
         variant="error"
       />
     );
@@ -633,9 +622,9 @@ export default function SearchTabScreen() {
       style={styles.screen}
     >
       <AppBar
-        subtitle="한글 별칭, 영문 그룹명, 릴리즈명, 예정 headline까지 같은 selector semantics로 찾습니다."
+        subtitle="한글 별칭, 영문 그룹명, 릴리즈명, 예정 헤드라인까지 같은 검색 규칙으로 찾습니다."
         testID="search-app-bar"
-        title="Search"
+        title="검색"
       />
 
       {datasetRiskDisclosure ? (
@@ -751,16 +740,16 @@ export default function SearchTabScreen() {
                   style={styles.resultCard}
                   testID={`suggested-team-${team.slug}`}
                 >
-                  <TeamIdentityRow
-                    badgeImageUrl={team.badge?.imageUrl}
-                    meta={team.agency ?? 'Tracked team'}
-                    monogram={formatSuggestedLabel(team)}
-                    name={team.displayName}
-                    testID={`suggested-team-copy-${team.slug}`}
-                  />
+                    <TeamIdentityRow
+                      badgeImageUrl={team.badge?.imageUrl}
+                      meta={team.agency ?? '추적 대상 팀'}
+                      monogram={formatSuggestedLabel(team)}
+                      name={team.displayName}
+                      testID={`suggested-team-copy-${team.slug}`}
+                    />
                   <ActionButton
                     accessibilityLabel={`${team.displayName} 팀 열기`}
-                    label="팀 페이지"
+                    label={MOBILE_COPY.action.teamPage}
                     onPress={() => openTeamDetail(team.slug)}
                     testID={`suggested-team-open-${team.slug}`}
                   />
@@ -858,6 +847,7 @@ export default function SearchTabScreen() {
                       meta={`${result.release.displayGroup} · ${formatReleaseMeta(result.release)}`}
                       monogram={result.release.displayGroup.slice(0, 2).toUpperCase()}
                       name={result.release.releaseTitle}
+                      nameNumberOfLines={2}
                       testID={`search-release-result-${result.release.id}`}
                     />
                   </Pressable>
@@ -954,7 +944,7 @@ export default function SearchTabScreen() {
                         links={[
                           {
                             key: `${result.upcoming.id}-source`,
-                            label: resolveUpcomingSourceLabel(result.upcoming.sourceType),
+                            label: resolveSourceLinkLabel(result.upcoming.sourceType),
                             onPress: () => void handleUpcomingSourcePress(result),
                             type: 'source',
                             url: result.upcoming.sourceUrl,
@@ -1015,7 +1005,7 @@ function createStyles(theme: ReturnType<typeof useAppTheme>) {
     },
     inlineButton: {
       alignSelf: 'flex-start',
-      minHeight: 44,
+      minHeight: theme.size.button.heightSecondary,
       paddingHorizontal: theme.space[12],
       paddingVertical: theme.space[8],
       borderRadius: theme.radius.button,
@@ -1070,7 +1060,7 @@ function createStyles(theme: ReturnType<typeof useAppTheme>) {
       borderWidth: 1,
       borderColor: theme.colors.border.subtle,
       backgroundColor: theme.colors.surface.base,
-      minHeight: 44,
+      minHeight: theme.size.button.heightSecondary,
       paddingHorizontal: theme.space[12],
       paddingVertical: theme.space[8],
     },
@@ -1099,6 +1089,8 @@ function createStyles(theme: ReturnType<typeof useAppTheme>) {
     },
     resultPressable: {
       gap: theme.space[8],
+      minHeight: theme.size.row.minHeight,
+      justifyContent: 'center',
     },
     resultPressed: {
       opacity: 0.84,

--- a/mobile/app/artists/[slug].tsx
+++ b/mobile/app/artists/[slug].tsx
@@ -22,6 +22,12 @@ import {
   buildDatasetRiskDisclosure,
   buildEntitySourceDisclosure,
 } from '../../src/features/surfaceDisclosures';
+import {
+  MOBILE_COPY,
+  formatMonthOnlyDateLabel,
+  resolveUpcomingConfidenceLabel as resolveUpcomingConfidenceChipLabel,
+  resolveUpcomingStatusWithFallback,
+} from '../../src/copy/mobileCopy';
 import { useActiveDatasetScreen } from '../../src/features/useActiveDatasetScreen';
 import { selectEntityDetailSnapshot } from '../../src/selectors';
 import { loadActiveMobileDataset } from '../../src/services/activeDataset';
@@ -67,14 +73,14 @@ function getSingleParam(value: string | string[] | undefined): string | null {
 
 function formatUpcomingMeta(event: UpcomingEventModel): string {
   if (event.datePrecision === 'exact' && event.scheduledDate) {
-    return `${event.scheduledDate} · ${event.status ?? '예정'}`;
+    return `${event.scheduledDate} · ${resolveUpcomingStatusWithFallback(event.status)}`;
   }
 
   if (event.scheduledMonth) {
-    return `${event.scheduledMonth} · 날짜 미정 · ${event.status ?? '예정'}`;
+    return `${formatMonthOnlyDateLabel(event.scheduledMonth)} · ${resolveUpcomingStatusWithFallback(event.status)}`;
   }
 
-  return event.status ?? '예정';
+  return resolveUpcomingStatusWithFallback(event.status);
 }
 
 function formatReleaseMeta(release: ReleaseSummaryModel): string {
@@ -127,41 +133,16 @@ function getReleaseKindLabel(release: ReleaseSummaryModel): string {
   return 'RELEASE';
 }
 
-function resolveUpcomingStatusLabel(status?: UpcomingEventModel['status']): string {
-  switch (status) {
-    case 'confirmed':
-      return '확정';
-    case 'rumor':
-      return '루머';
-    case 'scheduled':
-    default:
-      return '예정';
-  }
-}
-
-function resolveUpcomingConfidenceLabel(confidence?: UpcomingEventModel['confidence']): string | null {
-  switch (confidence) {
-    case 'high':
-      return '신뢰 높음';
-    case 'medium':
-      return '신뢰 보통';
-    case 'low':
-      return '신뢰 낮음';
-    default:
-      return null;
-  }
-}
-
 function resolveUpcomingTimingLabel(event: UpcomingEventModel): string {
   if (event.datePrecision === 'exact' && event.scheduledDate) {
     return event.scheduledDate;
   }
 
   if (event.scheduledMonth) {
-    return `${event.scheduledMonth} · 날짜 미정`;
+    return formatMonthOnlyDateLabel(event.scheduledMonth);
   }
 
-  return '날짜 미정';
+  return MOBILE_COPY.date.unknown;
 }
 
 function buildLatestReleaseServiceButtons(release: ReleaseSummaryModel): EntityServiceButtonItem[] {
@@ -380,7 +361,7 @@ export default function ArtistDetailScreen() {
             onPress: () => router.push('/(tabs)/search'),
           }}
           body="팀 slug가 없거나 잘못되어 화면을 열 수 없습니다."
-          eyebrow="SAFE RECOVERY"
+          eyebrow="안전 복구"
           testID="entity-missing-state"
           title="팀 상세"
           variant="empty"
@@ -395,7 +376,7 @@ export default function ArtistDetailScreen() {
         <Stack.Screen options={{ title: screenTitle }} />
         <ScreenFeedbackState
           body="팀 요약, 다음 컴백, 최근 앨범을 불러오는 중입니다."
-          eyebrow="DETAIL LOADING"
+          eyebrow="상세 로딩"
           title="팀 상세"
           variant="loading"
         />
@@ -409,11 +390,11 @@ export default function ArtistDetailScreen() {
         <Stack.Screen options={{ title: screenTitle }} />
         <ScreenFeedbackState
           action={{
-            label: '다시 시도',
+            label: MOBILE_COPY.action.retry,
             onPress: () => setReloadCount((count) => count + 1),
           }}
           body={datasetState.message}
-          eyebrow="LOAD ERROR"
+          eyebrow="로드 오류"
           title="팀 상세"
           variant="error"
         />
@@ -431,7 +412,7 @@ export default function ArtistDetailScreen() {
             onPress: () => router.push('/(tabs)/search'),
           }}
           body="해당 팀 데이터를 찾지 못했습니다."
-          eyebrow="SAFE RECOVERY"
+          eyebrow="안전 복구"
           testID="entity-missing-state"
           title="팀 상세"
           variant="empty"
@@ -463,7 +444,7 @@ export default function ArtistDetailScreen() {
           onPress: () => router.back(),
           testID: 'entity-detail-back',
         }}
-        subtitle="팀 페이지"
+        subtitle={MOBILE_COPY.action.teamPage}
         testID="entity-detail-app-bar"
         title={snapshot.team.displayName}
       />
@@ -535,15 +516,15 @@ export default function ArtistDetailScreen() {
           <View testID="entity-next-upcoming-card" style={styles.primaryCard}>
             <View style={styles.chipRow}>
               <InfoChip label={resolveUpcomingTimingLabel(snapshot.nextUpcoming)} styles={styles} />
-              <InfoChip label={resolveUpcomingStatusLabel(snapshot.nextUpcoming.status)} styles={styles} />
-              {resolveUpcomingConfidenceLabel(snapshot.nextUpcoming.confidence) ? (
+              <InfoChip label={resolveUpcomingStatusWithFallback(snapshot.nextUpcoming.status)} styles={styles} />
+              {resolveUpcomingConfidenceChipLabel(snapshot.nextUpcoming.confidence) ? (
                 <InfoChip
-                  label={resolveUpcomingConfidenceLabel(snapshot.nextUpcoming.confidence)!}
+                  label={resolveUpcomingConfidenceChipLabel(snapshot.nextUpcoming.confidence)!}
                   styles={styles}
                 />
               ) : null}
             </View>
-            <Text style={styles.primaryCardTitle}>
+            <Text numberOfLines={2} style={styles.primaryCardTitle}>
               {snapshot.nextUpcoming.releaseLabel ?? snapshot.nextUpcoming.headline}
             </Text>
             <Text style={styles.primaryCardMeta}>{formatUpcomingMeta(snapshot.nextUpcoming)}</Text>
@@ -555,7 +536,7 @@ export default function ArtistDetailScreen() {
                 onPress={() => void handleExternalLink(snapshot.nextUpcoming!.sourceUrl!, 'source')}
                 style={({ pressed }) => [styles.metaButton, pressed ? styles.buttonPressed : null]}
               >
-                <Text style={styles.metaButtonLabel}>출처 보기</Text>
+                <Text style={styles.metaButtonLabel}>{MOBILE_COPY.action.sourceView}</Text>
               </Pressable>
             ) : null}
           </View>
@@ -578,7 +559,7 @@ export default function ArtistDetailScreen() {
                 )}
               </View>
               <View style={styles.releaseCopy}>
-                <Text style={styles.primaryCardTitle}>{snapshot.latestRelease.releaseTitle}</Text>
+                <Text numberOfLines={2} style={styles.primaryCardTitle}>{snapshot.latestRelease.releaseTitle}</Text>
                 <Text style={styles.primaryCardMeta}>{formatReleaseMeta(snapshot.latestRelease)}</Text>
                 <Text style={styles.primaryCardBody}>
                   {snapshot.latestRelease.representativeSongTitle ?? '상세 화면으로 이동'}
@@ -604,7 +585,7 @@ export default function ArtistDetailScreen() {
               }}
               style={({ pressed }) => [styles.primaryButton, pressed ? styles.buttonPressed : null]}
             >
-              <Text style={styles.primaryButtonLabel}>상세 보기</Text>
+              <Text style={styles.primaryButtonLabel}>{MOBILE_COPY.action.detailView}</Text>
             </Pressable>
             <ServiceButtonGroup
               buttons={latestReleaseServiceButtons.map((button) => ({
@@ -621,7 +602,7 @@ export default function ArtistDetailScreen() {
                 style={({ pressed }) => [styles.metaTextLink, pressed ? styles.buttonPressed : null]}
                 testID="entity-latest-release-source-link"
               >
-                <Text style={styles.metaTextLinkLabel}>출처 보기</Text>
+                <Text style={styles.metaTextLinkLabel}>{MOBILE_COPY.action.sourceView}</Text>
               </Pressable>
             ) : null}
           </View>
@@ -665,7 +646,7 @@ export default function ArtistDetailScreen() {
               )}
             </View>
             <View style={styles.singleAlbumCopy}>
-              <Text style={styles.albumTitle}>{snapshot.recentAlbums[0]!.releaseTitle}</Text>
+              <Text numberOfLines={2} style={styles.albumTitle}>{snapshot.recentAlbums[0]!.releaseTitle}</Text>
               <Text style={styles.albumMeta}>{formatReleaseMeta(snapshot.recentAlbums[0]!)}</Text>
             </View>
           </Pressable>
@@ -698,7 +679,7 @@ export default function ArtistDetailScreen() {
                     </Text>
                   )}
                 </View>
-                <Text style={styles.albumTitle}>{release.releaseTitle}</Text>
+                <Text numberOfLines={2} style={styles.albumTitle}>{release.releaseTitle}</Text>
                 <Text style={styles.albumMeta}>{formatReleaseMeta(release)}</Text>
               </Pressable>
             ))}
@@ -711,14 +692,14 @@ export default function ArtistDetailScreen() {
       {snapshot.sourceTimeline.length > 0 ? (
         <SectionCard title="추가 정보" styles={styles}>
           <Pressable
-            accessibilityLabel={showAdditionalInfo ? '소스 타임라인 접기' : '소스 타임라인 보기'}
+            accessibilityLabel={showAdditionalInfo ? MOBILE_COPY.action.hideSourceTimeline : MOBILE_COPY.action.showSourceTimeline}
             accessibilityRole="button"
             onPress={() => setShowAdditionalInfo((value) => !value)}
             style={({ pressed }) => [styles.secondaryButton, pressed ? styles.buttonPressed : null]}
             testID="entity-source-timeline-toggle"
           >
             <Text style={styles.secondaryButtonLabel}>
-              {showAdditionalInfo ? '소스 타임라인 접기' : '소스 타임라인 보기'}
+              {showAdditionalInfo ? MOBILE_COPY.action.hideSourceTimeline : MOBILE_COPY.action.showSourceTimeline}
             </Text>
           </Pressable>
           {showAdditionalInfo ? (
@@ -737,7 +718,7 @@ export default function ArtistDetailScreen() {
                       onPress={() => void handleExternalLink(item.sourceUrl!, 'source')}
                       style={({ pressed }) => [styles.metaButton, pressed ? styles.buttonPressed : null]}
                     >
-                      <Text style={styles.metaButtonLabel}>열기</Text>
+                      <Text style={styles.metaButtonLabel}>{MOBILE_COPY.action.open}</Text>
                     </Pressable>
                   ) : null}
                 </View>
@@ -884,7 +865,7 @@ function createStyles(theme: ReturnType<typeof useAppTheme>) {
       gap: theme.space[8],
     },
     primaryButton: {
-      minHeight: 44,
+      minHeight: theme.size.button.heightPrimary,
       alignItems: 'center',
       justifyContent: 'center',
       paddingHorizontal: theme.space[16],
@@ -902,7 +883,7 @@ function createStyles(theme: ReturnType<typeof useAppTheme>) {
     },
     secondaryButton: {
       alignSelf: 'flex-start',
-      minHeight: 44,
+      minHeight: theme.size.button.heightSecondary,
       paddingHorizontal: theme.space[12],
       paddingVertical: theme.space[8],
       borderRadius: theme.radius.button,
@@ -1012,7 +993,8 @@ function createStyles(theme: ReturnType<typeof useAppTheme>) {
       justifyContent: 'center',
     },
     albumCard: {
-      width: 172,
+      width: '52%',
+      minWidth: 188,
       gap: theme.space[8],
       padding: theme.space[12],
       borderRadius: theme.radius.card,
@@ -1078,7 +1060,7 @@ function createStyles(theme: ReturnType<typeof useAppTheme>) {
       color: theme.colors.text.secondary,
     },
     metaButton: {
-      minHeight: 44,
+      minHeight: theme.size.button.heightSecondary,
       paddingHorizontal: theme.space[12],
       paddingVertical: theme.space[8],
       borderRadius: theme.radius.chip,

--- a/mobile/app/releases/[id].tsx
+++ b/mobile/app/releases/[id].tsx
@@ -27,6 +27,7 @@ import {
 import { useActiveDatasetScreen } from '../../src/features/useActiveDatasetScreen';
 import { selectReleaseDetailById } from '../../src/selectors';
 import { getFeatureGateState } from '../../src/config/featureGates';
+import { MOBILE_COPY } from '../../src/copy/mobileCopy';
 import { loadActiveMobileDataset } from '../../src/services/activeDataset';
 import { adaptBackendReleaseDetail } from '../../src/services/backendDisplayAdapters';
 import {
@@ -387,7 +388,7 @@ export default function ReleaseDetailScreen() {
     setHandoffFeedback(null);
   }
 
-  const screenTitle = detail?.releaseTitle ?? releaseId ?? 'Release Detail';
+  const screenTitle = detail?.releaseTitle ?? releaseId ?? '릴리즈 상세';
 
   if (!releaseId) {
     return (
@@ -395,13 +396,13 @@ export default function ReleaseDetailScreen() {
         <Stack.Screen options={{ title: screenTitle }} />
         <ScreenFeedbackState
           action={{
-            label: '이전 화면으로',
+            label: MOBILE_COPY.action.back,
             onPress: () => router.back(),
           }}
           body="릴리즈 ID가 없거나 잘못되어 상세 화면을 열 수 없습니다."
-          eyebrow="MISSING DETAIL"
+          eyebrow="상세 없음"
           testID="release-missing-state"
-          title="Release Detail"
+          title="릴리즈 상세"
           variant="empty"
         />
       </>
@@ -414,8 +415,8 @@ export default function ReleaseDetailScreen() {
         <Stack.Screen options={{ title: screenTitle }} />
         <ScreenFeedbackState
           body="앨범 액션, 트랙 리스트, MV 상태를 불러오는 중입니다."
-          eyebrow="DETAIL LOADING"
-          title="Release Detail"
+          eyebrow="상세 로딩"
+          title="릴리즈 상세"
           variant="loading"
         />
       </>
@@ -428,12 +429,12 @@ export default function ReleaseDetailScreen() {
         <Stack.Screen options={{ title: screenTitle }} />
         <ScreenFeedbackState
           action={{
-            label: '다시 시도',
+            label: MOBILE_COPY.action.retry,
             onPress: () => setReloadCount((count) => count + 1),
           }}
           body={datasetState.message}
-          eyebrow="LOAD ERROR"
-          title="Release Detail"
+          eyebrow="로드 오류"
+          title="릴리즈 상세"
           variant="error"
         />
       </>
@@ -446,13 +447,13 @@ export default function ReleaseDetailScreen() {
         <Stack.Screen options={{ title: screenTitle }} />
         <ScreenFeedbackState
           action={{
-            label: '이전 화면으로',
+            label: MOBILE_COPY.action.back,
             onPress: () => router.back(),
           }}
           body="해당 릴리즈 상세 데이터를 찾지 못했습니다."
-          eyebrow="MISSING DETAIL"
+          eyebrow="상세 없음"
           testID="release-missing-state"
-          title="Release Detail"
+          title="릴리즈 상세"
           variant="empty"
         />
       </>
@@ -473,7 +474,7 @@ export default function ReleaseDetailScreen() {
     detail.sourceUrl
       ? {
           key: 'release-source',
-          label: '출처 보기',
+          label: MOBILE_COPY.action.sourceView,
           onPress: () => void handleSupportingLinkOpen(detail.sourceUrl!),
           type: 'source' as const,
           url: detail.sourceUrl,
@@ -497,8 +498,8 @@ export default function ReleaseDetailScreen() {
       <AppBar
         leadingAction={{
           accessibilityHint: '이전 화면으로 돌아갑니다.',
-          accessibilityLabel: '이전으로',
-          label: '이전으로',
+          accessibilityLabel: MOBILE_COPY.action.back,
+          label: MOBILE_COPY.action.back,
           onPress: () => router.back(),
           testID: 'release-appbar-back',
         }}
@@ -511,7 +512,7 @@ export default function ReleaseDetailScreen() {
                 {
                   key: 'team-page',
                   accessibilityLabel: `${detail.displayGroup} 팀 페이지 열기`,
-                  label: '팀 페이지',
+                  label: MOBILE_COPY.action.teamPage,
                   onPress: () => router.push(`/artists/${teamProfile.slug}`),
                   testID: 'release-appbar-team-page',
                 },

--- a/mobile/src/README.md
+++ b/mobile/src/README.md
@@ -7,6 +7,8 @@
   - `actions/`: service button / grouped action row 공용 컴포넌트
   - `calendar/`: day cell / date detail sheet 공용 컴포넌트
   - `release/`: track row 공용 컴포넌트
+- `copy/`: RN 공용 문구 / 상태 라벨 / 날짜 라벨 helper
+  - `mobileCopy.ts`: Korean-first action/source/status/confidence/date copy 중앙화
 - `config/`: validated runtime config accessor
   - `featureGates.ts`: gate registry / fallback metadata / helper
   - `runtime.ts`: mobile profile / env validation + safe degraded runtime state
@@ -66,6 +68,11 @@ feedback state 관련 규칙:
 - screen-level loading / empty / error / retry는 `components/feedback/FeedbackState.tsx`를 우선 사용한다.
 - section 안의 empty / warning / retry copy도 가능하면 `InlineFeedbackNotice`로 통일한다.
 - 화면이 직접 `ActivityIndicator + 문구 + retry button` 조합을 반복해서 만들지 않는다.
+
+copy 관련 규칙:
+
+- `팀 페이지`, `상세 보기`, `소스 보기`, `다시 시도` 같은 공용 라벨은 `copy/mobileCopy.ts`를 우선 사용한다.
+- `날짜 미정`, `월 단위 일정`, `공식 공지`, `기사 원문`, confidence/status 라벨도 가능하면 같은 helper에서 파생한다.
 
 failure-policy 관련 규칙:
 

--- a/mobile/src/components/actions/ActionButton.tsx
+++ b/mobile/src/components/actions/ActionButton.tsx
@@ -52,6 +52,8 @@ function ActionButtonComponent({
         tone === 'primary' ? styles.primaryButton : null,
         tone === 'secondary' ? styles.secondaryButton : null,
         tone === 'meta' ? styles.metaButton : null,
+        tone === 'primary' ? styles.primarySize : null,
+        tone === 'secondary' ? styles.secondarySize : null,
         fullWidth ? styles.fullWidthButton : null,
         pressed && !isDisabled ? styles.pressed : null,
         isDisabled ? styles.disabled : null,
@@ -66,6 +68,7 @@ function ActionButtonComponent({
           />
           <Text
             allowFontScaling
+            numberOfLines={2}
             style={[
               styles.label,
               tone === 'primary' ? styles.primaryLabel : styles.secondaryLabel,
@@ -77,6 +80,7 @@ function ActionButtonComponent({
       ) : (
         <Text
           allowFontScaling
+          numberOfLines={tone === 'meta' ? 1 : 2}
           style={[
             styles.label,
             tone === 'primary' ? styles.primaryLabel : null,
@@ -94,7 +98,6 @@ function ActionButtonComponent({
 function createStyles(theme: MobileTheme) {
   return StyleSheet.create({
     button: {
-      minHeight: 44,
       alignItems: 'center',
       justifyContent: 'center',
       borderRadius: theme.radius.button,
@@ -107,10 +110,16 @@ function createStyles(theme: MobileTheme) {
     primaryButton: {
       backgroundColor: theme.colors.text.brand,
     },
+    primarySize: {
+      minHeight: theme.size.button.heightPrimary,
+    },
     secondaryButton: {
       backgroundColor: theme.colors.surface.interactive,
       borderWidth: 1,
       borderColor: theme.colors.border.default,
+    },
+    secondarySize: {
+      minHeight: theme.size.button.heightSecondary,
     },
     metaButton: {
       alignSelf: 'flex-start',

--- a/mobile/src/components/actions/ServiceButton.tsx
+++ b/mobile/src/components/actions/ServiceButton.tsx
@@ -64,6 +64,7 @@ function ServiceButtonComponent({
         </View>
         <Text
           allowFontScaling
+          numberOfLines={2}
           style={[
             styles.buttonLabel,
             styles[`${resolvedService}ButtonLabel`],
@@ -81,7 +82,7 @@ function ServiceButtonComponent({
 function createStyles(theme: MobileTheme) {
   return StyleSheet.create({
     button: {
-      minHeight: 48,
+      minHeight: theme.size.button.heightService,
       minWidth: 104,
       alignItems: 'center',
       justifyContent: 'center',

--- a/mobile/src/components/calendar/DateDetailSheet.test.tsx
+++ b/mobile/src/components/calendar/DateDetailSheet.test.tsx
@@ -64,8 +64,8 @@ describe('DateDetailSheet', () => {
     expect(tree!.root.findByProps({ testID: 'calendar-bottom-sheet' })).toBeDefined();
     expect(hasText(tree!, 'LOVE CATCHER')).toBe(true);
     expect(hasText(tree!, '3월 11일 발매/컴백')).toBe(true);
-    expect(hasText(tree!, 'Verified releases')).toBe(true);
-    expect(hasText(tree!, 'Scheduled comebacks')).toBe(true);
+    expect(hasText(tree!, '검증된 발매')).toBe(true);
+    expect(hasText(tree!, '날짜가 잡힌 예정 컴백')).toBe(true);
 
     await act(async () => {
       tree!.root.findByProps({ accessibilityLabel: '시트 닫기' }).props.onPress();

--- a/mobile/src/components/calendar/DateDetailSheet.tsx
+++ b/mobile/src/components/calendar/DateDetailSheet.tsx
@@ -70,7 +70,7 @@ function DateDetailSheetComponent({
         {verifiedRows.length > 0 ? (
           <View style={styles.subsection}>
             <Text allowFontScaling style={styles.subsectionTitle}>
-              Verified releases
+              검증된 발매
             </Text>
             {verifiedRows.map((row) => (
               <ReleaseSummaryRow key={row.testID ?? `${row.team.name}-${row.title}`} {...row} />
@@ -81,7 +81,7 @@ function DateDetailSheetComponent({
         {scheduledRows.length > 0 ? (
           <View style={styles.subsection}>
             <Text allowFontScaling style={styles.subsectionTitle}>
-              Scheduled comebacks
+              날짜가 잡힌 예정 컴백
             </Text>
             {scheduledRows.map((row) => (
               <UpcomingEventRow key={row.testID ?? `${row.team.name}-${row.headline}`} {...row} />

--- a/mobile/src/components/feedback/FeedbackState.test.tsx
+++ b/mobile/src/components/feedback/FeedbackState.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import renderer, { act } from 'react-test-renderer';
-import { Text } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
 
 import { InlineFeedbackNotice, ScreenFeedbackState } from './FeedbackState';
 
@@ -54,5 +54,33 @@ describe('shared feedback state components', () => {
     });
 
     expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  test('keeps screen-level feedback aligned to the current scroll context', async () => {
+    let tree: renderer.ReactTestRenderer;
+
+    await act(async () => {
+      tree = renderer.create(
+        <ScreenFeedbackState
+          body="팀 상세 데이터를 찾지 못했습니다."
+          eyebrow="빈 상태"
+          testID="screen-feedback"
+          title="팀 상세"
+          variant="empty"
+        />,
+      );
+    });
+
+    const container = tree!.root
+      .findAllByType(View)
+      .find((node) => node.props.testID === 'screen-feedback');
+    expect(container).toBeDefined();
+    if (!container) {
+      throw new Error('screen-feedback container not found');
+    }
+    const flattenedStyle = StyleSheet.flatten(container.props.style);
+
+    expect(flattenedStyle.justifyContent).toBe('flex-start');
+    expect(flattenedStyle.paddingTop).toBeGreaterThan(0);
   });
 });

--- a/mobile/src/components/feedback/FeedbackState.tsx
+++ b/mobile/src/components/feedback/FeedbackState.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
 
 import { useAppTheme, type MobileTheme } from '../../tokens/theme';
+import { MOBILE_COPY } from '../../copy/mobileCopy';
 
 type FeedbackTone = 'neutral' | 'error';
 
@@ -145,7 +146,7 @@ export function ErrorStateBlock({
       action={retryAction ?? backAction}
       body={message}
       testID={testID}
-      title="오류"
+      title={MOBILE_COPY.feedback.errorTitle}
       tone="error"
     />
   );
@@ -155,8 +156,9 @@ function createStyles(theme: MobileTheme) {
   return StyleSheet.create({
     screenContainer: {
       flex: 1,
-      justifyContent: 'center',
       paddingHorizontal: theme.space[24],
+      paddingTop: theme.space[24],
+      justifyContent: 'flex-start',
       gap: theme.space[12],
       backgroundColor: theme.colors.surface.base,
     },

--- a/mobile/src/components/identity/TeamIdentityRow.tsx
+++ b/mobile/src/components/identity/TeamIdentityRow.tsx
@@ -15,6 +15,7 @@ export interface TeamIdentityRowProps {
   meta?: string;
   monogram?: string;
   name: string;
+  nameNumberOfLines?: number;
   onPress?: () => void;
   testID?: string;
 }
@@ -24,6 +25,7 @@ function TeamIdentityRowComponent({
   meta,
   monogram,
   name,
+  nameNumberOfLines = 1,
   onPress,
   testID,
 }: TeamIdentityRowProps) {
@@ -43,7 +45,7 @@ function TeamIdentityRowComponent({
         )}
       </View>
       <View style={styles.copy}>
-        <Text allowFontScaling numberOfLines={1} style={styles.name}>
+        <Text allowFontScaling numberOfLines={nameNumberOfLines} style={styles.name}>
           {name}
         </Text>
         {meta ? (
@@ -81,6 +83,7 @@ function createStyles(theme: MobileTheme) {
     row: {
       flexDirection: 'row',
       alignItems: 'center',
+      minHeight: theme.size.row.minHeight,
       gap: theme.space[12],
     },
     pressed: {

--- a/mobile/src/components/layout/AppBar.tsx
+++ b/mobile/src/components/layout/AppBar.tsx
@@ -66,6 +66,7 @@ function createStyles(theme: MobileTheme) {
     container: {
       flexDirection: 'row',
       alignItems: 'flex-start',
+      minHeight: theme.size.button.heightPrimary,
       gap: theme.space[12],
     },
     actionSlot: {

--- a/mobile/src/components/layout/SummaryStrip.tsx
+++ b/mobile/src/components/layout/SummaryStrip.tsx
@@ -32,10 +32,10 @@ function SummaryStripComponent({
     <View style={[styles.row, layout === 'wrap' ? styles.wrapRow : null]} testID={testID}>
       {items.map((item) => (
         <View key={item.key} style={styles.card}>
-          <Text allowFontScaling style={styles.value}>
+          <Text allowFontScaling numberOfLines={1} style={styles.value}>
             {item.value}
           </Text>
-          <Text allowFontScaling style={styles.label}>
+          <Text allowFontScaling numberOfLines={1} style={styles.label}>
             {item.label}
           </Text>
         </View>

--- a/mobile/src/components/meta/SourceLinkRow.tsx
+++ b/mobile/src/components/meta/SourceLinkRow.tsx
@@ -43,7 +43,7 @@ function SourceLinkRowComponent({ links, testID }: SourceLinkRowProps) {
           onPress={link.onPress}
           style={({ pressed }) => [styles.link, pressed ? styles.pressed : null]}
         >
-          <Text allowFontScaling style={styles.linkLabel}>
+          <Text allowFontScaling numberOfLines={2} style={styles.linkLabel}>
             {link.label}
           </Text>
         </Pressable>

--- a/mobile/src/components/release/ReleaseSummaryRow.tsx
+++ b/mobile/src/components/release/ReleaseSummaryRow.tsx
@@ -46,7 +46,7 @@ function ReleaseSummaryRowComponent({
     <View style={styles.card} testID={testID}>
       <TeamIdentityRow {...team} />
       <View style={styles.copy}>
-        <Text allowFontScaling style={styles.title}>
+        <Text allowFontScaling numberOfLines={2} style={styles.title}>
           {title}
         </Text>
         <Text allowFontScaling style={styles.meta}>

--- a/mobile/src/components/release/TrackRow.test.tsx
+++ b/mobile/src/components/release/TrackRow.test.tsx
@@ -33,6 +33,9 @@ describe('TrackRow', () => {
     expect(tree!.root.findByProps({ testID: 'track-row-1' })).toBeDefined();
     expect(tree!.root.findByProps({ testID: 'track-row-title-badge-1' })).toBeDefined();
     expect(hasText(tree!, 'BLACKHOLE')).toBe(true);
+    expect(
+      tree!.root.findAllByType(Text).find((node) => node.props.children === 'BLACKHOLE')?.props.numberOfLines,
+    ).toBe(2);
 
     await act(async () => {
       tree!.root.findByProps({ testID: 'track-row-spotify' }).props.onPress();

--- a/mobile/src/components/release/TrackRow.tsx
+++ b/mobile/src/components/release/TrackRow.tsx
@@ -78,7 +78,7 @@ function TrackRowComponent({
       </Text>
       <View style={styles.trackCopy}>
         <View style={styles.trackTitleRow}>
-          <Text allowFontScaling style={styles.trackTitle}>
+          <Text allowFontScaling numberOfLines={2} style={styles.trackTitle}>
             {title}
           </Text>
           {isTitleTrack ? (
@@ -105,6 +105,7 @@ function createStyles(theme: MobileTheme) {
       flexDirection: 'row',
       gap: theme.space[12],
       alignItems: 'flex-start',
+      minHeight: theme.size.row.minHeight,
       padding: theme.space[12],
       borderRadius: theme.radius.card,
       backgroundColor: theme.colors.surface.elevated,

--- a/mobile/src/components/upcoming/UpcomingEventRow.tsx
+++ b/mobile/src/components/upcoming/UpcomingEventRow.tsx
@@ -40,7 +40,7 @@ function UpcomingEventRowComponent({
     <View style={styles.card} testID={testID}>
       <TeamIdentityRow {...team} />
       <View style={styles.copy}>
-        <Text allowFontScaling style={styles.title}>
+        <Text allowFontScaling numberOfLines={2} style={styles.title}>
           {headline}
         </Text>
         {scheduledDate ? (

--- a/mobile/src/copy/mobileCopy.test.ts
+++ b/mobile/src/copy/mobileCopy.test.ts
@@ -1,0 +1,35 @@
+import {
+  MOBILE_COPY,
+  formatMonthOnlyDateLabel,
+  formatUpcomingDateLabel,
+  resolveSourceLinkLabel,
+  resolveUpcomingConfidenceLabel,
+  resolveUpcomingStatusLabel,
+  resolveUpcomingStatusWithFallback,
+} from './mobileCopy';
+
+describe('mobileCopy helpers', () => {
+  test('formats upcoming date labels with month-only fallback', () => {
+    expect(
+      formatUpcomingDateLabel({
+        scheduledDate: '2026-03-11',
+        scheduledMonth: '2026-03',
+      }),
+    ).toBe('2026-03-11');
+    expect(
+      formatUpcomingDateLabel({
+        scheduledMonth: '2026-03',
+      }),
+    ).toBe('2026-03 · 날짜 미정');
+    expect(formatMonthOnlyDateLabel()).toBe(MOBILE_COPY.date.unknown);
+  });
+
+  test('resolves normalized status, confidence, and source labels', () => {
+    expect(resolveUpcomingStatusLabel('confirmed')).toBe(MOBILE_COPY.status.confirmed);
+    expect(resolveUpcomingStatusWithFallback(undefined)).toBe(MOBILE_COPY.status.scheduled);
+    expect(resolveUpcomingConfidenceLabel('medium')).toBe(MOBILE_COPY.confidence.medium);
+    expect(resolveSourceLinkLabel('official_social')).toBe(MOBILE_COPY.source.officialNotice);
+    expect(resolveSourceLinkLabel('news_rss')).toBe(MOBILE_COPY.source.articleOriginal);
+    expect(resolveSourceLinkLabel('database')).toBe(MOBILE_COPY.source.sourceView);
+  });
+});

--- a/mobile/src/copy/mobileCopy.ts
+++ b/mobile/src/copy/mobileCopy.ts
@@ -1,0 +1,114 @@
+export const MOBILE_COPY = {
+  action: {
+    back: '이전으로',
+    detailView: '상세 보기',
+    open: '열기',
+    retry: '다시 시도',
+    showSourceTimeline: '소스 타임라인 보기',
+    hideSourceTimeline: '소스 타임라인 접기',
+    sourceView: '소스 보기',
+    teamPage: '팀 페이지',
+  },
+  feedback: {
+    errorTitle: '오류',
+  },
+  source: {
+    articleOriginal: '기사 원문',
+    officialNotice: '공식 공지',
+    sourceView: '소스 보기',
+  },
+  status: {
+    confirmed: '확정',
+    rumor: '루머',
+    scheduled: '예정',
+  },
+  confidence: {
+    high: '신뢰 높음',
+    low: '신뢰 낮음',
+    medium: '신뢰 보통',
+  },
+  date: {
+    unknown: '날짜 미정',
+  },
+} as const;
+
+type UpcomingStatusLike = 'confirmed' | 'rumor' | 'scheduled' | string | null | undefined;
+type UpcomingConfidenceLike = 'high' | 'medium' | 'low' | string | null | undefined;
+type UpcomingSourceTypeLike =
+  | 'agency_notice'
+  | 'weverse_notice'
+  | 'official_social'
+  | 'news_rss'
+  | string
+  | null
+  | undefined;
+
+export function formatMonthOnlyDateLabel(month?: string | null): string {
+  if (!month) {
+    return MOBILE_COPY.date.unknown;
+  }
+
+  return `${month} · ${MOBILE_COPY.date.unknown}`;
+}
+
+export function formatUpcomingDateLabel({
+  scheduledDate,
+  scheduledMonth,
+}: {
+  scheduledDate?: string | null;
+  scheduledMonth?: string | null;
+}): string {
+  if (scheduledDate) {
+    return scheduledDate;
+  }
+
+  return formatMonthOnlyDateLabel(scheduledMonth);
+}
+
+export function resolveUpcomingStatusLabel(status?: UpcomingStatusLike): string | undefined {
+  switch (status) {
+    case 'confirmed':
+      return MOBILE_COPY.status.confirmed;
+    case 'rumor':
+      return MOBILE_COPY.status.rumor;
+    case 'scheduled':
+      return MOBILE_COPY.status.scheduled;
+    default:
+      return undefined;
+  }
+}
+
+export function resolveUpcomingStatusWithFallback(status?: UpcomingStatusLike): string {
+  return resolveUpcomingStatusLabel(status) ?? MOBILE_COPY.status.scheduled;
+}
+
+export function resolveUpcomingConfidenceLabel(
+  confidence?: UpcomingConfidenceLike,
+): string | undefined {
+  switch (confidence) {
+    case 'high':
+      return MOBILE_COPY.confidence.high;
+    case 'medium':
+      return MOBILE_COPY.confidence.medium;
+    case 'low':
+      return MOBILE_COPY.confidence.low;
+    default:
+      return undefined;
+  }
+}
+
+export function resolveSourceLinkLabel(sourceType?: UpcomingSourceTypeLike): string {
+  if (
+    sourceType === 'agency_notice' ||
+    sourceType === 'weverse_notice' ||
+    sourceType === 'official_social'
+  ) {
+    return MOBILE_COPY.source.officialNotice;
+  }
+
+  if (sourceType === 'news_rss') {
+    return MOBILE_COPY.source.articleOriginal;
+  }
+
+  return MOBILE_COPY.source.sourceView;
+}

--- a/mobile/src/features/calendarBottomSheet.test.tsx
+++ b/mobile/src/features/calendarBottomSheet.test.tsx
@@ -68,8 +68,8 @@ describe('calendar selected-day bottom sheet', () => {
       true,
     );
     expect(tree.root.findAllByType(Text).some((node) => node.props.children === '발매 1 · 예정 1')).toBe(true);
-    expect(tree.root.findAllByType(Text).some((node) => node.props.children === 'Verified releases')).toBe(true);
-    expect(tree.root.findAllByType(Text).some((node) => node.props.children === 'Scheduled comebacks')).toBe(true);
+    expect(tree.root.findAllByType(Text).some((node) => node.props.children === '검증된 발매')).toBe(true);
+    expect(tree.root.findAllByType(Text).some((node) => node.props.children === '날짜가 잡힌 예정 컴백')).toBe(true);
     expect(tree.root.findAllByType(Text).some((node) => node.props.children === 'LOVE CATCHER')).toBe(true);
     expect(tree.root.findAllByType(Text).some((node) => node.props.children === '팀 페이지')).toBe(true);
 

--- a/mobile/src/features/calendarControls.test.tsx
+++ b/mobile/src/features/calendarControls.test.tsx
@@ -171,7 +171,7 @@ describe('calendar controls', () => {
       tree.root.findByProps({ testID: 'calendar-filter-apply' }).props.onPress();
     });
 
-    expect(hasText(tree, '현재 필터에서는 month-only 예정 신호를 숨깁니다.')).toBe(true);
+    expect(hasText(tree, '현재 필터에서는 월 단위 예정 신호를 숨깁니다.')).toBe(true);
     expect(mockTrackAnalyticsEvent).toHaveBeenCalledWith(
       'calendar_filter_changed',
       expect.objectContaining({
@@ -192,7 +192,7 @@ describe('calendar controls', () => {
       tree.root.findByProps({ testID: 'calendar-filter-apply' }).props.onPress();
     });
 
-    expect(hasText(tree, '현재 필터에서는 month-only 예정 신호를 숨깁니다.')).toBe(false);
+    expect(hasText(tree, '현재 필터에서는 월 단위 예정 신호를 숨깁니다.')).toBe(false);
     expect(mockTrackAnalyticsEvent).toHaveBeenCalledWith(
       'calendar_filter_changed',
       expect.objectContaining({
@@ -243,9 +243,9 @@ describe('calendar controls', () => {
     expect(tree.root.findByProps({ testID: 'calendar-view-list' }).props.accessibilityState.selected).toBe(
       true,
     );
-    expect(hasText(tree, 'Verified releases')).toBe(true);
-    expect(hasText(tree, 'Scheduled comebacks')).toBe(true);
-    expect(hasText(tree, 'Month-only signals')).toBe(true);
+    expect(hasText(tree, '검증된 발매')).toBe(true);
+    expect(hasText(tree, '날짜가 잡힌 예정 컴백')).toBe(true);
+    expect(hasText(tree, '월 단위 예정 신호')).toBe(true);
     expect(hasText(tree, 'LOVE CATCHER')).toBe(true);
     expect(hasText(tree, 'DUH!')).toBe(true);
     expect(hasTextContaining(tree, 'Rumored follow-up')).toBe(true);

--- a/mobile/src/selectors/index.ts
+++ b/mobile/src/selectors/index.ts
@@ -17,6 +17,12 @@ import type {
   TeamSummaryModel,
   UpcomingEventModel,
 } from '../types';
+import {
+  MOBILE_COPY,
+  formatMonthOnlyDateLabel,
+  resolveSourceLinkLabel,
+  resolveUpcomingStatusLabel,
+} from '../copy/mobileCopy';
 
 import {
   adaptLatestReleaseStreams,
@@ -583,14 +589,14 @@ export function selectEntityDetailSnapshot(
 
     const dateLabel =
       upcoming.datePrecision === 'exact'
-        ? upcoming.scheduledDate ?? '날짜 미정'
-        : `${upcoming.scheduledMonth ?? '날짜 미정'} · 날짜 미정`;
+        ? upcoming.scheduledDate ?? MOBILE_COPY.date.unknown
+        : formatMonthOnlyDateLabel(upcoming.scheduledMonth);
 
     sourceTimeline.push({
       id: `${upcoming.id}-source`,
       kind: 'upcoming_source',
       title: upcoming.releaseLabel ?? upcoming.headline,
-      meta: `${dateLabel} · ${upcoming.status ?? '예정'}`,
+      meta: `${dateLabel} · ${resolveUpcomingStatusLabel(upcoming.status) ?? MOBILE_COPY.status.scheduled}`,
       sourceUrl: upcoming.sourceUrl,
     });
   }
@@ -646,7 +652,7 @@ function parseIsoDate(value: string | undefined): number | null {
 
 function resolveDayLabel(todayIsoDate: string, scheduledDate?: string): string {
   if (!scheduledDate) {
-    return '날짜 미정';
+    return MOBILE_COPY.date.unknown;
   }
 
   const todayTime = parseIsoDate(todayIsoDate);
@@ -674,31 +680,11 @@ function resolveDayLabel(todayIsoDate: string, scheduledDate?: string): string {
 }
 
 function resolveRadarSourceLabel(sourceType: UpcomingEventModel['sourceType']): string {
-  if (sourceType === 'agency_notice' || sourceType === 'weverse_notice' || sourceType === 'official_social') {
-    return '공식 공지';
-  }
-
-  if (sourceType === 'news_rss') {
-    return '기사 원문';
-  }
-
-  return '소스 보기';
+  return resolveSourceLinkLabel(sourceType);
 }
 
 function resolveChangeStatusLabel(status?: string | null): string | null {
-  if (status === 'confirmed') {
-    return '확정';
-  }
-
-  if (status === 'scheduled') {
-    return '예정';
-  }
-
-  if (status === 'rumor') {
-    return '루머';
-  }
-
-  return null;
+  return resolveUpcomingStatusLabel(status) ?? null;
 }
 
 function formatChangeScheduleLabel(date?: string | null, status?: string | null): string {

--- a/mobile/src/services/backendDisplayAdapters.ts
+++ b/mobile/src/services/backendDisplayAdapters.ts
@@ -35,6 +35,11 @@ import type {
   BackendSearchUpcoming,
 } from './backendReadClient';
 import {
+  MOBILE_COPY,
+  formatMonthOnlyDateLabel,
+  resolveUpcomingStatusWithFallback,
+} from '../copy/mobileCopy';
+import {
   buildMonogram,
   normalizeReleaseKind,
   normalizeReleaseStream,
@@ -154,8 +159,8 @@ function adaptRadarUpcomingCard(input: BackendRadarUpcoming): RadarUpcomingCardM
       displayName: input.display_name,
     }),
     upcoming,
-    dayLabel: upcoming.scheduledDate ?? upcoming.scheduledMonth ?? '날짜 미정',
-    sourceLabel: input.release_format ?? input.date_status ?? '예정',
+    dayLabel: upcoming.scheduledDate ?? upcoming.scheduledMonth ?? MOBILE_COPY.date.unknown,
+    sourceLabel: input.release_format ?? resolveUpcomingStatusWithFallback(input.date_status),
     sourceUrl: input.source_url ?? undefined,
   };
 }
@@ -174,7 +179,7 @@ function adaptRadarChangeFeedItem(input: BackendRadarChangeFeedItem): RadarChang
       occurredAtLabel: input.occurred_at ?? undefined,
       releaseLabel: input.release_title ?? undefined,
       headline: input.release_title ?? undefined,
-      sourceLabel: 'Verified release',
+      sourceLabel: '검증된 발매',
     };
   }
 
@@ -185,13 +190,16 @@ function adaptRadarChangeFeedItem(input: BackendRadarChangeFeedItem): RadarChang
       displayName: input.display_name,
     }),
     changeTypeLabel: '예정 신호',
-    previousScheduleLabel: input.scheduled_month && !input.scheduled_date ? `${input.scheduled_month} · 날짜 미정` : '일정 조정',
+    previousScheduleLabel:
+      input.scheduled_month && !input.scheduled_date
+        ? formatMonthOnlyDateLabel(input.scheduled_month)
+        : '일정 조정',
     nextScheduleLabel:
-      input.scheduled_date ?? input.scheduled_month ?? input.headline ?? '날짜 미정',
+      input.scheduled_date ?? input.scheduled_month ?? input.headline ?? MOBILE_COPY.date.unknown,
     occurredAtLabel: input.occurred_at ?? undefined,
     releaseLabel: input.headline ?? undefined,
     headline: input.headline ?? undefined,
-    sourceLabel: 'Upcoming signal',
+    sourceLabel: '예정 신호',
   };
 }
 


### PR DESCRIPTION
## Summary
- align shared RN layout constraints with the mobile docs using token-driven sizing and line clamps
- centralize Korean-first copy/status/source labels in a shared helper and apply them across calendar, radar, search, entity detail, and release detail
- update affected tests for date-sheet copy and new shared helper behavior

## Verification
- cd mobile && npm run lint
- cd mobile && npm run typecheck
- cd mobile && npm test -- --runInBand src/copy/mobileCopy.test.ts src/components/release/TrackRow.test.tsx src/components/feedback/FeedbackState.test.tsx src/components/calendar/DateDetailSheet.test.tsx src/features/calendarBottomSheet.test.tsx src/features/calendarControls.test.tsx src/features/searchTab.test.tsx src/features/radarTab.test.tsx src/features/entityDetailScreen.test.tsx src/features/releaseDetailScreen.test.tsx
- git diff --check

Closes #430
Closes #431