### PR TITLE
[RN] Implement launch gate, motion, and loading feedback polish

### DIFF
--- a/docs/specs/mobile/accessibility-platform-spec.md
+++ b/docs/specs/mobile/accessibility-platform-spec.md
@@ -32,6 +32,9 @@
   - push/pop은 기본 전환 유지
   - 추가 fade/translate 최소화
   - spring/bounce 효과 제거
+  - launch intro는 정적 소개 카드 + 짧은 hold로 축소
+  - loading skeleton pulse는 정지하고 정적 placeholder로 유지
+  - sheet는 slide 대신 fade를 우선 사용
 
 ## 7. Platform Behavior
 ### 7.1 iOS

--- a/docs/specs/mobile/navigation-motion-spec.md
+++ b/docs/specs/mobile/navigation-motion-spec.md
@@ -33,6 +33,7 @@
 - 목적: 맥락 심화
 - 뒤로 가기: 이전 화면 상태 복원
 - 애니메이션: 기본 네이티브 push
+- launch 직후 첫 진입은 짧은 branded launch gate 뒤에 본문으로 이어진다.
 
 ### 3.3 Bottom Sheet
 - 대상: Date Detail, Filter, Language/Settings
@@ -40,6 +41,7 @@
 - 배경: dim 처리
 - 닫기: swipe down, background tap, explicit close(optional)
 - 애니메이션: 기본 sheet open/close
+- 기본 모션: 일반 환경 `slide`, reduced motion 환경 `fade`
 
 ### 3.4 External Open
 - 대상: Spotify, YouTube Music, YouTube MV, 기사 원문, 공식 공지
@@ -118,6 +120,7 @@
 - bottom sheet open/close
 - content change 시 짧은 fade/translate
 - subtle press feedback
+- launch 직후 1회성 짧은 fade/settle intro
 
 ### 9.2 금지
 - 과한 spring/bounce
@@ -128,6 +131,13 @@
 - 탭/버튼 press feedback: 120~160ms 수준
 - sheet: 명확하고 예측 가능하게
 - long blocking transition 금지
+- launch intro: 1초 미만
+- loading skeleton pulse: 저강도 반복만 허용
+
+### 9.4 Reduced Motion
+- launch gate는 정적 카드 + 짧은 hold 후 즉시 해제한다.
+- sheet는 slide 대신 fade를 사용한다.
+- loading skeleton은 pulse를 정지하고 정적 블록으로 유지한다.
 
 ## 10. Gesture Conflict
 - bottom sheet 내부 목록 스크롤이 상단 경계에 도달한 경우에만 swipe down close를 허용한다.

--- a/docs/specs/mobile/state-feedback-spec.md
+++ b/docs/specs/mobile/state-feedback-spec.md
@@ -8,6 +8,13 @@
 - loading 동안 destructive shift 금지
 - 버튼은 disabled 또는 skeleton 대체
 - loading이 길어질 경우 빈 화면처럼 보이지 않게 최소 구조 유지
+- screen-level loading은 surface 문맥을 반영한 skeleton layout을 사용한다.
+  - calendar: month header + summary + day/list rhythm
+  - search: search bar + segment rail + result row rhythm
+  - radar: featured block + feed row rhythm
+  - detail: artwork/header + meta row rhythm
+- skeleton은 soft pulse까지만 허용하고 shimmer sweep는 기본값으로 쓰지 않는다.
+- skeleton은 아주 짧은 fetch에서는 즉시 번쩍이지 않도록 짧은 reveal delay를 둔다.
 
 ## 3. Empty
 - empty는 오류가 아니다.
@@ -26,6 +33,8 @@
 - 기본 문구: `정보를 불러오지 못했습니다.`
 - CTA: `다시 시도`
 - 심각하지 않으면 이전 데이터 유지 가능
+- retry CTA는 primary prominence를 갖되 destructive 톤으로 과장하지 않는다.
+- degraded cache/bundled fallback이 있으면 즉시 구조를 유지하고, 문제 원인은 notice로만 보조한다.
 
 ### 5.2 External Open Error
 - 기본 문구: `앱을 열 수 없습니다.` 또는 `링크를 열 수 없습니다.`
@@ -48,6 +57,7 @@
 - loading: spinner보다 skeleton/disabled 우선
 - partial link absence: 해당 버튼 숨김
 - error: retry CTA 우선, 무의미한 service button 노출 금지
+- retry 버튼은 `busy / disabled / restored` 흐름을 설명 가능한 상태로 유지한다.
 
 ## 9. 서비스 링크 실패
 - canonical URL 실패 시 검색 fallback 재시도 가능

