### PR TITLE
RN handoff, copy, and density polish

### DIFF
--- a/docs/assets/distribution/rn_handoff_visual_copy_polish_local_2026-03-11.md
+++ b/docs/assets/distribution/rn_handoff_visual_copy_polish_local_2026-03-11.md
@@ -1,0 +1,36 @@
+# RN Handoff / Visual / Copy Polish Local Note (2026-03-11)
+
+## Scope
+- GitHub issues: `#505`, `#506`, `#507`
+- Branch: `codex/rn-handoff-copy-polish`
+
+## What changed
+- Service handoff buttons now expose Korean-first mode hints:
+  - `앱 우선`
+  - `검색 결과`
+- Canonical vs search fallback behavior is surfaced through accessibility hints on:
+  - calendar release actions
+  - search release actions
+  - team detail latest release actions
+  - release detail album, track, MV actions
+- Shared mobile copy now centralizes:
+  - handoff failure title/body
+  - partial-data title
+  - short surface labels for `검색`, `레이더`
+  - compact summary labels such as `이달 발매`, `예정 일정`, `가까운 일정`
+- Shared surface primitives were tightened for large-text legibility:
+  - compact hero
+  - inset section
+  - tonal panel
+  - release/upcoming summary rows
+
+## Local verification
+- `cd mobile && npm test -- --runInBand src/features/calendarControls.test.tsx src/features/searchTab.test.tsx src/features/radarTab.test.tsx src/features/entityDetailScreen.test.tsx src/features/releaseDetailScreen.test.tsx`
+- `cd mobile && npm test -- --runInBand src/services/handoff.test.ts src/components/layout/SummaryStrip.test.tsx src/components/surfaces/SurfacePrimitives.test.tsx src/components/actions/ServiceButtonGroup.test.tsx src/components/identity/TeamIdentityRow.test.tsx`
+- `cd mobile && npm run typecheck`
+- `cd mobile && npm run lint`
+- `git diff --check`
+
+## Notes
+- `npm run lint` remains green with the pre-existing warning in `mobile/.expo/types/router.d.ts`.
+- This pass validates handoff semantics through canonical/search-fallback resolution and rendered button hints. It does not claim real-device third-party app install QA beyond those runtime contracts.

--- a/docs/specs/mobile/copy-localization-spec.md
+++ b/docs/specs/mobile/copy-localization-spec.md
@@ -36,6 +36,9 @@
 ### 4.2 Service
 - 표면 라벨은 서비스 이름만 사용
 - `검색 열기`는 tooltip 또는 보조 문구에만 사용
+- canonical link가 있으면 보조 라벨은 `앱 우선`
+- canonical link가 없고 search fallback만 있으면 보조 라벨은 `검색 결과`
+- accessibility hint는 `앱 설치 시 앱 우선 / 미설치 시 안전한 웹 fallback` 또는 `검색 결과만 연다`를 한국어로 설명
 
 ### 4.3 Meta
 - `기사 원문`
@@ -53,6 +56,9 @@
 - 공통: `정보를 불러오지 못했습니다.`
 - retry CTA: `다시 시도`
 - 부분 실패: `일부 정보만 표시됩니다.`
+- 외부 handoff 실패 title: `외부 이동을 완료하지 못했습니다.`
+- 외부 handoff retryable body: `외부 앱을 열지 못했습니다. 같은 화면에서 다시 시도해 주세요.`
+- handoff unavailable body: `지금은 열 수 있는 서비스 경로가 없습니다.`
 
 ## 7. Date Copy
 - 한국어: `2026년 4월 13일`

--- a/docs/specs/mobile/visual-design-spec.md
+++ b/docs/specs/mobile/visual-design-spec.md
@@ -68,6 +68,8 @@ launch-grade visual identity의 표면 계층과 child issue 분리는 `launch-g
 - 아이콘 좌측, 라벨 우측
 - 전체 fill보다 soft tint 배경 우선
 - 모든 서비스 버튼은 동일 구조 유지
+- secondary hint는 최대 1줄, `앱 우선` 또는 `검색 결과`처럼 짧은 상태 라벨만 허용
+- large text에서도 버튼 1행 구조를 우선 유지하고, copy는 `label 2줄 + hint 1줄`까지만 허용
 
 ### 7.4 Meta Link
 - 텍스트형 또는 아주 약한 outline형
@@ -90,6 +92,7 @@ launch-grade visual identity의 표면 계층과 child issue 분리는 `launch-g
 - 레이더 카드: medium density
 - 팀 상세: mixed density
 - 릴리즈 상세 트랙 리스트: dense but tappable
+- large text 모드에서는 title/meta line clamp를 유지하고, spacing 축소보다 먼저 줄 수와 button wrap 규칙으로 해결한다
 
 ## 10. Icon Sizing
 - 탭 아이콘: 22~24

