### PR TITLE
Stabilize mobile typography scale for iOS large-text accessibility

### DIFF
--- a/mobile/app/(tabs)/calendar.tsx
+++ b/mobile/app/(tabs)/calendar.tsx
@@ -5,6 +5,7 @@ import {
   ScrollView,
   StyleSheet,
   Text,
+  useWindowDimensions,
   View,
 } from 'react-native';
 
@@ -70,6 +71,7 @@ import {
   type RouteResumeTarget,
 } from '../../src/services/routeResume';
 import { useAppTheme } from '../../src/tokens/theme';
+import { MOBILE_TEXT_SCALE_LIMITS, isLargeTextMode } from '../../src/tokens/accessibility';
 import type { ServiceButtonGroupItem } from '../../src/components/actions/ServiceButtonGroup';
 import type { SourceLinkRowItem } from '../../src/components/meta/SourceLinkRow';
 import type {
@@ -208,7 +210,9 @@ export default function CalendarTabScreen() {
     view?: string | string[];
   }>();
   const theme = useAppTheme();
-  const styles = useMemo(() => createStyles(theme), [theme]);
+  const { fontScale } = useWindowDimensions();
+  const largeTextMode = isLargeTextMode(fontScale);
+  const styles = useMemo(() => createStyles(theme, largeTextMode), [theme, largeTextMode]);
   const today = useMemo(() => new Date(), []);
   const currentMonth = useMemo(() => buildMonthKey(today), [today]);
   const todayIsoDate = useMemo(() => today.toISOString().slice(0, 10), [today]);
@@ -809,53 +813,95 @@ export default function CalendarTabScreen() {
           <View style={styles.monthCluster}>
             <Text
               accessibilityRole="header"
-              style={styles.monthTitle}
+              allowFontScaling
+              maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.screenTitle}
+              style={[styles.monthTitle, largeTextMode ? styles.monthTitleCompact : null]}
               testID="calendar-month-title"
             >
               {formatMonthLabel(filteredSnapshot.month)}
             </Text>
-            <View style={styles.monthNav}>
+            <View style={[styles.monthNav, largeTextMode ? styles.actionRowLargeText : null]}>
               <Pressable
                 accessibilityHint="이전 달 일정을 봅니다."
                 accessibilityLabel={`${formatMonthLabel(moveMonthKey(activeMonth, -1))}로 이동`}
                 accessibilityRole="button"
                 onPress={() => moveToRelativeMonth(-1)}
-                style={({ pressed }) => [styles.headerButton, pressed ? styles.headerButtonPressed : null]}
+                style={({ pressed }) => [
+                  styles.headerButton,
+                  largeTextMode ? styles.headerButtonLargeText : null,
+                  pressed ? styles.headerButtonPressed : null,
+                ]}
                 testID="calendar-month-prev"
               >
-                <Text style={styles.headerButtonLabel}>이전</Text>
+                <Text
+                  allowFontScaling
+                  maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.buttonService}
+                  style={styles.headerButtonLabel}
+                >
+                  이전
+                </Text>
               </Pressable>
               <Pressable
                 accessibilityHint="다음 달 일정을 봅니다."
                 accessibilityLabel={`${formatMonthLabel(moveMonthKey(activeMonth, 1))}로 이동`}
                 accessibilityRole="button"
                 onPress={() => moveToRelativeMonth(1)}
-                style={({ pressed }) => [styles.headerButton, pressed ? styles.headerButtonPressed : null]}
+                style={({ pressed }) => [
+                  styles.headerButton,
+                  largeTextMode ? styles.headerButtonLargeText : null,
+                  pressed ? styles.headerButtonPressed : null,
+                ]}
                 testID="calendar-month-next"
               >
-                <Text style={styles.headerButtonLabel}>다음</Text>
+                <Text
+                  allowFontScaling
+                  maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.buttonService}
+                  style={styles.headerButtonLabel}
+                >
+                  다음
+                </Text>
               </Pressable>
             </View>
           </View>
-          <View style={styles.trailingActions}>
+          <View style={[styles.trailingActions, largeTextMode ? styles.actionRowLargeText : null]}>
             <Pressable
               accessibilityLabel="검색 탭으로 이동"
               accessibilityRole="button"
               onPress={openSearchTab}
-              style={({ pressed }) => [styles.headerButton, pressed ? styles.headerButtonPressed : null]}
+              style={({ pressed }) => [
+                styles.headerButton,
+                largeTextMode ? styles.headerButtonLargeText : null,
+                pressed ? styles.headerButtonPressed : null,
+              ]}
               testID="calendar-search-open"
             >
-              <Text style={styles.headerButtonLabel}>검색</Text>
+              <Text
+                allowFontScaling
+                maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.buttonService}
+                style={styles.headerButtonLabel}
+              >
+                검색
+              </Text>
             </Pressable>
             <Pressable
               accessibilityLabel="캘린더 필터 열기"
               accessibilityRole="button"
               accessibilityState={{ selected: filterMode !== 'all' || isFilterSheetOpen }}
               onPress={openFilterSheet}
-              style={({ pressed }) => [styles.headerButton, pressed ? styles.headerButtonPressed : null]}
+              style={({ pressed }) => [
+                styles.headerButton,
+                largeTextMode ? styles.headerButtonLargeText : null,
+                pressed ? styles.headerButtonPressed : null,
+              ]}
               testID="calendar-filter-open"
             >
-              <Text style={styles.headerButtonLabel}>필터</Text>
+              <Text
+                allowFontScaling
+                maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.buttonService}
+                style={styles.headerButtonLabel}
+              >
+                필터
+              </Text>
             </Pressable>
           </View>
         </View>
@@ -887,11 +933,18 @@ export default function CalendarTabScreen() {
         ) : null}
 
         <View style={styles.sectionCard}>
-          <View style={styles.sectionHeader}>
-            <Text accessibilityRole="header" style={styles.sectionTitle}>
-              보기
+            <View style={styles.sectionHeader}>
+              <Text
+                accessibilityRole="header"
+                allowFontScaling
+                maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.sectionTitle}
+                style={styles.sectionTitle}
+              >
+                보기
+              </Text>
+            <Text allowFontScaling maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.body} style={styles.sectionMeta}>
+              {formatFilterLabel(filterMode)}
             </Text>
