### PR TITLE
Fix mobile backend detail rendering and service icon fallbacks

### DIFF
--- a/backend/src/route-contract.test.ts
+++ b/backend/src/route-contract.test.ts
@@ -151,6 +151,10 @@ function buildEntityDetailPayload() {
       stream: 'song',
       release_kind: 'single',
       release_format: 'single',
+      representative_song_title: 'Hate Rodrigo (feat. Yuqi)',
+      spotify_url: 'https://open.spotify.com/track/hate-rodrigo',
+      youtube_music_url: 'https://music.youtube.com/watch?v=hate-rodrigo',
+      youtube_mv_url: 'https://www.youtube.com/watch?v=hate-rodrigo',
       artwork: {
         cover_image_url: 'https://cdn.example.com/hate-rodrigo-cover.jpg',
         thumbnail_image_url: 'https://cdn.example.com/hate-rodrigo-thumb.jpg',
@@ -167,6 +171,10 @@ function buildEntityDetailPayload() {
         stream: 'album',
         release_kind: 'ep',
         release_format: 'ep',
+        representative_song_title: 'LOVE CATCHER',
+        spotify_url: 'https://open.spotify.com/album/love-catcher',
+        youtube_music_url: 'https://music.youtube.com/playlist?list=PLLOVECATCHER',
+        youtube_mv_url: null,
         artwork: {
           cover_image_url: 'https://cdn.example.com/love-catcher-cover.jpg',
           thumbnail_image_url: 'https://cdn.example.com/love-catcher-thumb.jpg',
@@ -798,6 +806,10 @@ class FakeDb {
       return this.result<Row>([]);
     }
 
+    if (normalizedSql.includes('from release_detail_projection') && normalizedSql.includes('where release_id = any($1::uuid[])')) {
+      return this.result<Row>([]);
+    }
+
     if (normalizedSql.includes('from calendar_month_projection')) {
       if (params[0] === '2026-03') {
         return this.result<Row>([
@@ -1237,9 +1249,16 @@ test('GET /v1/entities/:slug returns entity detail projection payload', async (t
   assert.equal(body.data.next_upcoming.source_url, 'https://starnews.example/yena-love-catcher');
   assert.equal(body.data.next_upcoming.source_count, 2);
   assert.equal(body.data.latest_release.release_format, 'single');
+  assert.equal(body.data.latest_release.representative_song_title, 'Hate Rodrigo (feat. Yuqi)');
+  assert.equal(body.data.latest_release.spotify_url, 'https://open.spotify.com/track/hate-rodrigo');
+  assert.equal(body.data.latest_release.youtube_music_url, 'https://music.youtube.com/watch?v=hate-rodrigo');
+  assert.equal(body.data.latest_release.youtube_mv_url, 'https://www.youtube.com/watch?v=hate-rodrigo');
   assert.equal(body.data.latest_release.artwork.cover_image_url, 'https://cdn.example.com/hate-rodrigo-cover.jpg');
   assert.equal(body.data.recent_albums.length, 1);
   assert.equal(body.data.recent_albums[0].release_format, 'ep');
+  assert.equal(body.data.recent_albums[0].representative_song_title, 'LOVE CATCHER');
+  assert.equal(body.data.recent_albums[0].spotify_url, 'https://open.spotify.com/album/love-catcher');
+  assert.equal(body.data.recent_albums[0].youtube_music_url, 'https://music.youtube.com/playlist?list=PLLOVECATCHER');
   assert.equal(body.data.recent_albums[0].artwork.thumbnail_image_url, 'https://cdn.example.com/love-catcher-thumb.jpg');
   assert.equal(body.data.source_timeline[0].event_type, 'official_announcement');
   assert.equal(body.data.source_timeline[0].summary, 'ep · confirmed · 2026-03-11');

--- a/backend/src/routes/entities.ts
+++ b/backend/src/routes/entities.ts
@@ -30,6 +30,11 @@ type EntityDetailProjectionRow = {
   generated_at: Date | string;
 };
 
+type ReleaseDetailProjectionRow = {
+  release_id: string;
+  payload: unknown;
+};
+
 type EntitySlugParams = {
   slug: string;
 };
@@ -87,6 +92,11 @@ type ReleaseSummary = {
   stream: string;
   release_kind: string | null;
   release_format: string | null;
+  representative_song_title: string | null;
+  spotify_url: string | null;
+  youtube_music_url: string | null;
+  youtube_mv_url: string | null;
+  source_url: string | null;
   artwork: ArtworkSummary | null;
 };
 
@@ -216,6 +226,11 @@ function normalizeReleaseSummary(value: unknown): ReleaseSummary | null {
     stream,
     release_kind: asNullableString(value.release_kind),
     release_format: asNullableString(value.release_format),
+    representative_song_title: asNullableString(value.representative_song_title),
+    spotify_url: asNullableString(value.spotify_url),
+    youtube_music_url: asNullableString(value.youtube_music_url),
+    youtube_mv_url: asNullableString(value.youtube_mv_url),
+    source_url: asNullableString(value.source_url),
     artwork: normalizeArtworkSummary(value.artwork),
   };
 }
@@ -228,6 +243,80 @@ function normalizeReleaseSummaryArray(value: unknown): ReleaseSummary[] {
   return value
     .map(normalizeReleaseSummary)
     .filter((item): item is ReleaseSummary => item !== null);
+}
+
+function extractRepresentativeSongTitle(tracks: unknown): string | null {
+  if (!Array.isArray(tracks)) {
+    return null;
+  }
+
+  const titleTrack = tracks.find((track) => {
+    if (!isRecord(track)) {
+      return false;
+    }
+
+    return track.is_title_track === true && typeof track.title === 'string' && track.title.length > 0;
+  });
+
+  if (!isRecord(titleTrack)) {
+    return null;
+  }
+
+  return asNullableString(titleTrack.title);
+}
+
+function mergeReleaseSummaryWithDetail(
+  release: ReleaseSummary,
+  detailPayload: unknown,
+): ReleaseSummary {
+  if (!isRecord(detailPayload)) {
+    return release;
+  }
+
+  const serviceLinks = isRecord(detailPayload.service_links) ? detailPayload.service_links : null;
+  const spotify = serviceLinks && isRecord(serviceLinks.spotify) ? serviceLinks.spotify : null;
+  const youtubeMusic =
+    serviceLinks && isRecord(serviceLinks.youtube_music) ? serviceLinks.youtube_music : null;
+  const mv = isRecord(detailPayload.mv) ? detailPayload.mv : null;
+  const artwork = normalizeArtworkSummary(detailPayload.artwork);
+
+  return {
+    ...release,
+    representative_song_title:
+      extractRepresentativeSongTitle(detailPayload.tracks) ?? release.representative_song_title,
+    spotify_url: asNullableString(spotify?.url) ?? release.spotify_url,
+    youtube_music_url: asNullableString(youtubeMusic?.url) ?? release.youtube_music_url,
+    youtube_mv_url: asNullableString(mv?.url) ?? release.youtube_mv_url,
+    artwork: artwork ?? release.artwork,
+  };
+}
+
+async function hydrateReleaseSummaries(
+  db: DbQueryable,
+  releases: ReleaseSummary[],
+): Promise<ReleaseSummary[]> {
+  const releaseIds = [...new Set(releases.map((release) => release.release_id).filter(Boolean))];
+
+  if (releaseIds.length === 0) {
+    return releases;
+  }
+
+  const result = await db.query<ReleaseDetailProjectionRow>(
+    `
+      select release_id::text as release_id, payload
+      from release_detail_projection
+      where release_id = any($1::uuid[])
+    `,
+    [releaseIds],
+  );
+
+  const payloadByReleaseId = new Map(
+    result.rows.map((row) => [row.release_id, row.payload] as const),
+  );
+
+  return releases.map((release) =>
+    mergeReleaseSummaryWithDetail(release, payloadByReleaseId.get(release.release_id)),
+  );
 }
 
 function normalizeSourceTimeline(value: unknown): SourceTimelineItem[] {
@@ -481,12 +570,23 @@ export function registerEntityRoutes(app: FastifyInstance, context: EntityRouteC
       throw routeError(404, 'not_found', 'No entity matched the supplied slug.', { entity_slug: slug });
     }
 
-    const data = normalizeEntityDetailPayload(row.payload, slug);
-    if (!data) {
+    const normalized = normalizeEntityDetailPayload(row.payload, slug);
+    if (!normalized) {
       throw routeError(500, 'stale_projection', 'entity_detail_projection returned an unexpected payload shape.', {
         entity_slug: slug,
       });
     }
+
+    const [latestRelease] = await hydrateReleaseSummaries(
+      context.db,
+      normalized.latest_release ? [normalized.latest_release] : [],
+    );
+    const recentAlbums = await hydrateReleaseSummaries(context.db, normalized.recent_albums);
+    const data: EntityDetailPayload = {
+      ...normalized,
+      latest_release: latestRelease ?? normalized.latest_release,
+      recent_albums: recentAlbums,
+    };
 
     return buildReadDataEnvelope(
       request,

--- a/mobile/app/releases/[id].tsx
+++ b/mobile/app/releases/[id].tsx
@@ -135,6 +135,18 @@ function formatReleaseMeta(detail: ReleaseDetailModel): string {
   return `${detail.releaseDate} · ${getReleaseKindLabel(detail)}`;
 }
 
+function resolveTeamDetailSlug(detail: ReleaseDetailModel, teamProfileSlug?: string | null): string {
+  if (teamProfileSlug) {
+    return teamProfileSlug;
+  }
+
+  return detail.group
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
 function getMvStatusCopy(status?: YoutubeVideoStatus): string | null {
   switch (status) {
     case 'manual_override':
@@ -295,13 +307,16 @@ export default function ReleaseDetailScreen() {
       }
 
       try {
-        const resolved = await client.getReleaseDetailByLegacyId(releaseId);
+        const detailResponse = await client.getReleaseDetailForRouteId(releaseId);
         return {
-          data: adaptBackendReleaseDetail(resolved.detail.data),
-          generatedAt: resolved.detail.meta?.generatedAt ?? resolved.lookup.meta?.generatedAt ?? null,
+          data: adaptBackendReleaseDetail(detailResponse.data),
+          generatedAt: detailResponse.meta?.generatedAt ?? null,
         };
       } catch (error) {
-        if (error instanceof BackendReadError && error.status === 404) {
+        if (
+          error instanceof BackendReadError &&
+          (error.status === 404 || error.code === 'invalid_release_lookup')
+        ) {
           return {
             data: null,
             generatedAt: null,
@@ -333,6 +348,7 @@ export default function ReleaseDetailScreen() {
     detail
       ? bundledProfiles.find((profile) => profile.slug === detail.group || profile.group === detail.group) ?? null
       : null;
+  const teamDetailSlug = detail ? resolveTeamDetailSlug(detail, teamProfile?.slug ?? null) : null;
 
   useEffect(() => {
     setHandoffFeedback(null);
@@ -561,13 +577,13 @@ export default function ReleaseDetailScreen() {
         title={detail.releaseTitle}
         titleTestID="release-detail-appbar-title"
         trailingActions={
-          teamProfile
+          teamDetailSlug
             ? [
                 {
                   key: 'team-page',
                   accessibilityLabel: `${detail.displayGroup} 팀 페이지 열기`,
                   label: MOBILE_COPY.action.teamPage,
-                  onPress: () => router.push(`/artists/${teamProfile.slug}`),
+                  onPress: () => router.push(`/artists/${teamDetailSlug}`),
                   testID: 'release-appbar-team-page',
                 },
           ]

--- a/mobile/src/components/actions/ServiceButton.test.tsx
+++ b/mobile/src/components/actions/ServiceButton.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import { Image, Text } from 'react-native';
+
+import { ServiceButton } from './ServiceButton';
+
+function hasText(tree: renderer.ReactTestRenderer, value: string): boolean {
+  return tree.root.findAllByType(Text).some((node) => node.props.children === value);
+}
+
+describe('ServiceButton', () => {
+  test('renders the service icon by default', async () => {
+    let tree: renderer.ReactTestRenderer;
+
+    await act(async () => {
+      tree = renderer.create(
+        <ServiceButton
+          accessibilityLabel="Spotify 열기"
+          label="Spotify"
+          testID="service-button-spotify"
+          tone="spotify"
+        />,
+      );
+    });
+
+    expect(tree!.root.findByProps({ testID: 'service-button-spotify-icon' })).toBeDefined();
+    expect(tree!.root.findAllByProps({ testID: 'service-button-spotify-fallback-glyph' })).toHaveLength(0);
+  });
+
+  test('shows a visible fallback glyph when the icon asset fails to load', async () => {
+    let tree: renderer.ReactTestRenderer;
+
+    await act(async () => {
+      tree = renderer.create(
+        <ServiceButton
+          accessibilityLabel="YouTube Music 열기"
+          label="YouTube Music"
+          testID="service-button-youtube-music"
+          tone="youtubeMusic"
+        />,
+      );
+    });
+
+    await act(async () => {
+      tree!.root.findByType(Image).props.onError?.();
+    });
+
+    expect(tree!.root.findByProps({ testID: 'service-button-youtube-music-fallback-glyph' })).toBeDefined();
+    expect(hasText(tree!, 'YM')).toBe(true);
+  });
+});

--- a/mobile/src/components/actions/ServiceButton.tsx
+++ b/mobile/src/components/actions/ServiceButton.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useMemo } from 'react';
+import React, { memo, useEffect, useMemo, useState } from 'react';
 import {
   Image,
   Pressable,
@@ -12,7 +12,10 @@ import { useAppTheme } from '../../tokens/theme';
 import type { MobileTheme } from '../../tokens/theme';
 import { MOBILE_TEXT_SCALE_LIMITS } from '../../tokens/accessibility';
 import { useReducedMotion } from '../../hooks/useReducedMotion';
-import { serviceIconAssets } from '../../utils/assetRegistry';
+import {
+  resolveServiceIconFallbackGlyph,
+  resolveServiceIconSource,
+} from '../../utils/assetRegistry';
 
 export type ServiceButtonTone = 'spotify' | 'youtubeMusic' | 'youtubeMv';
 
@@ -47,6 +50,13 @@ function ServiceButtonComponent({
   const styles = useMemo(() => createStyles(theme), [theme]);
   const resolvedService = service ?? tone ?? 'spotify';
   const labelMultiplier = fontScale >= 1.4 ? MOBILE_TEXT_SCALE_LIMITS.buttonService : MOBILE_TEXT_SCALE_LIMITS.buttonPrimary;
+  const [iconLoadFailed, setIconLoadFailed] = useState(false);
+  const serviceIconSource = resolveServiceIconSource(resolvedService);
+  const fallbackGlyph = resolveServiceIconFallbackGlyph(resolvedService);
+
+  useEffect(() => {
+    setIconLoadFailed(false);
+  }, [resolvedService]);
 
   return (
     <Pressable
@@ -66,10 +76,24 @@ function ServiceButtonComponent({
     >
       <View style={styles.buttonContent}>
         <View style={[styles.mark, styles[`${resolvedService}Mark`]]}>
-          <Image
-            source={serviceIconAssets[resolvedService]}
-            style={[styles.markIcon, styles[`${resolvedService}MarkIcon`]]}
-          />
+          {iconLoadFailed ? (
+            <Text
+              allowFontScaling={false}
+              style={[styles.markFallbackGlyph, styles[`${resolvedService}MarkFallbackGlyph`]]}
+              testID={testID ? `${testID}-fallback-glyph` : undefined}
+            >
+              {fallbackGlyph}
+            </Text>
+          ) : (
+            <Image
+              accessibilityIgnoresInvertColors
+              fadeDuration={0}
+              onError={() => setIconLoadFailed(true)}
+              source={serviceIconSource}
+              style={[styles.markIcon, styles[`${resolvedService}MarkIcon`]]}
+              testID={testID ? `${testID}-icon` : undefined}
+            />
+          )}
         </View>
         <Text
           allowFontScaling
@@ -143,6 +167,11 @@ function createStyles(theme: MobileTheme) {
       height: 14,
       resizeMode: 'contain',
     },
+    markFallbackGlyph: {
+      ...metaTypography,
+      fontWeight: '800',
+      letterSpacing: 0.3,
+    },
     buttonLabelDisabled: {
       color: theme.colors.text.tertiary,
     },
@@ -159,6 +188,9 @@ function createStyles(theme: MobileTheme) {
     spotifyMarkIcon: {
       tintColor: theme.colors.text.inverse,
     },
+    spotifyMarkFallbackGlyph: {
+      color: theme.colors.text.inverse,
+    },
     youtubeMusicButton: {
       backgroundColor: theme.colors.service.youtubeMusic.bg,
       borderColor: theme.colors.service.youtubeMusic.icon,
@@ -172,6 +204,9 @@ function createStyles(theme: MobileTheme) {
     youtubeMusicMarkIcon: {
       tintColor: theme.colors.text.inverse,
     },
+    youtubeMusicMarkFallbackGlyph: {
+      color: theme.colors.text.inverse,
+    },
     youtubeMvButton: {
       backgroundColor: theme.colors.service.youtubeMv.bg,
       borderColor: theme.colors.service.youtubeMv.icon,
@@ -184,6 +219,9 @@ function createStyles(theme: MobileTheme) {
     },
     youtubeMvMarkIcon: {
       tintColor: theme.colors.text.inverse,
+    },
+    youtubeMvMarkFallbackGlyph: {
+      color: theme.colors.text.inverse,
     },
     modeHint: {
       ...metaTypography,

--- a/mobile/src/services/backendDisplayAdapters.test.ts
+++ b/mobile/src/services/backendDisplayAdapters.test.ts
@@ -181,6 +181,74 @@ describe('backend display adapter parity', () => {
     expect(snapshot.sourceTimeline[0]?.sourceUrl).toBeUndefined();
   });
 
+  test('preserves enriched canonical release links and representative track data on entity detail payloads', () => {
+    const data: BackendEntityDetailData = {
+      identity: {
+        entity_slug: 'yena',
+        display_name: 'YENA',
+        canonical_name: 'YENA',
+        entity_type: 'solo',
+      },
+      official_links: {
+        youtube: 'https://www.youtube.com/@YENA_OFFICIAL',
+        x: null,
+        instagram: null,
+      },
+      youtube_channels: {
+        primary_team_channel_url: 'https://www.youtube.com/@YENA_OFFICIAL',
+        mv_allowlist_urls: ['https://www.youtube.com/@YENA_OFFICIAL'],
+      },
+      tracking_state: {},
+      next_upcoming: null,
+      latest_release: {
+        release_id: 'release-yena',
+        release_title: 'Hate Rodrigo',
+        release_date: '2025-06-29',
+        stream: 'song',
+        release_kind: 'single',
+        release_format: 'single',
+        representative_song_title: 'Hate Rodrigo (feat. Yuqi)',
+        spotify_url: 'https://open.spotify.com/track/hate-rodrigo',
+        youtube_music_url: 'https://music.youtube.com/watch?v=hate-rodrigo',
+        youtube_mv_url: 'https://www.youtube.com/watch?v=hate-rodrigo',
+        artwork: {
+          cover_image_url: 'https://cdn.example.com/hate-rodrigo-cover.jpg',
+        },
+      },
+      recent_albums: [
+        {
+          release_id: 'release-love-catcher',
+          release_title: 'LOVE CATCHER',
+          release_date: '2026-03-11',
+          stream: 'album',
+          release_kind: 'ep',
+          release_format: 'ep',
+          representative_song_title: 'LOVE CATCHER',
+          spotify_url: 'https://open.spotify.com/album/love-catcher',
+          youtube_music_url: 'https://music.youtube.com/playlist?list=PLLOVECATCHER',
+          youtube_mv_url: null,
+          artwork: {
+            thumbnail_image_url: 'https://cdn.example.com/love-catcher-thumb.jpg',
+          },
+        },
+      ],
+      source_timeline: [],
+      artist_source_url: null,
+    };
+
+    const snapshot = adaptBackendEntityDetail(data);
+
+    expect(snapshot.latestRelease?.representativeSongTitle).toBe('Hate Rodrigo (feat. Yuqi)');
+    expect(snapshot.latestRelease?.spotifyUrl).toBe('https://open.spotify.com/track/hate-rodrigo');
+    expect(snapshot.latestRelease?.youtubeMusicUrl).toBe('https://music.youtube.com/watch?v=hate-rodrigo');
+    expect(snapshot.latestRelease?.youtubeMvUrl).toBe('https://www.youtube.com/watch?v=hate-rodrigo');
+    expect(snapshot.recentAlbums[0]?.representativeSongTitle).toBe('LOVE CATCHER');
+    expect(snapshot.recentAlbums[0]?.spotifyUrl).toBe('https://open.spotify.com/album/love-catcher');
+    expect(snapshot.recentAlbums[0]?.youtubeMusicUrl).toBe(
+      'https://music.youtube.com/playlist?list=PLLOVECATCHER',
+    );
+  });
+
   test('keeps release detail service links and MV state explicit without fake fallback values', () => {
     const data: BackendReleaseDetailData = {
       release: {

--- a/mobile/src/services/backendDisplayAdapters.ts
+++ b/mobile/src/services/backendDisplayAdapters.ts
@@ -118,6 +118,12 @@ function adaptReleaseSummary(
     releaseDate: input.release_date ?? '',
     releaseKind: normalizeReleaseKind(input.release_kind ?? null),
     stream: normalizeReleaseStream(input.stream),
+    representativeSongTitle:
+      'representative_song_title' in input ? input.representative_song_title ?? undefined : undefined,
+    spotifyUrl: 'spotify_url' in input ? input.spotify_url ?? undefined : undefined,
+    youtubeMusicUrl: 'youtube_music_url' in input ? input.youtube_music_url ?? undefined : undefined,
+    youtubeMvUrl: 'youtube_mv_url' in input ? input.youtube_mv_url ?? undefined : undefined,
+    sourceUrl: 'source_url' in input ? input.source_url ?? undefined : undefined,
     coverImageUrl:
       'artwork' in input
         ? input.artwork?.cover_image_url ?? input.artwork?.thumbnail_image_url ?? undefined

--- a/mobile/src/services/backendReadClient.test.ts
+++ b/mobile/src/services/backendReadClient.test.ts
@@ -133,6 +133,41 @@ describe('mobile backend read client', () => {
     expect(response.detail.data.release.release_id).toBe('release-uuid-1');
   });
 
+  test('reads canonical release ids directly without attempting the legacy lookup helper', async () => {
+    const fetchMock = jest.fn(async () =>
+      createJsonResponse({
+        meta: {
+          generatedAt: '2026-03-10T00:00:01.000Z',
+        },
+        data: {
+          release: {
+            release_id: '550e8400-e29b-41d4-a716-446655440000',
+            entity_slug: 'ive',
+            display_name: 'IVE',
+            release_title: 'REVIVE+',
+            release_date: '2026-02-23',
+            stream: 'album',
+            release_kind: 'ep',
+          },
+          tracks: [],
+          mv: {
+            status: 'unresolved',
+          },
+        },
+      }),
+    );
+
+    const client = createBackendReadClient(buildRuntimeConfig(), fetchMock as unknown as typeof fetch);
+    const response = await client.getReleaseDetailForRouteId('550e8400-e29b-41d4-a716-446655440000');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [firstRequestUrl] = fetchMock.mock.calls[0] as unknown as [string, RequestInit | undefined];
+    expect(firstRequestUrl).toBe(
+      'https://example.com/api/v1/releases/550e8400-e29b-41d4-a716-446655440000',
+    );
+    expect(response.data.release.release_title).toBe('REVIVE+');
+  });
+
   test('throws a typed error when the backend returns an error envelope', async () => {
     const fetchMock = jest.fn(async () =>
       createJsonResponse(

--- a/mobile/src/services/backendReadClient.ts
+++ b/mobile/src/services/backendReadClient.ts
@@ -4,6 +4,8 @@ const DEFAULT_BACKEND_TIMEOUT_MS = 4500;
 const DEFAULT_BACKEND_RETRY_COUNT = 1;
 const DEFAULT_BACKEND_RETRY_DELAY_MS = 350;
 const RETRYABLE_STATUS_CODES = new Set([408, 429, 502, 503, 504]);
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 export type BackendReadEnvelope<T> = {
   meta?: {
@@ -190,6 +192,11 @@ export type BackendEntityReleaseSummary = {
   stream: string;
   release_kind?: string | null;
   release_format?: string | null;
+  representative_song_title?: string | null;
+  spotify_url?: string | null;
+  youtube_music_url?: string | null;
+  youtube_mv_url?: string | null;
+  source_url?: string | null;
   artwork?: {
     cover_image_url?: string | null;
     thumbnail_image_url?: string | null;
@@ -421,6 +428,10 @@ function parseLegacyReleaseId(legacyReleaseId: string): {
   };
 }
 
+function isCanonicalReleaseId(value: string): boolean {
+  return UUID_PATTERN.test(value.trim());
+}
+
 async function readJsonResponse<T>(response: Response): Promise<BackendReadEnvelope<T>> {
   let payload: unknown = null;
 
@@ -475,6 +486,7 @@ export type BackendReadClient = {
     stream: string;
   }): Promise<BackendReadEnvelope<BackendReleaseLookupData>>;
   getReleaseDetail(releaseId: string): Promise<BackendReadEnvelope<BackendReleaseDetailData>>;
+  getReleaseDetailForRouteId(routeReleaseId: string): Promise<BackendReadEnvelope<BackendReleaseDetailData>>;
   getReleaseDetailByLegacyId(legacyReleaseId: string): Promise<BackendResolvedReleaseDetail>;
 };
 
@@ -606,6 +618,17 @@ export function createBackendReadClient(
     },
     getReleaseDetail(releaseId) {
       return get<BackendReleaseDetailData>(`/v1/releases/${encodeURIComponent(releaseId)}`);
+    },
+    getReleaseDetailForRouteId(routeReleaseId) {
+      const trimmedRouteReleaseId = routeReleaseId.trim();
+
+      if (isCanonicalReleaseId(trimmedRouteReleaseId)) {
+        return get<BackendReleaseDetailData>(
+          `/v1/releases/${encodeURIComponent(trimmedRouteReleaseId)}`,
+        );
+      }
+
+      return this.getReleaseDetailByLegacyId(trimmedRouteReleaseId).then((resolved) => resolved.detail);
     },
     async getReleaseDetailByLegacyId(legacyReleaseId) {
       const parsed = parseLegacyReleaseId(legacyReleaseId);

--- a/mobile/src/utils/assetRegistry.test.ts
+++ b/mobile/src/utils/assetRegistry.test.ts
@@ -4,6 +4,9 @@ import {
   badgeFallbackAssets,
   resolveFallbackArtSource,
   resolveLaunchMarkSource,
+  resolveServiceIconFallbackGlyph,
+  resolveServiceIconSource,
+  serviceIconAssets,
 } from './assetRegistry';
 
 describe('asset registry', () => {
@@ -22,5 +25,12 @@ describe('asset registry', () => {
   test('resolves launch mark by scheme', () => {
     expect(resolveLaunchMarkSource('light')).toBe(launchMarkAssets.light);
     expect(resolveLaunchMarkSource('dark')).toBe(launchMarkAssets.dark);
+  });
+
+  test('resolves service icon sources and fallback glyphs', () => {
+    expect(resolveServiceIconSource('spotify')).toBe(serviceIconAssets.spotify.source);
+    expect(resolveServiceIconSource('youtubeMusic')).toBe(serviceIconAssets.youtubeMusic.source);
+    expect(resolveServiceIconFallbackGlyph('spotify')).toBe('SP');
+    expect(resolveServiceIconFallbackGlyph('youtubeMv')).toBe('MV');
   });
 });

--- a/mobile/src/utils/assetRegistry.ts
+++ b/mobile/src/utils/assetRegistry.ts
@@ -17,10 +17,25 @@ export const placeholderAssets = {
 } as const satisfies Record<ThemeScheme, Record<string, ImageSourcePropType>>;
 
 export const serviceIconAssets = {
-  spotify: require('../../assets/services/spotify.png'),
-  youtubeMusic: require('../../assets/services/youtube-music.png'),
-  youtubeMv: require('../../assets/services/youtube-mv.png'),
-} as const satisfies Record<string, ImageSourcePropType>;
+  spotify: {
+    source: require('../../assets/services/spotify.png'),
+    fallbackGlyph: 'SP',
+  },
+  youtubeMusic: {
+    source: require('../../assets/services/youtube-music.png'),
+    fallbackGlyph: 'YM',
+  },
+  youtubeMv: {
+    source: require('../../assets/services/youtube-mv.png'),
+    fallbackGlyph: 'MV',
+  },
+} as const satisfies Record<
+  string,
+  {
+    source: ImageSourcePropType;
+    fallbackGlyph: string;
+  }
+>;
 
 export const badgeFallbackAssets = {
   light: {
@@ -71,4 +86,16 @@ export function resolveFallbackArtSource(
 
 export function resolveLaunchMarkSource(scheme: ThemeScheme = 'light'): ImageSourcePropType {
   return launchMarkAssets[scheme];
+}
+
+export function resolveServiceIconSource(
+  key: ServiceIconAssetKey,
+): ImageSourcePropType {
+  return serviceIconAssets[key].source;
+}
+
+export function resolveServiceIconFallbackGlyph(
+  key: ServiceIconAssetKey,
+): string {
+  return serviceIconAssets[key].fallbackGlyph;
 }


### PR DESCRIPTION
## Summary
- fix mobile release detail loading so backend-primary routes accept canonical release ids
- hydrate backend entity detail release summaries with canonical release detail links and representative song data
- add resilient service icon fallback glyphs and regression tests

Closes #584
Closes #585