### PR TITLE
Gate Pages publish on backend freshness handoff

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -84,12 +84,26 @@ jobs:
           BACKEND_PUBLIC_URL: ${{ vars.BACKEND_PUBLIC_URL }}
         run: npm run smoke:live -- --target preview --base-url "$BACKEND_PUBLIC_URL" --report-path ./reports/live_backend_smoke_preview.json
 
+      - name: Build preview backend freshness handoff artifact
+        working-directory: backend
+        env:
+          BACKEND_PUBLIC_URL: ${{ vars.BACKEND_PUBLIC_URL }}
+        run: npm run freshness:handoff -- --target preview --backend-public-url "$BACKEND_PUBLIC_URL" --report-path ./reports/backend_freshness_handoff_preview.json
+
       - name: Upload preview live smoke report
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: backend-live-smoke-preview
           path: backend/reports/live_backend_smoke_preview.json
+          if-no-files-found: warn
+
+      - name: Upload preview backend freshness handoff artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-freshness-handoff-preview
+          path: backend/reports/backend_freshness_handoff_preview.json
           if-no-files-found: warn
 
   deploy-production:
@@ -154,10 +168,24 @@ jobs:
           BACKEND_PUBLIC_URL: ${{ vars.BACKEND_PUBLIC_URL }}
         run: npm run smoke:live -- --target production --base-url "$BACKEND_PUBLIC_URL" --report-path ./reports/live_backend_smoke_production.json
 
+      - name: Build production backend freshness handoff artifact
+        working-directory: backend
+        env:
+          BACKEND_PUBLIC_URL: ${{ vars.BACKEND_PUBLIC_URL }}
+        run: npm run freshness:handoff -- --target production --backend-public-url "$BACKEND_PUBLIC_URL" --report-path ./reports/backend_freshness_handoff_production.json
+
       - name: Upload production live smoke report
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: backend-live-smoke-production
           path: backend/reports/live_backend_smoke_production.json
+          if-no-files-found: warn
+
+      - name: Upload production backend freshness handoff artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-freshness-handoff-production
+          path: backend/reports/backend_freshness_handoff_production.json
           if-no-files-found: warn

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -64,6 +64,13 @@ jobs:
           VITE_BACKEND_TARGET_ENV: production
         run: npm run verify:pages-backend-target
 
+      - name: Verify backend freshness handoff
+        working-directory: web
+        env:
+          VITE_API_BASE_URL: ${{ vars.VITE_API_BASE_URL }}
+          VITE_BACKEND_TARGET_ENV: production
+        run: npm run verify:pages-backend-handoff
+
       - name: Build site
         working-directory: web
         env:

--- a/.github/workflows/weekly-kpop-scan.yml
+++ b/.github/workflows/weekly-kpop-scan.yml
@@ -54,6 +54,7 @@ jobs:
       - name: Rebuild watchlist and scan future candidates
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          BACKEND_PUBLIC_URL: ${{ vars.VITE_API_BASE_URL }}
         run: |
           python build_tracking_watchlist.py
           python scan_upcoming_candidates.py
@@ -73,6 +74,7 @@ jobs:
             (
               cd backend
               npm run shadow:verify
+              npm run freshness:handoff -- --target production --backend-public-url "$BACKEND_PUBLIC_URL"
             )
           else
             echo "DATABASE_URL not configured; skipping upcoming/release pipeline DB sync and post-sync backend verification."
@@ -87,6 +89,14 @@ jobs:
         working-directory: web
         run: npm run build
 
+      - name: Upload backend freshness handoff artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-freshness-handoff-production
+          path: backend/reports/backend_freshness_handoff.json
+          if-no-files-found: warn
+
       - name: Commit refreshed data
         run: |
           if git diff --quiet; then
@@ -95,6 +105,6 @@ jobs:
           fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add tracking_watchlist.json tracking_watchlist.csv upcoming_release_candidates.json upcoming_release_candidates.csv manual_review_queue.json manual_review_queue.csv mv_manual_review_queue.json mv_manual_review_queue.csv web/src/data/watchlist.json web/src/data/upcomingCandidates.json web/src/data/releases.json web/src/data/releaseArtwork.json web/src/data/releaseDetails.json web/src/data/releaseChangeLog.json backend/reports/projection_refresh_summary.json backend/reports/backend_json_parity_report.json backend/reports/backend_shadow_read_report.json
+          git add tracking_watchlist.json tracking_watchlist.csv upcoming_release_candidates.json upcoming_release_candidates.csv manual_review_queue.json manual_review_queue.csv mv_manual_review_queue.json mv_manual_review_queue.csv web/src/data/watchlist.json web/src/data/upcomingCandidates.json web/src/data/releases.json web/src/data/releaseArtwork.json web/src/data/releaseDetails.json web/src/data/releaseChangeLog.json backend/reports/projection_refresh_summary.json backend/reports/backend_json_parity_report.json backend/reports/backend_shadow_read_report.json backend/reports/backend_freshness_handoff.json
           git commit -m "chore: refresh upcoming scan data"
           git push