--- a/mobile/app/(tabs)/calendar.tsx
+++ b/mobile/app/(tabs)/calendar.tsx
@@ -59,6 +59,7 @@ import {
   trackFailureObserved,
 } from '../../src/services/analytics';
 import {
+  describeServiceHandoffBehavior,
   openServiceHandoff,
   resolveServiceHandoff,
   type ServiceHandoffFailure,
@@ -599,28 +600,39 @@ export default function CalendarTabScreen() {
 
     return [
       {
+        accessibilityHint: describeServiceHandoffBehavior(spotify),
         accessibilityLabel: `Spotify에서 ${release.releaseTitle} 열기`,
         key: `${release.id}-spotify`,
         label: 'Spotify',
         mode: spotify.mode,
+        modeHintLabel:
+          spotify.mode === 'canonical' ? MOBILE_COPY.handoff.appPreferred : MOBILE_COPY.handoff.searchFallback,
         onPress: () => void handleServiceHandoff(spotify),
         service: 'spotify',
         testID: `calendar-release-service-spotify-${release.id}`,
       },
       {
+        accessibilityHint: describeServiceHandoffBehavior(youtubeMusic),
         accessibilityLabel: `YouTube Music에서 ${release.releaseTitle} 열기`,
         key: `${release.id}-youtube-music`,
         label: 'YouTube Music',
         mode: youtubeMusic.mode,
+        modeHintLabel:
+          youtubeMusic.mode === 'canonical'
+            ? MOBILE_COPY.handoff.appPreferred
+            : MOBILE_COPY.handoff.searchFallback,
         onPress: () => void handleServiceHandoff(youtubeMusic),
         service: 'youtubeMusic',
         testID: `calendar-release-service-youtube-music-${release.id}`,
       },
       {
+        accessibilityHint: describeServiceHandoffBehavior(youtubeMv),
         accessibilityLabel: `YouTube에서 ${release.representativeSongTitle ?? release.releaseTitle} MV 열기`,
         key: `${release.id}-youtube-mv`,
         label: 'YouTube MV',
         mode: youtubeMv.mode,
+        modeHintLabel:
+          youtubeMv.mode === 'canonical' ? MOBILE_COPY.handoff.appPreferred : MOBILE_COPY.handoff.searchFallback,
         onPress: () => void handleServiceHandoff(youtubeMv),
         service: 'youtubeMv',
         testID: `calendar-release-service-youtube-mv-${release.id}`,
@@ -931,9 +943,9 @@ export default function CalendarTabScreen() {
 
         <SummaryStrip
           items={[
-            { key: 'release-count', label: '이번 달 발매', value: filteredSnapshot.releaseCount },
-            { key: 'upcoming-count', label: '예정 컴백', value: filteredSnapshot.upcomingCount },
-            { key: 'nearest-upcoming', label: '가장 가까운 일정', value: nearestSummary },
+            { key: 'release-count', label: MOBILE_COPY.summary.monthRelease, value: filteredSnapshot.releaseCount },
+            { key: 'upcoming-count', label: MOBILE_COPY.summary.upcoming, value: filteredSnapshot.upcomingCount },
+            { key: 'nearest-upcoming', label: MOBILE_COPY.summary.nearestUpcoming, value: nearestSummary },
           ]}
           layout="wrap"
           testID="calendar-summary-strip"
@@ -952,7 +964,7 @@ export default function CalendarTabScreen() {
           <InlineFeedbackNotice
             body={handoffFeedback}
             testID="calendar-handoff-feedback"
-            title="외부 이동을 완료하지 못했습니다."
+            title={MOBILE_COPY.feedback.handoffFailedTitle}
           />
         ) : null}
 

--- a/mobile/app/(tabs)/radar.tsx
+++ b/mobile/app/(tabs)/radar.tsx
@@ -505,7 +505,7 @@ export default function RadarTabScreen() {
         body="가장 가까운 컴백과 레이더 요약을 불러오는 중입니다."
         eyebrow="데이터 로딩"
         loadingLayout="radar"
-        title="레이더"
+        title={MOBILE_COPY.surface.radarTitle}
         variant="loading"
       />
     );
@@ -521,7 +521,7 @@ export default function RadarTabScreen() {
         }}
         body={datasetState.message}
         eyebrow="로드 오류"
-        title="레이더"
+        title={MOBILE_COPY.surface.radarTitle}
         variant="error"
       />
     );
@@ -532,7 +532,7 @@ export default function RadarTabScreen() {
       <ScreenFeedbackState
         body="레이더 스냅샷을 찾지 못했습니다."
         eyebrow="빈 스냅샷"
-        title="레이더"
+        title={MOBILE_COPY.surface.radarTitle}
         variant="empty"
       />
     );
@@ -553,7 +553,7 @@ export default function RadarTabScreen() {
   return (
     <>
       <ScrollView style={styles.screen} contentContainerStyle={styles.content}>
-        <AppBar subtitle={source.sourceLabel} testID="radar-app-bar" title="레이더" />
+        <AppBar subtitle={source.sourceLabel} testID="radar-app-bar" title={MOBILE_COPY.surface.radarTitle} />
         <View style={styles.appBarActions}>
           <Pressable
             testID="radar-search-button"
@@ -602,7 +602,7 @@ export default function RadarTabScreen() {
           <TonalPanel
             body={buildRadarPartialBody(partialSections)}
             testID="radar-partial-notice"
-            title="일부 정보만 표시됩니다."
+            title={MOBILE_COPY.feedback.partialTitle}
           />
         ) : null}
 
@@ -612,9 +612,9 @@ export default function RadarTabScreen() {
 
         <SummaryStrip
           items={[
-            { key: 'weekly', label: '이번 주 예정', value: filteredWeeklyUpcoming.length },
-            { key: 'change', label: '일정 변경', value: filteredChangeFeed.length },
-            { key: 'long-gap', label: '장기 공백', value: filteredLongGap.length },
+            { key: 'weekly', label: MOBILE_COPY.summary.weeklyUpcoming, value: filteredWeeklyUpcoming.length },
+            { key: 'change', label: MOBILE_COPY.summary.changedSchedule, value: filteredChangeFeed.length },
+            { key: 'long-gap', label: MOBILE_COPY.summary.longGap, value: filteredLongGap.length },
           ]}
           layout="wrap"
           testID="radar-summary-strip"

--- a/mobile/app/(tabs)/search.tsx
+++ b/mobile/app/(tabs)/search.tsx
@@ -53,7 +53,12 @@ import {
   type SearchSubmitSource,
 } from '../../src/services/analytics';
 import { openExternalLink, normalizeExternalLinkUrl } from '../../src/services/externalLinks';
-import { openServiceHandoff, resolveServiceHandoff, type MusicService } from '../../src/services/handoff';
+import {
+  describeServiceHandoffBehavior,
+  openServiceHandoff,
+  resolveServiceHandoff,
+  type MusicService,
+} from '../../src/services/handoff';
 import { clearRecentQueries, persistRecentQuery, readRecentQueries } from '../../src/services/recentQueries';
 import {
   runWithPendingRouteResume,
@@ -172,6 +177,10 @@ function resolveSearchSegmentLabel(segment: SearchSegment): string {
   }
 
   return '예정';
+}
+
+function resolveHandoffModeHintLabel(mode: 'canonical' | 'searchFallback'): string {
+  return mode === 'canonical' ? MOBILE_COPY.handoff.appPreferred : MOBILE_COPY.handoff.searchFallback;
 }
 
 function buildTeamResultAccessibilityLabel(result: SearchTeamResultModel): string {
@@ -589,7 +598,7 @@ export default function SearchTabScreen() {
         body="검색 대상 팀, 발매, 예정 데이터를 불러오는 중입니다."
         eyebrow="데이터 로딩"
         loadingLayout="search"
-        title="검색"
+        title={MOBILE_COPY.surface.searchTitle}
         variant="loading"
       />
     );
@@ -604,7 +613,7 @@ export default function SearchTabScreen() {
         }}
         body={datasetState.message}
         eyebrow="로드 오류"
-        title="검색"
+        title={MOBILE_COPY.surface.searchTitle}
         variant="error"
       />
     );
@@ -644,9 +653,9 @@ export default function SearchTabScreen() {
       style={styles.screen}
     >
       <AppBar
-        subtitle="한글 별칭, 영문 그룹명, 릴리즈명, 예정 헤드라인까지 같은 검색 규칙으로 찾습니다."
+        subtitle={MOBILE_COPY.surface.searchSubtitle}
         testID="search-app-bar"
-        title="검색"
+        title={MOBILE_COPY.surface.searchTitle}
       />
 
       {datasetRiskDisclosure ? (
@@ -690,7 +699,7 @@ export default function SearchTabScreen() {
                 testID="search-clear-button"
               >
                 <Text allowFontScaling maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.buttonService} style={styles.inlineButtonLabel}>
-                  지우기
+                  {MOBILE_COPY.action.clear}
                 </Text>
               </Pressable>
             ) : null}
@@ -814,7 +823,7 @@ export default function SearchTabScreen() {
             <InlineFeedbackNotice
               body={handoffFeedback}
               testID="search-handoff-feedback"
-              title="외부 열기 실패"
+              title={MOBILE_COPY.feedback.handoffFailedTitle}
               tone="error"
             />
           ) : null}
@@ -823,7 +832,7 @@ export default function SearchTabScreen() {
             <InlineFeedbackNotice
               body={`일부 세그먼트만 결과가 있습니다. 팀 ${segmentCounts.entities} · 발매 ${segmentCounts.releases} · 예정 ${segmentCounts.upcoming}`}
               testID="search-partial-result-notice"
-              title="일부 세그먼트만 결과가 있습니다."
+              title={MOBILE_COPY.feedback.partialTitle}
             />
           ) : null}
 
@@ -878,7 +887,24 @@ export default function SearchTabScreen() {
             : null}
 
           {activeSegment === 'releases'
-            ? results.releases.map((result) => (
+            ? results.releases.map((result) => {
+                const spotifyHandoff = resolveServiceHandoff({
+                  service: 'spotify',
+                  query: buildReleaseServiceQuery(result.release),
+                  canonicalUrl: result.release.spotifyUrl,
+                });
+                const youtubeMusicHandoff = resolveServiceHandoff({
+                  service: 'youtubeMusic',
+                  query: buildReleaseServiceQuery(result.release),
+                  canonicalUrl: result.release.youtubeMusicUrl,
+                });
+                const youtubeMvHandoff = resolveServiceHandoff({
+                  service: 'youtubeMv',
+                  query: buildReleaseMvQuery(result.release),
+                  canonicalUrl: result.release.youtubeMvUrl,
+                });
+
+                return (
                 <View key={result.release.id} style={styles.resultCard}>
                   <Pressable
                     accessibilityHint="릴리즈 상세 화면으로 이동합니다."
@@ -907,40 +933,34 @@ export default function SearchTabScreen() {
                     <ServiceButtonGroup
                       buttons={[
                         {
+                          accessibilityHint: describeServiceHandoffBehavior(spotifyHandoff),
                           key: `${result.release.id}-spotify`,
                           accessibilityLabel: `${result.release.releaseTitle} Spotify 열기`,
                           label: 'Spotify',
-                          mode: resolveServiceHandoff({
-                            service: 'spotify',
-                            query: buildReleaseServiceQuery(result.release),
-                            canonicalUrl: result.release.spotifyUrl,
-                          }).mode,
+                          mode: spotifyHandoff.mode,
+                          modeHintLabel: resolveHandoffModeHintLabel(spotifyHandoff.mode),
                           onPress: () => void handleReleaseServicePress(result.release, 'spotify'),
                           service: 'spotify',
                           testID: `search-release-service-spotify-${result.release.id}`,
                         },
                         {
+                          accessibilityHint: describeServiceHandoffBehavior(youtubeMusicHandoff),
                           key: `${result.release.id}-youtube-music`,
                           accessibilityLabel: `${result.release.releaseTitle} YouTube Music 열기`,
                           label: 'YouTube Music',
-                          mode: resolveServiceHandoff({
-                            service: 'youtubeMusic',
-                            query: buildReleaseServiceQuery(result.release),
-                            canonicalUrl: result.release.youtubeMusicUrl,
-                          }).mode,
+                          mode: youtubeMusicHandoff.mode,
+                          modeHintLabel: resolveHandoffModeHintLabel(youtubeMusicHandoff.mode),
                           onPress: () => void handleReleaseServicePress(result.release, 'youtubeMusic'),
                           service: 'youtubeMusic',
                           testID: `search-release-service-youtube-music-${result.release.id}`,
                         },
                         {
+                          accessibilityHint: describeServiceHandoffBehavior(youtubeMvHandoff),
                           key: `${result.release.id}-youtube-mv`,
                           accessibilityLabel: `${result.release.releaseTitle} YouTube MV 열기`,
                           label: 'YouTube MV',
-                          mode: resolveServiceHandoff({
-                            service: 'youtubeMv',
-                            query: buildReleaseMvQuery(result.release),
-                            canonicalUrl: result.release.youtubeMvUrl,
-                          }).mode,
+                          mode: youtubeMvHandoff.mode,
+                          modeHintLabel: resolveHandoffModeHintLabel(youtubeMvHandoff.mode),
                           onPress: () => void handleReleaseServicePress(result.release, 'youtubeMv'),
                           service: 'youtubeMv',
                           testID: `search-release-service-youtube-mv-${result.release.id}`,
@@ -950,7 +970,8 @@ export default function SearchTabScreen() {
                     />
                   </View>
                 </View>
-              ))
+                );
+              })
             : null}
 
           {activeSegment === 'upcoming'

--- a/mobile/app/artists/[slug].tsx
+++ b/mobile/app/artists/[slug].tsx
@@ -45,6 +45,7 @@ import {
 } from '../../src/services/analytics';
 import { openExternalLink, normalizeExternalLinkUrl } from '../../src/services/externalLinks';
 import {
+  describeServiceHandoffBehavior,
   openServiceHandoff,
   resolveServiceHandoff,
   type ServiceHandoffFailure,
@@ -155,44 +156,57 @@ function resolveUpcomingTimingLabel(event: UpcomingEventModel): string {
   return MOBILE_COPY.date.unknown;
 }
 
+function resolveHandoffModeHintLabel(mode: 'canonical' | 'searchFallback'): string {
+  return mode === 'canonical' ? MOBILE_COPY.handoff.appPreferred : MOBILE_COPY.handoff.searchFallback;
+}
+
 function buildLatestReleaseServiceButtons(release: ReleaseSummaryModel): EntityServiceButtonItem[] {
   const releaseQuery = `${release.displayGroup} ${release.releaseTitle}`;
   const mvQuery = `${release.displayGroup} ${release.representativeSongTitle ?? release.releaseTitle}`;
+  const spotifyHandoff = resolveServiceHandoff({
+    service: 'spotify',
+    query: releaseQuery,
+    canonicalUrl: release.spotifyUrl,
+  });
+  const youtubeMusicHandoff = resolveServiceHandoff({
+    service: 'youtubeMusic',
+    query: releaseQuery,
+    canonicalUrl: release.youtubeMusicUrl,
+  });
+  const youtubeMvHandoff = resolveServiceHandoff({
+    service: 'youtubeMv',
+    query: mvQuery,
+    canonicalUrl: release.youtubeMvUrl,
+  });
 
   return [
     {
       accessibilityLabel: `Spotify에서 ${release.releaseTitle} 열기`,
+      accessibilityHint: describeServiceHandoffBehavior(spotifyHandoff),
       key: 'spotify',
       label: 'Spotify',
-      handoff: resolveServiceHandoff({
-        service: 'spotify',
-        query: releaseQuery,
-        canonicalUrl: release.spotifyUrl,
-      }),
+      modeHintLabel: resolveHandoffModeHintLabel(spotifyHandoff.mode),
+      handoff: spotifyHandoff,
       testID: 'entity-latest-release-service-spotify',
       tone: 'spotify',
     },
     {
       accessibilityLabel: `YouTube Music에서 ${release.releaseTitle} 열기`,
+      accessibilityHint: describeServiceHandoffBehavior(youtubeMusicHandoff),
       key: 'youtubeMusic',
       label: 'YouTube Music',
-      handoff: resolveServiceHandoff({
-        service: 'youtubeMusic',
-        query: releaseQuery,
-        canonicalUrl: release.youtubeMusicUrl,
-      }),
+      modeHintLabel: resolveHandoffModeHintLabel(youtubeMusicHandoff.mode),
+      handoff: youtubeMusicHandoff,
       testID: 'entity-latest-release-service-youtube-music',
       tone: 'youtubeMusic',
     },
     {
       accessibilityLabel: `YouTube에서 ${release.releaseTitle} 공식 MV 열기`,
+      accessibilityHint: describeServiceHandoffBehavior(youtubeMvHandoff),
       key: 'youtubeMv',
       label: 'YouTube MV',
-      handoff: resolveServiceHandoff({
-        service: 'youtubeMv',
-        query: mvQuery,
-        canonicalUrl: release.youtubeMvUrl,
-      }),
+      modeHintLabel: resolveHandoffModeHintLabel(youtubeMvHandoff.mode),
+      handoff: youtubeMvHandoff,
       testID: 'entity-latest-release-service-youtube-mv',
       tone: 'youtubeMv',
     },
@@ -671,6 +685,7 @@ export default function ArtistDetailScreen() {
           <InlineFeedbackNotice
             body={handoffFeedback}
             testID="entity-latest-release-handoff-feedback"
+            title={MOBILE_COPY.feedback.handoffFailedTitle}
             tone="error"
           />
         ) : null}

--- a/mobile/app/releases/[id].tsx
+++ b/mobile/app/releases/[id].tsx
@@ -40,6 +40,7 @@ import {
 } from '../../src/services/backendReadClient';
 import { cloneBundledDatasetFixture } from '../../src/services/bundledDatasetFixture';
 import {
+  describeServiceHandoffBehavior,
   openServiceHandoff,
   resolveServiceHandoff,
   resolveServiceHandoffGroup,
@@ -68,6 +69,10 @@ type ReleaseServiceButtonItem = ServiceButtonGroupItem & {
   service: MusicService;
   handoff: ServiceHandoffResolution | ServiceHandoffFailure;
 };
+
+function resolveHandoffModeHintLabel(mode: 'canonical' | 'searchFallback'): string {
+  return mode === 'canonical' ? MOBILE_COPY.handoff.appPreferred : MOBILE_COPY.handoff.searchFallback;
+}
 
 type ReleaseHandoffContext =
   | {
@@ -157,27 +162,33 @@ function buildAlbumServiceButtons(detail: ReleaseDetailModel): ReleaseServiceBut
   const buttons: ReleaseServiceButtonItem[] = [
     {
       accessibilityLabel: `Spotify에서 ${detail.releaseTitle} 열기`,
+      accessibilityHint: describeServiceHandoffBehavior(handoffs.spotify),
       key: 'spotify',
       label: 'Spotify',
       handoff: handoffs.spotify,
+      modeHintLabel: resolveHandoffModeHintLabel(handoffs.spotify.mode),
       service: 'spotify',
       testID: 'release-service-spotify',
       tone: 'spotify',
     },
     {
       accessibilityLabel: `YouTube Music에서 ${detail.releaseTitle} 열기`,
+      accessibilityHint: describeServiceHandoffBehavior(handoffs.youtubeMusic),
       key: 'youtubeMusic',
       label: 'YouTube Music',
       handoff: handoffs.youtubeMusic,
+      modeHintLabel: resolveHandoffModeHintLabel(handoffs.youtubeMusic.mode),
       service: 'youtubeMusic',
       testID: 'release-service-youtube-music',
       tone: 'youtubeMusic',
     },
     {
       accessibilityLabel: `YouTube에서 ${detail.releaseTitle} 공식 MV 열기`,
+      accessibilityHint: describeServiceHandoffBehavior(handoffs.youtubeMv),
       key: 'youtubeMv',
       label: 'YouTube MV',
       handoff: handoffs.youtubeMv,
+      modeHintLabel: resolveHandoffModeHintLabel(handoffs.youtubeMv.mode),
       service: 'youtubeMv',
       testID: 'release-service-youtube-mv',
       tone: 'youtubeMv',
@@ -189,30 +200,36 @@ function buildAlbumServiceButtons(detail: ReleaseDetailModel): ReleaseServiceBut
 
 function buildTrackServiceButtons(detail: ReleaseDetailModel, track: TrackModel): ReleaseServiceButtonItem[] {
   const query = `${detail.displayGroup} ${track.title}`;
+  const spotifyHandoff = resolveServiceHandoff({
+    service: 'spotify',
+    query,
+    canonicalUrl: track.spotifyUrl,
+  });
+  const youtubeMusicHandoff = resolveServiceHandoff({
+    service: 'youtubeMusic',
+    query,
+    canonicalUrl: track.youtubeMusicUrl,
+  });
 
   return [
     {
       accessibilityLabel: `Spotify에서 ${track.title} 트랙 열기`,
+      accessibilityHint: describeServiceHandoffBehavior(spotifyHandoff),
       key: 'spotify',
       label: 'Spotify',
-      handoff: resolveServiceHandoff({
-        service: 'spotify',
-        query,
-        canonicalUrl: track.spotifyUrl,
-      }),
+      modeHintLabel: resolveHandoffModeHintLabel(spotifyHandoff.mode),
+      handoff: spotifyHandoff,
       service: 'spotify',
       testID: `release-track-${track.order}-spotify`,
       tone: 'spotify',
     },
     {
       accessibilityLabel: `YouTube Music에서 ${track.title} 트랙 열기`,
+      accessibilityHint: describeServiceHandoffBehavior(youtubeMusicHandoff),
       key: 'youtubeMusic',
       label: 'YouTube Music',
-      handoff: resolveServiceHandoff({
-        service: 'youtubeMusic',
-        query,
-        canonicalUrl: track.youtubeMusicUrl,
-      }),
+      modeHintLabel: resolveHandoffModeHintLabel(youtubeMusicHandoff.mode),
+      handoff: youtubeMusicHandoff,
       service: 'youtubeMusic',
       testID: `release-track-${track.order}-youtube-music`,
       tone: 'youtubeMusic',
@@ -596,7 +613,12 @@ export default function ReleaseDetailScreen() {
       </InsetSection>
 
       {handoffFeedback ? (
-        <InlineFeedbackNotice body={handoffFeedback} testID="release-handoff-feedback" tone="error" />
+        <InlineFeedbackNotice
+          body={handoffFeedback}
+          testID="release-handoff-feedback"
+          title={MOBILE_COPY.feedback.handoffFailedTitle}
+          tone="error"
+        />
       ) : null}
 
       {releaseDependencyDisclosure ? (
@@ -633,6 +655,7 @@ export default function ReleaseDetailScreen() {
                             disabled: spotifyButton.disabled,
                             label: spotifyButton.label,
                             mode: spotifyButton.mode,
+                            modeHintLabel: spotifyButton.modeHintLabel,
                             onPress: () =>
                               void handleHandoff(spotifyButton.handoff, {
                                 kind: 'track',
@@ -653,6 +676,7 @@ export default function ReleaseDetailScreen() {
                             disabled: youtubeMusicButton.disabled,
                             label: youtubeMusicButton.label,
                             mode: youtubeMusicButton.mode,
+                            modeHintLabel: youtubeMusicButton.modeHintLabel,
                             onPress: () =>
                               void handleHandoff(youtubeMusicButton.handoff, {
                                 kind: 'track',
@@ -722,22 +746,24 @@ export default function ReleaseDetailScreen() {
             </Text>
             <ServiceButtonGroup
               buttons={[
-                {
-                  accessibilityLabel: `YouTube에서 ${detail.releaseTitle} 공식 MV 열기`,
-                  key: 'youtubeMv',
-                  label: 'YouTube MV',
-                  onPress: () =>
-                    void handleHandoff(
-                      resolveServiceHandoff({
-                        service: 'youtubeMv',
-                        query: `${detail.displayGroup} ${detail.releaseTitle}`,
-                        canonicalUrl: mvUrl,
-                      }),
-                      { kind: 'mv' },
-                    ),
-                  testID: 'release-mv-button',
-                  tone: 'youtubeMv',
-                },
+                (() => {
+                  const mvHandoff = resolveServiceHandoff({
+                    service: 'youtubeMv',
+                    query: `${detail.displayGroup} ${detail.releaseTitle}`,
+                    canonicalUrl: mvUrl,
+                  });
+
+                  return {
+                    accessibilityLabel: `YouTube에서 ${detail.releaseTitle} 공식 MV 열기`,
+                    accessibilityHint: describeServiceHandoffBehavior(mvHandoff),
+                    key: 'youtubeMv',
+                    label: 'YouTube MV',
+                    modeHintLabel: resolveHandoffModeHintLabel(mvHandoff.mode),
+                    onPress: () => void handleHandoff(mvHandoff, { kind: 'mv' }),
+                    testID: 'release-mv-button',
+                    tone: 'youtubeMv',
+                  };
+                })(),
               ]}
               testID="release-mv-button-group"
             />

--- a/mobile/src/components/actions/ServiceButton.tsx
+++ b/mobile/src/components/actions/ServiceButton.tsx
@@ -22,6 +22,7 @@ export interface ServiceButtonProps {
   disabled?: boolean;
   label: string;
   mode?: 'canonical' | 'searchFallback';
+  modeHintLabel?: string;
   onPress?: () => void;
   service?: ServiceButtonTone;
   testID?: string;
@@ -34,6 +35,7 @@ function ServiceButtonComponent({
   disabled = false,
   label,
   mode = 'canonical',
+  modeHintLabel,
   onPress,
   service,
   testID,
@@ -82,9 +84,9 @@ function ServiceButtonComponent({
           {label}
         </Text>
       </View>
-      {mode === 'searchFallback' ? (
+      {modeHintLabel || mode === 'searchFallback' ? (
         <Text allowFontScaling maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.meta} style={styles.modeHint}>
-          검색 결과
+          {modeHintLabel ?? '검색 결과'}
         </Text>
       ) : null}
     </Pressable>
@@ -99,18 +101,20 @@ function createStyles(theme: MobileTheme) {
   return StyleSheet.create({
     button: {
       minHeight: theme.size.button.heightService,
-      minWidth: 104,
+      minWidth: 112,
       alignItems: 'center',
       justifyContent: 'center',
       paddingHorizontal: theme.space[12],
-      paddingVertical: theme.space[12],
+      paddingVertical: theme.space[8],
       borderRadius: theme.radius.button,
       gap: theme.space[4],
+      borderWidth: 1,
     },
     buttonContent: {
       flexDirection: 'row',
       alignItems: 'center',
       gap: theme.space[8],
+      minWidth: 0,
     },
     buttonPressed: {
       transform: [{ scale: 0.985 }],
@@ -144,6 +148,7 @@ function createStyles(theme: MobileTheme) {
     },
     spotifyButton: {
       backgroundColor: theme.colors.service.spotify.bg,
+      borderColor: theme.colors.service.spotify.icon,
     },
     spotifyButtonLabel: {
       color: theme.colors.service.spotify.icon,
@@ -156,6 +161,7 @@ function createStyles(theme: MobileTheme) {
     },
     youtubeMusicButton: {
       backgroundColor: theme.colors.service.youtubeMusic.bg,
+      borderColor: theme.colors.service.youtubeMusic.icon,
     },
     youtubeMusicButtonLabel: {
       color: theme.colors.service.youtubeMusic.icon,
@@ -168,6 +174,7 @@ function createStyles(theme: MobileTheme) {
     },
     youtubeMvButton: {
       backgroundColor: theme.colors.service.youtubeMv.bg,
+      borderColor: theme.colors.service.youtubeMv.icon,
     },
     youtubeMvButtonLabel: {
       color: theme.colors.service.youtubeMv.icon,
@@ -181,6 +188,7 @@ function createStyles(theme: MobileTheme) {
     modeHint: {
       ...metaTypography,
       color: theme.colors.text.tertiary,
+      textAlign: 'center',
     },
   });
 }

--- a/mobile/src/components/actions/ServiceButtonGroup.tsx
+++ b/mobile/src/components/actions/ServiceButtonGroup.tsx
@@ -47,6 +47,7 @@ function createStyles(theme: MobileTheme) {
     row: {
       flexDirection: 'row',
       gap: theme.space[8],
+      rowGap: theme.space[8],
     },
     wrapRow: {
       flexWrap: 'wrap',

--- a/mobile/src/components/identity/TeamIdentityRow.tsx
+++ b/mobile/src/components/identity/TeamIdentityRow.tsx
@@ -9,6 +9,7 @@ import {
 
 import { FallbackArt } from '../visual/FallbackArt';
 import { resolveBadgeFallbackAssetKey, type BadgeFallbackAssetKey } from '../../utils/assetRegistry';
+import { MOBILE_TEXT_SCALE_LIMITS } from '../../tokens/accessibility';
 import { useAppTheme } from '../../tokens/theme';
 import type { MobileTheme } from '../../tokens/theme';
 
@@ -52,11 +53,21 @@ function TeamIdentityRowComponent({
         )}
       </View>
       <View style={styles.copy}>
-        <Text allowFontScaling numberOfLines={nameNumberOfLines} style={styles.name}>
+        <Text
+          allowFontScaling
+          maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.body}
+          numberOfLines={nameNumberOfLines}
+          style={styles.name}
+        >
           {name}
         </Text>
         {meta ? (
-          <Text allowFontScaling numberOfLines={2} style={styles.meta}>
+          <Text
+            allowFontScaling
+            maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.meta}
+            numberOfLines={2}
+            style={styles.meta}
+          >
             {meta}
           </Text>
         ) : null}

--- a/mobile/src/components/release/ReleaseSummaryRow.tsx
+++ b/mobile/src/components/release/ReleaseSummaryRow.tsx
@@ -15,6 +15,7 @@ import { InfoChip } from '../meta/InfoChip';
 import { SourceLinkRow, type SourceLinkRowItem } from '../meta/SourceLinkRow';
 import { useAppTheme } from '../../tokens/theme';
 import type { MobileTheme } from '../../tokens/theme';
+import { MOBILE_TEXT_SCALE_LIMITS } from '../../tokens/accessibility';
 
 export interface ReleaseSummaryRowProps {
   chips?: { key: string; label: string }[];
@@ -44,12 +45,22 @@ function ReleaseSummaryRowComponent({
 
   return (
     <View style={styles.card} testID={testID}>
-      <TeamIdentityRow {...team} />
+      <TeamIdentityRow {...team} nameNumberOfLines={team.nameNumberOfLines ?? 2} />
       <View style={styles.copy}>
-        <Text allowFontScaling numberOfLines={2} style={styles.title}>
+        <Text
+          allowFontScaling
+          maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.body}
+          numberOfLines={2}
+          style={styles.title}
+        >
           {title}
         </Text>
-        <Text allowFontScaling style={styles.meta}>
+        <Text
+          allowFontScaling
+          maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.meta}
+          numberOfLines={2}
+          style={styles.meta}
+        >
           {date}
         </Text>
         {chips.length ? (
@@ -75,7 +86,7 @@ function ReleaseSummaryRowComponent({
 function createStyles(theme: MobileTheme) {
   return StyleSheet.create({
     card: {
-      gap: theme.space[12],
+      gap: theme.space[8],
       padding: theme.space[16],
       borderRadius: theme.radius.card,
       backgroundColor: theme.colors.surface.elevated,

--- a/mobile/src/components/release/TrackRow.tsx
+++ b/mobile/src/components/release/TrackRow.tsx
@@ -20,6 +20,7 @@ interface TrackRowServiceButton {
   disabled?: boolean;
   label: string;
   mode?: 'canonical' | 'searchFallback';
+  modeHintLabel?: string;
   onPress: () => void;
   testID?: string;
 }
@@ -140,7 +141,7 @@ function createStyles(theme: MobileTheme) {
       flexShrink: 1,
     },
     trackActions: {
-      alignSelf: 'flex-end',
+      alignSelf: 'flex-start',
     },
   });
 }

--- a/mobile/src/components/surfaces/CompactHero.tsx
+++ b/mobile/src/components/surfaces/CompactHero.tsx
@@ -51,6 +51,7 @@ function CompactHeroComponent({
               accessibilityRole="header"
               allowFontScaling
               maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.screenTitle}
+              numberOfLines={2}
               style={styles.title}
               testID={titleTestID}
             >
@@ -60,6 +61,7 @@ function CompactHeroComponent({
               <Text
                 allowFontScaling
                 maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.body}
+                numberOfLines={2}
                 style={styles.meta}
               >
                 {meta}
@@ -69,6 +71,7 @@ function CompactHeroComponent({
               <Text
                 allowFontScaling
                 maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.body}
+                numberOfLines={2}
                 style={styles.secondaryMeta}
               >
                 {secondaryMeta}
@@ -78,6 +81,7 @@ function CompactHeroComponent({
               <Text
                 allowFontScaling
                 maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.body}
+                numberOfLines={3}
                 style={styles.body}
               >
                 {body}
@@ -105,8 +109,8 @@ function createStyles(theme: MobileTheme) {
       backgroundColor: theme.colors.text.brand,
     },
     content: {
-      gap: theme.space[12],
-      padding: theme.space[16],
+      gap: theme.space[8],
+      padding: theme.space[12],
     },
     row: {
       flexDirection: 'row',
@@ -120,7 +124,7 @@ function createStyles(theme: MobileTheme) {
     },
     copy: {
       flex: 1,
-      minWidth: 180,
+      minWidth: 0,
       gap: theme.space[4],
     },
     eyebrow: {

--- a/mobile/src/components/surfaces/InsetSection.tsx
+++ b/mobile/src/components/surfaces/InsetSection.tsx
@@ -31,6 +31,7 @@ function InsetSectionComponent({
             accessibilityRole="header"
             allowFontScaling
             maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.sectionTitle}
+            numberOfLines={2}
             style={styles.title}
           >
             {title}
@@ -39,6 +40,7 @@ function InsetSectionComponent({
             <Text
               allowFontScaling
               maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.body}
+              numberOfLines={3}
               style={styles.description}
             >
               {description}
@@ -55,7 +57,7 @@ function InsetSectionComponent({
 function createStyles(theme: MobileTheme) {
   return StyleSheet.create({
     section: {
-      gap: theme.space[12],
+      gap: theme.space[8],
       padding: theme.space[16],
       borderRadius: theme.radius.card,
       backgroundColor: theme.colors.surface.elevated,
@@ -86,7 +88,7 @@ function createStyles(theme: MobileTheme) {
       justifyContent: 'flex-start',
     },
     body: {
-      gap: theme.space[12],
+      gap: theme.space[8],
     },
   });
 }

--- a/mobile/src/components/surfaces/TonalPanel.tsx
+++ b/mobile/src/components/surfaces/TonalPanel.tsx
@@ -67,6 +67,7 @@ function TonalPanelComponent({
             accessibilityRole="header"
             allowFontScaling
             maxFontSizeMultiplier={titleMaxFontSizeMultiplier}
+            numberOfLines={2}
             style={styles.title}
             testID={titleTestID}
           >
@@ -77,6 +78,7 @@ function TonalPanelComponent({
           <Text
             allowFontScaling
             maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.body}
+            numberOfLines={4}
             style={[
               styles.body,
               tone === 'critical' ? styles.bodyCritical : null,
@@ -110,7 +112,7 @@ function createStyles(theme: MobileTheme) {
       backgroundColor: theme.colors.surface.elevated,
     },
     band: {
-      height: 6,
+      height: 4,
       backgroundColor: theme.colors.border.strong,
     },
     bandAccent: {
@@ -121,7 +123,7 @@ function createStyles(theme: MobileTheme) {
     },
     content: {
       gap: theme.space[8],
-      padding: theme.space[16],
+      padding: theme.space[12],
     },
     eyebrow: {
       ...theme.typography.meta,

--- a/mobile/src/components/upcoming/UpcomingEventRow.tsx
+++ b/mobile/src/components/upcoming/UpcomingEventRow.tsx
@@ -11,6 +11,7 @@ import { InfoChip } from '../meta/InfoChip';
 import { SourceLinkRow, type SourceLinkRowItem } from '../meta/SourceLinkRow';
 import { useAppTheme } from '../../tokens/theme';
 import type { MobileTheme } from '../../tokens/theme';
+import { MOBILE_TEXT_SCALE_LIMITS } from '../../tokens/accessibility';
 
 export interface UpcomingEventRowProps {
   confidenceChip?: string;
@@ -38,13 +39,23 @@ function UpcomingEventRowComponent({
 
   return (
     <View style={styles.card} testID={testID}>
-      <TeamIdentityRow {...team} />
+      <TeamIdentityRow {...team} nameNumberOfLines={team.nameNumberOfLines ?? 2} />
       <View style={styles.copy}>
-        <Text allowFontScaling numberOfLines={2} style={styles.title}>
+        <Text
+          allowFontScaling
+          maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.body}
+          numberOfLines={2}
+          style={styles.title}
+        >
           {headline}
         </Text>
         {scheduledDate ? (
-          <Text allowFontScaling style={styles.meta}>
+          <Text
+            allowFontScaling
+            maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.meta}
+            numberOfLines={2}
+            style={styles.meta}
+          >
             {scheduledDate}
           </Text>
         ) : null}
@@ -64,7 +75,7 @@ function UpcomingEventRowComponent({
 function createStyles(theme: MobileTheme) {
   return StyleSheet.create({
     card: {
-      gap: theme.space[12],
+      gap: theme.space[8],
       padding: theme.space[16],
       borderRadius: theme.radius.card,
       backgroundColor: theme.colors.surface.elevated,

--- a/mobile/src/copy/mobileCopy.ts
+++ b/mobile/src/copy/mobileCopy.ts
@@ -2,6 +2,8 @@ export const MOBILE_COPY = {
   action: {
     back: '이전으로',
     detailView: '상세 보기',
+    clear: '지우기',
+    close: '닫기',
     open: '열기',
     retry: '다시 시도',
     showSourceTimeline: '소스 타임라인 보기',
@@ -11,11 +13,33 @@ export const MOBILE_COPY = {
   },
   feedback: {
     errorTitle: '오류',
+    partialTitle: '일부 정보만 표시됩니다.',
+    handoffFailedTitle: '외부 이동을 완료하지 못했습니다.',
+    handoffRetryable: '외부 앱을 열지 못했습니다. 같은 화면에서 다시 시도해 주세요.',
+    handoffUnavailable: '지금은 열 수 있는 서비스 경로가 없습니다.',
+  },
+  surface: {
+    calendarTitle: '캘린더',
+    searchTitle: '검색',
+    searchSubtitle: '한글 별칭, 팀명, 릴리즈명, 예정 헤드라인을 같은 규칙으로 찾습니다.',
+    radarTitle: '레이더',
+  },
+  summary: {
+    monthRelease: '이달 발매',
+    upcoming: '예정 일정',
+    nearestUpcoming: '가까운 일정',
+    weeklyUpcoming: '이번 주 예정',
+    changedSchedule: '일정 변경',
+    longGap: '장기 공백',
   },
   source: {
     articleOriginal: '기사 원문',
     officialNotice: '공식 공지',
     sourceView: '소스 보기',
+  },
+  handoff: {
+    appPreferred: '앱 우선',
+    searchFallback: '검색 결과',
   },
   status: {
     confirmed: '확정',

--- a/mobile/src/features/calendarControls.test.tsx
+++ b/mobile/src/features/calendarControls.test.tsx
@@ -116,9 +116,9 @@ describe('calendar controls', () => {
     expect(tree.root.findByProps({ testID: 'calendar-month-title' }).props.maxFontSizeMultiplier).toBe(
       MOBILE_TEXT_SCALE_LIMITS.screenTitle,
     );
-    expect(hasText(tree, '이번 달 발매')).toBe(true);
-    expect(hasText(tree, '예정 컴백')).toBe(true);
-    expect(hasText(tree, '가장 가까운 일정')).toBe(true);
+    expect(hasText(tree, '이달 발매')).toBe(true);
+    expect(hasText(tree, '예정 일정')).toBe(true);
+    expect(hasText(tree, '가까운 일정')).toBe(true);
     expect(tree.root.findByProps({ testID: 'calendar-view-calendar' }).props.accessibilityState.selected).toBe(
       true,
     );

--- a/mobile/src/features/releaseDetailScreen.test.tsx
+++ b/mobile/src/features/releaseDetailScreen.test.tsx
@@ -146,9 +146,14 @@ describe('mobile release detail screen', () => {
     expect(tree.root.findByProps({ testID: 'release-service-spotify' }).props.accessibilityLabel).toBe(
       'Spotify에서 LOVE CATCHER 열기',
     );
+    expect(tree.root.findByProps({ testID: 'release-service-spotify' }).props.accessibilityHint).toBe(
+      'Spotify 앱이 있으면 앱으로, 없으면 안전한 웹 fallback으로 엽니다.',
+    );
     expect(tree.root.findByProps({ testID: 'release-service-spotify' })).toBeDefined();
     expect(tree.root.findByProps({ testID: 'release-service-youtube-music' })).toBeDefined();
     expect(tree.root.findByProps({ testID: 'release-service-youtube-mv' })).toBeDefined();
+    expect(hasText(tree, '앱 우선')).toBe(true);
+    expect(hasText(tree, '검색 결과')).toBe(true);
     expect(tree.root.findByProps({ testID: 'release-supporting-links' })).toBeDefined();
     expect(tree.root.findByProps({ testID: 'release-track-row-1' })).toBeDefined();
     expect(tree.root.findByProps({ testID: 'release-track-row-title-badge-1' })).toBeDefined();
@@ -232,7 +237,7 @@ describe('mobile release detail screen', () => {
       feedback: {
         level: 'warning',
         retryable: true,
-        message: 'External handoff failed. Keep the current route stack and show retry feedback.',
+        message: '외부 앱을 열지 못했습니다. 같은 화면에서 다시 시도해 주세요.',
       },
     });
 
@@ -243,9 +248,8 @@ describe('mobile release detail screen', () => {
       await Promise.resolve();
     });
 
-    expect(hasText(tree, 'External handoff failed. Keep the current route stack and show retry feedback.')).toBe(
-      true,
-    );
+    expect(hasText(tree, '외부 이동을 완료하지 못했습니다.')).toBe(true);
+    expect(hasText(tree, '외부 앱을 열지 못했습니다. 같은 화면에서 다시 시도해 주세요.')).toBe(true);
     expect(tree.root.findByProps({ testID: 'release-detail-title' }).props.children).toBe('LOVE CATCHER');
     expect(mockTrackAnalyticsEvent).toHaveBeenCalledWith(
       'service_handoff_completed',

--- a/mobile/src/features/searchTab.test.tsx
+++ b/mobile/src/features/searchTab.test.tsx
@@ -341,7 +341,7 @@ describe('mobile search tab', () => {
       feedback: {
         level: 'warning',
         retryable: true,
-        message: 'External handoff failed. Keep the current route stack and show retry feedback.',
+        message: '외부 앱을 열지 못했습니다. 같은 화면에서 다시 시도해 주세요.',
       },
     });
 

--- a/mobile/src/services/handoff.test.ts
+++ b/mobile/src/services/handoff.test.ts
@@ -1,5 +1,6 @@
 import {
   buildServiceSearchFallbackUrl,
+  describeServiceHandoffBehavior,
   openServiceHandoff,
   resolveServiceHandoff,
   resolveServiceHandoffGroup,
@@ -99,6 +100,7 @@ describe('mobile external handoff service', () => {
       code: 'handoff_unavailable',
       feedback: {
         retryable: false,
+        message: '지금은 열 수 있는 서비스 경로가 없습니다.',
       },
     });
   });
@@ -198,6 +200,7 @@ describe('mobile external handoff service', () => {
       code: 'handoff_open_failed',
       feedback: {
         retryable: true,
+        message: '외부 앱을 열지 못했습니다. 같은 화면에서 다시 시도해 주세요.',
       },
     });
   });
@@ -221,5 +224,33 @@ describe('mobile external handoff service', () => {
     expect(group.spotify.mode).toBe('canonical');
     expect(group.youtubeMusic.mode).toBe('searchFallback');
     expect(group.youtubeMv.primaryUrl).toBe('https://www.youtube.com/watch?v=2GJfWMYCWY0');
+  });
+
+  test('describes installed-app and fallback behavior in Korean-first hints', () => {
+    const canonical = resolveServiceHandoff({
+      service: 'spotify',
+      query: 'BLACKPINK DEADLINE',
+      canonicalUrl: 'https://open.spotify.com/album/12345',
+    });
+    const searchFallback = resolveServiceHandoff({
+      service: 'youtubeMusic',
+      query: 'YENA LOVE CATCHER',
+      canonicalUrl: null,
+    });
+    const unavailable = resolveServiceHandoff({
+      service: 'youtubeMv',
+      query: '   ',
+      canonicalUrl: null,
+    });
+
+    expect(describeServiceHandoffBehavior(canonical)).toBe(
+      'Spotify 앱이 있으면 앱으로, 없으면 안전한 웹 fallback으로 엽니다.',
+    );
+    expect(describeServiceHandoffBehavior(searchFallback)).toBe(
+      'YouTube Music 설치 여부와 관계없이 검색 결과로 엽니다.',
+    );
+    expect(describeServiceHandoffBehavior(unavailable)).toBe(
+      '현재는 연결 가능한 앱 또는 검색 경로가 아직 준비되지 않았습니다.',
+    );
   });
 });

--- a/mobile/src/services/handoff.ts
+++ b/mobile/src/services/handoff.ts
@@ -25,8 +25,8 @@ export type ServiceHandoffFailure = {
     level: 'warning';
     retryable: boolean;
     message:
-      | 'No canonical or search fallback handoff is available yet.'
-      | 'External handoff failed. Keep the current route stack and show retry feedback.';
+      | '지금은 열 수 있는 서비스 경로가 없습니다.'
+      | '외부 앱을 열지 못했습니다. 같은 화면에서 다시 시도해 주세요.';
   };
 };
 
@@ -48,6 +48,12 @@ export type HandoffLinkingAdapter = {
 const DEFAULT_LINKING_ADAPTER: HandoffLinkingAdapter = {
   canOpenURL: Linking.canOpenURL,
   openURL: Linking.openURL,
+};
+
+const SERVICE_LABEL: Record<MusicService, string> = {
+  spotify: 'Spotify',
+  youtubeMusic: 'YouTube Music',
+  youtubeMv: 'YouTube',
 };
 
 function isServiceHandoffFailure(
@@ -182,7 +188,7 @@ export function resolveServiceHandoff(input: {
       feedback: {
         level: 'warning',
         retryable: false,
-        message: 'No canonical or search fallback handoff is available yet.',
+        message: '지금은 열 수 있는 서비스 경로가 없습니다.',
       },
     };
   }
@@ -247,9 +253,29 @@ export async function openServiceHandoff(
     feedback: {
       level: 'warning',
       retryable: true,
-      message: 'External handoff failed. Keep the current route stack and show retry feedback.',
+      message: '외부 앱을 열지 못했습니다. 같은 화면에서 다시 시도해 주세요.',
     },
   };
+}
+
+export function describeServiceHandoffBehavior(
+  handoff: ServiceHandoffResolution | ServiceHandoffFailure,
+): string {
+  if (isServiceHandoffFailure(handoff)) {
+    if (handoff.code === 'handoff_unavailable') {
+      return '현재는 연결 가능한 앱 또는 검색 경로가 아직 준비되지 않았습니다.';
+    }
+
+    return '외부 앱 연결에 실패하면 현재 화면을 유지한 채 다시 시도할 수 있습니다.';
+  }
+
+  const serviceLabel = SERVICE_LABEL[handoff.service];
+
+  if (handoff.mode === 'canonical') {
+    return `${serviceLabel} 앱이 있으면 앱으로, 없으면 안전한 웹 fallback으로 엽니다.`;
+  }
+
+  return `${serviceLabel} 설치 여부와 관계없이 검색 결과로 엽니다.`;
 }
 
 export function resolveServiceHandoffGroup(input: {


### PR DESCRIPTION
## Summary
- polish Korean-first copy and compact summary labels across calendar, search, radar, entity detail, and release detail
- surface canonical vs search-fallback handoff behavior through service button hints and accessibility copy
- tighten shared surface/button density for large-text layouts and capture local verification notes

Closes #505
Closes #506
Closes #507