### PR TITLE
[RN] Harden iOS backend runtime fallback UX

### DIFF
--- a/docs/assets/distribution/rn_ios_backend_runtime_polish_local_2026-03-11.md
+++ b/docs/assets/distribution/rn_ios_backend_runtime_polish_local_2026-03-11.md
@@ -1,0 +1,47 @@
+# RN iOS Backend Runtime Polish Local Note (2026-03-11)
+
+## Scope
+- Issue target: `#544`
+- Related but not fully closed in this note: `#545`
+
+## Implemented
+- backend read client now applies:
+  - `GET` timeout `4.5s`
+  - retry `1`
+  - retry delay `350ms`
+  - retryable status handling for `408/429/502/503/504`
+- cached/bundled fallback disclosure now includes clearer Korean copy for:
+  - live request failed -> cached snapshot retained
+  - live request failed -> bundled fallback used
+- backend request id is appended to runtime-facing failure copy when available.
+- calendar/search/entity detail/release detail surfaces now expose an explicit retry CTA from degraded-state disclosure.
+- iPhone density polish included:
+  - calendar summary strip moved into the month header panel
+  - compact hero stacks vertically on narrow iPhone widths / large-text mode
+  - summary strip full-width stacking threshold tightened so regular iPhone widths stay denser
+  - search submit dismisses keyboard and focus state more cleanly
+
+## Automated verification
+- `cd mobile && npm test -- --runInBand src/services/backendReadClient.test.ts src/features/useActiveDatasetScreen.test.tsx src/config/debugMetadata.test.ts`
+- `cd mobile && npm test -- --runInBand src/features/calendarControls.test.tsx src/features/searchTab.test.tsx src/features/radarTab.test.tsx src/features/entityDetailScreen.test.tsx src/features/releaseDetailScreen.test.tsx src/components/layout/SummaryStrip.test.tsx`
+- `cd mobile && npm run typecheck`
+- `cd mobile && npm run lint`
+- `git diff --check`
+
+All commands passed. `npm run lint` still reports the existing generated-file warning in `mobile/.expo/types/router.d.ts` only.
+
+## iOS runtime check
+- Local backend was started with:
+  - `source ~/.config/idol-song-app/neon.env && PORT=3213 APP_TIMEZONE=Asia/Seoul npm run start`
+- Preview dev client was launched on `iPhone 16e` simulator with:
+  - `EXPO_PUBLIC_API_BASE_URL=http://127.0.0.1:3213 npm run qa:preview:ios:sim`
+  - `APP_ENV=preview EXPO_PUBLIC_API_BASE_URL=http://127.0.0.1:3213 npx expo start --dev-client --port 8082`
+- Backend logs confirmed preview client traffic against the local API, including:
+  - `GET /v1/calendar/month`
+  - `GET /v1/search`
+  - `GET /v1/radar`
+  - `GET /v1/entities/:slug`
+
+## Limitation observed
+- `simctl openurl` based route-driving still hit iOS confirmation modal / dev-client home inconsistently, so stable full-surface screenshots were not reliable from automation alone.
+- Because of that, this note is sufficient to support the runtime hardening issue `#544`, but not a full visual sign-off for `#545`.

--- a/mobile/app/(tabs)/calendar.tsx
+++ b/mobile/app/(tabs)/calendar.tsx
@@ -9,6 +9,7 @@ import {
   View,
 } from 'react-native';
 
+import { ActionButton } from '../../src/components/actions/ActionButton';
 import { DateDetailSheet } from '../../src/components/calendar/DateDetailSheet';
 import { DayCell } from '../../src/components/calendar/DayCell';
 import { SegmentedControl } from '../../src/components/controls/SegmentedControl';
