### PR TITLE
Add canonical backend smoke fixtures

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -78,7 +78,7 @@ jobs:
           RAILWAY_SERVICE_ID: ${{ vars.RAILWAY_SERVICE_ID }}
         run: node ./backend/scripts/deploy-backend.mjs
 
-      - name: Run preview live smoke checks
+      - name: Run preview canonical fixture smoke checks
         working-directory: backend
         env:
           BACKEND_PUBLIC_URL: ${{ vars.BACKEND_PUBLIC_URL }}
@@ -148,7 +148,7 @@ jobs:
           RAILWAY_SERVICE_ID: ${{ vars.RAILWAY_SERVICE_ID }}
         run: node ./backend/scripts/deploy-backend.mjs
 
-      - name: Run production live smoke checks
+      - name: Run production canonical fixture smoke checks
         working-directory: backend
         env:
           BACKEND_PUBLIC_URL: ${{ vars.BACKEND_PUBLIC_URL }}

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ npm run build
 - 두 경로 모두 backend `npm ci`, `npm run build`, `npm run test`를 선행한 뒤 Railway CLI deploy를 실행
 - GitHub Environment `preview`, `production`에 `RAILWAY_TOKEN`, `RAILWAY_PROJECT_ID`, `RAILWAY_ENVIRONMENT_ID`, `RAILWAY_SERVICE_ID`, `BACKEND_PUBLIC_URL`를 설정해야 함
 
-backend deploy topology와 rehearsal 규칙은 `docs/specs/backend/preview-staging-backend-path.md`, public read rate-limit 정책은 `docs/specs/backend/public-read-rate-limit-policy.md`, 운영 entrypoint는 `backend/README.md`에 정리돼 있습니다.
+backend deploy topology와 rehearsal 규칙은 `docs/specs/backend/preview-staging-backend-path.md`, public read rate-limit 정책은 `docs/specs/backend/public-read-rate-limit-policy.md`, canonical live smoke fixture registry와 운영 entrypoint는 `backend/README.md`에 정리돼 있습니다.
 
 ## 현재 방향
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -221,17 +221,19 @@ deploy helper는 아래 스크립트다.
 
 - `backend/scripts/deploy-backend.mjs`
 - `backend/scripts/run-live-smoke-checks.mjs`
+- `backend/fixtures/live_backend_smoke_fixtures.json`
 
-deploy workflow는 Railway deploy 직후 같은 live smoke contract를 preview / production 모두에 적용한다.
+deploy workflow는 Railway deploy 직후 canonical fixture registry를 읽는 같은 live smoke contract를 preview / production 모두에 적용한다.
 
 - `/health`
 - `/ready`
 - `/v1/search?q=최예나`
+- `/v1/calendar/month?month=2026-03`
 - `/v1/entities/yena`
-- `/v1/releases/lookup?entity_slug=ive&title=REVIVE%2B&date=2026-02-23&stream=album`
+- `/v1/releases/lookup?entity_slug=ive&title=REVIVE%2B&date=2026-02-23&stream=album` -> `/v1/releases/:id`
 - `/v1/radar`
 
-`/ready`는 현재 deploy smoke 기준으로 `ready` 또는 `degraded`를 허용하고, `database.status=ready`는 필수로 본다. smoke 실패 시 job은 non-zero로 끝나고 deploy workflow도 실패한다.
+`/ready`는 현재 deploy smoke 기준으로 `ready` 또는 `degraded`를 허용하고, `database.status=ready`는 필수로 본다. fixture smoke는 known-good calendar / radar / entity / release detail payload가 `404/not_found` 또는 invalid shape로 내려오면 즉시 non-zero로 끝나고 deploy workflow도 실패한다.
 
 artifact:
 