-            <Text style={styles.sectionMeta}>{formatFilterLabel(filterMode)}</Text>
           </View>
           <SegmentedControl
             items={[
@@ -907,17 +960,27 @@ export default function CalendarTabScreen() {
         {viewMode === 'calendar' && monthGrid ? (
           <View style={styles.sectionCard}>
             <View style={styles.sectionHeader}>
-              <Text accessibilityRole="header" style={styles.sectionTitle}>
+              <Text
+                accessibilityRole="header"
+                allowFontScaling
+                maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.sectionTitle}
+                style={styles.sectionTitle}
+              >
                 월간 캘린더
               </Text>
-              <Text style={styles.sectionMeta}>
+              <Text allowFontScaling maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.body} style={styles.sectionMeta}>
                 {selectedDay ? selectedDay.label : formatMonthLabel(filteredSnapshot.month)}
               </Text>
             </View>
 
             <View style={styles.weekdayRow}>
               {monthGrid.weekdayLabels.map((label) => (
-                <Text key={label} style={styles.weekdayLabel}>
+                <Text
+                  key={label}
+                  allowFontScaling
+                  maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.meta}
+                  style={styles.weekdayLabel}
+                >
                   {label}
                 </Text>
               ))}
@@ -966,11 +1029,18 @@ export default function CalendarTabScreen() {
 
         {viewMode === 'calendar' ? (
           <View style={styles.sectionCard}>
-            <View style={styles.sectionHeader}>
-              <Text accessibilityRole="header" style={styles.sectionTitle}>
+              <View style={styles.sectionHeader}>
+              <Text
+                accessibilityRole="header"
+                allowFontScaling
+                maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.sectionTitle}
+                style={styles.sectionTitle}
+              >
                 월 단위 예정 신호
               </Text>
-              <Text style={styles.sectionMeta}>{filteredSnapshot.monthOnlyUpcoming.length}건</Text>
+              <Text allowFontScaling maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.body} style={styles.sectionMeta}>
+                {filteredSnapshot.monthOnlyUpcoming.length}건
+              </Text>
             </View>
             {filterMode === 'releases' ? (
               <InlineFeedbackNotice body="현재 필터에서는 월 단위 예정 신호를 숨깁니다." />
@@ -991,10 +1061,17 @@ export default function CalendarTabScreen() {
             {filterMode !== 'upcoming' ? (
               <View style={styles.sectionCard}>
                 <View style={styles.sectionHeader}>
-                  <Text accessibilityRole="header" style={styles.sectionTitle}>
+                  <Text
+                    accessibilityRole="header"
+                    allowFontScaling
+                    maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.sectionTitle}
+                    style={styles.sectionTitle}
+                  >
                     검증된 발매
                   </Text>
-                  <Text style={styles.sectionMeta}>{listReleaseRows.length}건</Text>
+                  <Text allowFontScaling maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.body} style={styles.sectionMeta}>
+                    {listReleaseRows.length}건
+                  </Text>
                 </View>
                 {listReleaseRows.length > 0 ? (
                   <View style={styles.sectionStack}>
@@ -1011,10 +1088,17 @@ export default function CalendarTabScreen() {
             {filterMode !== 'releases' ? (
               <View style={styles.sectionCard}>
                 <View style={styles.sectionHeader}>
-                  <Text accessibilityRole="header" style={styles.sectionTitle}>
+                  <Text
+                    accessibilityRole="header"
+                    allowFontScaling
+                    maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.sectionTitle}
+                    style={styles.sectionTitle}
+                  >
                     날짜가 잡힌 예정 컴백
                   </Text>
-                  <Text style={styles.sectionMeta}>{listExactUpcomingRows.length}건</Text>
+                  <Text allowFontScaling maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.body} style={styles.sectionMeta}>
+                    {listExactUpcomingRows.length}건
+                  </Text>
                 </View>
                 {listExactUpcomingRows.length > 0 ? (
                   <View style={styles.sectionStack}>
@@ -1030,10 +1114,17 @@ export default function CalendarTabScreen() {
 
             <View style={styles.sectionCard}>
               <View style={styles.sectionHeader}>
-                <Text accessibilityRole="header" style={styles.sectionTitle}>
+                <Text
+                  accessibilityRole="header"
+                  allowFontScaling
+                  maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.sectionTitle}
+                  style={styles.sectionTitle}
+                >
                   월 단위 예정 신호
                 </Text>
-                <Text style={styles.sectionMeta}>{listMonthOnlyRows.length}건</Text>
+                <Text allowFontScaling maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.body} style={styles.sectionMeta}>
+                  {listMonthOnlyRows.length}건
+                </Text>
               </View>
               {filterMode === 'releases' ? (
                 <InlineFeedbackNotice body="현재 필터에서는 월 단위 예정 신호를 숨깁니다." />
@@ -1079,7 +1170,7 @@ export default function CalendarTabScreen() {
   );
 }
 
-function createStyles(theme: ReturnType<typeof useAppTheme>) {
+function createStyles(theme: ReturnType<typeof useAppTheme>, largeTextMode: boolean) {
   const { lineHeight: _screenTitleLineHeight, ...screenTitleTypography } =
     theme.typography.screenTitle;
   const { lineHeight: _buttonServiceLineHeight, ...buttonServiceTypography } =
@@ -1113,7 +1204,18 @@ function createStyles(theme: ReturnType<typeof useAppTheme>) {
       ...screenTitleTypography,
       color: theme.colors.text.primary,
     },
+    monthTitleCompact: {
+      fontSize: theme.typography.sectionTitle.fontSize,
+      fontWeight: theme.typography.sectionTitle.fontWeight,
+      letterSpacing: theme.typography.sectionTitle.letterSpacing,
+    },
     monthNav: {
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+      gap: theme.space[8],
+    },
+    actionRowLargeText: {
+      width: '100%',
       flexDirection: 'row',
       flexWrap: 'wrap',
       gap: theme.space[8],
@@ -1134,6 +1236,11 @@ function createStyles(theme: ReturnType<typeof useAppTheme>) {
       backgroundColor: theme.colors.surface.elevated,
       borderWidth: 1,
       borderColor: theme.colors.border.subtle,
+    },
+    headerButtonLargeText: {
+      flexGrow: 1,
+      flexBasis: largeTextMode ? '48%' : undefined,
+      minWidth: 0,
     },
     headerButtonPressed: {
       opacity: 0.84,

--- a/mobile/app/(tabs)/radar.tsx
+++ b/mobile/app/(tabs)/radar.tsx
@@ -41,6 +41,7 @@ import {
   runWithPendingRouteResume,
   type RouteResumeTarget,
 } from '../../src/services/routeResume';
+import { MOBILE_TEXT_SCALE_LIMITS } from '../../src/tokens/accessibility';
 import { useAppTheme } from '../../src/tokens/theme';
 import {
   MOBILE_COPY,
@@ -556,7 +557,9 @@ export default function RadarTabScreen() {
             onPress={openSearchTab}
             style={({ pressed }) => [styles.appBarButton, pressed ? styles.buttonPressed : null]}
           >
-            <Text style={styles.appBarButtonLabel}>검색</Text>
+            <Text allowFontScaling maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.buttonService} style={styles.appBarButtonLabel}>
+              검색
+            </Text>
           </Pressable>
             <Pressable
               testID="radar-filter-button"
@@ -566,7 +569,9 @@ export default function RadarTabScreen() {
               onPress={openFilterSheet}
               style={({ pressed }) => [styles.appBarButton, pressed ? styles.buttonPressed : null]}
             >
-            <Text style={styles.appBarButtonLabel}>필터</Text>
+            <Text allowFontScaling maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.buttonService} style={styles.appBarButtonLabel}>
+              필터
+            </Text>
           </Pressable>
         </View>
 
@@ -708,7 +713,14 @@ function RadarFeaturedSection({
   return (
     <View style={styles.sectionCard}>
       <View style={styles.sectionHeader}>
-        <Text accessibilityRole="header" style={styles.sectionTitle}>가장 가까운 컴백</Text>
+        <Text
+          accessibilityRole="header"
+          allowFontScaling
+          maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.sectionTitle}
+          style={styles.sectionTitle}
+        >
+          가장 가까운 컴백
+        </Text>
       </View>
       {item ? (
         <View
@@ -756,7 +768,14 @@ function RadarSection({
   return (
     <View style={styles.sectionCard}>
       <View style={styles.sectionHeader}>
-        <Text accessibilityRole="header" style={styles.sectionTitle}>{title}</Text>
+        <Text
+          accessibilityRole="header"
+          allowFontScaling
+          maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.sectionTitle}
+          style={styles.sectionTitle}
+        >
+          {title}
+        </Text>
       </View>
       {children}
     </View>

--- a/mobile/app/(tabs)/search.tsx
+++ b/mobile/app/(tabs)/search.tsx
@@ -57,6 +57,7 @@ import {
   runWithPendingRouteResume,
   type RouteResumeTarget,
 } from '../../src/services/routeResume';
+import { MOBILE_TEXT_SCALE_LIMITS } from '../../src/tokens/accessibility';
 import { useAppTheme } from '../../src/tokens/theme';
 import type {
   ReleaseSummaryModel,
@@ -683,7 +684,9 @@ export default function SearchTabScreen() {
                 style={styles.inlineButton}
                 testID="search-clear-button"
               >
-                <Text style={styles.inlineButtonLabel}>지우기</Text>
+                <Text allowFontScaling maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.buttonService} style={styles.inlineButtonLabel}>
+                  지우기
+                </Text>
               </Pressable>
             ) : null}
             {showCancelAction ? (
@@ -694,7 +697,9 @@ export default function SearchTabScreen() {
                 style={styles.inlineButton}
                 testID="search-cancel-button"
               >
-                <Text style={styles.inlineButtonLabel}>취소</Text>
+                <Text allowFontScaling maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.buttonService} style={styles.inlineButtonLabel}>
+                  취소
+                </Text>
               </Pressable>
             ) : null}
           </View>
@@ -716,7 +721,14 @@ export default function SearchTabScreen() {
         <>
           <View style={styles.sectionCard}>
             <View style={styles.sectionHeader}>
-              <Text accessibilityRole="header" style={styles.sectionTitle}>최근 검색</Text>
+              <Text
+                accessibilityRole="header"
+                allowFontScaling
+                maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.sectionTitle}
+                style={styles.sectionTitle}
+              >
+                최근 검색
+              </Text>
               {recentQueries.length ? (
                 <Pressable
                   testID="search-clear-history"
@@ -725,7 +737,9 @@ export default function SearchTabScreen() {
                   onPress={() => void handleClearHistory()}
                   style={styles.inlineButton}
                 >
-                  <Text style={styles.inlineButtonLabel}>전체 삭제</Text>
+                  <Text allowFontScaling maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.buttonService} style={styles.inlineButtonLabel}>
+                    전체 삭제
+                  </Text>
                 </Pressable>
               ) : null}
             </View>
@@ -741,7 +755,9 @@ export default function SearchTabScreen() {
                     onPress={() => void handleRecentQueryPress(recentQuery)}
                     style={({ pressed }) => [styles.historyChip, pressed ? styles.segmentButtonPressed : null]}
                   >
-                    <Text style={styles.historyChipLabel}>{recentQuery}</Text>
+                    <Text allowFontScaling maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.body} style={styles.historyChipLabel}>
+                      {recentQuery}
+                    </Text>
                   </Pressable>
                 ))}
               </View>
@@ -751,7 +767,14 @@ export default function SearchTabScreen() {
           </View>
 
           <View style={styles.sectionCard}>
-            <Text accessibilityRole="header" style={styles.sectionTitle}>추천 팀</Text>
+            <Text
+              accessibilityRole="header"
+              allowFontScaling
+              maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.sectionTitle}
+              style={styles.sectionTitle}
+            >
+              추천 팀
+            </Text>
             <View style={styles.suggestedGrid}>
               {suggestedTeams.map((team) => (
                 <View
@@ -780,8 +803,17 @@ export default function SearchTabScreen() {
       ) : (
         <View style={styles.sectionCard}>
           <View style={styles.sectionHeader}>
-            <Text accessibilityRole="header" style={styles.sectionTitle}>검색 결과</Text>
-            <Text style={styles.sectionMeta}>{segmentCounts[activeSegment]}건</Text>
+            <Text
+              accessibilityRole="header"
+              allowFontScaling
+              maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.sectionTitle}
+              style={styles.sectionTitle}
+            >
+              검색 결과
+            </Text>
+            <Text allowFontScaling maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.body} style={styles.sectionMeta}>
+              {segmentCounts[activeSegment]}건
+            </Text>
           </View>
 
           {handoffFeedback ? (

--- a/mobile/app/artists/[slug].tsx
+++ b/mobile/app/artists/[slug].tsx
@@ -50,6 +50,7 @@ import {
   runWithPendingRouteResume,
   type RouteResumeTarget,
 } from '../../src/services/routeResume';
+import { MOBILE_TEXT_SCALE_LIMITS } from '../../src/tokens/accessibility';
 import { useAppTheme } from '../../src/tokens/theme';
 import type {
   ReleaseSummaryModel,
@@ -466,11 +467,19 @@ export default function ArtistDetailScreen() {
         <View style={styles.heroCard}>
           <EntityBadge team={snapshot.team} styles={styles} />
           <View style={styles.heroCopy}>
-            <Text accessibilityRole="header" testID="entity-detail-title" style={styles.heroTitle}>
+            <Text
+              accessibilityRole="header"
+              allowFontScaling
+              maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.screenTitle}
+              testID="entity-detail-title"
+              style={styles.heroTitle}
+            >
               {snapshot.team.displayName}
             </Text>
-            <Text style={styles.heroMeta}>{snapshot.team.agency ?? '소속사 정보 없음'}</Text>
-            <Text style={styles.heroBody}>
+            <Text allowFontScaling maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.body} style={styles.heroMeta}>
+              {snapshot.team.agency ?? '소속사 정보 없음'}
+            </Text>
+            <Text allowFontScaling maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.body} style={styles.heroBody}>
               해당 팀의 다음 컴백과 최신 발매를 빠르게 확인할 수 있습니다.
             </Text>
           </View>
@@ -488,7 +497,9 @@ export default function ArtistDetailScreen() {
                 onPress={() => void handleExternalLink(link.url, 'official')}
                 style={({ pressed }) => [styles.metaTextLink, pressed ? styles.buttonPressed : null]}
               >
-                <Text style={styles.metaTextLinkLabel}>{link.label}</Text>
+                <Text allowFontScaling maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.meta} style={styles.metaTextLinkLabel}>
+                  {link.label}
+                </Text>
               </Pressable>
             ))}
           </View>
@@ -503,7 +514,9 @@ export default function ArtistDetailScreen() {
             onPress={() => void handleExternalLink(snapshot.team.artistSourceUrl!, 'artist_source')}
             style={({ pressed }) => [styles.metaTextLink, pressed ? styles.buttonPressed : null]}
           >
-            <Text style={styles.metaTextLinkLabel}>아티스트 출처</Text>
+            <Text allowFontScaling maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.meta} style={styles.metaTextLinkLabel}>
+              아티스트 출처
+            </Text>
           </Pressable>
         ) : null}
       </View>
@@ -537,11 +550,20 @@ export default function ArtistDetailScreen() {
                 />
               ) : null}
             </View>
-            <Text numberOfLines={2} style={styles.primaryCardTitle}>
+            <Text
+              allowFontScaling
+              maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.sectionTitle}
+              numberOfLines={2}
+              style={styles.primaryCardTitle}
+            >
               {snapshot.nextUpcoming.releaseLabel ?? snapshot.nextUpcoming.headline}
             </Text>
-            <Text style={styles.primaryCardMeta}>{formatUpcomingMeta(snapshot.nextUpcoming)}</Text>
-            <Text style={styles.primaryCardBody}>{snapshot.nextUpcoming.headline}</Text>
+            <Text allowFontScaling maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.body} style={styles.primaryCardMeta}>
+              {formatUpcomingMeta(snapshot.nextUpcoming)}
+            </Text>
+            <Text allowFontScaling maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.body} style={styles.primaryCardBody}>
+              {snapshot.nextUpcoming.headline}
+            </Text>
             {snapshot.nextUpcoming.sourceUrl ? (
               <Pressable
                 accessibilityLabel={`${snapshot.team.displayName} 다음 컴백 출처 열기`}
@@ -572,9 +594,18 @@ export default function ArtistDetailScreen() {
                 )}
               </View>
               <View style={styles.releaseCopy}>
-                <Text numberOfLines={2} style={styles.primaryCardTitle}>{snapshot.latestRelease.releaseTitle}</Text>
-                <Text style={styles.primaryCardMeta}>{formatReleaseMeta(snapshot.latestRelease)}</Text>
-                <Text style={styles.primaryCardBody}>
+                <Text
+                  allowFontScaling
+                  maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.sectionTitle}
+                  numberOfLines={2}
+                  style={styles.primaryCardTitle}
+                >
+                  {snapshot.latestRelease.releaseTitle}
+                </Text>
+                <Text allowFontScaling maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.body} style={styles.primaryCardMeta}>
+                  {formatReleaseMeta(snapshot.latestRelease)}
+                </Text>
+                <Text allowFontScaling maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.body} style={styles.primaryCardBody}>
                   {snapshot.latestRelease.representativeSongTitle ?? '상세 화면으로 이동'}
                 </Text>
                 <View style={styles.chipRow}>
@@ -615,7 +646,9 @@ export default function ArtistDetailScreen() {
                 style={({ pressed }) => [styles.metaTextLink, pressed ? styles.buttonPressed : null]}
                 testID="entity-latest-release-source-link"
               >
-                <Text style={styles.metaTextLinkLabel}>{MOBILE_COPY.action.sourceView}</Text>
+                <Text allowFontScaling maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.meta} style={styles.metaTextLinkLabel}>
+                  {MOBILE_COPY.action.sourceView}
+                </Text>
               </Pressable>
             ) : null}
           </View>
@@ -659,8 +692,17 @@ export default function ArtistDetailScreen() {
               )}
             </View>
             <View style={styles.singleAlbumCopy}>
-              <Text numberOfLines={2} style={styles.albumTitle}>{snapshot.recentAlbums[0]!.releaseTitle}</Text>
-              <Text style={styles.albumMeta}>{formatReleaseMeta(snapshot.recentAlbums[0]!)}</Text>
+              <Text
+                allowFontScaling
+                maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.body}
+                numberOfLines={2}
+                style={styles.albumTitle}
+              >
+                {snapshot.recentAlbums[0]!.releaseTitle}
+              </Text>
+              <Text allowFontScaling maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.meta} style={styles.albumMeta}>
+                {formatReleaseMeta(snapshot.recentAlbums[0]!)}
+              </Text>
             </View>
           </Pressable>
         ) : snapshot.recentAlbums.length > 1 ? (
@@ -692,8 +734,17 @@ export default function ArtistDetailScreen() {
                     </Text>
                   )}
                 </View>
-                <Text numberOfLines={2} style={styles.albumTitle}>{release.releaseTitle}</Text>
-                <Text style={styles.albumMeta}>{formatReleaseMeta(release)}</Text>
+                <Text
+                  allowFontScaling
+                  maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.body}
+                  numberOfLines={2}
+                  style={styles.albumTitle}
+                >
+                  {release.releaseTitle}
+                </Text>
+                <Text allowFontScaling maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.meta} style={styles.albumMeta}>
+                  {formatReleaseMeta(release)}
+                </Text>
               </Pressable>
             ))}
           </ScrollView>