--- a/mobile/app.config.ts
+++ b/mobile/app.config.ts
@@ -222,6 +222,15 @@ export default ({ config }: ConfigContext): ExpoConfig => {
     experiments: {
       typedRoutes: true,
     },
+    splash: {
+      image: './assets/app-icon/icon-adaptive-foreground.png',
+      resizeMode: 'contain',
+      backgroundColor: '#F6F3EE',
+      dark: {
+        image: './assets/app-icon/icon-adaptive-foreground.png',
+        backgroundColor: '#171411',
+      },
+    },
     ios: {
       supportsTablet: true,
       bundleIdentifier: profileConfig.iosBundleIdentifier,

--- a/mobile/app/(tabs)/calendar.tsx
+++ b/mobile/app/(tabs)/calendar.tsx
@@ -767,6 +767,7 @@ export default function CalendarTabScreen() {
       <ScreenFeedbackState
         body="현재 월 데이터와 예정 신호를 불러오는 중입니다."
         eyebrow="데이터 로딩"
+        loadingLayout="calendar"
         title="캘린더"
         variant="loading"
       />

--- a/mobile/app/(tabs)/radar.tsx
+++ b/mobile/app/(tabs)/radar.tsx
@@ -500,6 +500,7 @@ export default function RadarTabScreen() {
       <ScreenFeedbackState
         body="가장 가까운 컴백과 레이더 요약을 불러오는 중입니다."
         eyebrow="데이터 로딩"
+        loadingLayout="radar"
         title="레이더"
         variant="loading"
       />

--- a/mobile/app/(tabs)/search.tsx
+++ b/mobile/app/(tabs)/search.tsx
@@ -585,6 +585,7 @@ export default function SearchTabScreen() {
       <ScreenFeedbackState
         body="검색 대상 팀, 발매, 예정 데이터를 불러오는 중입니다."
         eyebrow="데이터 로딩"
+        loadingLayout="search"
         title="검색"
         variant="loading"
       />

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -1,17 +1,20 @@
 import { Stack } from 'expo-router';
 
+import { LaunchGate } from '../src/components/launch/LaunchGate';
 import { MobileThemeProvider } from '../src/tokens/theme';
 
 export default function RootLayout() {
   return (
     <MobileThemeProvider>
-      <Stack>
-        <Stack.Screen name="index" options={{ headerShown: false }} />
-        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-        <Stack.Screen name="artists/[slug]" options={{ headerShown: false }} />
-        <Stack.Screen name="releases/[id]" options={{ headerShown: false }} />
-        <Stack.Screen name="debug/metadata" options={{ title: 'Debug Metadata' }} />
-      </Stack>
+      <LaunchGate>
+        <Stack>
+          <Stack.Screen name="index" options={{ headerShown: false }} />
+          <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+          <Stack.Screen name="artists/[slug]" options={{ headerShown: false }} />
+          <Stack.Screen name="releases/[id]" options={{ headerShown: false }} />
+          <Stack.Screen name="debug/metadata" options={{ title: 'Debug Metadata' }} />
+        </Stack>
+      </LaunchGate>
     </MobileThemeProvider>
   );
 }

--- a/mobile/app/artists/[slug].tsx
+++ b/mobile/app/artists/[slug].tsx
@@ -391,6 +391,7 @@ export default function ArtistDetailScreen() {
         <ScreenFeedbackState
           body="팀 요약, 다음 컴백, 최근 앨범을 불러오는 중입니다."
           eyebrow="상세 로딩"
+          loadingLayout="detail"
           title="팀 상세"
           variant="loading"
         />

--- a/mobile/app/releases/[id].tsx
+++ b/mobile/app/releases/[id].tsx
@@ -430,6 +430,7 @@ export default function ReleaseDetailScreen() {
         <ScreenFeedbackState
           body="앨범 액션, 트랙 리스트, MV 상태를 불러오는 중입니다."
           eyebrow="상세 로딩"
+          loadingLayout="detail"
           title="릴리즈 상세"
           variant="loading"
         />

--- a/mobile/src/README.md
+++ b/mobile/src/README.md
@@ -5,6 +5,7 @@
 - `components/`: 표시 컴포넌트
   - `feedback/`: screen-level loading/empty/error/retry + inline notice 공용 컴포넌트
   - `actions/`: service button / grouped action row 공용 컴포넌트
+  - `launch/`: app launch gate / intro overlay 공용 컴포넌트
   - `calendar/`: day cell / date detail sheet 공용 컴포넌트
   - `release/`: track row 공용 컴포넌트
 - `copy/`: RN 공용 문구 / 상태 라벨 / 날짜 라벨 helper
@@ -34,6 +35,8 @@
 - `tokens/`: design token / theme
   - `theme.tsx`: theme provider + `useAppTheme()` access convention
   - `colors.ts`, `spacing.ts`, `radii.ts`, `typography.ts`, `sizes.ts`, `elevation.ts`, `motion.ts`
+- `hooks/`: runtime-adaptive UI helper
+  - `useReducedMotion.ts`: OS reduce-motion 선호 동기화
 - `types/`: shared TypeScript model
   - `displayModels.ts`: screen-facing display model types
   - `rawData.ts`: current static dataset contract types
@@ -68,6 +71,12 @@ feedback state 관련 규칙:
 - screen-level loading / empty / error / retry는 `components/feedback/FeedbackState.tsx`를 우선 사용한다.
 - section 안의 empty / warning / retry copy도 가능하면 `InlineFeedbackNotice`로 통일한다.
 - 화면이 직접 `ActivityIndicator + 문구 + retry button` 조합을 반복해서 만들지 않는다.
+- loading은 surface 문맥을 반영한 skeleton layout을 기본으로 하고, 짧은 fetch에는 reveal delay를 둔다.
+
+motion 관련 규칙:
+
+- launch intro, loading pulse, sheet open은 `tokens/motion.ts`와 `hooks/useReducedMotion.ts`를 공통 기준으로 사용한다.
+- reduced motion 환경에서는 long fade/slide를 줄이고 정적 fallback을 우선한다.
 
 copy 관련 규칙:
 

--- a/mobile/src/components/actions/ActionButton.tsx
+++ b/mobile/src/components/actions/ActionButton.tsx
@@ -11,6 +11,7 @@ import {
 import { useAppTheme } from '../../tokens/theme';
 import type { MobileTheme } from '../../tokens/theme';
 import { MOBILE_TEXT_SCALE_LIMITS } from '../../tokens/accessibility';
+import { useReducedMotion } from '../../hooks/useReducedMotion';
 
 export type ActionButtonTone = 'primary' | 'secondary' | 'meta';
 
@@ -38,6 +39,7 @@ function ActionButtonComponent({
   tone = 'primary',
 }: ActionButtonProps) {
   const theme = useAppTheme();
+  const reducedMotion = useReducedMotion();
   const { fontScale } = useWindowDimensions();
   const styles = useMemo(() => createStyles(theme), [theme]);
   const isDisabled = disabled || loading;
@@ -60,7 +62,7 @@ function ActionButtonComponent({
         tone === 'primary' ? styles.primarySize : null,
         tone === 'secondary' ? styles.secondarySize : null,
         fullWidth ? styles.fullWidthButton : null,
-        pressed && !isDisabled ? styles.pressed : null,
+        pressed && !isDisabled ? (reducedMotion ? styles.pressedReducedMotion : styles.pressed) : null,
         isDisabled ? styles.disabled : null,
       ]}
       testID={testID}
@@ -141,7 +143,11 @@ function createStyles(theme: MobileTheme) {
       backgroundColor: 'transparent',
     },
     pressed: {
+      transform: [{ scale: 0.985 }],
       opacity: 0.84,
+    },
+    pressedReducedMotion: {
+      opacity: 0.88,
     },
     disabled: {
       opacity: 0.5,

--- a/mobile/src/components/actions/ServiceButton.tsx
+++ b/mobile/src/components/actions/ServiceButton.tsx
@@ -10,6 +10,7 @@ import {
 import { useAppTheme } from '../../tokens/theme';
 import type { MobileTheme } from '../../tokens/theme';
 import { MOBILE_TEXT_SCALE_LIMITS } from '../../tokens/accessibility';
+import { useReducedMotion } from '../../hooks/useReducedMotion';
 
 export type ServiceButtonTone = 'spotify' | 'youtubeMusic' | 'youtubeMv';
 
@@ -37,6 +38,7 @@ function ServiceButtonComponent({
   tone,
 }: ServiceButtonProps) {
   const theme = useAppTheme();
+  const reducedMotion = useReducedMotion();
   const { fontScale } = useWindowDimensions();
   const styles = useMemo(() => createStyles(theme), [theme]);
   const resolvedService = service ?? tone ?? 'spotify';
@@ -55,7 +57,7 @@ function ServiceButtonComponent({
       style={({ pressed }) => [
         styles.button,
         styles[`${resolvedService}Button`],
-        pressed && !disabled ? styles.buttonPressed : null,
+        pressed && !disabled ? (reducedMotion ? styles.buttonPressedReducedMotion : styles.buttonPressed) : null,
         disabled ? styles.buttonDisabled : null,
       ]}
       testID={testID}
@@ -110,7 +112,11 @@ function createStyles(theme: MobileTheme) {
       gap: theme.space[8],
     },
     buttonPressed: {
+      transform: [{ scale: 0.985 }],
       opacity: 0.84,
+    },
+    buttonPressedReducedMotion: {
+      opacity: 0.88,
     },
     buttonDisabled: {
       opacity: 0.45,

--- a/mobile/src/components/feedback/FeedbackState.test.tsx
+++ b/mobile/src/components/feedback/FeedbackState.test.tsx
@@ -9,23 +9,35 @@ function hasText(tree: renderer.ReactTestRenderer, value: string): boolean {
 }
 
 describe('shared feedback state components', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   test('renders a screen-level loading state with copy', async () => {
     let tree: renderer.ReactTestRenderer;
+
+    jest.useFakeTimers();
 
     await act(async () => {
       tree = renderer.create(
         <ScreenFeedbackState
           body="데이터를 불러오는 중입니다."
           eyebrow="LOADING"
+          loadingLayout="calendar"
           title="Calendar"
           variant="loading"
         />,
       );
     });
 
+    await act(async () => {
+      jest.advanceTimersByTime(180);
+    });
+
     expect(hasText(tree!, 'LOADING')).toBe(true);
     expect(hasText(tree!, 'Calendar')).toBe(true);
     expect(hasText(tree!, '데이터를 불러오는 중입니다.')).toBe(true);
+    expect(tree!.root.findByProps({ testID: 'loading-skeleton-calendar' })).toBeDefined();
   });
 
   test('renders an inline notice action and calls the handler', async () => {

--- a/mobile/src/components/feedback/FeedbackState.tsx
+++ b/mobile/src/components/feedback/FeedbackState.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
-import { ActivityIndicator, Pressable, StyleSheet, Text, useWindowDimensions, View } from 'react-native';
+import { Animated, Easing, StyleSheet, Text, useWindowDimensions, View } from 'react-native';
 
 import { useAppTheme, type MobileTheme } from '../../tokens/theme';
 import { MOBILE_COPY } from '../../copy/mobileCopy';
 import { MOBILE_TEXT_SCALE_LIMITS } from '../../tokens/accessibility';
+import { useReducedMotion } from '../../hooks/useReducedMotion';
+import { ActionButton } from '../actions/ActionButton';
 
 type FeedbackTone = 'neutral' | 'error';
 
@@ -16,6 +18,7 @@ type FeedbackAction = {
 type ScreenFeedbackStateProps = {
   body: string;
   eyebrow: string;
+  loadingLayout?: 'generic' | 'calendar' | 'search' | 'radar' | 'detail';
   title: string;
   variant: 'loading' | 'empty' | 'error';
   action?: FeedbackAction;
@@ -34,6 +37,7 @@ export function ScreenFeedbackState({
   action,
   body,
   eyebrow,
+  loadingLayout = 'generic',
   testID,
   title,
   variant,
@@ -42,28 +46,48 @@ export function ScreenFeedbackState({
   const { fontScale } = useWindowDimensions();
   const styles = React.useMemo(() => createStyles(theme), [theme]);
   const titleMultiplier = fontScale >= 1.4 ? MOBILE_TEXT_SCALE_LIMITS.sectionTitle : MOBILE_TEXT_SCALE_LIMITS.screenTitle;
+  const [showLoadingSkeleton, setShowLoadingSkeleton] = React.useState(variant !== 'loading');
+
+  React.useEffect(() => {
+    if (variant !== 'loading') {
+      setShowLoadingSkeleton(true);
+      return;
+    }
+
+    setShowLoadingSkeleton(false);
+    const timer = setTimeout(() => {
+      setShowLoadingSkeleton(true);
+    }, theme.motion.loadingDelay);
+
+    return () => clearTimeout(timer);
+  }, [theme.motion.loadingDelay, variant]);
 
   return (
     <View style={styles.screenContainer} testID={testID}>
-      {variant === 'loading' ? <ActivityIndicator color={theme.colors.text.brand} /> : null}
       <Text allowFontScaling maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.meta} style={styles.eyebrow}>{eyebrow}</Text>
       <Text accessibilityRole="header" allowFontScaling maxFontSizeMultiplier={titleMultiplier} style={styles.screenTitle}>
         {title}
       </Text>
       <Text allowFontScaling maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.body} style={styles.body}>{body}</Text>
-      {action ? (
-        <Pressable
+      {variant === 'loading' ? (
+        showLoadingSkeleton ? (
+          <LoadingSkeleton layout={loadingLayout} />
+        ) : (
+          <View style={styles.loadingHoldFrame} testID={testID ? `${testID}-loading-hold` : undefined}>
+            <Text allowFontScaling maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.meta} style={styles.loadingHint}>
+              구조를 먼저 고정한 뒤 내용을 채우고 있습니다.
+            </Text>
+          </View>
+        )
+      ) : action ? (
+        <ActionButton
           accessibilityLabel={action.label}
-          accessibilityRole="button"
+          fullWidth={false}
+          label={action.label}
           onPress={action.onPress}
-          style={({ pressed }) => [
-            styles.primaryAction,
-            pressed ? styles.primaryActionPressed : null,
-          ]}
           testID={action.testID}
-        >
-          <Text allowFontScaling maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.buttonPrimary} style={styles.primaryActionLabel}>{action.label}</Text>
-        </Pressable>
+          tone={variant === 'error' ? 'primary' : 'secondary'}
+        />
       ) : null}
     </View>
   );
@@ -99,18 +123,13 @@ export function InlineFeedbackNotice({
         {body}
       </Text>
       {action ? (
-        <Pressable
+        <ActionButton
           accessibilityLabel={action.label}
-          accessibilityRole="button"
+          label={action.label}
           onPress={action.onPress}
-          style={({ pressed }) => [
-            styles.secondaryAction,
-            pressed ? styles.secondaryActionPressed : null,
-          ]}
           testID={action.testID}
-        >
-          <Text allowFontScaling maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.buttonService} style={styles.secondaryActionLabel}>{action.label}</Text>
-        </Pressable>
+          tone={tone === 'error' ? 'primary' : 'secondary'}
+        />
       ) : null}
     </View>
   );
@@ -159,6 +178,60 @@ export function ErrorStateBlock({
   );
 }
 
+function LoadingSkeleton({ layout }: { layout: ScreenFeedbackStateProps['loadingLayout'] }) {
+  const theme = useAppTheme();
+  const reducedMotion = useReducedMotion();
+  const styles = React.useMemo(() => createStyles(theme), [theme]);
+  const pulse = React.useRef(new Animated.Value(reducedMotion ? 1 : 0.72)).current;
+
+  React.useEffect(() => {
+    if (reducedMotion) {
+      pulse.setValue(1);
+      return;
+    }
+
+    const animation = Animated.loop(
+      Animated.sequence([
+        Animated.timing(pulse, {
+          toValue: 1,
+          duration: theme.motion.loadingPulse,
+          easing: Easing.inOut(Easing.quad),
+          useNativeDriver: true,
+        }),
+        Animated.timing(pulse, {
+          toValue: 0.72,
+          duration: theme.motion.loadingPulse,
+          easing: Easing.inOut(Easing.quad),
+          useNativeDriver: true,
+        }),
+      ]),
+    );
+
+    animation.start();
+    return () => animation.stop();
+  }, [pulse, reducedMotion, theme.motion.loadingPulse]);
+
+  const animatedStyle = reducedMotion ? null : { opacity: pulse };
+  const rows =
+    layout === 'calendar'
+      ? [styles.skeletonHero, styles.skeletonGridRow, styles.skeletonGridRow, styles.skeletonListRow]
+      : layout === 'search'
+        ? [styles.skeletonSearchBar, styles.skeletonSegmentRow, styles.skeletonResultRow, styles.skeletonResultRow]
+        : layout === 'radar'
+          ? [styles.skeletonHero, styles.skeletonWideRow, styles.skeletonWideRow, styles.skeletonListRow]
+          : layout === 'detail'
+            ? [styles.skeletonArtwork, styles.skeletonTitleRow, styles.skeletonTitleRowShort, styles.skeletonButtonRow]
+            : [styles.skeletonWideRow, styles.skeletonWideRow, styles.skeletonListRow];
+
+  return (
+    <View style={styles.skeletonFrame} testID={`loading-skeleton-${layout ?? 'generic'}`}>
+      {rows.map((rowStyle, index) => (
+        <Animated.View key={`${layout ?? 'generic'}-${index}`} style={[styles.skeletonBlock, rowStyle, animatedStyle]} />
+      ))}
+    </View>
+  );
+}
+
 function createStyles(theme: MobileTheme) {
   return StyleSheet.create({
     screenContainer: {
@@ -182,20 +255,24 @@ function createStyles(theme: MobileTheme) {
       ...theme.typography.body,
       color: theme.colors.text.secondary,
     },
-    primaryAction: {
-      alignSelf: 'flex-start',
-      marginTop: theme.space[4],
-      paddingHorizontal: theme.space[16],
-      paddingVertical: theme.space[12],
-      borderRadius: theme.radius.button,
+    loadingHoldFrame: {
+      width: '100%',
+      paddingTop: theme.space[8],
+    },
+    loadingHint: {
+      ...theme.typography.meta,
+      color: theme.colors.text.tertiary,
+    },
+    skeletonFrame: {
+      width: '100%',
+      gap: theme.space[12],
+      paddingTop: theme.space[8],
+    },
+    skeletonBlock: {
+      borderRadius: theme.radius.card,
       backgroundColor: theme.colors.surface.interactive,
-    },
-    primaryActionPressed: {
-      opacity: 0.84,
-    },
-    primaryActionLabel: {
-      ...theme.typography.buttonPrimary,
-      color: theme.colors.text.primary,
+      borderWidth: 1,
+      borderColor: theme.colors.border.subtle,
     },
     inlineCard: {
       gap: theme.space[8],
@@ -216,19 +293,48 @@ function createStyles(theme: MobileTheme) {
     inlineBodyError: {
       color: theme.colors.text.danger,
     },
-    secondaryAction: {
-      alignSelf: 'flex-start',
-      paddingHorizontal: theme.space[12],
-      paddingVertical: theme.space[8],
+    skeletonHero: {
+      minHeight: 112,
+    },
+    skeletonGridRow: {
+      minHeight: 72,
+    },
+    skeletonListRow: {
+      minHeight: 52,
+    },
+    skeletonSearchBar: {
+      minHeight: 54,
       borderRadius: theme.radius.button,
-      backgroundColor: theme.colors.surface.interactive,
     },
-    secondaryActionPressed: {
-      opacity: 0.84,
+    skeletonSegmentRow: {
+      minHeight: 42,
+      width: '72%',
+      borderRadius: theme.radius.button,
     },
-    secondaryActionLabel: {
-      ...theme.typography.buttonService,
-      color: theme.colors.text.primary,
+    skeletonResultRow: {
+      minHeight: 68,
+    },
+    skeletonWideRow: {
+      minHeight: 84,
+    },
+    skeletonArtwork: {
+      minHeight: 168,
+      borderRadius: theme.radius.sheet,
+    },
+    skeletonTitleRow: {
+      minHeight: 20,
+      width: '76%',
+      borderRadius: theme.radius.chip,
+    },
+    skeletonTitleRowShort: {
+      minHeight: 20,
+      width: '48%',
+      borderRadius: theme.radius.chip,
+    },
+    skeletonButtonRow: {
+      minHeight: 48,
+      width: '64%',
+      borderRadius: theme.radius.button,
     },
   });
 }

--- a/mobile/src/components/launch/LaunchGate.test.tsx
+++ b/mobile/src/components/launch/LaunchGate.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import { Text } from 'react-native';
+
+import { LaunchGate } from './LaunchGate';
+import { MobileThemeProvider } from '../../tokens/theme';
+
+const mockUseReducedMotion = jest.fn(() => false);
+
+jest.mock('../../hooks/useReducedMotion', () => ({
+  useReducedMotion: () => mockUseReducedMotion(),
+}));
+
+describe('LaunchGate', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+    mockUseReducedMotion.mockReset();
+    mockUseReducedMotion.mockReturnValue(false);
+  });
+
+  test('shows the launch overlay briefly before revealing the app chrome', async () => {
+    jest.useFakeTimers();
+    let tree: renderer.ReactTestRenderer;
+
+    await act(async () => {
+      tree = renderer.create(
+        <MobileThemeProvider schemeOverride="light">
+          <LaunchGate>
+            <Text>앱 본문</Text>
+          </LaunchGate>
+        </MobileThemeProvider>,
+      );
+    });
+
+    expect(tree!.root.findByProps({ testID: 'launch-gate-overlay' })).toBeDefined();
+
+    await act(async () => {
+      jest.advanceTimersByTime(900);
+    });
+
+    expect(tree!.root.findAllByProps({ testID: 'launch-gate-overlay' })).toHaveLength(0);
+  });
+
+  test('skips long animation when reduced motion is enabled', async () => {
+    jest.useFakeTimers();
+    mockUseReducedMotion.mockReturnValue(true);
+
+    let tree: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(
+        <MobileThemeProvider schemeOverride="light">
+          <LaunchGate>
+            <Text>앱 본문</Text>
+          </LaunchGate>
+        </MobileThemeProvider>,
+      );
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(140);
+    });
+
+    expect(tree!.root.findAllByProps({ testID: 'launch-gate-overlay' })).toHaveLength(0);
+  });
+});

--- a/mobile/src/components/launch/LaunchGate.tsx
+++ b/mobile/src/components/launch/LaunchGate.tsx
@@ -1,0 +1,221 @@
+import React from 'react';
+import {
+  Animated,
+  Easing,
+  Image,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+
+import { useReducedMotion } from '../../hooks/useReducedMotion';
+import { useAppTheme, type MobileTheme } from '../../tokens/theme';
+
+const APP_ICON = require('../../../assets/app-icon/icon-adaptive-foreground.png');
+
+export interface LaunchGateProps {
+  children: React.ReactNode;
+}
+
+export function LaunchGate({ children }: LaunchGateProps) {
+  const theme = useAppTheme();
+  const reducedMotion = useReducedMotion();
+  const styles = React.useMemo(() => createStyles(theme), [theme]);
+  const progress = React.useRef(new Animated.Value(0)).current;
+  const [isVisible, setIsVisible] = React.useState(true);
+
+  React.useEffect(() => {
+    let cancelled = false;
+
+    if (reducedMotion) {
+      const timer = setTimeout(() => {
+        if (!cancelled) {
+          setIsVisible(false);
+        }
+      }, 120);
+
+      return () => {
+        cancelled = true;
+        clearTimeout(timer);
+      };
+    }
+
+    const animation = Animated.sequence([
+      Animated.timing(progress, {
+        toValue: 1,
+        duration: theme.motion.launchEnter,
+        easing: Easing.out(Easing.cubic),
+        useNativeDriver: true,
+      }),
+      Animated.delay(theme.motion.launchHold),
+      Animated.timing(progress, {
+        toValue: 2,
+        duration: theme.motion.launchExit,
+        easing: Easing.inOut(Easing.quad),
+        useNativeDriver: true,
+      }),
+    ]);
+
+    animation.start(({ finished }) => {
+      if (!cancelled && finished) {
+        setIsVisible(false);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+      animation.stop();
+    };
+  }, [progress, reducedMotion, theme.motion.launchEnter, theme.motion.launchExit, theme.motion.launchHold]);
+
+  const overlayOpacity = reducedMotion
+    ? 1
+    : progress.interpolate({
+        inputRange: [0, 1, 2],
+        outputRange: [1, 1, 0],
+      });
+  const cardOpacity = reducedMotion
+    ? 1
+    : progress.interpolate({
+        inputRange: [0, 0.8, 1.4, 2],
+        outputRange: [0.32, 1, 1, 0],
+      });
+  const cardScale = reducedMotion
+    ? 1
+    : progress.interpolate({
+        inputRange: [0, 1, 2],
+        outputRange: [0.96, 1, 1.02],
+      });
+
+  return (
+    <View style={styles.root}>
+      {children}
+      {isVisible ? (
+        <Animated.View
+          pointerEvents="none"
+          style={[styles.overlay, { opacity: overlayOpacity }]}
+          testID="launch-gate-overlay"
+        >
+          <Animated.View
+            style={[
+              styles.card,
+              {
+                opacity: cardOpacity,
+                transform: [{ scale: cardScale }],
+              },
+            ]}
+          >
+            <View style={styles.markRow}>
+              <View style={styles.markBadge}>
+                <Image source={APP_ICON} style={styles.markImage} />
+              </View>
+              <View style={styles.copyBlock}>
+                <Text allowFontScaling={false} style={styles.kicker}>
+                  IDOL SONG APP
+                </Text>
+                <Text allowFontScaling={false} style={styles.title}>
+                  이번 주 발매와
+                  {'\n'}
+                  다음 컴백을 정리합니다
+                </Text>
+              </View>
+            </View>
+            <View style={styles.metaRail}>
+              <Text allowFontScaling={false} style={styles.metaText}>
+                CALENDAR
+              </Text>
+              <Text allowFontScaling={false} style={styles.metaDot}>
+                ·
+              </Text>
+              <Text allowFontScaling={false} style={styles.metaText}>
+                RADAR
+              </Text>
+              <Text allowFontScaling={false} style={styles.metaDot}>
+                ·
+              </Text>
+              <Text allowFontScaling={false} style={styles.metaText}>
+                RELEASES
+              </Text>
+            </View>
+          </Animated.View>
+        </Animated.View>
+      ) : null}
+    </View>
+  );
+}
+
+function createStyles(theme: MobileTheme) {
+  return StyleSheet.create({
+    root: {
+      flex: 1,
+    },
+    overlay: {
+      ...StyleSheet.absoluteFillObject,
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: theme.colors.surface.base,
+      paddingHorizontal: theme.space[24],
+    },
+    card: {
+      width: '100%',
+      maxWidth: 360,
+      gap: theme.space[16],
+      paddingHorizontal: theme.space[24],
+      paddingVertical: theme.space[24],
+      borderRadius: theme.radius.sheet,
+      backgroundColor: theme.colors.surface.elevated,
+      borderWidth: 1,
+      borderColor: theme.colors.border.subtle,
+      shadowColor: '#000000',
+      shadowOpacity: theme.scheme === 'dark' ? 0.32 : 0.12,
+      shadowRadius: 18,
+      shadowOffset: { width: 0, height: 10 },
+      elevation: 8,
+    },
+    markRow: {
+      flexDirection: 'row',
+      gap: theme.space[16],
+      alignItems: 'center',
+    },
+    markBadge: {
+      width: 72,
+      height: 72,
+      alignItems: 'center',
+      justifyContent: 'center',
+      borderRadius: 24,
+      backgroundColor: theme.colors.surface.interactive,
+    },
+    markImage: {
+      width: 48,
+      height: 48,
+      resizeMode: 'contain',
+    },
+    copyBlock: {
+      flex: 1,
+      gap: theme.space[8],
+    },
+    kicker: {
+      ...theme.typography.meta,
+      color: theme.colors.text.brand,
+      letterSpacing: 1.2,
+    },
+    title: {
+      ...theme.typography.sectionTitle,
+      color: theme.colors.text.primary,
+    },
+    metaRail: {
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+      alignItems: 'center',
+      gap: theme.space[8],
+    },
+    metaText: {
+      ...theme.typography.meta,
+      color: theme.colors.text.secondary,
+    },
+    metaDot: {
+      ...theme.typography.meta,
+      color: theme.colors.text.tertiary,
+    },
+  });
+}

--- a/mobile/src/components/layout/BottomSheetFrame.test.tsx
+++ b/mobile/src/components/layout/BottomSheetFrame.test.tsx
@@ -4,17 +4,38 @@ import { Text } from 'react-native';
 
 import { BottomSheetFrame } from './BottomSheetFrame';
 
+const mockUseReducedMotion = jest.fn(() => false);
+
+jest.mock('../../hooks/useReducedMotion', () => ({
+  useReducedMotion: () => mockUseReducedMotion(),
+}));
+
 jest.mock('react-native/Libraries/Modal/Modal', () => {
   const React = jest.requireActual<typeof import('react')>('react');
 
   return {
     __esModule: true,
-    default: ({ children, visible }: { children?: React.ReactNode; visible?: boolean }) =>
-      visible ? React.createElement(React.Fragment, null, children) : null,
+    default: ({
+      animationType,
+      children,
+      visible,
+    }: {
+      animationType?: string;
+      children?: React.ReactNode;
+      visible?: boolean;
+    }) =>
+      visible
+        ? React.createElement('modal-host', { animationType, visible }, children)
+        : null,
   };
 });
 
 describe('BottomSheetFrame', () => {
+  afterEach(() => {
+    mockUseReducedMotion.mockReset();
+    mockUseReducedMotion.mockReturnValue(false);
+  });
+
   test('renders the modal frame with accessibility metadata and dismiss affordances', async () => {
     const onClose = jest.fn();
     let tree: renderer.ReactTestRenderer;
@@ -37,6 +58,7 @@ describe('BottomSheetFrame', () => {
 
     expect(tree!.root.findByProps({ testID: 'bottom-sheet' }).props.accessibilityViewIsModal).toBe(true);
     expect(tree!.root.findByProps({ testID: 'bottom-sheet-backdrop' })).toBeDefined();
+    expect(tree!.root.findByType('modal-host' as any).props.animationType).toBe('slide');
 
     await act(async () => {
       tree!.root.findByProps({ testID: 'bottom-sheet-close' }).props.onPress();
@@ -60,5 +82,20 @@ describe('BottomSheetFrame', () => {
     });
 
     expect(tree!.root.findAllByProps({ testID: 'bottom-sheet' })).toHaveLength(0);
+  });
+
+  test('falls back to fade animation when reduced motion is enabled', async () => {
+    mockUseReducedMotion.mockReturnValue(true);
+
+    let tree: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(
+        <BottomSheetFrame isOpen onClose={jest.fn()} sheetTestID="bottom-sheet" title="공통 시트">
+          <Text>시트 내용</Text>
+        </BottomSheetFrame>,
+      );
+    });
+
+    expect(tree!.root.findByType('modal-host' as any).props.animationType).toBe('fade');
   });
 });

--- a/mobile/src/components/layout/BottomSheetFrame.tsx
+++ b/mobile/src/components/layout/BottomSheetFrame.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react-native';
 
 import { SheetHeader } from './SheetHeader';
+import { useReducedMotion } from '../../hooks/useReducedMotion';
 import { useAppTheme } from '../../tokens/theme';
 import type { MobileTheme } from '../../tokens/theme';
 
@@ -30,7 +31,7 @@ export interface BottomSheetFrameProps {
 
 function BottomSheetFrameComponent({
   accessibilityLabel,
-  animationType = 'fade',
+  animationType,
   backdropTestID,
   children,
   closeButtonTestID,
@@ -44,7 +45,9 @@ function BottomSheetFrameComponent({
   title,
 }: BottomSheetFrameProps) {
   const theme = useAppTheme();
+  const reducedMotion = useReducedMotion();
   const styles = useMemo(() => createStyles(theme), [theme]);
+  const resolvedAnimationType = animationType ?? (reducedMotion ? 'fade' : 'slide');
   const sheetStyle = useMemo<StyleProp<ViewStyle>>(
     () => [
       styles.sheet,
@@ -60,7 +63,7 @@ function BottomSheetFrameComponent({
 
   return (
     <Modal
-      animationType={animationType}
+      animationType={resolvedAnimationType}
       onRequestClose={onClose}
       presentationStyle="overFullScreen"
       transparent

--- a/mobile/src/features/route-shell.smoke.test.tsx
+++ b/mobile/src/features/route-shell.smoke.test.tsx
@@ -102,6 +102,14 @@ jest.mock('../features/useActiveDatasetScreen', () => {
   };
 });
 
+jest.mock('../components/launch/LaunchGate', () => {
+  const React = jest.requireActual<typeof import('react')>('react');
+
+  return {
+    LaunchGate: ({ children }: { children?: React.ReactNode }) => React.createElement(React.Fragment, null, children),
+  };
+});
+
 jest.mock('../services/routeResume', () => ({
   consumePendingRouteResume: jest.fn(async () => null),
 }));

--- a/mobile/src/hooks/useReducedMotion.ts
+++ b/mobile/src/hooks/useReducedMotion.ts
@@ -1,0 +1,36 @@
+import React from 'react';
+import { AccessibilityInfo } from 'react-native';
+
+export function useReducedMotion(): boolean {
+  const [isReducedMotionEnabled, setIsReducedMotionEnabled] = React.useState(false);
+
+  React.useEffect(() => {
+    let mounted = true;
+
+    const syncPreference = async () => {
+      try {
+        const enabled = await AccessibilityInfo.isReduceMotionEnabled();
+        if (mounted) {
+          setIsReducedMotionEnabled(enabled);
+        }
+      } catch {
+        if (mounted) {
+          setIsReducedMotionEnabled(false);
+        }
+      }
+    };
+
+    void syncPreference();
+
+    const subscription = AccessibilityInfo.addEventListener('reduceMotionChanged', (enabled) => {
+      setIsReducedMotionEnabled(enabled);
+    });
+
+    return () => {
+      mounted = false;
+      subscription.remove();
+    };
+  }, []);
+
+  return isReducedMotionEnabled;
+}

--- a/mobile/src/tokens/motion.ts
+++ b/mobile/src/tokens/motion.ts
@@ -1,13 +1,25 @@
 export type MotionTokens = {
   pressFast: number;
+  pressResponsive: number;
   fadeStandard: number;
+  loadingPulse: number;
+  loadingDelay: number;
   sheetOpen: number;
   navigationPush: number;
+  launchEnter: number;
+  launchHold: number;
+  launchExit: number;
 };
 
 export const motionTokens: MotionTokens = {
   pressFast: 90,
+  pressResponsive: 140,
   fadeStandard: 180,
+  loadingPulse: 860,
+  loadingDelay: 140,
   sheetOpen: 240,
   navigationPush: 260,
+  launchEnter: 220,
+  launchHold: 280,
+  launchExit: 180,
 };


### PR DESCRIPTION
## Summary
- add a Korean-first launch gate, native splash configuration, and reduced-motion handling for launch and sheets
- replace spinner-first screen loading states with contextual skeleton layouts and stronger retry feedback
- document the updated motion and feedback rules for mobile launch-grade UI

Closes #513
Closes #514
Closes #517