--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ python3 sync_release_pipeline_to_neon.py
 - run note: `backend/sql/README.md`
 - upcoming dual-write report: `backend/reports/upcoming_pipeline_db_sync_summary.json`
 - projection refresh report: `backend/reports/projection_refresh_summary.json`
+- backend freshness handoff artifact: `backend/reports/backend_freshness_handoff.json`
 - endpoint shadow-read report: `backend/reports/backend_shadow_read_report.json`
 - backup/restore drill artifact: `backend/reports/neon_backup_restore_drill_2026-03-08.json`
 - backend secret rotation tabletop artifact: `backend/reports/backend_secret_rotation_tabletop_2026-03-08.md`
@@ -228,7 +229,8 @@ npm run dev
 - committed JSON snapshot은 import/parity/debug artifact로 유지되지만, shipped web cut-over surface의 runtime source switch로는 더 이상 사용하지 않는다.
 - `web/.env.example`에는 Pages / preview rehearsal에서 쓰는 API base env baseline이 들어 있다.
 - `.github/workflows/deploy-pages.yml`은 GitHub Pages build에 `VITE_API_BASE_URL`과 `VITE_BACKEND_TARGET_ENV=production`을 함께 주입한다.
-- `npm run build`는 Pages read bridge(`web/public/__bridge/v1/**`)를 먼저 생성하고, deploy workflow도 `npm run verify:pages-read-bridge`, `npm run verify:pages-backend-target`로 bridge completeness와 active backend target wiring을 같이 gate로 막는다.
+- `npm run build`는 Pages read bridge(`web/public/__bridge/v1/**`)를 먼저 생성하고, deploy workflow도 `npm run verify:pages-read-bridge`, `npm run verify:pages-backend-target`, `npm run verify:pages-backend-handoff`로 bridge completeness, active backend target wiring, latest backend freshness handoff를 같이 gate로 막는다.
+- `backend/reports/backend_freshness_handoff.json`은 latest release sync, latest upcoming sync, projection refresh 순서와 Pages target URL 정합성을 요약한 deploy-time artifact다.
 - 내부 inspection path는 `/__bridge/v1/meta/backend-target.json`이며, 앱에서는 `?inspect=backend-target` query로 현재 runtime target 진단 패널을 열 수 있다.
 
 ### 프로덕션 빌드
@@ -250,6 +252,7 @@ npm run build
 - exact date 예정 컴백 기준 release hydration 수행
 - 변경 로그 산출
 - 웹 앱 데이터 동기화
+- canonical DB sync / projection refresh 뒤 `backend/reports/backend_freshness_handoff.json` 생성
 - 프론트엔드 빌드 검증
 - 데이터 변경 시 자동 커밋
 
@@ -258,6 +261,7 @@ npm run build
 파일: `.github/workflows/deploy-pages.yml`
 
 - `web/` 앱을 빌드
+- Pages target env / backend target / backend freshness handoff를 모두 검증한 뒤에만 publish
 - `web/dist`를 GitHub Pages에 배포
 - `main` 브랜치의 웹 변경 사항을 자동 반영
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -20,6 +20,7 @@ cut-over surface의 primary read path는 API이고, committed JSON은 transition
   - preview / production runtime config baseline
 - `reports/`
   - import / dual-write / projection refresh / parity summary artifact
+  - Pages publish gate가 읽는 backend freshness handoff artifact
   - backup / restore recovery drill artifact
   - secret rotation tabletop artifact
 - `sql/migrations/`
@@ -239,6 +240,17 @@ artifact:
 
 - preview: `backend/reports/live_backend_smoke_preview.json`
 - production: `backend/reports/live_backend_smoke_production.json`
+- preview freshness handoff: `backend/reports/backend_freshness_handoff_preview.json`
+- production freshness handoff: `backend/reports/backend_freshness_handoff_production.json`
+- repo-tracked Pages gate artifact: `backend/reports/backend_freshness_handoff.json`
+
+Pages publish path는 repo에 커밋된 `backend/reports/backend_freshness_handoff.json`을 읽어 아래를 같이 검증한다.
+
+- latest release pipeline sync summary가 존재하는지
+- latest upcoming pipeline sync summary가 존재하는지
+- projection refresh가 위 sync들 뒤에 실행됐는지
+- artifact target URL / env가 `VITE_API_BASE_URL`, `VITE_BACKEND_TARGET_ENV`와 일치하는지
+- handoff artifact가 과도하게 오래되지 않았는지
 
 manual smoke 예시:
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,6 +13,7 @@
     "projection:refresh": "node ./scripts/refresh-projections.mjs",
     "shadow:verify": "npm run build && node ./scripts/build-shadow-read-report.mjs",
     "smoke:live": "node ./scripts/run-live-smoke-checks.mjs",
+    "freshness:handoff": "node ./scripts/build-backend-freshness-handoff.mjs",
     "migration:scorecard": "node ./scripts/build-migration-readiness-scorecard.mjs",
     "recovery:drill": "node ./scripts/run-backup-restore-drill.mjs",
     "runtime:measure": "node ./scripts/measure-read-api-runtime.mjs",

