### PR TITLE
Run RN release-readiness gate before preview sign-off

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,8 @@ python3 sync_release_pipeline_to_neon.py
   - preview / production은 backend-api primary, bundled static은 explicit fallback로만 유지
 - storage/cache layer: `mobile/src/services/storage.ts`, `mobile/src/services/datasetCache.ts`, `mobile/src/services/recentQueries.ts`
 - external handoff layer: `mobile/src/services/handoff.ts`
+- preview release-readiness artifact: `docs/specs/mobile/rn-release-readiness-gate-2026-03-10.md`
+- local readiness evidence: `docs/assets/distribution/rn_release_readiness_local_2026-03-10.md`
 - token/theme layer: `mobile/src/tokens/`, `mobile/src/tokens/theme.tsx`
 - selector/adapter layer: `mobile/src/selectors/`, `mobile/src/types/displayModels.ts`, `mobile/src/types/rawData.ts`
 - quality baseline: `mobile/eslint.config.js`, `mobile/jest.config.js`, `mobile/src/features/route-shell.smoke.test.tsx`, `mobile/src/config/runtime.test.ts`

--- a/docs/assets/distribution/rn_release_readiness_local_2026-03-10.md
+++ b/docs/assets/distribution/rn_release_readiness_local_2026-03-10.md
@@ -1,0 +1,113 @@
+# RN Release Readiness Local Evidence 2026-03-10
+
+## Scope
+- Issue: [#454](https://github.com/iAmSomething/idol-song-app/issues/454)
+- Branch: `codex/454-rn-release-readiness-gate`
+- Target: preview sign-off 전 RN release-readiness gate 실행
+
+## Commands
+
+### Preview config
+```bash
+cd /Users/gimtaehun/Desktop/idol-song-app/mobile
+EXPO_PUBLIC_API_BASE_URL=https://api.idol-song-app.example.com npm run config:preview
+```
+
+Result: `PASS`
+
+Notes:
+- `name`: `Idol Song App (Preview)`
+- `extra.mobileProfile`: `preview`
+- `extra.runtimeConfig.services.apiBaseUrl`: `https://api.idol-song-app.example.com/`
+- `extra.runtimeConfig.dataSource.mode`: `backend-api`
+
+### Quality gates
+```bash
+cd /Users/gimtaehun/Desktop/idol-song-app/mobile
+npm run lint
+npm run typecheck
+npm test -- --runInBand
+```
+
+Result:
+- `lint`: `PASS`
+- `typecheck`: `PASS`
+- `test`: `PASS`
+
+Test summary:
+- Suites: `34`
+- Tests: `134`
+- Failed: `0`
+
+### Static export smoke
+```bash
+cd /Users/gimtaehun/Desktop/idol-song-app/mobile
+EXPO_PUBLIC_API_BASE_URL=https://api.idol-song-app.example.com npx expo export --platform ios --output-dir /tmp/idol-song-app-mobile-export-ios-2026-03-10
+EXPO_PUBLIC_API_BASE_URL=https://api.idol-song-app.example.com npx expo export --platform android --output-dir /tmp/idol-song-app-mobile-export-android-2026-03-10
+```
+
+Result:
+- iOS export: `PASS`
+- Android export: `PASS`
+
+Outputs:
+- `/tmp/idol-song-app-mobile-export-ios-2026-03-10`
+- `/tmp/idol-song-app-mobile-export-android-2026-03-10`
+
+## Runtime Availability Checks
+
+### iOS simulator inventory
+```bash
+xcrun simctl list devices available
+xcrun xcdevice list
+```
+
+Result:
+- available simulator confirmed: `iPhone 16 Pro` / iOS `18.5`
+- attached physical iOS device evidence: none
+
+### iOS simulator boot
+```bash
+xcrun simctl boot 'iPhone 16 Pro'
+xcrun simctl bootstatus 'iPhone 16 Pro' -b
+xcrun simctl shutdown 'iPhone 16 Pro'
+```
+
+Result: `PASS`
+
+Notes:
+- bootstatus finished after simulator-side migration/bootstrap
+- this proves simulator runtime availability only
+- app-level manual walkthrough was not executed in this environment
+
+### Android runtime inventory
+```bash
+emulator -list-avds
+adb devices -l
+```
+
+Result:
+- `emulator -list-avds`: `BLOCKED` (`command not found`)
+- `adb devices -l`: `BLOCKED` (no attached devices)
+
+## Manual QA Matrix Status
+| Scenario | iOS | Android | Notes |
+| --- | --- | --- | --- |
+| QA-UC-01 Calendar Drill-in | NOT RUN | BLOCKED | runtime interaction evidence missing |
+| QA-UC-02 Empty Day | NOT RUN | BLOCKED | runtime interaction evidence missing |
+| QA-UC-03 Alias Search | NOT RUN | BLOCKED | backend/search logic auto-tested, manual runtime not executed |
+| QA-UC-04 Team Detail Hub | NOT RUN | BLOCKED | runtime interaction evidence missing |
+| QA-UC-05 Release Detail Consumption | NOT RUN | BLOCKED | runtime interaction evidence missing |
+
+## Accessibility / Platform Status
+- Code-level accessibility audit: `PASS`
+  - ref: `docs/specs/mobile/accessibility-audit-2026-03-09.md`
+- VoiceOver / TalkBack walkthrough on actual runtime: `BLOCKED`
+- largest text walkthrough on actual runtime: `BLOCKED`
+- iOS swipe-back / sheet gesture runtime QA: `NOT RUN`
+- Android hardware back / handoff return / state restore runtime QA: `BLOCKED`
+
+## Conclusion
+- Automated and document-backed readiness signals are strong.
+- Preview sign-off remains `BLOCKED` because the device matrix and accessibility/platform walkthrough are incomplete.
+- Follow-up issue: [#486](https://github.com/iAmSomething/idol-song-app/issues/486)

--- a/docs/specs/mobile/README.md
+++ b/docs/specs/mobile/README.md
@@ -106,12 +106,14 @@
    - 전체 mobile spec 문서와 RN issue 매핑
 50. `rn-selector-contract-audit.md`
    - selector/adaptor/display-model naming 및 contract parity audit
+51. `rn-release-readiness-gate-2026-03-10.md`
+   - preview sign-off 전 RN release-readiness gate 실행 결과와 blocker 분류
 ### Screen Specs
-51. `calendar-screen.md`
-52. `radar-screen.md`
-53. `search-screen.md`
-54. `team-detail-screen.md`
-55. `release-detail-screen.md`
+52. `calendar-screen.md`
+53. `radar-screen.md`
+54. `search-screen.md`
+55. `team-detail-screen.md`
+56. `release-detail-screen.md`
 
 ## 읽는 순서
 1. `master-spec.md`
@@ -161,9 +163,10 @@
 45. `rn-freshness-review-2026-03-10.md`
 46. `rn-traceability-matrix.md`
 47. `rn-selector-contract-audit.md`
-48. 각 화면 스펙
-49. `edge-case-catalog.md`
-50. `qa-acceptance-spec.md`
+48. `rn-release-readiness-gate-2026-03-10.md`
+49. 각 화면 스펙
+50. `edge-case-catalog.md`
+51. `qa-acceptance-spec.md`
 
 ## 구현 원칙
 - 모바일은 웹과 다른 레이아웃을 사용한다.

--- a/docs/specs/mobile/rn-release-readiness-gate-2026-03-10.md
+++ b/docs/specs/mobile/rn-release-readiness-gate-2026-03-10.md
@@ -1,0 +1,59 @@
+# RN Release Readiness Gate 2026-03-10
+
+## Decision
+- Preview sign-off: `BLOCKED`
+- Decision date: `2026-03-10`
+- Blocking follow-up: [#486](https://github.com/iAmSomething/idol-song-app/issues/486)
+- Local evidence: `docs/assets/distribution/rn_release_readiness_local_2026-03-10.md`
+
+## Summary
+자동 검증과 코드/문서 기반 구조 검증은 통과했다. 다만 preview sign-off 차단 조건인 실제 iOS/Android runtime QA matrix와 VoiceOver/TalkBack, largest text 재검증이 이 환경에서 완료되지 않았다. 따라서 이번 판정은 `GO`가 아니라 `BLOCKED`다.
+
+## Gate Result
+| Gate | Result | Evidence | Notes |
+| --- | --- | --- | --- |
+| Product | PASS | `rn-screen-structure-validation-2026-03-10.md`, `rn-journey-walkthrough-2026-03-10.md` | Calendar, Search, Radar, Team Detail, Release Detail 핵심 플로우 구조와 journey 검증 통과 |
+| Data | PASS | `npm test -- --runInBand`, `specParity.test.ts`, `searchTab.test.tsx` | alias search, release detail, month-only separation, backend/bundled fallback contract 자동 검증 통과 |
+| UX | PASS | `rn-screen-structure-validation-2026-03-10.md`, `qa-acceptance-spec.md` 기준 regression tests | action hierarchy, empty/error/partial state, sheet/list/grid 구조 유지 |
+| Accessibility | BLOCKED | `accessibility-audit-2026-03-09.md` | 코드 레벨 blocker는 해소됐지만 실제 iOS/Android VoiceOver/TalkBack, largest text walkthrough 미실행 |
+| Platform | BLOCKED | iOS simulator boot evidence, Android runtime availability check | iOS handoff/gesture, Android hardware back/handoff/state restore를 실제 runtime에서 재검증하지 못함 |
+| Test | BLOCKED | `lint`, `typecheck`, `test`, iOS/Android export PASS | 자동 검증은 통과했지만 QA-UC-01~05 manual checklist가 완료되지 않음 |
+| Ops | PASS | `config:preview`, export smoke, handoff/analytics guards existing tests | preview runtime config는 required env를 주면 정상 생성됨 |
+
+## Automated Checks
+| Check | Result | Notes |
+| --- | --- | --- |
+| `EXPO_PUBLIC_API_BASE_URL=... npm run config:preview` | PASS | preview profile, backend-api mode, API base URL 포함 config 생성 확인 |
+| `npm run lint` | PASS | no lint errors |
+| `npm run typecheck` | PASS | no type errors |
+| `npm test -- --runInBand` | PASS | `34` suites, `134` tests |
+| `npx expo export --platform ios` | PASS | output: `/tmp/idol-song-app-mobile-export-ios-2026-03-10` |
+| `npx expo export --platform android` | PASS | output: `/tmp/idol-song-app-mobile-export-android-2026-03-10` |
+
+## Device And Runtime Matrix
+| Runtime target | Result | Notes |
+| --- | --- | --- |
+| iOS Simulator `iPhone 16 Pro` / iOS `18.5` | PARTIAL | simulator boot completed with `xcrun simctl bootstatus`; app-level manual walkthrough는 이 환경에서 미실행 |
+| iOS physical device | BLOCKED | `xcrun xcdevice list` 기준 attached iPhone/iPad evidence 없음 |
+| Android emulator | BLOCKED | `emulator -list-avds` command unavailable |
+| Android physical device | BLOCKED | `adb devices -l` returned no attached devices |
+
+## Blockers
+1. `qa-acceptance-spec.md`의 QA-UC-01 ~ QA-UC-05 manual walkthrough 결과가 실제 iOS/Android runtime 기준으로 남아 있지 않다.
+2. `accessibility-platform-spec.md` 기준 VoiceOver / TalkBack / largest text 재검증 결과가 없다.
+3. Android runtime에서 hardware back, external handoff return, state restoration을 실제로 확인하지 못했다.
+
+## Non-Blockers
+1. preview runtime config는 required env(`EXPO_PUBLIC_API_BASE_URL`)를 주면 정상 생성된다.
+2. 구조/여정/접근성 코드 레벨 audit에서 현재 구현 blocker는 없다.
+3. JS bundle export는 iOS/Android 모두 성공했다.
+4. automated regression suite는 현재 기준 clean이다.
+
+## Sign-off Rule
+- 아래 세 항목이 모두 채워지기 전까지 preview sign-off는 `NO-GO`다.
+  1. iOS runtime manual matrix 결과
+  2. Android runtime manual matrix 결과
+  3. VoiceOver / TalkBack / largest text walkthrough 결과
+
+## Next Step
+- [#486](https://github.com/iAmSomething/idol-song-app/issues/486)에서 실제 runtime QA matrix와 accessibility walkthrough를 실행하고, 이 문서의 blocker를 `pass` 또는 `non-blocking residual risk`로 갱신한다.


### PR DESCRIPTION
## Summary
- add the dated RN release-readiness gate artifact and local evidence log
- record the current preview decision as BLOCKED with blocker vs non-blocker separation
- link the blocking follow-up runtime QA issue #486

## Validation
- EXPO_PUBLIC_API_BASE_URL=https://api.idol-song-app.example.com npm run config:preview
- npm run lint
- npm run typecheck
- npm test -- --runInBand
- EXPO_PUBLIC_API_BASE_URL=https://api.idol-song-app.example.com npx expo export --platform ios --output-dir /tmp/idol-song-app-mobile-export-ios-2026-03-10
- EXPO_PUBLIC_API_BASE_URL=https://api.idol-song-app.example.com npx expo export --platform android --output-dir /tmp/idol-song-app-mobile-export-android-2026-03-10
- xcrun simctl list devices available
- xcrun xcdevice list
- xcrun simctl boot 'iPhone 16 Pro' && xcrun simctl bootstatus 'iPhone 16 Pro' -b && xcrun simctl shutdown 'iPhone 16 Pro'
- emulator -list-avds || true
- adb devices -l || true
- git diff --check

## Decision
- preview sign-off: BLOCKED
- blocker follow-up: #486

Closes #454