@@ -852,12 +853,32 @@ export default function CalendarTabScreen() {
   const nearestSummary = filteredSnapshot.nearestUpcoming?.scheduledDate
     ? `${filteredSnapshot.nearestUpcoming.displayGroup} · ${formatShortDateLabel(filteredSnapshot.nearestUpcoming.scheduledDate)}`
     : '없음';
+  const runtimeRetryAction = datasetRiskDisclosure ? (
+    <ActionButton
+      accessibilityLabel="라이브 캘린더 데이터 다시 시도"
+      label={MOBILE_COPY.action.retry}
+      onPress={() => setReloadCount((count) => count + 1)}
+      testID="calendar-dataset-risk-retry"
+      tone="secondary"
+    />
+  ) : null;
 
   return (
     <>
       <ScrollView contentContainerStyle={scrollContentStyle} style={styles.screen}>
         <TonalPanel
           body={`현재 필터 · ${formatFilterLabel(filterMode)}`}
+          footer={
+            <SummaryStrip
+              items={[
+                { key: 'release-count', label: MOBILE_COPY.summary.monthRelease, value: filteredSnapshot.releaseCount },
+                { key: 'upcoming-count', label: MOBILE_COPY.summary.upcoming, value: filteredSnapshot.upcomingCount },
+                { key: 'nearest-upcoming', label: MOBILE_COPY.summary.nearestUpcoming, value: nearestSummary },
+              ]}
+              layout="wrap"
+              testID="calendar-summary-strip"
+            />
+          }
           testID="calendar-header-panel"
           title={formatMonthLabel(filteredSnapshot.month)}
           titleMaxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.screenTitle}
@@ -953,19 +974,10 @@ export default function CalendarTabScreen() {
           </View>
         </TonalPanel>
 
-        <SummaryStrip
-          items={[
-            { key: 'release-count', label: MOBILE_COPY.summary.monthRelease, value: filteredSnapshot.releaseCount },
-            { key: 'upcoming-count', label: MOBILE_COPY.summary.upcoming, value: filteredSnapshot.upcomingCount },
-            { key: 'nearest-upcoming', label: MOBILE_COPY.summary.nearestUpcoming, value: nearestSummary },
-          ]}
-          layout="wrap"
-          testID="calendar-summary-strip"
-        />
-
         {datasetRiskDisclosure ? (
           <TonalPanel
             body={datasetRiskDisclosure.body}
+            footer={runtimeRetryAction}
             testID={datasetRiskDisclosure.testID}
             title={datasetRiskDisclosure.title}
             tone="accent"

--- a/mobile/app/(tabs)/search.tsx
+++ b/mobile/app/(tabs)/search.tsx
@@ -412,6 +412,9 @@ export default function SearchTabScreen() {
       return;
     }
 
+    Keyboard.dismiss();
+    inputRef.current?.blur();
+    setIsInputFocused(false);
     setQuery(normalized);
     setHandoffFeedback(null);
     const metrics = buildSearchSubmissionMetrics(normalized);
@@ -675,6 +678,15 @@ export default function SearchTabScreen() {
       {datasetRiskDisclosure ? (
         <TonalPanel
           body={datasetRiskDisclosure.body}
+          footer={
+            <ActionButton
+              accessibilityLabel="라이브 검색 데이터 다시 시도"
+              label={MOBILE_COPY.action.retry}
+              onPress={() => setReloadCount((count) => count + 1)}
+              testID="search-dataset-risk-retry"
+              tone="secondary"
+            />
+          }
           testID={datasetRiskDisclosure.testID}
           title={datasetRiskDisclosure.title}
           tone="accent"

--- a/mobile/app/artists/[slug].tsx
+++ b/mobile/app/artists/[slug].tsx
@@ -13,6 +13,7 @@ import {
   InlineFeedbackNotice,
   ScreenFeedbackState,
 } from '../../src/components/feedback/FeedbackState';
+import { ActionButton } from '../../src/components/actions/ActionButton';
 import {
   ServiceButtonGroup,
   type ServiceButtonGroupItem,
@@ -549,6 +550,15 @@ export default function ArtistDetailScreen() {
       {datasetRiskDisclosure ? (
         <TonalPanel
           body={datasetRiskDisclosure.body}
+          footer={
+            <ActionButton
+              accessibilityLabel="라이브 팀 상세 데이터 다시 시도"
+              label={MOBILE_COPY.action.retry}
+              onPress={() => setReloadCount((count) => count + 1)}
+              testID="entity-dataset-risk-retry"
+              tone="secondary"
+            />
+          }
           testID={datasetRiskDisclosure.testID}
           title={datasetRiskDisclosure.title}
           tone="accent"

--- a/mobile/app/releases/[id].tsx
+++ b/mobile/app/releases/[id].tsx
@@ -12,6 +12,7 @@ import {
   InlineFeedbackNotice,
   ScreenFeedbackState,
 } from '../../src/components/feedback/FeedbackState';
+import { ActionButton } from '../../src/components/actions/ActionButton';
 import { AppBar } from '../../src/components/layout/AppBar';
 import {
   ServiceButtonGroup,
@@ -574,15 +575,6 @@ export default function ReleaseDetailScreen() {
         }
       />
 
-      {datasetRiskDisclosure ? (
-        <TonalPanel
-          body={datasetRiskDisclosure.body}
-          testID={datasetRiskDisclosure.testID}
-          title={datasetRiskDisclosure.title}
-          tone="accent"
-        />
-      ) : null}
-
       <CompactHero
         eyebrow={datasetState.source.sourceLabel}
         footer={
@@ -609,6 +601,24 @@ export default function ReleaseDetailScreen() {
         title={detail.releaseTitle}
         titleTestID="release-detail-title"
       />
+
+      {datasetRiskDisclosure ? (
+        <TonalPanel
+          body={datasetRiskDisclosure.body}
+          footer={
+            <ActionButton
+              accessibilityLabel="라이브 릴리즈 상세 데이터 다시 시도"
+              label={MOBILE_COPY.action.retry}
+              onPress={() => setReloadCount((count) => count + 1)}
+              testID="release-dataset-risk-retry"
+              tone="secondary"
+            />
+          }
+          testID={datasetRiskDisclosure.testID}
+          title={datasetRiskDisclosure.title}
+          tone="accent"
+        />
+      ) : null}
 
       <InsetSection
         description="canonical link가 있으면 바로 열고, 없으면 service fallback 규칙을 적용합니다."

--- a/mobile/src/components/layout/SummaryStrip.tsx
+++ b/mobile/src/components/layout/SummaryStrip.tsx
@@ -31,7 +31,7 @@ function SummaryStripComponent({
   const { fontScale, width } = useWindowDimensions();
   const styles = useMemo(() => createStyles(theme), [theme]);
   const largeTextMode = isLargeTextMode(fontScale);
-  const useFullWidthCards = layout === 'wrap' && (width <= 430 || largeTextMode);
+  const useFullWidthCards = layout === 'wrap' && (width <= 360 || largeTextMode);
 
   return (
     <View style={[styles.row, layout === 'wrap' ? styles.wrapRow : null]} testID={testID}>

--- a/mobile/src/components/surfaces/CompactHero.tsx
+++ b/mobile/src/components/surfaces/CompactHero.tsx
@@ -1,7 +1,10 @@
 import React, { memo, useMemo } from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, Text, useWindowDimensions, View } from 'react-native';
 
-import { MOBILE_TEXT_SCALE_LIMITS } from '../../tokens/accessibility';
+import {
+  MOBILE_TEXT_SCALE_LIMITS,
+  isLargeTextMode,
+} from '../../tokens/accessibility';
 import { useAppTheme } from '../../tokens/theme';
 import type { MobileTheme } from '../../tokens/theme';
 
@@ -29,14 +32,16 @@ function CompactHeroComponent({
   titleTestID,
 }: CompactHeroProps) {
   const theme = useAppTheme();
+  const { fontScale, width } = useWindowDimensions();
   const styles = useMemo(() => createStyles(theme), [theme]);
+  const stackedLayout = width <= 410 || isLargeTextMode(fontScale);
 
   return (
     <View style={styles.hero} testID={testID}>
       <View style={styles.band} />
       <View style={styles.content}>
-        <View style={styles.row}>
-          <View style={styles.media}>{media}</View>
+        <View style={[styles.row, stackedLayout ? styles.rowStacked : null]}>
+          <View style={[styles.media, stackedLayout ? styles.mediaStacked : null]}>{media}</View>
           <View style={styles.copy}>
             {eyebrow ? (
               <Text
@@ -50,7 +55,11 @@ function CompactHeroComponent({
             <Text
               accessibilityRole="header"
               allowFontScaling
-              maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.screenTitle}
+              maxFontSizeMultiplier={
+                stackedLayout
+                  ? MOBILE_TEXT_SCALE_LIMITS.sectionTitle
+                  : MOBILE_TEXT_SCALE_LIMITS.screenTitle
+              }
               numberOfLines={2}
               style={styles.title}
               testID={titleTestID}
@@ -118,9 +127,16 @@ function createStyles(theme: MobileTheme) {
       flexWrap: 'wrap',
       gap: theme.space[16],
     },
+    rowStacked: {
+      flexDirection: 'column',
+      gap: theme.space[12],
+    },
     media: {
       alignItems: 'flex-start',
       justifyContent: 'flex-start',
+    },
+    mediaStacked: {
+      width: '100%',
     },
     copy: {
       flex: 1,

--- a/mobile/src/config/debugMetadata.test.ts
+++ b/mobile/src/config/debugMetadata.test.ts
@@ -82,6 +82,7 @@ describe('debug metadata helpers', () => {
       commitSha: 'abc123',
       dataSourceMode: 'backend-api',
       dataSourcePolicy: 'Backend API primary + bundled fallback',
+      networkPolicy: 'GET timeout 4.5s + 1 retry + cache/bundled degraded fallback',
       apiBaseUrl: 'https://example.com/api',
       apiHost: 'example.com',
       backendTargetLabel: 'Custom backend target',

--- a/mobile/src/config/debugMetadata.ts
+++ b/mobile/src/config/debugMetadata.ts
@@ -16,6 +16,7 @@ export type MobileDebugMetadata = {
   commitSha: string | null;
   dataSourceMode: MobileRuntimeConfig['dataSource']['mode'];
   dataSourcePolicy: string;
+  networkPolicy: string;
   apiBaseUrl: string | null;
   apiHost: string | null;
   backendTargetLabel: 'Bundled-only' | 'Public preview backend' | 'Temporary tunnel backend' | 'Custom backend target';
@@ -70,6 +71,10 @@ export function getDebugMetadata(
       runtimeConfig.dataSource.mode === 'backend-api'
         ? 'Backend API primary + bundled fallback'
         : 'Bundled static primary',
+    networkPolicy:
+      runtimeConfig.dataSource.mode === 'backend-api'
+        ? 'GET timeout 4.5s + 1 retry + cache/bundled degraded fallback'
+        : 'Bundled static only',
     apiBaseUrl: runtimeConfig.services.apiBaseUrl,
     apiHost: runtimeConfig.services.apiBaseUrl ? new URL(runtimeConfig.services.apiBaseUrl).host : null,
     backendTargetLabel: getBackendTargetLabel(runtimeConfig.services.apiBaseUrl),

--- a/mobile/src/features/surfaceDisclosures.ts
+++ b/mobile/src/features/surfaceDisclosures.ts
@@ -39,6 +39,12 @@ export function buildDatasetRiskDisclosure(
     return null;
   }
 
+  const sourceStateLead =
+    source.activeSource === 'backend-cache'
+      ? '마지막 라이브 요청이 실패해 저장된 백엔드 스냅샷으로 화면을 유지하고 있습니다.'
+      : source.activeSource === 'bundled-static-fallback'
+        ? '라이브 응답과 캐시를 모두 확보하지 못해 앱 번들 데이터를 임시로 보여 주고 있습니다.'
+        : '현재 런타임이 degraded 상태라 최신 동기화 대신 안전한 읽기 경로를 우선합니다.';
   const freshnessNote =
     source.activeSource.includes('cache')
       ? source.freshness.rollingReferenceAt
@@ -48,7 +54,7 @@ export function buildDatasetRiskDisclosure(
 
   return {
     title: '데이터 최신화 유의',
-    body: `${surfaceLabel} 화면은 현재 ${source.sourceLabel} 기준으로 유지되고 있습니다. ${freshnessNote} ${summarizeIssues(source.issues)} 일부 정보는 늦게 채워지거나 최소 정보만 표시될 수 있습니다.`,
+    body: `${surfaceLabel} 화면은 현재 ${source.sourceLabel} 기준으로 유지되고 있습니다. ${sourceStateLead} ${freshnessNote} ${summarizeIssues(source.issues)} 다시 시도하면 라이브 응답으로 복귀할 수 있습니다.`,
     testID,
   };
 }

--- a/mobile/src/features/useActiveDatasetScreen.test.tsx
+++ b/mobile/src/features/useActiveDatasetScreen.test.tsx
@@ -16,12 +16,30 @@ const mockCreateBackendReadClient = jest.fn();
 const mockTrackDatasetDegraded = jest.fn();
 const mockTrackDatasetLoadFailed = jest.fn();
 
+class MockBackendReadError extends Error {
+  status: number | null;
+  code: string | null;
+  requestId: string | null;
+
+  constructor(
+    message: string,
+    options: { status?: number | null; code?: string | null; requestId?: string | null } = {},
+  ) {
+    super(message);
+    this.name = 'BackendReadError';
+    this.status = options.status ?? null;
+    this.code = options.code ?? null;
+    this.requestId = options.requestId ?? null;
+  }
+}
+
 jest.mock('../config/runtime', () => ({
   getRuntimeConfigState: () => mockGetRuntimeConfigState(),
   getRuntimeConfig: () => mockGetRuntimeConfig(),
 }));
 
 jest.mock('../services/backendReadClient', () => ({
+  BackendReadError: MockBackendReadError,
   createBackendReadClient: (...args: unknown[]) => mockCreateBackendReadClient(...args),
 }));
 
@@ -193,6 +211,31 @@ describe('useActiveDatasetScreen', () => {
     expect(secondTree.root.findByProps({ testID: 'hook-source' }).props.children).toBe('backend-cache');
     expect(secondTree.root.findByProps({ testID: 'hook-value' }).props.children).toBe('fresh-backend');
     expect(secondTree.root.findByProps({ testID: 'hook-issues' }).props.children).toContain('Backend timed out.');
+  });
+
+  test('appends the backend request id when cached fallback is used after a live failure', async () => {
+    mockGetRuntimeConfigState.mockReturnValue(buildRuntimeState('normal'));
+    mockCreateBackendReadClient.mockReturnValue({ name: 'backend-client' });
+
+    await renderHarness({
+      loadBundled: async () => ({ value: 'bundled' }),
+      loadBackend: async () => ({
+        data: { value: 'fresh-backend' },
+        generatedAt: '2026-03-10T00:00:00.000Z',
+      }),
+    });
+
+    const tree = await renderHarness({
+      loadBundled: async () => ({ value: 'bundled' }),
+      loadBackend: async () => {
+        throw new MockBackendReadError('백엔드 응답이 지연되어 요청을 중단했습니다. 다시 시도해 주세요.', {
+          code: 'timeout',
+          requestId: 'req_test_123',
+        });
+      },
+    });
+
+    expect(tree.root.findByProps({ testID: 'hook-issues' }).props.children).toContain('요청 ID: req_test_123');
   });
 
   test('falls back to bundled data when runtime is degraded and cache is unavailable', async () => {

--- a/mobile/src/features/useActiveDatasetScreen.ts
+++ b/mobile/src/features/useActiveDatasetScreen.ts
@@ -6,7 +6,9 @@ import {
   trackDatasetLoadFailed,
   type AnalyticsSurface,
 } from '../services/analytics';
-import { createBackendReadClient } from '../services/backendReadClient';
+import {
+  createBackendReadClient,
+} from '../services/backendReadClient';
 import {
   readScreenSnapshotCacheEntry,
   writeScreenSnapshotCacheEntry,
@@ -56,6 +58,36 @@ export function buildActiveDatasetEventKey(
 
 function dedupeIssues(issues: string[]): string[] {
   return [...new Set(issues.filter(Boolean))];
+}
+
+function appendRequestId(message: string, requestId?: string | null): string {
+  if (!requestId) {
+    return message;
+  }
+
+  return `${message} 요청 ID: ${requestId}`;
+}
+
+function formatLiveReadFailureIssue(
+  message: string,
+  fallbackKind: 'cache' | 'bundled',
+  requestId?: string | null,
+): string {
+  const fallbackLabel =
+    fallbackKind === 'cache'
+      ? '저장된 스냅샷으로 유지합니다.'
+      : '저장된 스냅샷이 없어 앱 번들 데이터로 전환합니다.';
+
+  return `라이브 요청 실패: ${appendRequestId(message, requestId)} ${fallbackLabel}`;
+}
+
+function isBackendReadErrorLike(
+  error: unknown,
+): error is Error & { requestId?: string | null } {
+  return (
+    error instanceof Error &&
+    (error.name === 'BackendReadError' || 'requestId' in error)
+  );
 }
 
 function buildReadySource<T>(args: {
@@ -139,6 +171,8 @@ export function useActiveDatasetScreen<T>({
         } catch (error) {
           const backendMessage =
             error instanceof Error ? error.message : fallbackErrorMessage;
+          const backendRequestId =
+            isBackendReadErrorLike(error) ? error.requestId : null;
           const cached = await readScreenSnapshotCacheEntry<T>(surface, cacheKey);
 
           if (cached) {
@@ -146,7 +180,10 @@ export function useActiveDatasetScreen<T>({
               activeSource: 'backend-cache',
               sourceLabel: 'Cached backend snapshot',
               data: cached.value,
-              issues: [...runtimeIssues, backendMessage],
+              issues: [
+                ...runtimeIssues,
+                formatLiveReadFailureIssue(backendMessage, 'cache', backendRequestId),
+              ],
               runtimeState,
               rollingReferenceAt: cached.generatedAt ?? cached.cachedAt,
               cachedAt: cached.cachedAt,
@@ -159,7 +196,10 @@ export function useActiveDatasetScreen<T>({
             activeSource: 'bundled-static-fallback',
             sourceLabel: 'Bundled static fallback',
             data: bundledData,
-            issues: [...runtimeIssues, backendMessage],
+            issues: [
+              ...runtimeIssues,
+              formatLiveReadFailureIssue(backendMessage, 'bundled', backendRequestId),
+            ],
             runtimeState,
           });
         }
@@ -215,7 +255,12 @@ export function useActiveDatasetScreen<T>({
           return;
         }
 
-        const message = error instanceof Error ? error.message : fallbackErrorMessage;
+        const message =
+          isBackendReadErrorLike(error)
+            ? appendRequestId(error.message, error.requestId)
+            : error instanceof Error
+              ? error.message
+              : fallbackErrorMessage;
         const datasetEventKey = `error:${message}`;
         if (datasetEventKeyRef.current !== datasetEventKey) {
           datasetEventKeyRef.current = datasetEventKey;

--- a/mobile/src/services/backendReadClient.test.ts
+++ b/mobile/src/services/backendReadClient.test.ts
@@ -160,4 +160,52 @@ describe('mobile backend read client', () => {
       code: 'not_found',
     });
   });
+
+  test('retries a retryable backend response once before succeeding', async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce(
+        createJsonResponse(
+          {
+            error: {
+              code: 'service_unavailable',
+              message: 'Projection refresh is in progress.',
+            },
+          },
+          503,
+        ),
+      )
+      .mockResolvedValueOnce(
+        createJsonResponse({
+          meta: {
+            generatedAt: '2026-03-10T00:00:02.000Z',
+          },
+          data: {
+            summary: {
+              verified_count: 2,
+              exact_upcoming_count: 1,
+              month_only_upcoming_count: 1,
+            },
+            nearest_upcoming: null,
+            days: [],
+            month_only_upcoming: [],
+            verified_list: [],
+            scheduled_list: [],
+          },
+        }),
+      );
+
+    const client = createBackendReadClient(
+      buildRuntimeConfig(),
+      fetchMock as unknown as typeof fetch,
+      {
+        retryCount: 1,
+        retryDelayMs: 0,
+      },
+    );
+    const response = await client.getCalendarMonth('2026-03');
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(response.data.summary.verified_count).toBe(2);
+  });
 });

--- a/mobile/src/services/backendReadClient.ts
+++ b/mobile/src/services/backendReadClient.ts
@@ -1,5 +1,10 @@
 import { getRuntimeConfig, type MobileRuntimeConfig } from '../config/runtime';
 
+const DEFAULT_BACKEND_TIMEOUT_MS = 4500;
+const DEFAULT_BACKEND_RETRY_COUNT = 1;
+const DEFAULT_BACKEND_RETRY_DELAY_MS = 350;
+const RETRYABLE_STATUS_CODES = new Set([408, 429, 502, 503, 504]);
+
 export type BackendReadEnvelope<T> = {
   meta?: {
     generatedAt?: string | null;
@@ -341,14 +346,25 @@ export type BackendResolvedReleaseDetail = {
 export class BackendReadError extends Error {
   status: number | null;
   code: string | null;
+  requestId: string | null;
 
-  constructor(message: string, options: { status?: number | null; code?: string | null } = {}) {
+  constructor(
+    message: string,
+    options: { status?: number | null; code?: string | null; requestId?: string | null } = {},
+  ) {
     super(message);
     this.name = 'BackendReadError';
     this.status = options.status ?? null;
     this.code = options.code ?? null;
+    this.requestId = options.requestId ?? null;
   }
 }
+
+export type BackendReadClientOptions = {
+  retryCount?: number;
+  retryDelayMs?: number;
+  timeoutMs?: number;
+};
 
 function buildUrl(baseUrl: string, pathname: string, searchParams?: Record<string, string | number | undefined>): string {
   const trimmedBaseUrl = baseUrl.replace(/\/+$/, '');
@@ -416,6 +432,12 @@ async function readJsonResponse<T>(response: Response): Promise<BackendReadEnvel
     });
   }
 
+  const requestId =
+    response.headers?.get?.('x-request-id') ??
+    response.headers?.get?.('x-correlation-id') ??
+    response.headers?.get?.('x-vercel-id') ??
+    null;
+
   if (!response.ok) {
     const message =
       isRecord(payload) && isRecord(payload.error) && typeof payload.error.message === 'string'
@@ -428,11 +450,14 @@ async function readJsonResponse<T>(response: Response): Promise<BackendReadEnvel
     throw new BackendReadError(message, {
       status: response.status,
       code,
+      requestId,
     });
   }
 
   if (!isRecord(payload) || !('data' in payload)) {
-    throw new BackendReadError('Backend response envelope was missing data.');
+    throw new BackendReadError('Backend response envelope was missing data.', {
+      requestId,
+    });
   }
 
   return payload as BackendReadEnvelope<T>;
@@ -453,9 +478,53 @@ export type BackendReadClient = {
   getReleaseDetailByLegacyId(legacyReleaseId: string): Promise<BackendResolvedReleaseDetail>;
 };
 
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError';
+}
+
+function isRetryableBackendError(error: BackendReadError): boolean {
+  if (error.code === 'timeout' || error.code === 'network_unavailable') {
+    return true;
+  }
+
+  if (error.status && RETRYABLE_STATUS_CODES.has(error.status)) {
+    return true;
+  }
+
+  return false;
+}
+
+function wrapFetchError(error: unknown): BackendReadError {
+  if (error instanceof BackendReadError) {
+    return error;
+  }
+
+  if (isAbortError(error)) {
+    return new BackendReadError('백엔드 응답이 지연되어 요청을 중단했습니다. 다시 시도해 주세요.', {
+      code: 'timeout',
+    });
+  }
+
+  const message =
+    error instanceof Error && error.message
+      ? error.message
+      : '백엔드에 연결하지 못했습니다. 잠시 후 다시 시도해 주세요.';
+
+  return new BackendReadError(message, {
+    code: 'network_unavailable',
+  });
+}
+
 export function createBackendReadClient(
   runtimeConfig: MobileRuntimeConfig = getRuntimeConfig(),
   fetchImpl: typeof fetch = fetch,
+  options: BackendReadClientOptions = {},
 ): BackendReadClient {
   const baseUrl = runtimeConfig.services.apiBaseUrl;
 
@@ -464,24 +533,54 @@ export function createBackendReadClient(
   }
 
   const resolvedBaseUrl = baseUrl;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_BACKEND_TIMEOUT_MS;
+  const retryCount = options.retryCount ?? DEFAULT_BACKEND_RETRY_COUNT;
+  const retryDelayMs = options.retryDelayMs ?? DEFAULT_BACKEND_RETRY_DELAY_MS;
 
   async function get<T>(pathname: string, searchParams?: Record<string, string | number | undefined>) {
     const url = buildUrl(resolvedBaseUrl, pathname, searchParams);
-    let response: Response;
+    let lastError: BackendReadError | null = null;
 
-    try {
-      response = await fetchImpl(url, {
-        method: 'GET',
-        headers: {
-          Accept: 'application/json',
-        },
-      });
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Backend request failed.';
-      throw new BackendReadError(message);
+    for (let attempt = 0; attempt <= retryCount; attempt += 1) {
+      const controller =
+        typeof AbortController === 'function' ? new AbortController() : null;
+      const timeoutId =
+        controller && timeoutMs > 0
+          ? setTimeout(() => controller.abort(), timeoutMs)
+          : null;
+
+      try {
+        const response = await fetchImpl(url, {
+          method: 'GET',
+          headers: {
+            Accept: 'application/json',
+          },
+          signal: controller?.signal,
+        });
+
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+        }
+
+        return await readJsonResponse<T>(response);
+      } catch (error) {
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+        }
+
+        const backendError = wrapFetchError(error);
+        lastError = backendError;
+
+        if (attempt < retryCount && isRetryableBackendError(backendError)) {
+          await delay(retryDelayMs);
+          continue;
+        }
+
+        throw backendError;
+      }
     }
 
-    return readJsonResponse<T>(response);
+    throw lastError ?? new BackendReadError('Backend request failed.');
   }
 
   return {


### PR DESCRIPTION
## Summary
- add timeout/retry/request-id handling to the mobile backend read client
- surface explicit stale-cache and bundled fallback disclosures with retry actions on iOS-facing screens
- tighten iPhone density in calendar/release/search polish and record local runtime evidence

## Testing
- cd mobile && npm test -- --runInBand src/services/backendReadClient.test.ts src/features/useActiveDatasetScreen.test.tsx src/config/debugMetadata.test.ts src/features/calendarControls.test.tsx src/features/searchTab.test.tsx src/features/radarTab.test.tsx src/features/entityDetailScreen.test.tsx src/features/releaseDetailScreen.test.tsx src/components/layout/SummaryStrip.test.tsx
- cd mobile && npm run typecheck
- cd mobile && npm run lint
- cd mobile && EXPO_PUBLIC_API_BASE_URL=https://api.idol-song-app.example.com npm run config:preview
- git diff --check

Closes #544

Note: includes a small subset of iPhone polish related to #545, but does not close #545 because full surface walkthrough evidence is still incomplete.