--- a/backend/reports/backend_freshness_handoff.json
+++ b/backend/reports/backend_freshness_handoff.json
@@ -1,0 +1,122 @@
+{
+  "generated_at": "2026-03-10T13:18:55.371Z",
+  "artifact_version": 1,
+  "status": "pass",
+  "target": {
+    "environment": "production",
+    "classification": "production",
+    "backend_public_url": "https://api.idol-song-app.example.com"
+  },
+  "source": {
+    "kind": "manual",
+    "workflow_name": null,
+    "git_commit_sha": null,
+    "github_run_id": null
+  },
+  "source_reports": {
+    "release_pipeline_sync": {
+      "path": "release_pipeline_db_sync_summary.json",
+      "generated_at": "2026-03-07T07:51:00.028Z"
+    },
+    "upcoming_pipeline_sync": {
+      "path": "upcoming_pipeline_db_sync_summary.json",
+      "generated_at": "2026-03-07T08:21:49.354Z"
+    },
+    "projection_refresh": {
+      "path": "projection_refresh_summary.json",
+      "generated_at": "2026-03-08T23:52:59.908Z"
+    },
+    "runtime_gate": {
+      "path": "runtime_gate_report.json",
+      "generated_at": "2026-03-09T00:10:27.541Z"
+    }
+  },
+  "prerequisite_checks": {
+    "release_pipeline_sync": {
+      "status": "pass",
+      "observed": {
+        "generated_at": "2026-03-07T07:51:00.028Z",
+        "scope": "release_pipeline",
+        "summary_path": "backend/reports/release_pipeline_db_sync_summary.json"
+      }
+    },
+    "upcoming_pipeline_sync": {
+      "status": "pass",
+      "observed": {
+        "generated_at": "2026-03-07T08:21:49.354Z",
+        "scope": "upcoming_pipeline",
+        "summary_path": "backend/reports/upcoming_pipeline_db_sync_summary.json"
+      }
+    },
+    "projection_row_counts": {
+      "status": "pass",
+      "observed": {
+        "generated_at": "2026-03-08T23:52:59.908Z",
+        "row_counts": {
+          "entity_search_documents": 117,
+          "calendar_month_projection": 216,
+          "entity_detail_projection": 117,
+          "release_detail_projection": 1771,
+          "radar_projection": 1
+        },
+        "missing_or_empty_keys": []
+      }
+    },
+    "sequence_after_sync": {
+      "status": "pass",
+      "observed": {
+        "release_sync_generated_at": "2026-03-07T07:51:00.028Z",
+        "upcoming_sync_generated_at": "2026-03-07T08:21:49.354Z",
+        "latest_sync_generated_at": "2026-03-07T08:21:49.354Z",
+        "projection_generated_at": "2026-03-08T23:52:59.908Z"
+      }
+    },
+    "artifact_freshness": {
+      "status": "pass",
+      "observed": {
+        "projection_generated_at": "2026-03-08T23:52:59.908Z",
+        "age_hours": 37.43
+      },
+      "thresholds": {
+        "passAgeHours": 96,
+        "reviewAgeHours": 168
+      }
+    },
+    "target_binding": {
+      "status": "pass",
+      "observed": {
+        "target_environment": "production",
+        "backend_public_url": "https://api.idol-song-app.example.com",
+        "classified_target": "production"
+      }
+    }
+  },
+  "runtime_gate_summary": {
+    "generated_at": "2026-03-09T00:10:27.541Z",
+    "projection_freshness_status": "pass",
+    "stage_gates": {
+      "shadow_to_web_cutover": "fail",
+      "web_cutover_to_json_demotion": "fail"
+    },
+    "summary_lines": [
+      "api latency: needs_review (worst p95=1148.96ms)",
+      "api error rate: needs_review (error rate=0)",
+      "projection freshness: pass (lag=17.46m)",
+      "worker cadence: fail (failure rate=n/a)",
+      "parity dependency: fail",
+      "shadow dependency: fail",
+      "historical catalog completeness dependency: fail",
+      "shadow -> web cutover gate: fail",
+      "web cutover -> JSON demotion gate: fail"
+    ]
+  },
+  "summary_lines": [
+    "status: pass",
+    "release sync: pass",
+    "upcoming sync: pass",
+    "projection rows: pass",
+    "projection after sync: pass",
+    "artifact freshness: pass (37.43h old)",
+    "target binding: pass (production -> production)"
+  ]
+}