@@ -244,6 +246,8 @@ manual smoke 예시:
 cd backend
 npm run smoke:live -- --target preview --base-url https://preview.example.com --report-path ./reports/live_backend_smoke_preview.json
 ```
+
+fixture registry를 바꿔서 deploy gate를 재현하고 싶으면 `--fixtures-path`로 다른 JSON을 넘기면 된다.
 
 manual dry-run 예시:
 

--- a/backend/fixtures/live_backend_smoke_fixtures.json
+++ b/backend/fixtures/live_backend_smoke_fixtures.json
@@ -1,0 +1,78 @@
+{
+  "version": 1,
+  "fixtures": [
+    {
+      "key": "search-yena",
+      "surface": "search",
+      "request": {
+        "query": "최예나"
+      },
+      "expect": {
+        "entity_slug": "yena",
+        "display_name": "YENA"
+      }
+    },
+    {
+      "key": "calendar-2026-03",
+      "surface": "calendar_month",
+      "request": {
+        "month": "2026-03"
+      },
+      "expect": {
+        "verified_release": {
+          "entity_slug": "tunexx",
+          "release_title": "SET BY US ONLY",
+          "date": "2026-03-03"
+        },
+        "exact_upcoming": {
+          "entity_slug": "yena",
+          "scheduled_date": "2026-03-11"
+        },
+        "require_month_only_bucket": true
+      }
+    },
+    {
+      "key": "radar-default",
+      "surface": "radar",
+      "request": {},
+      "expect": {
+        "long_gap_entity_slug": "weeekly",
+        "rookie_entity_slug": "allday-project"
+      }
+    },
+    {
+      "key": "entity-yena",
+      "surface": "entity_detail",
+      "request": {
+        "entity_slug": "yena"
+      },
+      "expect": {
+        "entity_slug": "yena",
+        "display_name": "YENA",
+        "next_upcoming_date": "2026-03-11",
+        "official_youtube_required": true
+      }
+    },
+    {
+      "key": "release-ive-revive-plus",
+      "surface": "release_detail",
+      "request": {
+        "entity_slug": "ive",
+        "title": "REVIVE+",
+        "date": "2026-02-23",
+        "stream": "album"
+      },
+      "expect": {
+        "entity_slug": "ive",
+        "release_title": "REVIVE+",
+        "release_date": "2026-02-23",
+        "stream": "album",
+        "title_tracks": [
+          "BLACKHOLE",
+          "BANG BANG"
+        ],
+        "youtube_music_status": "manual_override"
+      }
+    }
+  ]
+}

--- a/backend/scripts/run-live-smoke-checks.mjs
+++ b/backend/scripts/run-live-smoke-checks.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { randomUUID } from 'node:crypto';
-import { mkdir, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { performance } from 'node:perf_hooks';
 
@@ -9,6 +9,9 @@ const DEFAULT_TIMEOUT_MS = 5000;
 const DEFAULT_TARGET = 'preview';
 const DEFAULT_READY_STATUSES = ['ready', 'degraded'];
 const DEFAULT_REPORT_PATH = resolve(process.cwd(), './reports/live_backend_smoke_report.json');
+const DEFAULT_FIXTURES_PATH = resolve(process.cwd(), './fixtures/live_backend_smoke_fixtures.json');
+const VALID_STREAMS = new Set(['album', 'song']);
+const VALID_FIXTURE_SURFACES = new Set(['search', 'calendar_month', 'radar', 'entity_detail', 'release_detail']);
 
 function parseArgs(argv) {
   const options = {
@@ -16,6 +19,7 @@ function parseArgs(argv) {
     target: DEFAULT_TARGET,
     timeoutMs: DEFAULT_TIMEOUT_MS,
     reportPath: DEFAULT_REPORT_PATH,
+    fixturesPath: DEFAULT_FIXTURES_PATH,
     allowReadyStatuses: [...DEFAULT_READY_STATUSES],
     skipReady: false,
   };
@@ -43,6 +47,12 @@ function parseArgs(argv) {
 
     if (value === '--report-path') {
       options.reportPath = resolve(process.cwd(), argv[index + 1] ?? DEFAULT_REPORT_PATH);
+      index += 1;
+      continue;
+    }
+
+    if (value === '--fixtures-path') {
+      options.fixturesPath = resolve(process.cwd(), argv[index + 1] ?? DEFAULT_FIXTURES_PATH);
       index += 1;
       continue;
     }
@@ -81,6 +91,46 @@ function parseArgs(argv) {
     ...options,
     baseUrl: options.baseUrl.replace(/\/+$/, ''),
   };
+}
+
+function isRecord(value) {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function requireRecord(value, label) {
+  if (!isRecord(value)) {
+    throw new Error(`${label} must be an object.`);
+  }
+
+  return value;
+}
+
+function requireString(value, label) {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new Error(`${label} must be a non-empty string.`);
+  }
+
+  return value.trim();
+}
+
+function requireBoolean(value, label) {
+  if (typeof value !== 'boolean') {
+    throw new Error(`${label} must be a boolean.`);
+  }
+
+  return value;
+}
+
+function requireStringArray(value, label) {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error(`${label} must be a non-empty string array.`);
+  }
+
+  for (const entry of value) {
+    requireString(entry, `${label}[]`);
+  }
+
+  return value;
 }
 
 function buildRequestId(label) {
@@ -153,218 +203,665 @@ async function parseResponseBody(response) {
   }
 }
 
-async function runCheck(check, options) {
-  const requestId = buildRequestId(check.label);
-  const startedAt = performance.now();
+function buildRequestPath(urlString) {
+  const url = new URL(urlString);
+  return `${url.pathname}${url.search}`;
+}
+
+function describePath(request) {
+  return request?.path ?? 'unknown-path';
+}
+
+function validateJsonEnvelope(request) {
+  if (request.network_error) {
+    return `Network error for ${describePath(request)}: ${request.network_error}`;
+  }
+
+  if (request.status !== 200) {
+    return `Expected 200 from ${describePath(request)}, received ${String(request.status)}`;
+  }
+
+  if (!isRecord(request.body) || !('data' in request.body)) {
+    return `Expected a JSON read envelope from ${describePath(request)}.`;
+  }
+
+  return null;
+}
+
+function buildFailure(error, requests, status = null) {
+  return {
+    ok: false,
+    error,
+    status,
+    requests,
+  };
+}
+
+function buildSuccess(requests, status = 200) {
+  return {
+    ok: true,
+    error: null,
+    status,
+    requests,
+  };
+}
+
+async function requestJson(url, label, options) {
+  const requestId = buildRequestId(label);
 
   try {
-    const descriptor = await check.createRequest(options.baseUrl, requestId);
-    const response = await fetch(descriptor.url, {
-      method: descriptor.method ?? 'GET',
-      headers: descriptor.headers ?? buildHeaders(requestId),
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: buildHeaders(requestId),
       signal: AbortSignal.timeout(options.timeoutMs),
     });
     const { body, bodyPreview } = await parseResponseBody(response);
-    const durationMs = Number((performance.now() - startedAt).toFixed(2));
-    const validation = check.validate({ response, body, options });
 
     return {
-      label: check.label,
-      ok: validation.ok,
+      label,
+      path: buildRequestPath(url),
+      url,
       status: response.status,
-      duration_ms: durationMs,
       request_id_sent: requestId,
       response_request_id: readResponseRequestId(body, response),
       headers: selectHeaders(response),
+      body,
       body_preview: bodyPreview,
-      error: validation.ok ? null : validation.error,
+      network_error: null,
     };
   } catch (error) {
     return {
-      label: check.label,
-      ok: false,
+      label,
+      path: buildRequestPath(url),
+      url,
       status: null,
-      duration_ms: Number((performance.now() - startedAt).toFixed(2)),
       request_id_sent: requestId,
       response_request_id: null,
       headers: {},
+      body: null,
       body_preview: null,
-      error: error instanceof Error ? error.message : String(error),
+      network_error: error instanceof Error ? error.message : String(error),
     };
   }
 }
 
-function buildChecks(options) {
-  const checks = [
-    {
-      label: 'health',
-      createRequest(baseUrl, requestId) {
-        return {
-          url: `${baseUrl}/health`,
-          headers: buildHeaders(requestId),
-        };
-      },
-      validate({ response }) {
-        if (response.status !== 200) {
-          return {
-            ok: false,
-            error: `Expected 200 from /health, received ${response.status}`,
-          };
-        }
+function validateFixtureRegistry(fixtureRegistry) {
+  const registry = requireRecord(fixtureRegistry, 'fixture registry');
+  const fixtures = registry.fixtures;
 
-        return { ok: true, error: null };
-      },
-    },
-  ];
-
-  if (!options.skipReady) {
-    checks.push({
-      label: 'ready',
-      createRequest(baseUrl, requestId) {
-        return {
-          url: `${baseUrl}/ready`,
-          headers: buildHeaders(requestId),
-        };
-      },
-      validate({ response, body, options }) {
-        if (response.status !== 200) {
-          return {
-            ok: false,
-            error: `Expected 200 from /ready, received ${response.status}`,
-          };
-        }
-
-        const readyStatus = body && typeof body === 'object' && body !== null ? body.status : null;
-        const databaseStatus =
-          body &&
-          typeof body === 'object' &&
-          body !== null &&
-          typeof body.database === 'object' &&
-          body.database !== null
-            ? body.database.status
-            : null;
-
-        if (!options.allowReadyStatuses.includes(String(readyStatus))) {
-          return {
-            ok: false,
-            error: `Expected /ready status in [${options.allowReadyStatuses.join(', ')}], received ${String(readyStatus)}`,
-          };
-        }
-
-        if (databaseStatus !== 'ready') {
-          return {
-            ok: false,
-            error: `Expected /ready database.status to be ready, received ${String(databaseStatus)}`,
-          };
-        }
-
-        return { ok: true, error: null };
-      },
-    });
+  if (!Array.isArray(fixtures) || fixtures.length === 0) {
+    throw new Error('fixture registry.fixtures must be a non-empty array.');
   }
 
-  checks.push(
-    {
-      label: 'search-yena',
-      createRequest(baseUrl, requestId) {
-        return {
-          url: `${baseUrl}/v1/search?q=${encodeURIComponent('최예나')}`,
-          headers: buildHeaders(requestId),
-        };
-      },
-      validate({ response, body }) {
-        const entityMatches = Array.isArray(body?.data?.entities) ? body.data.entities : [];
-        const hasYena = entityMatches.some((entry) => entry?.entity_slug === 'yena');
+  const seenKeys = new Set();
 
-        if (response.status !== 200 || !hasYena) {
-          return {
-            ok: false,
-            error: 'Expected /v1/search?q=최예나 to return a YENA entity match',
-          };
+  fixtures.forEach((fixture, index) => {
+    const entry = requireRecord(fixture, `fixture[${index}]`);
+    const key = requireString(entry.key, `fixture[${index}].key`);
+    const surface = requireString(entry.surface, `fixture[${index}].surface`);
+
+    if (!VALID_FIXTURE_SURFACES.has(surface)) {
+      throw new Error(`fixture[${index}].surface must be one of ${Array.from(VALID_FIXTURE_SURFACES).join(', ')}.`);
+    }
+
+    if (seenKeys.has(key)) {
+      throw new Error(`fixture keys must be unique. Duplicate key: ${key}`);
+    }
+    seenKeys.add(key);
+
+    const request = requireRecord(entry.request, `fixture[${index}].request`);
+    const expect = requireRecord(entry.expect, `fixture[${index}].expect`);
+
+    switch (surface) {
+      case 'search':
+        requireString(request.query, `fixture[${index}].request.query`);
+        requireString(expect.entity_slug, `fixture[${index}].expect.entity_slug`);
+        if (expect.display_name !== undefined) {
+          requireString(expect.display_name, `fixture[${index}].expect.display_name`);
         }
-
-        return { ok: true, error: null };
-      },
-    },
-    {
-      label: 'entity-yena',
-      createRequest(baseUrl, requestId) {
-        return {
-          url: `${baseUrl}/v1/entities/yena`,
-          headers: buildHeaders(requestId),
-        };
-      },
-      validate({ response, body }) {
-        const entitySlug = body?.data?.identity?.entity_slug ?? body?.data?.entity_slug ?? null;
-
-        if (response.status !== 200 || entitySlug !== 'yena') {
-          return {
-            ok: false,
-            error: 'Expected /v1/entities/yena to return entity identity for YENA',
-          };
+        break;
+      case 'calendar_month':
+        requireString(request.month, `fixture[${index}].request.month`);
+        if (!/^\d{4}-\d{2}$/.test(request.month)) {
+          throw new Error(`fixture[${index}].request.month must be YYYY-MM.`);
         }
-
-        return { ok: true, error: null };
-      },
-    },
-    {
-      label: 'release-lookup-ive-revive-plus',
-      createRequest(baseUrl, requestId) {
-        return {
-          url: `${baseUrl}/v1/releases/lookup?entity_slug=ive&title=${encodeURIComponent('REVIVE+')}&date=2026-02-23&stream=album`,
-          headers: buildHeaders(requestId),
-        };
-      },
-      validate({ response, body }) {
-        const releaseId = body?.data?.release_id;
-
-        if (response.status !== 200 || typeof releaseId !== 'string' || releaseId.length === 0) {
-          return {
-            ok: false,
-            error: 'Expected /v1/releases/lookup to resolve IVE / REVIVE+ to a release_id',
-          };
+        {
+          const verifiedRelease = requireRecord(expect.verified_release, `fixture[${index}].expect.verified_release`);
+          requireString(verifiedRelease.entity_slug, `fixture[${index}].expect.verified_release.entity_slug`);
+          requireString(verifiedRelease.release_title, `fixture[${index}].expect.verified_release.release_title`);
+          requireString(verifiedRelease.date, `fixture[${index}].expect.verified_release.date`);
         }
-
-        return { ok: true, error: null };
-      },
-    },
-    {
-      label: 'radar',
-      createRequest(baseUrl, requestId) {
-        return {
-          url: `${baseUrl}/v1/radar`,
-          headers: buildHeaders(requestId),
-        };
-      },
-      validate({ response, body }) {
-        const data = body?.data;
-        const weekly = Array.isArray(data?.weekly_upcoming) ? data.weekly_upcoming : null;
-        const rookie = Array.isArray(data?.rookie) ? data.rookie : null;
-
-        if (response.status !== 200 || weekly === null || rookie === null) {
-          return {
-            ok: false,
-            error: 'Expected /v1/radar to return weekly_upcoming and rookie arrays',
-          };
+        if (expect.exact_upcoming !== undefined) {
+          const exactUpcoming = requireRecord(expect.exact_upcoming, `fixture[${index}].expect.exact_upcoming`);
+          requireString(exactUpcoming.entity_slug, `fixture[${index}].expect.exact_upcoming.entity_slug`);
+          requireString(exactUpcoming.scheduled_date, `fixture[${index}].expect.exact_upcoming.scheduled_date`);
         }
+        if (expect.require_month_only_bucket !== undefined) {
+          requireBoolean(expect.require_month_only_bucket, `fixture[${index}].expect.require_month_only_bucket`);
+        }
+        break;
+      case 'radar':
+        requireString(expect.long_gap_entity_slug, `fixture[${index}].expect.long_gap_entity_slug`);
+        requireString(expect.rookie_entity_slug, `fixture[${index}].expect.rookie_entity_slug`);
+        break;
+      case 'entity_detail':
+        requireString(request.entity_slug, `fixture[${index}].request.entity_slug`);
+        requireString(expect.entity_slug, `fixture[${index}].expect.entity_slug`);
+        if (expect.display_name !== undefined) {
+          requireString(expect.display_name, `fixture[${index}].expect.display_name`);
+        }
+        if (expect.next_upcoming_date !== undefined) {
+          requireString(expect.next_upcoming_date, `fixture[${index}].expect.next_upcoming_date`);
+        }
+        if (expect.official_youtube_required !== undefined) {
+          requireBoolean(expect.official_youtube_required, `fixture[${index}].expect.official_youtube_required`);
+        }
+        break;
+      case 'release_detail':
+        requireString(request.entity_slug, `fixture[${index}].request.entity_slug`);
+        requireString(request.title, `fixture[${index}].request.title`);
+        requireString(request.date, `fixture[${index}].request.date`);
+        if (!/^\d{4}-\d{2}-\d{2}$/.test(request.date)) {
+          throw new Error(`fixture[${index}].request.date must be YYYY-MM-DD.`);
+        }
+        requireString(request.stream, `fixture[${index}].request.stream`);
+        if (!VALID_STREAMS.has(request.stream)) {
+          throw new Error(`fixture[${index}].request.stream must be album or song.`);
+        }
+        requireString(expect.entity_slug, `fixture[${index}].expect.entity_slug`);
+        requireString(expect.release_title, `fixture[${index}].expect.release_title`);
+        requireString(expect.release_date, `fixture[${index}].expect.release_date`);
+        requireString(expect.stream, `fixture[${index}].expect.stream`);
+        requireStringArray(expect.title_tracks, `fixture[${index}].expect.title_tracks`);
+        if (expect.youtube_music_status !== undefined) {
+          requireString(expect.youtube_music_status, `fixture[${index}].expect.youtube_music_status`);
+        }
+        break;
+      default:
+        throw new Error(`Unsupported fixture surface: ${surface}`);
+    }
+  });
 
-        return { ok: true, error: null };
-      },
+  return registry;
+}
+
+async function loadFixtureRegistry(fixturesPath) {
+  const raw = await readFile(fixturesPath, 'utf8');
+  const parsed = JSON.parse(raw);
+  return validateFixtureRegistry(parsed);
+}
+
+function buildHealthCheck() {
+  return {
+    label: 'health',
+    surface: 'health',
+    fixtureKey: null,
+    async execute(options) {
+      const request = await requestJson(`${options.baseUrl}/health`, 'health', options);
+      if (request.network_error) {
+        return buildFailure(`Network error for ${describePath(request)}: ${request.network_error}`, [request], request.status);
+      }
+
+      if (request.status !== 200) {
+        return buildFailure(`Expected 200 from ${request.path}, received ${String(request.status)}`, [request], request.status);
+      }
+
+      if (!isRecord(request.body) || request.body.status !== 'ok') {
+        return buildFailure(`Expected ${request.path} to return status=ok.`, [request], request.status);
+      }
+
+      return buildSuccess([request], request.status ?? 200);
     },
-  );
+  };
+}
 
-  return checks;
+function buildReadyCheck() {
+  return {
+    label: 'ready',
+    surface: 'readiness',
+    fixtureKey: null,
+    async execute(options) {
+      const request = await requestJson(`${options.baseUrl}/ready`, 'ready', options);
+      const envelopeError = validateJsonEnvelope(request);
+
+      if (envelopeError) {
+        return buildFailure(envelopeError, [request], request.status);
+      }
+
+      const readyStatus = request.body?.status;
+      const databaseStatus =
+        request.body &&
+        typeof request.body === 'object' &&
+        request.body !== null &&
+        typeof request.body.database === 'object' &&
+        request.body.database !== null
+          ? request.body.database.status
+          : null;
+
+      if (!options.allowReadyStatuses.includes(String(readyStatus))) {
+        return buildFailure(
+          `Expected /ready status in [${options.allowReadyStatuses.join(', ')}], received ${String(readyStatus)}`,
+          [request],
+          request.status,
+        );
+      }
+
+      if (databaseStatus !== 'ready') {
+        return buildFailure(
+          `Expected /ready database.status to be ready, received ${String(databaseStatus)}`,
+          [request],
+          request.status,
+        );
+      }
+
+      return buildSuccess([request], request.status ?? 200);
+    },
+  };
+}
+
+function buildSearchFixtureCheck(fixture) {
+  return {
+    label: `fixture:${fixture.key}`,
+    surface: fixture.surface,
+    fixtureKey: fixture.key,
+    async execute(options) {
+      const url = `${options.baseUrl}/v1/search?q=${encodeURIComponent(fixture.request.query)}`;
+      const request = await requestJson(url, fixture.key, options);
+      const envelopeError = validateJsonEnvelope(request);
+
+      if (envelopeError) {
+        return buildFailure(envelopeError, [request], request.status);
+      }
+
+      const entities = Array.isArray(request.body?.data?.entities) ? request.body.data.entities : null;
+      if (entities === null) {
+        return buildFailure(`Expected ${request.path} to return an entities array.`, [request], request.status);
+      }
+
+      const match = entities.find((entry) => entry?.entity_slug === fixture.expect.entity_slug);
+      if (!match) {
+        return buildFailure(
+          `Expected ${request.path} to contain entity_slug=${fixture.expect.entity_slug}.`,
+          [request],
+          request.status,
+        );
+      }
+
+      if (fixture.expect.display_name && match.display_name !== fixture.expect.display_name) {
+        return buildFailure(
+          `Expected ${request.path} to return display_name=${fixture.expect.display_name} for ${fixture.expect.entity_slug}.`,
+          [request],
+          request.status,
+        );
+      }
+
+      return buildSuccess([request], request.status ?? 200);
+    },
+  };
+}
+
+function buildCalendarFixtureCheck(fixture) {
+  return {
+    label: `fixture:${fixture.key}`,
+    surface: fixture.surface,
+    fixtureKey: fixture.key,
+    async execute(options) {
+      const url = `${options.baseUrl}/v1/calendar/month?month=${encodeURIComponent(fixture.request.month)}`;
+      const request = await requestJson(url, fixture.key, options);
+      const envelopeError = validateJsonEnvelope(request);
+
+      if (envelopeError) {
+        return buildFailure(envelopeError, [request], request.status);
+      }
+
+      const data = request.body?.data;
+      if (!isRecord(data) || !isRecord(data.summary)) {
+        return buildFailure(`Expected ${request.path} to return summary data.`, [request], request.status);
+      }
+
+      const summaryKeys = ['verified_count', 'exact_upcoming_count', 'month_only_upcoming_count'];
+      for (const key of summaryKeys) {
+        if (typeof data.summary[key] !== 'number') {
+          return buildFailure(`Expected ${request.path} summary.${key} to be numeric.`, [request], request.status);
+        }
+      }
+
+      const days = Array.isArray(data.days) ? data.days : null;
+      const monthOnlyUpcoming = Array.isArray(data.month_only_upcoming) ? data.month_only_upcoming : null;
+      const verifiedList = Array.isArray(data.verified_list) ? data.verified_list : [];
+
+      if (days === null || monthOnlyUpcoming === null) {
+        return buildFailure(
+          `Expected ${request.path} to return days and month_only_upcoming arrays.`,
+          [request],
+          request.status,
+        );
+      }
+
+      const hasInvalidExactUpcoming = days.some(
+        (day) =>
+          !Array.isArray(day?.exact_upcoming) ||
+          day.exact_upcoming.some((entry) => entry?.date_precision !== 'exact'),
+      );
+      if (hasInvalidExactUpcoming) {
+        return buildFailure(`Expected ${request.path} exact_upcoming items to stay exact-only.`, [request], request.status);
+      }
+
+      const hasInvalidMonthOnly = monthOnlyUpcoming.some((entry) => entry?.date_precision !== 'month_only');
+      if (hasInvalidMonthOnly) {
+        return buildFailure(
+          `Expected ${request.path} month_only_upcoming items to stay month_only.`,
+          [request],
+          request.status,
+        );
+      }
+
+      if (fixture.expect.require_month_only_bucket === true && monthOnlyUpcoming.length === 0) {
+        return buildFailure(`Expected ${request.path} to contain at least one month_only_upcoming item.`, [request], request.status);
+      }
+
+      const expectedVerified = fixture.expect.verified_release;
+      const verifiedMatch = verifiedList.find(
+        (entry) =>
+          entry?.entity_slug === expectedVerified.entity_slug &&
+          entry?.release_title === expectedVerified.release_title &&
+          entry?.release_date === expectedVerified.date,
+      );
+
+      if (!verifiedMatch) {
+        return buildFailure(
+          `Expected ${request.path} to include verified release ${expectedVerified.entity_slug}/${expectedVerified.release_title}/${expectedVerified.date}.`,
+          [request],
+          request.status,
+        );
+      }
+
+      if (fixture.expect.exact_upcoming) {
+        const expectedUpcoming = fixture.expect.exact_upcoming;
+        const exactUpcomingMatch = days.some(
+          (day) =>
+            Array.isArray(day?.exact_upcoming) &&
+            day.exact_upcoming.some(
+              (entry) =>
+                entry?.entity_slug === expectedUpcoming.entity_slug &&
+                entry?.scheduled_date === expectedUpcoming.scheduled_date &&
+                entry?.date_precision === 'exact',
+            ),
+        );
+
+        if (!exactUpcomingMatch) {
+          return buildFailure(
+            `Expected ${request.path} to include exact upcoming ${expectedUpcoming.entity_slug}/${expectedUpcoming.scheduled_date}.`,
+            [request],
+            request.status,
+          );
+        }
+      }
+
+      return buildSuccess([request], request.status ?? 200);
+    },
+  };
+}
+
+function buildRadarFixtureCheck(fixture) {
+  return {
+    label: `fixture:${fixture.key}`,
+    surface: fixture.surface,
+    fixtureKey: fixture.key,
+    async execute(options) {
+      const request = await requestJson(`${options.baseUrl}/v1/radar`, fixture.key, options);
+      const envelopeError = validateJsonEnvelope(request);
+
+      if (envelopeError) {
+        return buildFailure(envelopeError, [request], request.status);
+      }
+
+      const data = request.body?.data;
+      const longGap = Array.isArray(data?.long_gap) ? data.long_gap : null;
+      const rookie = Array.isArray(data?.rookie) ? data.rookie : null;
+      const weeklyUpcoming = Array.isArray(data?.weekly_upcoming) ? data.weekly_upcoming : null;
+      const changeFeed = Array.isArray(data?.change_feed) ? data.change_feed : null;
+
+      if (longGap === null || rookie === null || weeklyUpcoming === null || changeFeed === null) {
+        return buildFailure(
+          `Expected ${request.path} to return weekly_upcoming, change_feed, long_gap, and rookie arrays.`,
+          [request],
+          request.status,
+        );
+      }
+
+      if (!longGap.some((entry) => entry?.entity_slug === fixture.expect.long_gap_entity_slug)) {
+        return buildFailure(
+          `Expected ${request.path} long_gap to include ${fixture.expect.long_gap_entity_slug}.`,
+          [request],
+          request.status,
+        );
+      }
+
+      if (!rookie.some((entry) => entry?.entity_slug === fixture.expect.rookie_entity_slug)) {
+        return buildFailure(
+          `Expected ${request.path} rookie to include ${fixture.expect.rookie_entity_slug}.`,
+          [request],
+          request.status,
+        );
+      }
+
+      return buildSuccess([request], request.status ?? 200);
+    },
+  };
+}
+
+function buildEntityDetailFixtureCheck(fixture) {
+  return {
+    label: `fixture:${fixture.key}`,
+    surface: fixture.surface,
+    fixtureKey: fixture.key,
+    async execute(options) {
+      const request = await requestJson(`${options.baseUrl}/v1/entities/${fixture.request.entity_slug}`, fixture.key, options);
+      const envelopeError = validateJsonEnvelope(request);
+
+      if (envelopeError) {
+        return buildFailure(envelopeError, [request], request.status);
+      }
+
+      const data = request.body?.data;
+      const identity = isRecord(data?.identity) ? data.identity : null;
+      const officialLinks = isRecord(data?.official_links) ? data.official_links : null;
+      const nextUpcoming = isRecord(data?.next_upcoming) ? data.next_upcoming : null;
+      const recentAlbums = Array.isArray(data?.recent_albums) ? data.recent_albums : null;
+      const sourceTimeline = Array.isArray(data?.source_timeline) ? data.source_timeline : null;
+
+      if (identity === null || recentAlbums === null || sourceTimeline === null) {
+        return buildFailure(
+          `Expected ${request.path} to return identity, recent_albums, and source_timeline blocks.`,
+          [request],
+          request.status,
+        );
+      }
+
+      if (identity.entity_slug !== fixture.expect.entity_slug) {
+        return buildFailure(
+          `Expected ${request.path} identity.entity_slug=${fixture.expect.entity_slug}, received ${String(identity.entity_slug)}.`,
+          [request],
+          request.status,
+        );
+      }
+
+      if (fixture.expect.display_name && identity.display_name !== fixture.expect.display_name) {
+        return buildFailure(
+          `Expected ${request.path} identity.display_name=${fixture.expect.display_name}, received ${String(identity.display_name)}.`,
+          [request],
+          request.status,
+        );
+      }
+
+      if (fixture.expect.official_youtube_required === true) {
+        const youtubeUrl = officialLinks?.youtube;
+        if (typeof youtubeUrl !== 'string' || youtubeUrl.length === 0) {
+          return buildFailure(`Expected ${request.path} to return an official YouTube link.`, [request], request.status);
+        }
+      }
+
+      if (fixture.expect.next_upcoming_date) {
+        if (nextUpcoming === null || nextUpcoming.scheduled_date !== fixture.expect.next_upcoming_date) {
+          return buildFailure(
+            `Expected ${request.path} next_upcoming.scheduled_date=${fixture.expect.next_upcoming_date}.`,
+            [request],
+            request.status,
+          );
+        }
+      }
+
+      return buildSuccess([request], request.status ?? 200);
+    },
+  };
+}
+
+function buildReleaseDetailFixtureCheck(fixture) {
+  return {
+    label: `fixture:${fixture.key}`,
+    surface: fixture.surface,
+    fixtureKey: fixture.key,
+    async execute(options) {
+      const lookupParams = new URLSearchParams({
+        entity_slug: fixture.request.entity_slug,
+        title: fixture.request.title,
+        date: fixture.request.date,
+        stream: fixture.request.stream,
+      });
+      const lookupRequest = await requestJson(
+        `${options.baseUrl}/v1/releases/lookup?${lookupParams.toString()}`,
+        `${fixture.key}-lookup`,
+        options,
+      );
+      const lookupError = validateJsonEnvelope(lookupRequest);
+
+      if (lookupError) {
+        return buildFailure(lookupError, [lookupRequest], lookupRequest.status);
+      }
+
+      const releaseId = lookupRequest.body?.data?.release_id;
+      const canonicalPath = lookupRequest.body?.data?.canonical_path;
+
+      if (typeof releaseId !== 'string' || releaseId.length === 0 || typeof canonicalPath !== 'string' || canonicalPath.length === 0) {
+        return buildFailure(
+          `Expected ${lookupRequest.path} to resolve a release_id and canonical_path.`,
+          [lookupRequest],
+          lookupRequest.status,
+        );
+      }
+
+      const detailRequest = await requestJson(`${options.baseUrl}${canonicalPath}`, `${fixture.key}-detail`, options);
+      const detailError = validateJsonEnvelope(detailRequest);
+
+      if (detailError) {
+        return buildFailure(detailError, [lookupRequest, detailRequest], detailRequest.status ?? lookupRequest.status);
+      }
+
+      const data = detailRequest.body?.data;
+      const release = isRecord(data?.release) ? data.release : null;
+      const tracks = Array.isArray(data?.tracks) ? data.tracks : null;
+      const youtubeMusic = isRecord(data?.service_links?.youtube_music) ? data.service_links.youtube_music : null;
+
+      if (release === null || tracks === null) {
+        return buildFailure(
+          `Expected ${detailRequest.path} to return release and tracks blocks.`,
+          [lookupRequest, detailRequest],
+          detailRequest.status,
+        );
+      }
+
+      const releaseMatches =
+        release.entity_slug === fixture.expect.entity_slug &&
+        release.release_title === fixture.expect.release_title &&
+        release.release_date === fixture.expect.release_date &&
+        release.stream === fixture.expect.stream;
+
+      if (!releaseMatches) {
+        return buildFailure(
+          `Expected ${detailRequest.path} to match ${fixture.expect.entity_slug}/${fixture.expect.release_title}/${fixture.expect.release_date}/${fixture.expect.stream}.`,
+          [lookupRequest, detailRequest],
+          detailRequest.status,
+        );
+      }
+
+      for (const titleTrack of fixture.expect.title_tracks) {
+        const trackMatch = tracks.find((entry) => entry?.title === titleTrack && entry?.is_title_track === true);
+        if (!trackMatch) {
+          return buildFailure(
+            `Expected ${detailRequest.path} to include title track ${titleTrack}.`,
+            [lookupRequest, detailRequest],
+            detailRequest.status,
+          );
+        }
+      }
+
+      if (fixture.expect.youtube_music_status) {
+        if (!youtubeMusic || youtubeMusic.status !== fixture.expect.youtube_music_status) {
+          return buildFailure(
+            `Expected ${detailRequest.path} youtube_music.status=${fixture.expect.youtube_music_status}.`,
+            [lookupRequest, detailRequest],
+            detailRequest.status,
+          );
+        }
+      }
+
+      return buildSuccess([lookupRequest, detailRequest], detailRequest.status ?? 200);
+    },
+  };
+}
+
+function buildFixtureCheck(fixture) {
+  switch (fixture.surface) {
+    case 'search':
+      return buildSearchFixtureCheck(fixture);
+    case 'calendar_month':
+      return buildCalendarFixtureCheck(fixture);
+    case 'radar':
+      return buildRadarFixtureCheck(fixture);
+    case 'entity_detail':
+      return buildEntityDetailFixtureCheck(fixture);
+    case 'release_detail':
+      return buildReleaseDetailFixtureCheck(fixture);
+    default:
+      throw new Error(`Unsupported fixture surface: ${fixture.surface}`);
+  }
+}
+
+function buildChecks(options, fixtureRegistry) {
+  const checks = [buildHealthCheck()];
+
+  if (!options.skipReady) {
+    checks.push(buildReadyCheck());
+  }
+
+  return checks.concat(fixtureRegistry.fixtures.map((fixture) => buildFixtureCheck(fixture)));
 }
 
 function buildSummary(checks) {
   const passed = checks.filter((check) => check.ok).length;
   const failed = checks.length - passed;
+  const bySurface = {};
+
+  for (const check of checks) {
+    const surface = check.surface ?? 'unknown';
+    const current = bySurface[surface] ?? { total: 0, passed: 0, failed: 0 };
+    current.total += 1;
+    if (check.ok) {
+      current.passed += 1;
+    } else {
+      current.failed += 1;
+    }
+    bySurface[surface] = current;
+  }
 
   return {
     total_checks: checks.length,
+    fixture_checks: checks.filter((check) => check.fixture_key !== null).length,
     passed_checks: passed,
     failed_checks: failed,
     ok: failed === 0,
+    by_surface: bySurface,
   };
 }
 
@@ -373,10 +870,52 @@ async function writeReport(reportPath, report) {
   await writeFile(reportPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
 }
 
+async function runCheck(check, options) {
+  const startedAt = performance.now();
+
+  try {
+    const result = await check.execute(options);
+
+    return {
+      label: check.label,
+      surface: check.surface ?? null,
+      fixture_key: check.fixtureKey ?? null,
+      ok: result.ok,
+      status: result.status ?? null,
+      duration_ms: Number((performance.now() - startedAt).toFixed(2)),
+      error: result.ok ? null : result.error,
+      requests: Array.isArray(result.requests)
+        ? result.requests.map((request) => ({
+            label: request.label,
+            path: request.path,
+            status: request.status,
+            request_id_sent: request.request_id_sent,
+            response_request_id: request.response_request_id,
+            headers: request.headers,
+            body_preview: request.body_preview,
+            network_error: request.network_error,
+          }))
+        : [],
+    };
+  } catch (error) {
+    return {
+      label: check.label,
+      surface: check.surface ?? null,
+      fixture_key: check.fixtureKey ?? null,
+      ok: false,
+      status: null,
+      duration_ms: Number((performance.now() - startedAt).toFixed(2)),
+      error: error instanceof Error ? error.message : String(error),
+      requests: [],
+    };
+  }
+}
+
 async function main() {
   const options = parseArgs(process.argv.slice(2));
   const startedAt = new Date().toISOString();
-  const checks = buildChecks(options);
+  const fixtureRegistry = await loadFixtureRegistry(options.fixturesPath);
+  const checks = buildChecks(options, fixtureRegistry);
   const results = [];
 
   for (const check of checks) {
@@ -389,6 +928,8 @@ async function main() {
     target: options.target,
     base_url: options.baseUrl,
     timeout_ms: options.timeoutMs,
+    fixtures_path: options.fixturesPath,
+    fixture_keys: fixtureRegistry.fixtures.map((fixture) => fixture.key),
     ready_statuses_allowed: options.allowReadyStatuses,
     ready_check_skipped: options.skipReady,
     summary: buildSummary(results),
@@ -397,7 +938,7 @@ async function main() {
 
   await writeReport(options.reportPath, report);
 
-  const summaryLine = `[live-smoke] target=${options.target} passed=${report.summary.passed_checks} failed=${report.summary.failed_checks} report=${options.reportPath}`;
+  const summaryLine = `[live-smoke] target=${options.target} fixtures=${fixtureRegistry.fixtures.length} passed=${report.summary.passed_checks} failed=${report.summary.failed_checks} report=${options.reportPath}`;
   console.log(summaryLine);
 
   if (!report.summary.ok) {

--- a/backend/src/lib/live-smoke-fixtures.test.ts
+++ b/backend/src/lib/live-smoke-fixtures.test.ts
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import test from 'node:test';
+
+const FIXTURES_PATH = resolve(process.cwd(), './fixtures/live_backend_smoke_fixtures.json');
+const VALID_SURFACES = new Set(['search', 'calendar_month', 'radar', 'entity_detail', 'release_detail']);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+test('canonical live smoke fixture registry covers required backend surfaces', async () => {
+  const raw = await readFile(FIXTURES_PATH, 'utf8');
+  const parsed = JSON.parse(raw) as unknown;
+
+  assert.ok(isRecord(parsed));
+  assert.ok(Array.isArray(parsed.fixtures));
+  assert.ok(parsed.fixtures.length >= 5);
+
+  const fixtures = parsed.fixtures as unknown[];
+  const keys = new Set<string>();
+  const surfaces = new Set<string>();
+
+  for (const fixture of fixtures) {
+    assert.ok(isRecord(fixture));
+
+    const keyValue = fixture.key;
+    const surfaceValue = fixture.surface;
+
+    if (typeof keyValue !== 'string') {
+      throw new Error('fixture.key must be a string');
+    }
+
+    if (typeof surfaceValue !== 'string') {
+      throw new Error('fixture.surface must be a string');
+    }
+
+    assert.ok(keyValue.length > 0);
+    assert.ok(VALID_SURFACES.has(surfaceValue));
+    assert.ok(isRecord(fixture.request));
+    assert.ok(isRecord(fixture.expect));
+    assert.equal(keys.has(keyValue), false);
+    keys.add(keyValue);
+    surfaces.add(surfaceValue);
+  }
+
+  assert.ok(surfaces.has('calendar_month'));
+  assert.ok(surfaces.has('radar'));
+  assert.ok(surfaces.has('entity_detail'));
+  assert.ok(surfaces.has('release_detail'));
+});
+
+test('release detail smoke fixture keeps the canonical IVE lookup contract', async () => {
+  const raw = await readFile(FIXTURES_PATH, 'utf8');
+  const parsed = JSON.parse(raw) as { fixtures: Array<Record<string, unknown>> };
+
+  const fixture = parsed.fixtures.find((entry) => entry.key === 'release-ive-revive-plus');
+  assert.ok(fixture);
+  assert.ok(isRecord(fixture.request));
+  assert.ok(isRecord(fixture.expect));
+
+  const request = fixture.request;
+  const expectBlock = fixture.expect;
+
+  assert.equal(request.entity_slug, 'ive');
+  assert.equal(request.title, 'REVIVE+');
+  assert.equal(request.date, '2026-02-23');
+  assert.equal(request.stream, 'album');
+  assert.deepEqual(expectBlock.title_tracks, ['BLACKHOLE', 'BANG BANG']);
+  assert.equal(expectBlock.youtube_music_status, 'manual_override');
+});


### PR DESCRIPTION
## Summary
- add a canonical live smoke fixture registry for search, calendar, radar, entity detail, and release detail
- make the live smoke script consume that registry and fail on missing or invalid fixture payloads
- document the fixture-driven deploy gate and cover the registry with backend tests

## Verification
- cd backend && npm run build
- cd backend && npm run test
- cd backend && npm run smoke:live -- --target preview --skip-ready --base-url http://127.0.0.1:3214 --report-path ./reports/live_backend_smoke_local.json
- cd backend && npm run smoke:live -- --target preview --skip-ready --base-url http://127.0.0.1:3214 --fixtures-path /tmp/idol-song-app-broken-live-smoke-fixtures.json --report-path ./reports/live_backend_smoke_local_broken.json
- git diff --check

Closes #402
Closes #411
Closes #412