### PR TITLE
[RN] Reconcile release-grade QA issue status from final sign-off evidence

### DIFF
--- a/docs/assets/distribution/rn_release_grade_issue_reconciliation_local_2026-03-11.md
+++ b/docs/assets/distribution/rn_release_grade_issue_reconciliation_local_2026-03-11.md
@@ -1,0 +1,48 @@
+# RN Release-Grade Issue Reconciliation Local 2026-03-11
+
+## Scope
+- target issues: `#502`, `#503`, `#504`, `#508`, `#509`, `#510`
+- purpose: verify which preview sign-off QA issues are already satisfied by the `2026-03-11` final evidence set and distinguish them from remaining non-blocking follow-up work
+
+## Inputs reviewed
+1. `gh issue view 502`
+2. `gh issue view 503`
+3. `gh issue view 504`
+4. `gh issue view 505`
+5. `gh issue view 506`
+6. `gh issue view 507`
+7. `gh issue view 508`
+8. `gh issue view 509`
+9. `gh issue view 510`
+10. `docs/specs/mobile/rn-release-readiness-gate-2026-03-11.md`
+11. `docs/specs/mobile/rn-runtime-device-qa-2026-03-11.md`
+12. `docs/assets/distribution/rn_ios_voiceover_signoff_local_2026-03-11.md`
+13. `docs/assets/distribution/rn_runtime_device_qa_local_2026-03-11.md`
+
+## Conclusion
+- ready to close:
+  - `#503`
+  - `#504`
+  - `#508`
+  - `#509`
+  - `#510`
+- umbrella closure justified:
+  - `#502`
+- keep open as non-blocking follow-up:
+  - `#505`
+  - `#506`
+  - `#507`
+
+## Rationale
+- `#503` and `#504`
+  - both iOS and Android runtime/device QA have `PASS` evidence in `rn-runtime-device-qa-2026-03-11.md`
+- `#508`
+  - large text, VoiceOver, TalkBack final pass is recorded as `GO`
+- `#509`
+  - preview runtime config, backend target, cached snapshot/degraded behavior are part of the same final sign-off bundle and no blocker remains
+- `#510`
+  - final sign-off verdict is explicitly `GO`
+- `#502`
+  - remaining blocker/non-blocker split is now explicit, and the preview candidate is no longer blocked
+- `#505`, `#506`, `#507`
+  - these can continue as richer installed-app or polish follow-up work, but they are no longer release-blocking according to the current gate

--- a/docs/specs/mobile/github-issue-breakdown-plan.md
+++ b/docs/specs/mobile/github-issue-breakdown-plan.md
@@ -140,6 +140,19 @@
 - 새 RN 작업은 위 순서를 기본으로 집행하되, dependency가 강한 항목은 한 PR에서 묶을 수 있다.
 - `#425`는 umbrella, `#456`은 traceability anchor, `#454`는 최종 gate로 유지한다.
 
+### 7.5 Release-Grade QA Closure Status
+- `2026-03-11` preview sign-off 기준으로 아래 이슈는 충족 상태다.
+  - `#503` iOS end-to-end QA
+  - `#504` Android end-to-end QA
+  - `#508` final accessibility freeze
+  - `#509` preview candidate runtime verification
+  - `#510` final release-readiness gate
+- release-grade umbrella `#502`는 blocker/non-blocker 구분과 sign-off verdict가 확정된 시점에 닫는다.
+- 아래 이슈는 non-blocking polish / richer real-device follow-up으로 남길 수 있다.
+  - `#505` native external handoff installed-app matrix
+  - `#506` final visual polish
+  - `#507` final Korean-first copy polish
+
 ## 8. Launch-Grade Visual Identity Track
 
 ### 8.1 Light-mode visual identity

--- a/docs/specs/mobile/rn-release-readiness-gate-2026-03-11.md
+++ b/docs/specs/mobile/rn-release-readiness-gate-2026-03-11.md
@@ -56,3 +56,16 @@
 
 ## Next Step
 - current preview sign-off gate is clear; next work can move to distribution / release operations as needed.
+
+## Issue Reconciliation
+- fulfilled and ready to close from this sign-off bundle:
+  - `#503` iOS end-to-end QA
+  - `#504` Android end-to-end QA
+  - `#508` final accessibility freeze
+  - `#509` production-like preview candidate verification
+  - `#510` final release-readiness gate
+- non-blocking follow-up work that can stay open after sign-off:
+  - `#505` installed-app external handoff matrix on richer real-device conditions
+  - `#506` final visual polish beyond launch-blocking defects
+  - `#507` final copy/truncation polish beyond launch-blocking defects
+- umbrella `#502`는 preview candidate의 blocker/non-blocker 구분과 sign-off verdict가 이 문서로 고정됐으므로 closure 조건을 충족한다.