--- a/backend/scripts/build-backend-freshness-handoff.mjs
+++ b/backend/scripts/build-backend-freshness-handoff.mjs
@@ -1,0 +1,415 @@
+#!/usr/bin/env node
+
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, relative, resolve } from 'node:path';
+
+const DEFAULT_REPORT_PATH = resolve(process.cwd(), './reports/backend_freshness_handoff.json');
+const DEFAULT_RELEASE_SYNC_REPORT_PATH = resolve(process.cwd(), './reports/release_pipeline_db_sync_summary.json');
+const DEFAULT_UPCOMING_SYNC_REPORT_PATH = resolve(process.cwd(), './reports/upcoming_pipeline_db_sync_summary.json');
+const DEFAULT_PROJECTION_REPORT_PATH = resolve(process.cwd(), './reports/projection_refresh_summary.json');
+const DEFAULT_RUNTIME_GATE_REPORT_PATH = resolve(process.cwd(), './reports/runtime_gate_report.json');
+
+const REQUIRED_PROJECTION_ROWS = [
+  'entity_search_documents',
+  'calendar_month_projection',
+  'entity_detail_projection',
+  'release_detail_projection',
+  'radar_projection',
+];
+
+const FRESHNESS_THRESHOLDS = {
+  passAgeHours: 96,
+  reviewAgeHours: 168,
+};
+
+function parseArgs(argv) {
+  const options = {
+    reportPath: DEFAULT_REPORT_PATH,
+    releaseSyncReportPath: DEFAULT_RELEASE_SYNC_REPORT_PATH,
+    upcomingSyncReportPath: DEFAULT_UPCOMING_SYNC_REPORT_PATH,
+    projectionReportPath: DEFAULT_PROJECTION_REPORT_PATH,
+    runtimeGateReportPath: DEFAULT_RUNTIME_GATE_REPORT_PATH,
+    target: '',
+    backendPublicUrl: '',
+    sourceKind: process.env.GITHUB_ACTIONS === 'true' ? 'automation' : 'manual',
+    workflowName: process.env.GITHUB_WORKFLOW ?? null,
+    gitCommitSha: process.env.GITHUB_SHA ?? null,
+    githubRunId: process.env.GITHUB_RUN_ID ?? null,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const value = argv[index];
+
+    if (value === '--report-path') {
+      options.reportPath = resolve(process.cwd(), argv[index + 1]);
+      index += 1;
+      continue;
+    }
+
+    if (value === '--release-sync-report-path') {
+      options.releaseSyncReportPath = resolve(process.cwd(), argv[index + 1]);
+      index += 1;
+      continue;
+    }
+
+    if (value === '--upcoming-sync-report-path') {
+      options.upcomingSyncReportPath = resolve(process.cwd(), argv[index + 1]);
+      index += 1;
+      continue;
+    }
+
+    if (value === '--projection-report-path') {
+      options.projectionReportPath = resolve(process.cwd(), argv[index + 1]);
+      index += 1;
+      continue;
+    }
+
+    if (value === '--runtime-gate-report-path') {
+      options.runtimeGateReportPath = resolve(process.cwd(), argv[index + 1]);
+      index += 1;
+      continue;
+    }
+
+    if (value === '--target') {
+      options.target = normalizeTargetEnvironment(argv[index + 1]);
+      index += 1;
+      continue;
+    }
+
+    if (value === '--backend-public-url') {
+      options.backendPublicUrl = normalizeApiBaseUrl(argv[index + 1]);
+      index += 1;
+      continue;
+    }
+
+    if (value === '--source-kind') {
+      options.sourceKind = String(argv[index + 1] ?? '').trim() || options.sourceKind;
+      index += 1;
+      continue;
+    }
+
+    if (value === '--workflow-name') {
+      options.workflowName = String(argv[index + 1] ?? '').trim() || null;
+      index += 1;
+      continue;
+    }
+
+    if (value === '--git-commit-sha') {
+      options.gitCommitSha = String(argv[index + 1] ?? '').trim() || null;
+      index += 1;
+      continue;
+    }
+
+    if (value === '--github-run-id') {
+      options.githubRunId = String(argv[index + 1] ?? '').trim() || null;
+      index += 1;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${value}`);
+  }
+
+  return options;
+}
+
+async function loadJson(filePath) {
+  const contents = await readFile(filePath, 'utf8');
+  return JSON.parse(contents);
+}
+
+function normalizeApiBaseUrl(value) {
+  const normalized = String(value ?? '').trim();
+  if (!normalized) {
+    return '';
+  }
+
+  return normalized.replace(/\/+$/, '');
+}
+
+function normalizeTargetEnvironment(value) {
+  const normalized = String(value ?? '').trim().toLowerCase();
+  return normalized === 'production' || normalized === 'preview' || normalized === 'local' || normalized === 'bridge'
+    ? normalized
+    : '';
+}
+
+function classifyBackendTarget(apiBaseUrl) {
+  if (!apiBaseUrl) {
+    return 'bridge';
+  }
+
+  try {
+    const hostname = new URL(apiBaseUrl).hostname.toLowerCase();
+    if (
+      hostname === 'localhost' ||
+      hostname === '127.0.0.1' ||
+      hostname.endsWith('.local') ||
+      hostname.startsWith('127.')
+    ) {
+      return 'local';
+    }
+
+    if (
+      hostname.includes('preview') ||
+      hostname.includes('staging') ||
+      hostname.includes('dev') ||
+      hostname.includes('test')
+    ) {
+      return 'preview';
+    }
+
+    return 'production';
+  } catch {
+    return 'unknown';
+  }
+}
+
+function parseIsoTimestamp(value) {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    return null;
+  }
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+
+  return parsed.toISOString();
+}
+
+function hoursSince(timestamp) {
+  if (!timestamp) {
+    return null;
+  }
+
+  const parsed = new Date(timestamp);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+
+  return Number((((Date.now() - parsed.getTime()) / 1000) / 60 / 60).toFixed(2));
+}
+
+function buildReportReference(baseDir, reportPath, report) {
+  return {
+    path: relative(baseDir, reportPath),
+    generated_at: parseIsoTimestamp(report?.generated_at ?? null),
+  };
+}
+
+function buildSyncCheck(report, expectedScope) {
+  const generatedAt = parseIsoTimestamp(report?.generated_at ?? null);
+  const scope = typeof report?.scope === 'string' ? report.scope : null;
+  const status = generatedAt && scope === expectedScope ? 'pass' : 'fail';
+
+  return {
+    status,
+    observed: {
+      generated_at: generatedAt,
+      scope,
+      summary_path: typeof report?.summary_path === 'string' ? report.summary_path : null,
+    },
+  };
+}
+
+function buildProjectionRowCountCheck(report) {
+  const rowCounts =
+    report?.row_counts && typeof report.row_counts === 'object' && !Array.isArray(report.row_counts)
+      ? report.row_counts
+      : null;
+  const missingKeys = REQUIRED_PROJECTION_ROWS.filter((key) => typeof rowCounts?.[key] !== 'number' || rowCounts[key] <= 0);
+
+  return {
+    status: missingKeys.length === 0 ? 'pass' : 'fail',
+    observed: {
+      generated_at: parseIsoTimestamp(report?.generated_at ?? null),
+      row_counts: rowCounts,
+      missing_or_empty_keys: missingKeys,
+    },
+  };
+}
+
+function buildSequenceCheck(releaseSyncReport, upcomingSyncReport, projectionReport) {
+  const releaseAt = parseIsoTimestamp(releaseSyncReport?.generated_at ?? null);
+  const upcomingAt = parseIsoTimestamp(upcomingSyncReport?.generated_at ?? null);
+  const projectionAt = parseIsoTimestamp(projectionReport?.generated_at ?? null);
+
+  const latestSyncAt = [releaseAt, upcomingAt]
+    .filter((value) => typeof value === 'string')
+    .sort()
+    .at(-1) ?? null;
+
+  const status =
+    latestSyncAt && projectionAt && new Date(projectionAt).getTime() >= new Date(latestSyncAt).getTime() ? 'pass' : 'fail';
+
+  return {
+    status,
+    observed: {
+      release_sync_generated_at: releaseAt,
+      upcoming_sync_generated_at: upcomingAt,
+      latest_sync_generated_at: latestSyncAt,
+      projection_generated_at: projectionAt,
+    },
+  };
+}
+
+function buildFreshnessCheck(projectionReport) {
+  const generatedAt = parseIsoTimestamp(projectionReport?.generated_at ?? null);
+  const ageHours = hoursSince(generatedAt);
+
+  let status = 'fail';
+  if (typeof ageHours === 'number' && ageHours <= FRESHNESS_THRESHOLDS.passAgeHours) {
+    status = 'pass';
+  } else if (typeof ageHours === 'number' && ageHours <= FRESHNESS_THRESHOLDS.reviewAgeHours) {
+    status = 'needs_review';
+  }
+
+  return {
+    status,
+    observed: {
+      projection_generated_at: generatedAt,
+      age_hours: ageHours,
+    },
+    thresholds: FRESHNESS_THRESHOLDS,
+  };
+}
+
+function buildTargetBindingCheck(target, backendPublicUrl) {
+  const classification = backendPublicUrl ? classifyBackendTarget(backendPublicUrl) : null;
+  const normalizedTarget = normalizeTargetEnvironment(target);
+  const status = normalizedTarget && (!backendPublicUrl || (classification !== 'unknown' && normalizedTarget === classification))
+    ? 'pass'
+    : 'fail';
+
+  return {
+    status,
+    observed: {
+      target_environment: normalizedTarget || null,
+      backend_public_url: backendPublicUrl || null,
+      classified_target: classification,
+    },
+  };
+}
+
+function buildRuntimeGateSummary(runtimeGateReport) {
+  const projectionFreshnessStatus =
+    typeof runtimeGateReport?.runtime_checks?.projection_freshness?.status === 'string'
+      ? runtimeGateReport.runtime_checks.projection_freshness.status
+      : null;
+  const stageGates =
+    runtimeGateReport?.stage_gates && typeof runtimeGateReport.stage_gates === 'object' && !Array.isArray(runtimeGateReport.stage_gates)
+      ? {
+          shadow_to_web_cutover:
+            typeof runtimeGateReport.stage_gates.shadow_to_web_cutover === 'string'
+              ? runtimeGateReport.stage_gates.shadow_to_web_cutover
+              : null,
+          web_cutover_to_json_demotion:
+            typeof runtimeGateReport.stage_gates.web_cutover_to_json_demotion === 'string'
+              ? runtimeGateReport.stage_gates.web_cutover_to_json_demotion
+              : null,
+        }
+      : {
+          shadow_to_web_cutover: null,
+          web_cutover_to_json_demotion: null,
+        };
+
+  return {
+    generated_at: parseIsoTimestamp(runtimeGateReport?.generated_at ?? null),
+    projection_freshness_status: projectionFreshnessStatus,
+    stage_gates: stageGates,
+    summary_lines: Array.isArray(runtimeGateReport?.summary_lines)
+      ? runtimeGateReport.summary_lines.filter((entry) => typeof entry === 'string')
+      : [],
+  };
+}
+
+function worstStatus(statuses) {
+  if (statuses.includes('fail')) {
+    return 'fail';
+  }
+  if (statuses.includes('needs_review')) {
+    return 'needs_review';
+  }
+  return 'pass';
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const [releaseSyncReport, upcomingSyncReport, projectionReport, runtimeGateReport] = await Promise.all([
+    loadJson(options.releaseSyncReportPath),
+    loadJson(options.upcomingSyncReportPath),
+    loadJson(options.projectionReportPath),
+    loadJson(options.runtimeGateReportPath).catch(() => null),
+  ]);
+
+  const reportDir = dirname(options.reportPath);
+  const releasePipelineSync = buildSyncCheck(releaseSyncReport, 'release_pipeline');
+  const upcomingPipelineSync = buildSyncCheck(upcomingSyncReport, 'upcoming_pipeline');
+  const projectionRowCounts = buildProjectionRowCountCheck(projectionReport);
+  const sequenceAfterSync = buildSequenceCheck(releaseSyncReport, upcomingSyncReport, projectionReport);
+  const artifactFreshness = buildFreshnessCheck(projectionReport);
+  const targetBinding = buildTargetBindingCheck(options.target, options.backendPublicUrl);
+
+  const overallStatus = worstStatus([
+    releasePipelineSync.status,
+    upcomingPipelineSync.status,
+    projectionRowCounts.status,
+    sequenceAfterSync.status,
+    artifactFreshness.status,
+    targetBinding.status,
+  ]);
+
+  const handoff = {
+    generated_at: new Date().toISOString(),
+    artifact_version: 1,
+    status: overallStatus,
+    target: {
+      environment: normalizeTargetEnvironment(options.target) || null,
+      classification: options.backendPublicUrl ? classifyBackendTarget(options.backendPublicUrl) : null,
+      backend_public_url: options.backendPublicUrl || null,
+    },
+    source: {
+      kind: options.sourceKind,
+      workflow_name: options.workflowName,
+      git_commit_sha: options.gitCommitSha,
+      github_run_id: options.githubRunId,
+    },
+    source_reports: {
+      release_pipeline_sync: buildReportReference(reportDir, options.releaseSyncReportPath, releaseSyncReport),
+      upcoming_pipeline_sync: buildReportReference(reportDir, options.upcomingSyncReportPath, upcomingSyncReport),
+      projection_refresh: buildReportReference(reportDir, options.projectionReportPath, projectionReport),
+      runtime_gate: runtimeGateReport
+        ? buildReportReference(reportDir, options.runtimeGateReportPath, runtimeGateReport)
+        : {
+            path: relative(reportDir, options.runtimeGateReportPath),
+            generated_at: null,
+          },
+    },
+    prerequisite_checks: {
+      release_pipeline_sync: releasePipelineSync,
+      upcoming_pipeline_sync: upcomingPipelineSync,
+      projection_row_counts: projectionRowCounts,
+      sequence_after_sync: sequenceAfterSync,
+      artifact_freshness: artifactFreshness,
+      target_binding: targetBinding,
+    },
+    runtime_gate_summary: buildRuntimeGateSummary(runtimeGateReport),
+  };
+
+  handoff.summary_lines = [
+    `status: ${handoff.status}`,
+    `release sync: ${releasePipelineSync.status}`,
+    `upcoming sync: ${upcomingPipelineSync.status}`,
+    `projection rows: ${projectionRowCounts.status}`,
+    `projection after sync: ${sequenceAfterSync.status}`,
+    `artifact freshness: ${artifactFreshness.status} (${artifactFreshness.observed.age_hours ?? 'n/a'}h old)`,
+    `target binding: ${targetBinding.status} (${handoff.target.environment ?? 'unknown'} -> ${handoff.target.classification ?? 'n/a'})`,
+  ];
+
+  await mkdir(reportDir, { recursive: true });
+  await writeFile(options.reportPath, JSON.stringify(handoff, null, 2) + '\n', 'utf8');
+
+  console.log(JSON.stringify(handoff, null, 2));
+}
+
+await main();

--- a/docs/specs/backend/migration-operations-runbook.md
+++ b/docs/specs/backend/migration-operations-runbook.md
@@ -42,6 +42,7 @@
 | release dual-write | `python3 sync_release_pipeline_to_neon.py` | `backend/reports/release_pipeline_db_sync_summary.json` |
 | upcoming dual-write | `python3 sync_upcoming_pipeline_to_neon.py` | `backend/reports/upcoming_pipeline_db_sync_summary.json` |
 | projection refresh | `cd backend && npm run projection:refresh` | `backend/reports/projection_refresh_summary.json` |
+| backend freshness handoff | `cd backend && npm run freshness:handoff -- --target production --backend-public-url <url>` | `backend/reports/backend_freshness_handoff.json` |
 | backend-vs-JSON parity | `python3 build_backend_json_parity_report.py` | `backend/reports/backend_json_parity_report.json` |
 | endpoint shadow verify | `cd backend && npm run shadow:verify` | `backend/reports/backend_shadow_read_report.json` |
 | runtime latency / error sample | `cd backend && npm run runtime:measure -- --base-url <url>` | `backend/reports/read_api_runtime_measurements.json` |
@@ -111,6 +112,7 @@ python3 build_backend_json_parity_report.py
 cd backend
 npm run shadow:verify
 npm run runtime:gate
+npm run freshness:handoff -- --target production --backend-public-url <url>
 npm run migration:scorecard
 cd ..
 ```
@@ -143,6 +145,7 @@ runbook을 따라 한 번 실제로 걷는 최소 경로는 아래다.
 - [ ] `runtime_gate_report.json`에서 해당 stage gate가 `pass` 또는 승인된 `needs_review`다.
 - [ ] `migration_readiness_scorecard.json`에서 overall이 blocker-free이고, blocker-grade category가 모두 허용 범위 안이다.
 - [ ] Pages / local build에 `VITE_API_BASE_URL`이 올바르게 들어간다.
+- [ ] `backend_freshness_handoff.json`이 latest sync / projection 순서와 target binding을 `pass`로 증명한다.
 - [ ] shipped web cut-over surface가 API-only runtime으로 동작한다.
 - [ ] operator가 JSON rollback이 아니라 deploy rollback / backend repair 절차를 알고 있다.
 

--- a/web/package.json
+++ b/web/package.json
@@ -13,7 +13,8 @@
     "verify:fallback-reasons": "tsx ./scripts/verify-fallback-reasons.ts",
     "verify:mobile-web-handoff-qa": "tsx ./scripts/build-mobile-web-handoff-qa-matrix.ts",
     "verify:pages-read-bridge": "node ./scripts/verify-pages-read-bridge.mjs",
-    "verify:pages-backend-target": "node ./scripts/verify-pages-backend-target.mjs"
+    "verify:pages-backend-target": "node ./scripts/verify-pages-backend-target.mjs",
+    "verify:pages-backend-handoff": "node ./scripts/verify-pages-backend-handoff.mjs"
   },
   "dependencies": {
     "react": "^19.2.0",

--- a/web/scripts/verify-pages-backend-handoff.mjs
+++ b/web/scripts/verify-pages-backend-handoff.mjs
@@ -1,0 +1,142 @@
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const webRoot = path.resolve(__dirname, '..')
+const repoRoot = path.resolve(webRoot, '..')
+const handoffPath = resolveArtifactPath(process.env.BACKEND_FRESHNESS_HANDOFF_PATH)
+
+const expectedApiBaseUrl = normalizeApiBaseUrl(process.env.VITE_API_BASE_URL ?? '')
+const explicitTargetEnvironment = normalizeTargetEnvironment(process.env.VITE_BACKEND_TARGET_ENV ?? '')
+const expectedTargetClassification = classifyBackendTarget(expectedApiBaseUrl)
+const expectedTargetEnvironment = explicitTargetEnvironment || (expectedApiBaseUrl ? expectedTargetClassification : 'bridge')
+
+const handoff = await readJson(handoffPath)
+const target = handoff?.target ?? {}
+const checks = handoff?.prerequisite_checks ?? {}
+
+ensurePass('release_pipeline_sync', checks.release_pipeline_sync)
+ensurePass('upcoming_pipeline_sync', checks.upcoming_pipeline_sync)
+ensurePass('projection_row_counts', checks.projection_row_counts)
+ensurePass('sequence_after_sync', checks.sequence_after_sync)
+ensurePass('artifact_freshness', checks.artifact_freshness)
+ensurePass('target_binding', checks.target_binding)
+
+const handoffTargetEnvironment = normalizeTargetEnvironment(target.environment ?? '')
+const handoffTargetClassification = normalizeTargetClassification(target.classification ?? '')
+const handoffApiBaseUrl = normalizeApiBaseUrl(target.backend_public_url ?? '')
+
+if (handoff.status !== 'pass') {
+  throw new Error(`Backend freshness handoff status must be pass. Got ${String(handoff.status)}.`)
+}
+
+if (handoffTargetEnvironment !== expectedTargetEnvironment) {
+  throw new Error(
+    `Backend freshness handoff target environment mismatch. Expected ${expectedTargetEnvironment}, got ${handoffTargetEnvironment || '(empty)'}.`,
+  )
+}
+
+if (handoffTargetClassification && handoffTargetClassification !== expectedTargetClassification) {
+  throw new Error(
+    `Backend freshness handoff target classification mismatch. Expected ${expectedTargetClassification}, got ${handoffTargetClassification || '(empty)'}.`,
+  )
+}
+
+if (handoffApiBaseUrl && handoffApiBaseUrl !== expectedApiBaseUrl) {
+  throw new Error(
+    `Backend freshness handoff API base mismatch. Expected ${expectedApiBaseUrl || '(empty)'}, got ${handoffApiBaseUrl || '(empty)'}.`,
+  )
+}
+
+console.log(
+  JSON.stringify(
+    {
+      handoffPath: path.relative(repoRoot, handoffPath),
+      generatedAt: handoff.generated_at ?? null,
+      targetEnvironment: handoffTargetEnvironment,
+      targetClassification: handoffTargetClassification,
+      backendPublicUrl: handoffApiBaseUrl || null,
+      summaryLines: Array.isArray(handoff.summary_lines) ? handoff.summary_lines : [],
+    },
+    null,
+    2,
+  ),
+)
+
+function resolveArtifactPath(value) {
+  if (!value) {
+    return path.join(repoRoot, 'backend', 'reports', 'backend_freshness_handoff.json')
+  }
+
+  return path.isAbsolute(value) ? value : path.resolve(webRoot, value)
+}
+
+function ensurePass(label, check) {
+  if (!check || check.status !== 'pass') {
+    throw new Error(`Backend freshness prerequisite ${label} must be pass. Got ${String(check?.status ?? 'missing')}.`)
+  }
+}
+
+function normalizeApiBaseUrl(value) {
+  const normalized = String(value ?? '').trim()
+  if (!normalized) {
+    return ''
+  }
+
+  return normalized.replace(/\/+$/, '')
+}
+
+function normalizeTargetEnvironment(value) {
+  const normalized = String(value ?? '').trim().toLowerCase()
+  return normalized === 'production' || normalized === 'preview' || normalized === 'local' || normalized === 'bridge'
+    ? normalized
+    : ''
+}
+
+function normalizeTargetClassification(value) {
+  const normalized = String(value ?? '').trim().toLowerCase()
+  return normalized === 'production' ||
+    normalized === 'preview' ||
+    normalized === 'local' ||
+    normalized === 'bridge' ||
+    normalized === 'unknown'
+    ? normalized
+    : ''
+}
+
+function classifyBackendTarget(apiBaseUrl) {
+  if (!apiBaseUrl) {
+    return 'bridge'
+  }
+
+  try {
+    const hostname = new URL(apiBaseUrl).hostname.toLowerCase()
+    if (
+      hostname === 'localhost' ||
+      hostname === '127.0.0.1' ||
+      hostname.endsWith('.local') ||
+      hostname.startsWith('127.')
+    ) {
+      return 'local'
+    }
+
+    if (
+      hostname.includes('preview') ||
+      hostname.includes('staging') ||
+      hostname.includes('dev') ||
+      hostname.includes('test')
+    ) {
+      return 'preview'
+    }
+
+    return 'production'
+  } catch {
+    return 'unknown'
+  }
+}
+
+async function readJson(targetPath) {
+  const contents = await readFile(targetPath, 'utf8')
+  return JSON.parse(contents)
+}


### PR DESCRIPTION
## Summary
- add a backend freshness handoff artifact that records release/upcoming sync, projection refresh ordering, and Pages target binding
- gate Pages publish on that handoff artifact alongside the existing bridge and backend target verification
- publish freshness handoff artifacts from weekly scan and backend deploy workflows, and document the release sequence in the runbook

## Verification
- cd backend && npm run build
- cd backend && npm run freshness:handoff -- --target production --backend-public-url https://api.idol-song-app.example.com
- cd web && npm run lint
- cd web && VITE_API_BASE_URL=https://api.idol-song-app.example.com VITE_BACKEND_TARGET_ENV=production npm run build:pages-read-bridge
- cd web && VITE_API_BASE_URL=https://api.idol-song-app.example.com VITE_BACKEND_TARGET_ENV=production npm run verify:pages-read-bridge
- cd web && VITE_API_BASE_URL=https://api.idol-song-app.example.com VITE_BACKEND_TARGET_ENV=production npm run verify:pages-backend-target
- cd web && VITE_API_BASE_URL=https://api.idol-song-app.example.com VITE_BACKEND_TARGET_ENV=production npm run verify:pages-backend-handoff
- simulate bad handoff: BACKEND_FRESHNESS_HANDOFF_PATH=/tmp/idol-song-app-bad-handoff.json ... npm run verify:pages-backend-handoff -> fail
- simulate bad target: VITE_API_BASE_URL=http://localhost:3213 VITE_BACKEND_TARGET_ENV=production npm run verify:pages-backend-target -> fail
- git diff --check

Closes #401
Closes #409
Closes #410
Closes #414