@@ -721,8 +772,12 @@ export default function ArtistDetailScreen() {
                 <View key={item.id} style={styles.timelineRow}>
                   <View style={styles.timelineDot} />
                   <View style={styles.timelineCopy}>
-                    <Text style={styles.timelineTitle}>{item.title}</Text>
-                    <Text style={styles.timelineMeta}>{item.meta}</Text>
+                    <Text allowFontScaling maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.body} style={styles.timelineTitle}>
+                      {item.title}
+                    </Text>
+                    <Text allowFontScaling maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.meta} style={styles.timelineMeta}>
+                      {item.meta}
+                    </Text>
                   </View>
                   {item.sourceUrl ? (
                     <Pressable
@@ -769,7 +824,14 @@ function SectionCard({
 }) {
   return (
     <View style={styles.sectionCard}>
-      <Text accessibilityRole="header" style={styles.sectionTitle}>{title}</Text>
+      <Text
+        accessibilityRole="header"
+        allowFontScaling
+        maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.sectionTitle}
+        style={styles.sectionTitle}
+      >
+        {title}
+      </Text>
       {children}
     </View>
   );

--- a/mobile/app/releases/[id].tsx
+++ b/mobile/app/releases/[id].tsx
@@ -54,6 +54,7 @@ import {
   runWithPendingRouteResume,
   type RouteResumeTarget,
 } from '../../src/services/routeResume';
+import { MOBILE_TEXT_SCALE_LIMITS } from '../../src/tokens/accessibility';
 import { useAppTheme } from '../../src/tokens/theme';
 import type { MobileTheme } from '../../src/tokens/theme';
 import type { ReleaseDetailModel, TrackModel, YoutubeVideoStatus } from '../../src/types';
@@ -534,7 +535,9 @@ export default function ReleaseDetailScreen() {
         }
       />
 
-      <Text style={styles.eyebrow}>{datasetState.source.sourceLabel}</Text>
+      <Text allowFontScaling maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.meta} style={styles.eyebrow}>
+        {datasetState.source.sourceLabel}
+      </Text>
 
       {datasetRiskDisclosure ? (
         <InlineFeedbackNotice
@@ -547,13 +550,23 @@ export default function ReleaseDetailScreen() {
       <View style={styles.heroCard}>
         <ReleaseCover detail={detail} styles={styles} />
         <View style={styles.heroCopy}>
-          <Text accessibilityRole="header" style={styles.releaseTitle} testID="release-detail-title">
+          <Text
+            accessibilityRole="header"
+            allowFontScaling
+            maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.screenTitle}
+            style={styles.releaseTitle}
+            testID="release-detail-title"
+          >
             {detail.releaseTitle}
           </Text>
-          <Text style={styles.releaseMeta}>{formatReleaseMeta(detail)}</Text>
+          <Text allowFontScaling maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.body} style={styles.releaseMeta}>
+            {formatReleaseMeta(detail)}
+          </Text>
           <View style={styles.identityRow}>
             <View style={styles.kindChip}>
-              <Text style={styles.kindChipLabel}>{getReleaseKindLabel(detail)}</Text>
+              <Text allowFontScaling maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.meta} style={styles.kindChipLabel}>
+                {getReleaseKindLabel(detail)}
+              </Text>
             </View>
           </View>
           <TeamIdentityRow
@@ -566,7 +579,14 @@ export default function ReleaseDetailScreen() {
       </View>
 
       <View style={styles.section} testID="release-album-actions-section">
-        <Text accessibilityRole="header" style={styles.sectionTitle}>앨범 액션</Text>
+        <Text
+          accessibilityRole="header"
+          allowFontScaling
+          maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.sectionTitle}
+          style={styles.sectionTitle}
+        >
+          앨범 액션
+        </Text>
         <ServiceButtonGroup
           buttons={albumServiceButtons.map((button) => ({
             ...button,
@@ -589,7 +609,14 @@ export default function ReleaseDetailScreen() {
       ) : null}
 
       <View style={styles.section}>
-        <Text accessibilityRole="header" style={styles.sectionTitle}>트랙 리스트</Text>
+        <Text
+          accessibilityRole="header"
+          allowFontScaling
+          maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.sectionTitle}
+          style={styles.sectionTitle}
+        >
+          트랙 리스트
+        </Text>
         {detail.tracks.length > 0 ? (
           <View style={styles.trackList}>
             {detail.tracks.map((track) => (
@@ -655,18 +682,31 @@ export default function ReleaseDetailScreen() {
       </View>
 
       <View style={styles.section} testID="release-supporting-info">
-        <Text accessibilityRole="header" style={styles.sectionTitle}>추가 정보</Text>
+        <Text
+          accessibilityRole="header"
+          allowFontScaling
+          maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.sectionTitle}
+          style={styles.sectionTitle}
+        >
+          추가 정보
+        </Text>
         {hasSupportingInfo ? (
           <>
             {detail.notes ? (
               <View style={styles.metaCard}>
-                <Text style={styles.metaLabel}>메모</Text>
-                <Text style={styles.metaBody}>{detail.notes}</Text>
+                <Text allowFontScaling maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.meta} style={styles.metaLabel}>
+                  메모
+                </Text>
+                <Text allowFontScaling maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.body} style={styles.metaBody}>
+                  {detail.notes}
+                </Text>
               </View>
             ) : null}
             {supportingLinks.length > 0 ? (
               <View style={styles.metaCard}>
-                <Text style={styles.metaLabel}>출처</Text>
+                <Text allowFontScaling maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.meta} style={styles.metaLabel}>
+                  출처
+                </Text>
                 <SourceLinkRow links={supportingLinks} testID="release-supporting-links" />
               </View>
             ) : null}
@@ -681,9 +721,18 @@ export default function ReleaseDetailScreen() {
 
       {mvUrl ? (
         <View style={styles.section} testID="release-mv-card">
-          <Text accessibilityRole="header" style={styles.sectionTitle}>공식 MV</Text>
+          <Text
+            accessibilityRole="header"
+            allowFontScaling
+            maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.sectionTitle}
+            style={styles.sectionTitle}
+          >
+            공식 MV
+          </Text>
           <View style={styles.metaCard}>
-            <Text style={styles.metaBody}>{mvDisclosure}</Text>
+            <Text allowFontScaling maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.body} style={styles.metaBody}>
+              {mvDisclosure}
+            </Text>
             <ServiceButtonGroup
               buttons={[
                 {

--- a/mobile/src/components/actions/ActionButton.tsx
+++ b/mobile/src/components/actions/ActionButton.tsx
@@ -4,11 +4,13 @@ import {
   Pressable,
   StyleSheet,
   Text,
+  useWindowDimensions,
   View,
 } from 'react-native';
 
 import { useAppTheme } from '../../tokens/theme';
 import type { MobileTheme } from '../../tokens/theme';
+import { MOBILE_TEXT_SCALE_LIMITS } from '../../tokens/accessibility';
 
 export type ActionButtonTone = 'primary' | 'secondary' | 'meta';
 
@@ -36,8 +38,11 @@ function ActionButtonComponent({
   tone = 'primary',
 }: ActionButtonProps) {
   const theme = useAppTheme();
+  const { fontScale } = useWindowDimensions();
   const styles = useMemo(() => createStyles(theme), [theme]);
   const isDisabled = disabled || loading;
+  const buttonLabelMultiplier =
+    tone === 'meta' ? MOBILE_TEXT_SCALE_LIMITS.meta : fontScale >= 1.4 ? MOBILE_TEXT_SCALE_LIMITS.buttonService : MOBILE_TEXT_SCALE_LIMITS.buttonPrimary;
 
   return (
     <Pressable
@@ -68,6 +73,7 @@ function ActionButtonComponent({
           />
           <Text
             allowFontScaling
+            maxFontSizeMultiplier={buttonLabelMultiplier}
             numberOfLines={2}
             style={[
               styles.label,
@@ -80,6 +86,7 @@ function ActionButtonComponent({
       ) : (
         <Text
           allowFontScaling
+          maxFontSizeMultiplier={buttonLabelMultiplier}
           numberOfLines={tone === 'meta' ? 1 : 2}
           style={[
             styles.label,

--- a/mobile/src/components/actions/ServiceButton.tsx
+++ b/mobile/src/components/actions/ServiceButton.tsx
@@ -3,11 +3,13 @@ import {
   Pressable,
   StyleSheet,
   Text,
+  useWindowDimensions,
   View,
 } from 'react-native';
 
 import { useAppTheme } from '../../tokens/theme';
 import type { MobileTheme } from '../../tokens/theme';
+import { MOBILE_TEXT_SCALE_LIMITS } from '../../tokens/accessibility';
 
 export type ServiceButtonTone = 'spotify' | 'youtubeMusic' | 'youtubeMv';
 
@@ -35,10 +37,12 @@ function ServiceButtonComponent({
   tone,
 }: ServiceButtonProps) {
   const theme = useAppTheme();
+  const { fontScale } = useWindowDimensions();
   const styles = useMemo(() => createStyles(theme), [theme]);
   const resolvedService = service ?? tone ?? 'spotify';
   const serviceMark =
     resolvedService === 'spotify' ? 'SP' : resolvedService === 'youtubeMusic' ? 'YM' : 'MV';
+  const labelMultiplier = fontScale >= 1.4 ? MOBILE_TEXT_SCALE_LIMITS.buttonService : MOBILE_TEXT_SCALE_LIMITS.buttonPrimary;
 
   return (
     <Pressable
@@ -58,12 +62,13 @@ function ServiceButtonComponent({
     >
       <View style={styles.buttonContent}>
         <View style={[styles.mark, styles[`${resolvedService}Mark`]]}>
-          <Text allowFontScaling style={styles.markLabel}>
+          <Text allowFontScaling={false} style={styles.markLabel}>
             {serviceMark}
           </Text>
         </View>
         <Text
           allowFontScaling
+          maxFontSizeMultiplier={labelMultiplier}
           numberOfLines={2}
           style={[
             styles.buttonLabel,
@@ -74,7 +79,11 @@ function ServiceButtonComponent({
           {label}
         </Text>
       </View>
-      {mode === 'searchFallback' ? <Text style={styles.modeHint}>검색 결과</Text> : null}
+      {mode === 'searchFallback' ? (
+        <Text allowFontScaling maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.meta} style={styles.modeHint}>
+          검색 결과
+        </Text>
+      ) : null}
     </Pressable>
   );
 }

--- a/mobile/src/components/calendar/DateDetailSheet.tsx
+++ b/mobile/src/components/calendar/DateDetailSheet.tsx
@@ -18,6 +18,7 @@ import {
 } from '../upcoming/UpcomingEventRow';
 import { useAppTheme } from '../../tokens/theme';
 import type { MobileTheme } from '../../tokens/theme';
+import { MOBILE_TEXT_SCALE_LIMITS } from '../../tokens/accessibility';
 
 interface DateDetailSheetProps {
   isOpen: boolean;
@@ -69,7 +70,11 @@ function DateDetailSheetComponent({
 
         {verifiedRows.length > 0 ? (
           <View style={styles.subsection}>
-            <Text allowFontScaling style={styles.subsectionTitle}>
+            <Text
+              allowFontScaling
+              maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.meta}
+              style={styles.subsectionTitle}
+            >
               검증된 발매
             </Text>
             {verifiedRows.map((row) => (
@@ -80,7 +85,11 @@ function DateDetailSheetComponent({
 
         {scheduledRows.length > 0 ? (
           <View style={styles.subsection}>
-            <Text allowFontScaling style={styles.subsectionTitle}>
+            <Text
+              allowFontScaling
+              maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.meta}
+              style={styles.subsectionTitle}
+            >
               날짜가 잡힌 예정 컴백
             </Text>
             {scheduledRows.map((row) => (

--- a/mobile/src/components/controls/SegmentedControl.tsx
+++ b/mobile/src/components/controls/SegmentedControl.tsx
@@ -3,11 +3,13 @@ import {
   Pressable,
   StyleSheet,
   Text,
+  useWindowDimensions,
   View,
 } from 'react-native';
 
 import { useAppTheme } from '../../tokens/theme';
 import type { MobileTheme } from '../../tokens/theme';
+import { MOBILE_TEXT_SCALE_LIMITS } from '../../tokens/accessibility';
 
 export interface SegmentedControlItem {
   key: string;
@@ -31,7 +33,9 @@ function SegmentedControlComponent({
   testID,
 }: SegmentedControlProps) {
   const theme = useAppTheme();
+  const { fontScale } = useWindowDimensions();
   const styles = useMemo(() => createStyles(theme), [theme]);
+  const labelMultiplier = fontScale >= 1.4 ? MOBILE_TEXT_SCALE_LIMITS.buttonService : MOBILE_TEXT_SCALE_LIMITS.buttonPrimary;
 
   return (
     <View style={[styles.row, isSticky ? styles.stickyRow : null]} testID={testID}>
@@ -54,11 +58,11 @@ function SegmentedControlComponent({
             ]}
             testID={testID ? `${testID}-${item.key}` : undefined}
           >
-            <Text allowFontScaling style={active ? styles.activeLabel : styles.label}>
+            <Text allowFontScaling maxFontSizeMultiplier={labelMultiplier} style={active ? styles.activeLabel : styles.label}>
               {item.label}
             </Text>
             {item.count !== undefined ? (
-              <Text allowFontScaling style={active ? styles.activeCount : styles.count}>
+              <Text allowFontScaling maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.meta} style={active ? styles.activeCount : styles.count}>
                 {item.count}
               </Text>
             ) : null}

--- a/mobile/src/components/feedback/FeedbackState.tsx
+++ b/mobile/src/components/feedback/FeedbackState.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
+import { ActivityIndicator, Pressable, StyleSheet, Text, useWindowDimensions, View } from 'react-native';
 
 import { useAppTheme, type MobileTheme } from '../../tokens/theme';
 import { MOBILE_COPY } from '../../copy/mobileCopy';
+import { MOBILE_TEXT_SCALE_LIMITS } from '../../tokens/accessibility';
 
 type FeedbackTone = 'neutral' | 'error';
 
@@ -38,16 +39,18 @@ export function ScreenFeedbackState({
   variant,
 }: ScreenFeedbackStateProps) {
   const theme = useAppTheme();
+  const { fontScale } = useWindowDimensions();
   const styles = React.useMemo(() => createStyles(theme), [theme]);
+  const titleMultiplier = fontScale >= 1.4 ? MOBILE_TEXT_SCALE_LIMITS.sectionTitle : MOBILE_TEXT_SCALE_LIMITS.screenTitle;
 
   return (
     <View style={styles.screenContainer} testID={testID}>
       {variant === 'loading' ? <ActivityIndicator color={theme.colors.text.brand} /> : null}
-      <Text style={styles.eyebrow}>{eyebrow}</Text>
-      <Text accessibilityRole="header" style={styles.screenTitle}>
+      <Text allowFontScaling maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.meta} style={styles.eyebrow}>{eyebrow}</Text>
+      <Text accessibilityRole="header" allowFontScaling maxFontSizeMultiplier={titleMultiplier} style={styles.screenTitle}>
         {title}
       </Text>
-      <Text style={styles.body}>{body}</Text>
+      <Text allowFontScaling maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.body} style={styles.body}>{body}</Text>
       {action ? (
         <Pressable
           accessibilityLabel={action.label}
@@ -59,7 +62,7 @@ export function ScreenFeedbackState({
           ]}
           testID={action.testID}
         >
-          <Text style={styles.primaryActionLabel}>{action.label}</Text>
+          <Text allowFontScaling maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.buttonPrimary} style={styles.primaryActionLabel}>{action.label}</Text>
         </Pressable>
       ) : null}
     </View>
@@ -74,7 +77,9 @@ export function InlineFeedbackNotice({
   tone = 'neutral',
 }: InlineFeedbackNoticeProps) {
   const theme = useAppTheme();
+  const { fontScale } = useWindowDimensions();
   const styles = React.useMemo(() => createStyles(theme), [theme]);
+  const titleMultiplier = fontScale >= 1.4 ? MOBILE_TEXT_SCALE_LIMITS.body : MOBILE_TEXT_SCALE_LIMITS.sectionTitle;
 
   return (
     <View
@@ -82,11 +87,13 @@ export function InlineFeedbackNotice({
       testID={testID}
     >
       {title ? (
-        <Text accessibilityRole="header" style={styles.inlineTitle}>
+        <Text accessibilityRole="header" allowFontScaling maxFontSizeMultiplier={titleMultiplier} style={styles.inlineTitle}>
           {title}
         </Text>
       ) : null}
       <Text
+        allowFontScaling
+        maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.body}
         style={[styles.body, tone === 'error' ? styles.inlineBodyError : null]}
       >
         {body}
@@ -102,7 +109,7 @@ export function InlineFeedbackNotice({
           ]}
           testID={action.testID}
         >
-          <Text style={styles.secondaryActionLabel}>{action.label}</Text>
+          <Text allowFontScaling maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.buttonService} style={styles.secondaryActionLabel}>{action.label}</Text>
         </Pressable>
       ) : null}
     </View>

--- a/mobile/src/components/layout/AppBar.tsx
+++ b/mobile/src/components/layout/AppBar.tsx
@@ -3,12 +3,14 @@ import {
   ActivityIndicator,
   StyleSheet,
   Text,
+  useWindowDimensions,
   View,
 } from 'react-native';
 
 import { ActionButton, type ActionButtonProps } from '../actions/ActionButton';
 import { useAppTheme } from '../../tokens/theme';
 import type { MobileTheme } from '../../tokens/theme';
+import { MOBILE_TEXT_SCALE_LIMITS, isLargeTextMode } from '../../tokens/accessibility';
 
 export interface AppBarAction extends Omit<ActionButtonProps, 'tone'> {
   key: string;
@@ -34,30 +36,39 @@ function AppBarComponent({
   trailingActions = [],
 }: AppBarProps) {
   const theme = useAppTheme();
+  const { fontScale } = useWindowDimensions();
   const styles = useMemo(() => createStyles(theme), [theme]);
   const hasActions = Boolean(leadingAction) || trailingActions.length > 0;
+  const largeTextMode = isLargeTextMode(fontScale);
 
   return (
     <View style={styles.container} testID={testID}>
       {hasActions ? (
-        <View style={styles.actionRow}>
-          <View style={styles.leadingAction}>
-            {leadingAction ? <ActionButton {...leadingAction} tone="secondary" /> : null}
+        <View style={[styles.actionRow, largeTextMode ? styles.actionRowLargeText : null]}>
+          <View style={[styles.leadingAction, largeTextMode ? styles.leadingActionLargeText : null]}>
+            {leadingAction ? <ActionButton {...leadingAction} fullWidth={largeTextMode} tone="secondary" /> : null}
           </View>
-          <View style={styles.trailingActions}>
+          <View style={[styles.trailingActions, largeTextMode ? styles.trailingActionsLargeText : null]}>
             {trailingActions.slice(0, 2).map(({ key, ...action }) => (
-              <ActionButton key={key} {...action} tone="secondary" />
+              <ActionButton key={key} {...action} fullWidth={largeTextMode} tone="secondary" />
             ))}
           </View>
         </View>
       ) : null}
       <View style={styles.copy}>
         {isLoading ? <ActivityIndicator color={theme.colors.text.brand} size="small" /> : null}
-        <Text accessibilityRole="header" numberOfLines={2} style={styles.title} testID={titleTestID}>
+        <Text
+          accessibilityRole="header"
+          allowFontScaling
+          maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.sectionTitle}
+          numberOfLines={2}
+          style={styles.title}
+          testID={titleTestID}
+        >
           {title}
         </Text>
         {subtitle ? (
-          <Text numberOfLines={2} style={styles.subtitle}>
+          <Text allowFontScaling maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.body} numberOfLines={2} style={styles.subtitle}>
             {subtitle}
           </Text>
         ) : null}
@@ -82,9 +93,19 @@ function createStyles(theme: MobileTheme) {
       rowGap: theme.space[8],
       gap: theme.space[12],
     },
+    actionRowLargeText: {
+      width: '100%',
+      flexDirection: 'column',
+      alignItems: 'stretch',
+      gap: theme.space[8],
+    },
     leadingAction: {
       alignItems: 'flex-start',
       maxWidth: '100%',
+    },
+    leadingActionLargeText: {
+      width: '100%',
+      alignItems: 'stretch',
     },
     copy: {
       gap: theme.space[4],
@@ -103,6 +124,11 @@ function createStyles(theme: MobileTheme) {
       gap: theme.space[8],
       justifyContent: 'flex-start',
       maxWidth: '100%',
+    },
+    trailingActionsLargeText: {
+      width: '100%',
+      flexDirection: 'column',
+      alignItems: 'stretch',
     },
   });
 }

--- a/mobile/src/components/layout/SheetHeader.tsx
+++ b/mobile/src/components/layout/SheetHeader.tsx
@@ -8,6 +8,7 @@ import {
 
 import { useAppTheme } from '../../tokens/theme';
 import type { MobileTheme } from '../../tokens/theme';
+import { MOBILE_TEXT_SCALE_LIMITS } from '../../tokens/accessibility';
 
 export interface SheetHeaderProps {
   closeButtonTestID?: string;
@@ -31,7 +32,12 @@ function SheetHeaderComponent({
     <View style={styles.wrapper}>
       <View style={styles.handle} />
       <View style={styles.header}>
-        <Text accessibilityRole="header" style={styles.title}>
+        <Text
+          accessibilityRole="header"
+          allowFontScaling
+          maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.sectionTitle}
+          style={styles.title}
+        >
           {title}
         </Text>
         {showCloseButton && onClose ? (
@@ -42,11 +48,21 @@ function SheetHeaderComponent({
             style={({ pressed }) => [styles.closeButton, pressed ? styles.pressed : null]}
             testID={closeButtonTestID}
           >
-            <Text style={styles.closeLabel}>닫기</Text>
+            <Text
+              allowFontScaling
+              maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.buttonService}
+              style={styles.closeLabel}
+            >
+              닫기
+            </Text>
           </Pressable>
         ) : null}
       </View>
-      {summary ? <Text style={styles.summary}>{summary}</Text> : null}
+      {summary ? (
+        <Text allowFontScaling maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.meta} style={styles.summary}>
+          {summary}
+        </Text>
+      ) : null}
     </View>
   );
 }

--- a/mobile/src/components/layout/SummaryStrip.test.tsx
+++ b/mobile/src/components/layout/SummaryStrip.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import * as ReactNative from 'react-native';
+import renderer, { act } from 'react-test-renderer';
+import { Text } from 'react-native';
+
+import { SummaryStrip } from './SummaryStrip';
+import { MOBILE_TEXT_SCALE_LIMITS } from '../../tokens/accessibility';
+
+const mockUseWindowDimensions = jest.spyOn(ReactNative, 'useWindowDimensions');
+
+describe('SummaryStrip', () => {
+  beforeEach(() => {
+    mockUseWindowDimensions.mockReturnValue({
+      fontScale: 1,
+      height: 844,
+      scale: 3,
+      width: 390,
+    });
+  });
+
+  afterEach(() => {
+    mockUseWindowDimensions.mockReset();
+  });
+
+  test('uses full-width cards in wrap layout when large-text mode is active', () => {
+    mockUseWindowDimensions.mockReturnValue({
+      fontScale: 1.7,
+      height: 844,
+      scale: 3,
+      width: 430,
+    });
+
+    let tree: renderer.ReactTestRenderer;
+
+    act(() => {
+      tree = renderer.create(
+        <SummaryStrip
+          items={[
+            { key: 'release-count', label: '이번 달 발매', value: 2 },
+            { key: 'upcoming-count', label: '예정 컴백', value: 3 },
+          ]}
+          layout="wrap"
+          testID="summary"
+        />,
+      );
+    });
+
+    const firstCard = tree!.root.findByProps({ testID: 'summary-item-release-count' });
+    const [valueText, labelText] = firstCard.findAllByType(Text);
+
+    expect(firstCard.props.style).toEqual(
+      expect.arrayContaining([expect.objectContaining({ flexBasis: '100%' })]),
+    );
+    expect(valueText.props.maxFontSizeMultiplier).toBe(MOBILE_TEXT_SCALE_LIMITS.summaryValue);
+    expect(labelText.props.maxFontSizeMultiplier).toBe(MOBILE_TEXT_SCALE_LIMITS.summaryLabel);
+  });
+});

--- a/mobile/src/components/layout/SummaryStrip.tsx
+++ b/mobile/src/components/layout/SummaryStrip.tsx
@@ -8,6 +8,7 @@ import {
 
 import { useAppTheme } from '../../tokens/theme';
 import type { MobileTheme } from '../../tokens/theme';
+import { MOBILE_TEXT_SCALE_LIMITS, isLargeTextMode } from '../../tokens/accessibility';
 
 export interface SummaryStripItem {
   key: string;
@@ -27,18 +28,33 @@ function SummaryStripComponent({
   testID,
 }: SummaryStripProps) {
   const theme = useAppTheme();
-  const { width } = useWindowDimensions();
+  const { fontScale, width } = useWindowDimensions();
   const styles = useMemo(() => createStyles(theme), [theme]);
-  const useFullWidthCards = layout === 'wrap' && width <= 430;
+  const largeTextMode = isLargeTextMode(fontScale);
+  const useFullWidthCards = layout === 'wrap' && (width <= 430 || largeTextMode);
 
   return (
     <View style={[styles.row, layout === 'wrap' ? styles.wrapRow : null]} testID={testID}>
       {items.map((item) => (
-        <View key={item.key} style={[styles.card, useFullWidthCards ? styles.fullWidthCard : null]}>
-          <Text allowFontScaling numberOfLines={2} style={styles.value}>
+        <View
+          key={item.key}
+          style={[styles.card, useFullWidthCards ? styles.fullWidthCard : null]}
+          testID={testID ? `${testID}-item-${item.key}` : undefined}
+        >
+          <Text
+            allowFontScaling
+            maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.summaryValue}
+            numberOfLines={2}
+            style={[styles.value, largeTextMode ? styles.valueCompact : null]}
+          >
             {item.value}
           </Text>
-          <Text allowFontScaling numberOfLines={2} style={styles.label}>
+          <Text
+            allowFontScaling
+            maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.summaryLabel}
+            numberOfLines={2}
+            style={styles.label}
+          >
             {item.label}
           </Text>
         </View>
@@ -76,6 +92,11 @@ function createStyles(theme: MobileTheme) {
     value: {
       ...sectionTitleTypography,
       color: theme.colors.text.primary,
+    },
+    valueCompact: {
+      fontSize: theme.typography.cardTitle.fontSize,
+      fontWeight: theme.typography.cardTitle.fontWeight,
+      letterSpacing: theme.typography.cardTitle.letterSpacing,
     },
     label: {
       ...metaTypography,

--- a/mobile/src/components/meta/InfoChip.tsx
+++ b/mobile/src/components/meta/InfoChip.tsx
@@ -7,6 +7,7 @@ import {
 
 import { useAppTheme } from '../../tokens/theme';
 import type { MobileTheme } from '../../tokens/theme';
+import { MOBILE_TEXT_SCALE_LIMITS } from '../../tokens/accessibility';
 
 export type InfoChipTone = 'default' | 'title';
 
@@ -27,7 +28,11 @@ function InfoChipComponent({ label, testID, tone = 'default' }: InfoChipProps) {
       style={[styles.chip, tone === 'title' ? styles.titleChip : null]}
       testID={testID}
     >
-      <Text allowFontScaling style={[styles.label, tone === 'title' ? styles.titleLabel : null]}>
+      <Text
+        allowFontScaling
+        maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.meta}
+        style={[styles.label, tone === 'title' ? styles.titleLabel : null]}
+      >
         {label}
       </Text>
     </View>

--- a/mobile/src/components/release/TrackRow.tsx
+++ b/mobile/src/components/release/TrackRow.tsx
@@ -12,6 +12,7 @@ import {
 import { InfoChip } from '../meta/InfoChip';
 import { useAppTheme } from '../../tokens/theme';
 import type { MobileTheme } from '../../tokens/theme';
+import { MOBILE_TEXT_SCALE_LIMITS } from '../../tokens/accessibility';
 
 interface TrackRowServiceButton {
   accessibilityHint?: string;
@@ -73,12 +74,17 @@ function TrackRowComponent({
       style={styles.trackRow}
       testID={`${testIDPrefix}-${order}`}
     >
-      <Text allowFontScaling style={styles.trackOrder}>
+      <Text allowFontScaling maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.body} style={styles.trackOrder}>
         {order}
       </Text>
       <View style={styles.trackCopy}>
         <View style={styles.trackTitleRow}>
-          <Text allowFontScaling numberOfLines={2} style={styles.trackTitle}>
+          <Text
+            allowFontScaling
+            maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.body}
+            numberOfLines={2}
+            style={styles.trackTitle}
+          >
             {title}
           </Text>
           {isTitleTrack ? (

--- a/mobile/src/features/calendarControls.test.tsx
+++ b/mobile/src/features/calendarControls.test.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
+import * as ReactNative from 'react-native';
 import renderer, { act } from 'react-test-renderer';
 import { Text } from 'react-native';
 
 import CalendarTabScreen from '../../app/(tabs)/calendar';
 import { trackAnalyticsEvent } from '../services/analytics';
+import { MOBILE_TEXT_SCALE_LIMITS } from '../tokens/accessibility';
 
 jest.mock('expo-router', () => {
   const useLocalSearchParams = jest.fn(() => ({}));
@@ -53,6 +55,7 @@ jest.mock('../services/analytics', () => {
   };
 });
 const mockTrackAnalyticsEvent = jest.mocked(trackAnalyticsEvent);
+const mockUseWindowDimensions = jest.spyOn(ReactNative, 'useWindowDimensions');
 
 async function renderCalendarScreen() {
   let tree: renderer.ReactTestRenderer;
@@ -93,16 +96,26 @@ describe('calendar controls', () => {
     __mock.push.mockReset();
     __mock.setParams.mockReset();
     mockTrackAnalyticsEvent.mockClear();
+    mockUseWindowDimensions.mockReturnValue({
+      fontScale: 1,
+      height: 844,
+      scale: 3,
+      width: 390,
+    });
   });
 
   afterEach(() => {
     jest.useRealTimers();
+    mockUseWindowDimensions.mockReset();
   });
 
   test('renders compact chrome and moves across months', async () => {
     const tree = await renderCalendarScreen();
 
     expect(tree.root.findByProps({ testID: 'calendar-month-title' }).props.children).toBe('2026년 3월');
+    expect(tree.root.findByProps({ testID: 'calendar-month-title' }).props.maxFontSizeMultiplier).toBe(
+      MOBILE_TEXT_SCALE_LIMITS.screenTitle,
+    );
     expect(hasText(tree, '이번 달 발매')).toBe(true);
     expect(hasText(tree, '예정 컴백')).toBe(true);
     expect(hasText(tree, '가장 가까운 일정')).toBe(true);
@@ -249,5 +262,25 @@ describe('calendar controls', () => {
     expect(hasText(tree, 'LOVE CATCHER')).toBe(true);
     expect(hasText(tree, 'DUH!')).toBe(true);
     expect(hasTextContaining(tree, 'Rumored follow-up')).toBe(true);
+  });
+
+  test('caps month title scaling and keeps summary cards stacked in large-text mode', async () => {
+    mockUseWindowDimensions.mockReturnValue({
+      fontScale: 1.8,
+      height: 844,
+      scale: 3,
+      width: 390,
+    });
+    const tree = await renderCalendarScreen();
+
+    const monthTitle = tree.root.findByProps({ testID: 'calendar-month-title' });
+    const summaryCard = tree.root.findByProps({ testID: 'calendar-summary-strip-item-release-count' });
+    const [valueText] = summaryCard.findAllByType(Text);
+
+    expect(monthTitle.props.maxFontSizeMultiplier).toBe(MOBILE_TEXT_SCALE_LIMITS.screenTitle);
+    expect(summaryCard.props.style).toEqual(
+      expect.arrayContaining([expect.objectContaining({ flexBasis: '100%' })]),
+    );
+    expect(valueText.props.maxFontSizeMultiplier).toBe(MOBILE_TEXT_SCALE_LIMITS.summaryValue);
   });
 });

--- a/mobile/src/tokens/accessibility.ts
+++ b/mobile/src/tokens/accessibility.ts
@@ -1,0 +1,14 @@
+export const MOBILE_TEXT_SCALE_LIMITS = {
+  screenTitle: 1.2,
+  sectionTitle: 1.15,
+  body: 1.1,
+  meta: 1.08,
+  buttonPrimary: 1.12,
+  buttonService: 1.08,
+  summaryValue: 1.15,
+  summaryLabel: 1.08,
+} as const;
+
+export function isLargeTextMode(fontScale: number): boolean {
+  return fontScale >= 1.3;
+}


### PR DESCRIPTION
## Summary
- add shared large-text scale caps and compact layout behavior across mobile chrome components
- stabilize the calendar header and summary strip under large-text mode and extend focused regression tests
- apply the same typography caps to team, release, search, and radar high-visibility titles and labels

## Verification
- cd mobile && npm run test -- --runInBand src/features/calendarControls.test.tsx src/components/layout/SummaryStrip.test.tsx
- cd mobile && npm run test -- --runInBand src/features/searchTab.test.tsx src/features/radarTab.test.tsx src/features/entityDetailScreen.test.tsx src/features/releaseDetailScreen.test.tsx
- cd mobile && npm run typecheck
- cd mobile && npm run lint
- git diff --check

Closes #501