--- a/docs/specs/mobile/rn-traceability-matrix.md
+++ b/docs/specs/mobile/rn-traceability-matrix.md
@@ -24,9 +24,9 @@
 | `layout-constraint-spec.md` | `#430` |  | open | surface layout/density |
 | `state-feedback-spec.md` | `#455` | `#454` | open | loading/empty/error/partial states |
 | `copy-localization-spec.md` | `#431` | `#455` | open | copy/localization 규칙 |
-| `accessibility-platform-spec.md` | `#454` | `#459` | open | QA/platform acceptance |
+| `accessibility-platform-spec.md` | `#454` | `#459`, `#508` | closed | QA/platform acceptance sign-off complete |
 | `edge-case-catalog.md` | `#455` | `#458` | open | null/missing/partial edge cases |
-| `qa-acceptance-spec.md` | `#454` | `#459` | open | preview sign-off gate |
+| `qa-acceptance-spec.md` | `#454` | `#459`, `#510` | closed | preview sign-off gate complete |
 | `interaction-matrix.md` | `#459` | `#426`, `#427`, `#433` | open | 탭/시트/push/external 행동 매트릭스 |
 | `sample-data-contracts.md` | `#458` | `#455` | open | fixture/sample parity 기준 |
 | `wireframe-block-diagrams.md` | `#430` | `#425` | open | 화면 구조 baseline |
@@ -36,8 +36,8 @@
 | `view-state-models.md` | `#457` | `#435`, `#458` | open | state/model naming 기준 |
 | `user-journey-sequences.md` | `#459` | `#454` | open | interaction + QA path |
 | `expo-implementation-guide.md` | `#425` | `#426`, `#434` | open | runtime/router implementation baseline |
-| `screen-delivery-checklists.md` | `#454` | `#425` | open | release gate checklist |
-| `testing-strategy-spec.md` | `#454` | `#458` | open | selector/UI smoke/test scope |
+| `screen-delivery-checklists.md` | `#454` | `#425`, `#510` | closed | release gate checklist executed |
+| `testing-strategy-spec.md` | `#454` | `#458`, `#510` | closed | selector/UI smoke/test scope satisfied for preview gate |
 | `typescript-interface-examples.md` | `#457` | `#458` | open | display model/type naming 기준 |
 | `github-issue-breakdown-plan.md` | `#425` | `#456` | open | live issue umbrella/order |
 | `domain-glossary.md` | `#457` | `#456` | open | 용어 고정점 |
@@ -46,8 +46,8 @@
 | `analytics-event-spec.md` | `#432` | `#459` | open | interaction/failure analytics |
 | `data-sync-freshness-spec.md` | `#455` | `#434` | open | stale/partial disclosure 기준 |
 | `privacy-security-spec.md` | `#433` | `#459` | open | external/handoff/privacy guard |
-| `accessibility-reading-order-spec.md` | `#454` | `#459` | open | reading order QA |
-| `release-readiness-gate.md` | `#454` | `#425` | open | preview sign-off barrier |
+| `accessibility-reading-order-spec.md` | `#454` | `#459`, `#508` | closed | reading order QA evidence complete |
+| `release-readiness-gate.md` | `#454` | `#425`, `#510` | closed | preview sign-off barrier cleared |
 | `route-param-contracts.md` | `#426` | `#435` | open | path/deep-link/back stack |
 | `configuration-environment-spec.md` | `#434` | `#419` | open | runtime/env/failure policy |
 | `observability-error-taxonomy.md` | `#432` | `#434` | open | analytics + runtime failures |
@@ -61,10 +61,10 @@
 
 | Document | Primary RN issue | Secondary issues | Status | Note |
 | --- | --- | --- | --- | --- |
-| `accessibility-audit-2026-03-09.md` | `#454` |  | open | pre-sign-off accessibility evidence |
+| `accessibility-audit-2026-03-09.md` | `#454` | `#508` | closed | pre-sign-off accessibility evidence archived under final pass |
 | `decision-log-review-checklist.md` | `#456` | `#425` | open | doc review/traceability anchor |
 | `rn-implementation-audit-2026-03-10.md` | `#456` | `#457`, `#458` | open | implementation audit evidence |
-| `rn-quality-coverage-matrix.md` | `#454` | `#458` | open | QA/coverage matrix |
+| `rn-quality-coverage-matrix.md` | `#454` | `#458`, `#510` | closed | QA/coverage matrix satisfied by final gate |
 | `rn-screen-structure-validation-2026-03-10.md` | `#430` | `#459` | open | structure/layout validation |
 | `rn-journey-walkthrough-2026-03-10.md` | `#459` | `#454` | open | journey execution evidence |
 | `rn-freshness-review-2026-03-10.md` | `#455` | `#434` | open | stale/fallback review evidence |


### PR DESCRIPTION
## Summary
- record which RN release-grade QA issues are already satisfied by the 2026-03-11 preview sign-off evidence
- update the release-grade QA plan and traceability matrix to separate closed sign-off work from remaining non-blocking polish follow-up
- add a local reconciliation note that ties the issue decisions back to the final runtime and accessibility artifacts

Closes #502
Closes #503
Closes #504
Closes #508
Closes #509
Closes #510