### PR TITLE
Resolve worker cadence null-based gating with warm-up evidence

### DIFF
--- a/backend/reports/migration_readiness_scorecard.json
+++ b/backend/reports/migration_readiness_scorecard.json
@@ -1,18 +1,92 @@
 {
-  "generated_at": "2026-03-11T08:31:07.905Z",
-  "report_bundle": null,
+  "generated_at": "2026-03-11T12:19:23.332Z",
+  "report_bundle": {
+    "generated_at": "2026-03-11T09:16:25.280Z",
+    "bundle_id": "post-sync-verification-57fe974c438e",
+    "bundle_kind": "post-sync-verification",
+    "cadence_profile": "daily-upcoming",
+    "source": {
+      "kind": "manual",
+      "workflow_name": null,
+      "git_commit_sha": null,
+      "github_run_id": null
+    },
+    "source_reports": {
+      "release_pipeline_sync": {
+        "path": "reports/release_pipeline_db_sync_summary.json",
+        "generated_at": "2026-03-07T07:51:00.028Z",
+        "scope": "release_pipeline"
+      },
+      "upcoming_pipeline_sync": {
+        "path": "reports/upcoming_pipeline_db_sync_summary.json",
+        "generated_at": "2026-03-11T07:53:51.250Z",
+        "scope": "upcoming_pipeline"
+      },
+      "projection_refresh": {
+        "path": "reports/projection_refresh_summary.json",
+        "generated_at": "2026-03-11T07:53:57.809Z"
+      },
+      "historical_coverage": {
+        "path": "reports/historical_release_detail_coverage_report.json",
+        "generated_at": "2026-03-10T00:00:00.000Z"
+      },
+      "canonical_null_coverage": {
+        "path": "reports/canonical_null_coverage_report.json",
+        "generated_at": "2026-03-11T08:30:30.464Z"
+      },
+      "canonical_null_recheck_queue": {
+        "path": "reports/canonical_null_recheck_queue.json",
+        "generated_at": "2026-03-11T08:30:31.766Z",
+        "queue_count": 3762
+      },
+      "null_coverage_trend": {
+        "path": "reports/null_coverage_trend_report.json",
+        "generated_at": "2026-03-11T08:30:32.119Z",
+        "baseline_available": false
+      },
+      "worker_cadence": {
+        "path": "reports/worker_cadence_report.json",
+        "generated_at": "2026-03-11T08:30:28.469Z",
+        "primary_path_key": "daily_upcoming"
+      },
+      "service_link_gap_queues": {
+        "path": "reports/service_link_gap_queues.json",
+        "generated_at": "2026-03-11T09:16:24.917Z",
+        "total": 5155
+      },
+      "title_track_gap_queue": {
+        "path": "reports/title_track_gap_queue.json",
+        "generated_at": "2026-03-11T09:16:24.922Z",
+        "total": 1694
+      },
+      "entity_identity_workbench": {
+        "path": "reports/entity_identity_workbench.json",
+        "generated_at": "2026-03-11T09:16:24.924Z",
+        "entities": 117,
+        "field_rows": 324
+      }
+    },
+    "summary_lines": [
+      "bundle id: post-sync-verification-57fe974c438e",
+      "bundle kind: post-sync-verification",
+      "cadence profile: daily-upcoming",
+      "workflow: manual"
+    ]
+  },
   "bundle_consistency": {
-    "status": "pass",
-    "expected_bundle_id": null,
+    "status": "fail",
+    "expected_bundle_id": "post-sync-verification-57fe974c438e",
     "observed": {
-      "parity_bundle": "post-sync-verification-b72033bd3150",
-      "shadow_bundle": "post-sync-verification-b72033bd3150",
-      "runtime_gate_bundle": "post-sync-verification-b72033bd3150",
-      "historical_coverage_generated_at": "2026-03-10T00:00:00.000Z",
+      "parity_bundle": "post-sync-verification-57fe974c438e",
+      "shadow_bundle": "post-sync-verification-57fe974c438e",
+      "runtime_gate_bundle": "post-sync-verification-57fe974c438e",
+      "historical_coverage_generated_at": "2026-03-11T00:00:00.000Z",
       "canonical_null_coverage_generated_at": "2026-03-11T08:30:30.464Z",
       "null_coverage_trend_generated_at": "2026-03-11T08:30:32.119Z"
     },
-    "mismatches": []
+    "mismatches": [
+      "historical coverage drift (2026-03-11T00:00:00.000Z)"
+    ]
   },
   "rubric": {
     "overall": {
@@ -85,7 +159,7 @@
     "historical_coverage_report": "backend/reports/historical_release_detail_coverage_report.json",
     "canonical_null_coverage_report": "backend/reports/canonical_null_coverage_report.json",
     "null_coverage_trend_report": "backend/reports/null_coverage_trend_report.json",
-    "bundle_report": "reports/report_bundle_metadata.json",
+    "bundle_report": "backend/reports/report_bundle_metadata.json",
     "fixture_registry": "backend/fixtures/live_backend_smoke_fixtures.json",
     "backend_deploy_workflow": ".github/workflows/backend-deploy.yml",
     "mobile_runtime_config": "mobile/src/config/runtime.ts",
@@ -94,15 +168,16 @@
   },
   "overall": {
     "status": "fail",
-    "score_ratio": 0.5959,
-    "score_percent": 59.6,
-    "weighted_points": 59.59,
+    "score_ratio": 0.5626,
+    "score_percent": 56.3,
+    "weighted_points": 56.26,
     "total_weight": 100,
     "blocker_categories": [
       {
         "key": "backend_runtime_health",
         "label": "Backend runtime health",
         "blocker_reasons": [
+          "projection_freshness=fail",
           "worker_cadence=fail",
           "stage_gate:shadow_to_web_cutover=fail",
           "stage_gate:web_cutover_to_json_demotion=fail"
@@ -127,8 +202,8 @@
         "key": "catalog_completeness",
         "label": "Catalog completeness",
         "blocker_reasons": [
-          "title_track_resolved overall=64.5 pre_2024=62",
-          "canonical_mv overall=6.3 pre_2024=3.3",
+          "title_track_resolved overall=67.9 pre_2024=65.2",
+          "canonical_mv overall=8.6 pre_2024=6.4",
           "releases.title_track latest 29.1% < 95.0%",
           "release_service_links.youtube_mv latest 10.2% < 80.0%",
           "entities.official_youtube latest 75.3% < 100.0%",
@@ -149,10 +224,11 @@
       "weight": 25,
       "blocker": true,
       "status": "fail",
-      "score_ratio": 0.42,
-      "score_percent": 42,
-      "weighted_points": 10.5,
+      "score_ratio": 0.27,
+      "score_percent": 27,
+      "weighted_points": 6.75,
       "blocker_reasons": [
+        "projection_freshness=fail",
         "worker_cadence=fail",
         "stage_gate:shadow_to_web_cutover=fail",
         "stage_gate:web_cutover_to_json_demotion=fail"
@@ -160,13 +236,13 @@
       "summary_lines": [
         "api latency: needs_review (worst p95=1148.96ms)",
         "api error rate: needs_review (error rate=0)",
-        "projection freshness: needs_review (lag=37.16m)",
-        "worker cadence: fail (failure rate=n/a)",
+        "projection freshness: fail (lag=265.33m)",
+        "worker cadence: fail (cadence_status=scheduled_evidence_missing, missed_windows=5)",
         "parity dependency: fail",
         "shadow dependency: fail",
         "historical catalog completeness dependency: fail",
         "critical null coverage dependency: fail",
-        "bundle consistency: pass",
+        "bundle consistency: fail",
         "shadow -> web cutover gate: fail",
         "web cutover -> JSON demotion gate: fail"
       ],
@@ -197,10 +273,10 @@
             }
           },
           "projection_freshness": {
-            "status": "needs_review",
+            "status": "fail",
             "observed": {
               "projection_generated_at": "2026-03-11T07:53:57.809Z",
-              "lag_minutes": 37.16
+              "lag_minutes": 265.33
             },
             "thresholds": {
               "passLagMinutes": 20,
@@ -215,7 +291,28 @@
               "scheduled_failure_rate": null,
               "last_success_age_hours": null,
               "scheduled_runs": 0,
-              "cadence_status": "no_scheduled_sample"
+              "cadence_status": "scheduled_evidence_missing",
+              "scheduled_evidence": {
+                "status": "scheduled_evidence_missing",
+                "reason": "Expected scheduled run windows have elapsed without a recorded scheduled sample.",
+                "cadence_label": "daily",
+                "workflow_created_at": "2026-03-06T07:34:09.000Z",
+                "workflow_updated_at": "2026-03-11T09:25:55.000Z",
+                "workflow_state": "active",
+                "workflow_html_url": "https://github.com/iAmSomething/idol-song-app/blob/main/.github/workflows/weekly-kpop-scan.yml",
+                "parsed_schedule": {
+                  "kind": "daily",
+                  "minute": 0,
+                  "hour": 0
+                },
+                "warmup_grace_hours": 12,
+                "first_expected_run_at": "2026-03-07T00:00:00.000Z",
+                "next_expected_run_at": "2026-03-12T00:00:00.000Z",
+                "warmup_deadline_at": "2026-03-07T12:00:00.000Z",
+                "expected_scheduled_runs_by_now": 5,
+                "observed_scheduled_runs": 0,
+                "missed_scheduled_windows": 5
+              }
             },
             "thresholds": {
               "passFailureRate": 0.1,
@@ -400,12 +497,12 @@
       "weight": 20,
       "blocker": true,
       "status": "fail",
-      "score_ratio": 0.7294,
-      "score_percent": 72.9,
-      "weighted_points": 14.59,
+      "score_ratio": 0.7506,
+      "score_percent": 75.1,
+      "weighted_points": 15.01,
       "blocker_reasons": [
-        "title_track_resolved overall=64.5 pre_2024=62",
-        "canonical_mv overall=6.3 pre_2024=3.3",
+        "title_track_resolved overall=67.9 pre_2024=65.2",
+        "canonical_mv overall=8.6 pre_2024=6.4",
         "releases.title_track latest 29.1% < 95.0%",
         "release_service_links.youtube_mv latest 10.2% < 80.0%",
         "entities.official_youtube latest 75.3% < 100.0%",
@@ -419,9 +516,13 @@
       "summary_lines": [
         "detail payload coverage: 1770/1770 (100.0%), pre-2024 1153/1153 (100.0%)",
         "detail trusted coverage: 1770/1770 (100.0%), pre-2024 1153/1153 (100.0%)",
-        "title-track resolved coverage: 1141/1770 (64.5%), pre-2024 715/1153 (62.0%), review queue 629",
-        "canonical MV coverage: 112/1770 (6.3%), pre-2024 38/1153 (3.3%), mv review 2",
+        "title-track resolved coverage: 1201/1770 (67.8%), pre-2024 752/1153 (65.2%), review queue 569",
+        "canonical MV coverage: 153/1770 (8.6%), pre-2024 74/1153 (6.4%), mv review 2",
+        "external acquisition pass: YTM attempted 113, resolved 0; MV attempted 56, resolved 0, review 2",
+        "youtube MV search pass: attempted 54, resolved 41, review 13, unresolved 1616, coverage lift +1",
         "migration-critical first slice: title-track 18/18 (100.0%), canonical MV 18/18 (100.0%), gate pass",
+        "worst title-track cohort: 2021-2023 ep 31.4% / target 74.0%",
+        "worst canonical MV cohort: 2024+ single 15.4% / target 72.0%",
         "release-detail null review queue: 1754 rows",
         "historical catalog cutover gate: fail",
         "migration_priority_slice rows=18/18 title_track=100 canonical_mv=100 gate=pass",
@@ -431,14 +532,14 @@
         "overall": {
           "detail_payload_ratio": 1,
           "detail_trusted_ratio": 1,
-          "title_track_resolved_ratio": 0.6446,
-          "canonical_mv_ratio": 0.0633
+          "title_track_resolved_ratio": 0.6785,
+          "canonical_mv_ratio": 0.0864
         },
         "pre_2024": {
           "detail_payload_ratio": 1,
           "detail_trusted_ratio": 1,
-          "title_track_resolved_ratio": 0.6201,
-          "canonical_mv_ratio": 0.033
+          "title_track_resolved_ratio": 0.6522,
+          "canonical_mv_ratio": 0.0642
         },
         "migration_priority_slice": {
           "expected_rows": 18,
@@ -474,7 +575,7 @@
             },
             "cutover_ready": true,
             "cutover_status": "pass",
-            "generated_at": "2026-03-10",
+            "generated_at": "2026-03-11",
             "summary_lines": [
               "detail_payload gate: pass (100.0% vs 100.0%)",
               "detail_trusted gate: pass (100.0% vs 100.0%)",
@@ -581,21 +682,21 @@
           "critical_regressions": []
         },
         "review_queues": {
-          "title_track_review_rows": 65,
+          "title_track_review_rows": 5,
           "mv_review_rows": 2,
           "title_track_unresolved_rows": 564,
-          "mv_unresolved_rows": 1655
+          "mv_unresolved_rows": 1614
         }
       }
     }
   ],
   "summary_lines": [
-    "overall readiness: fail (59.6/100)",
-    "Backend runtime health: fail (42/100) [BLOCKER] - worker_cadence=fail",
+    "overall readiness: fail (56.3/100)",
+    "Backend runtime health: fail (27/100) [BLOCKER] - projection_freshness=fail",
     "Backend deploy parity: fail (40/100) [BLOCKER] - parity_clean=false (latest_verified_release_selection drift=0)",
     "Web backend-only stability: fail (57.5/100) [BLOCKER] - entity_detail clean_ratio=0.5",
     "Mobile runtime mode: pass (100/100) - no blocker reason",
-    "Catalog completeness: fail (72.9/100) [BLOCKER] - title_track_resolved overall=64.5 pre_2024=62",
-    "bundle consistency: pass"
+    "Catalog completeness: fail (75.1/100) [BLOCKER] - title_track_resolved overall=67.9 pre_2024=65.2",
+    "bundle consistency: fail"
   ]
 }

--- a/backend/reports/migration_readiness_scorecard.md
+++ b/backend/reports/migration_readiness_scorecard.md
@@ -1,39 +1,39 @@
 # Migration Readiness Scorecard
 
-Generated at: 2026-03-11T08:31:07.905Z
+Generated at: 2026-03-11T12:19:23.332Z
 
 ## Overall
 
 - status: `fail`
-- score: `59.6/100`
+- score: `56.3/100`
 - cutover blocked: `true`
 
 ## Blockers
 
-- Backend runtime health: worker_cadence=fail; stage_gate:shadow_to_web_cutover=fail; stage_gate:web_cutover_to_json_demotion=fail
+- Backend runtime health: projection_freshness=fail; worker_cadence=fail; stage_gate:shadow_to_web_cutover=fail; stage_gate:web_cutover_to_json_demotion=fail
 - Backend deploy parity: parity_clean=false (latest_verified_release_selection drift=0)
 - Web backend-only stability: entity_detail clean_ratio=0.5; release_detail clean_ratio=0
-- Catalog completeness: title_track_resolved overall=64.5 pre_2024=62; canonical_mv overall=6.3 pre_2024=3.3; releases.title_track latest 29.1% < 95.0%; release_service_links.youtube_mv latest 10.2% < 80.0%; entities.official_youtube latest 75.3% < 100.0%; entities.official_x latest 97.8% < 100.0%; entities.official_instagram latest 98.9% < 100.0%; releases.title_track recent 0.0% < 85.0%; release_service_links.youtube_mv recent 0.0% < 55.0%; entities.official_youtube recent 72.2% < 95.0%
+- Catalog completeness: title_track_resolved overall=67.9 pre_2024=65.2; canonical_mv overall=8.6 pre_2024=6.4; releases.title_track latest 29.1% < 95.0%; release_service_links.youtube_mv latest 10.2% < 80.0%; entities.official_youtube latest 75.3% < 100.0%; entities.official_x latest 97.8% < 100.0%; entities.official_instagram latest 98.9% < 100.0%; releases.title_track recent 0.0% < 85.0%; release_service_links.youtube_mv recent 0.0% < 55.0%; entities.official_youtube recent 72.2% < 95.0%
 
 ## Category Table
 
 | Category | Weight | Score | Status | Blocker | Primary reason |
 | --- | ---: | ---: | --- | --- | --- |
-| Backend runtime health | 25 | 42 | fail | yes | worker_cadence=fail |
+| Backend runtime health | 25 | 27 | fail | yes | projection_freshness=fail |
 | Backend deploy parity | 20 | 40 | fail | yes | parity_clean=false (latest_verified_release_selection drift=0) |
 | Web backend-only stability | 20 | 57.5 | fail | yes | entity_detail clean_ratio=0.5 |
 | Mobile runtime mode | 15 | 100 | pass | yes | - |
-| Catalog completeness | 20 | 72.9 | fail | yes | title_track_resolved overall=64.5 pre_2024=62 |
+| Catalog completeness | 20 | 75.1 | fail | yes | title_track_resolved overall=67.9 pre_2024=65.2 |
 
 ## Summary Lines
 
-- overall readiness: fail (59.6/100)
-- Backend runtime health: fail (42/100) [BLOCKER] - worker_cadence=fail
+- overall readiness: fail (56.3/100)
+- Backend runtime health: fail (27/100) [BLOCKER] - projection_freshness=fail
 - Backend deploy parity: fail (40/100) [BLOCKER] - parity_clean=false (latest_verified_release_selection drift=0)
 - Web backend-only stability: fail (57.5/100) [BLOCKER] - entity_detail clean_ratio=0.5
 - Mobile runtime mode: pass (100/100) - no blocker reason
-- Catalog completeness: fail (72.9/100) [BLOCKER] - title_track_resolved overall=64.5 pre_2024=62
-- bundle consistency: pass
+- Catalog completeness: fail (75.1/100) [BLOCKER] - title_track_resolved overall=67.9 pre_2024=65.2
+- bundle consistency: fail
 
 ## Evidence Paths
 
@@ -43,7 +43,7 @@ Generated at: 2026-03-11T08:31:07.905Z
 - historical_coverage_report: `backend/reports/historical_release_detail_coverage_report.json`
 - canonical_null_coverage_report: `backend/reports/canonical_null_coverage_report.json`
 - null_coverage_trend_report: `backend/reports/null_coverage_trend_report.json`
-- bundle_report: `reports/report_bundle_metadata.json`
+- bundle_report: `backend/reports/report_bundle_metadata.json`
 - fixture_registry: `backend/fixtures/live_backend_smoke_fixtures.json`
 - backend_deploy_workflow: `.github/workflows/backend-deploy.yml`
 - mobile_runtime_config: `mobile/src/config/runtime.ts`

--- a/backend/reports/runtime_gate_report.json
+++ b/backend/reports/runtime_gate_report.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-03-11T09:17:40.447Z",
+  "generated_at": "2026-03-11T12:19:17.341Z",
   "report_bundle": {
     "generated_at": "2026-03-11T09:16:25.280Z",
     "bundle_id": "post-sync-verification-57fe974c438e",
@@ -74,17 +74,19 @@
     ]
   },
   "bundle_consistency": {
-    "status": "pass",
+    "status": "fail",
     "expected_bundle_id": "post-sync-verification-57fe974c438e",
     "observed": {
       "parity_bundle": "post-sync-verification-57fe974c438e",
       "shadow_bundle": "post-sync-verification-57fe974c438e",
       "runtime_gate_bundle": null,
-      "historical_coverage_generated_at": "2026-03-10T00:00:00.000Z",
+      "historical_coverage_generated_at": "2026-03-11T00:00:00.000Z",
       "canonical_null_coverage_generated_at": "2026-03-11T08:30:30.464Z",
       "null_coverage_trend_generated_at": "2026-03-11T08:30:32.119Z"
     },
-    "mismatches": []
+    "mismatches": [
+      "historical coverage drift (2026-03-11T00:00:00.000Z)"
+    ]
   },
   "thresholds": {
     "latency": {
@@ -122,13 +124,13 @@
   "summary_lines": [
     "api latency: needs_review (worst p95=1148.96ms)",
     "api error rate: needs_review (error rate=0)",
-    "projection freshness: fail (lag=83.71m)",
-    "worker cadence: fail (failure rate=n/a)",
+    "projection freshness: fail (lag=265.33m)",
+    "worker cadence: fail (cadence_status=scheduled_evidence_missing, missed_windows=5)",
     "parity dependency: fail",
     "shadow dependency: fail",
     "historical catalog completeness dependency: fail",
     "critical null coverage dependency: fail",
-    "bundle consistency: pass",
+    "bundle consistency: fail",
     "shadow -> web cutover gate: fail",
     "web cutover -> JSON demotion gate: fail"
   ],
@@ -161,7 +163,7 @@
       "status": "fail",
       "observed": {
         "projection_generated_at": "2026-03-11T07:53:57.809Z",
-        "lag_minutes": 83.71
+        "lag_minutes": 265.33
       },
       "thresholds": {
         "passLagMinutes": 20,
@@ -176,7 +178,28 @@
         "scheduled_failure_rate": null,
         "last_success_age_hours": null,
         "scheduled_runs": 0,
-        "cadence_status": "no_scheduled_sample"
+        "cadence_status": "scheduled_evidence_missing",
+        "scheduled_evidence": {
+          "status": "scheduled_evidence_missing",
+          "reason": "Expected scheduled run windows have elapsed without a recorded scheduled sample.",
+          "cadence_label": "daily",
+          "workflow_created_at": "2026-03-06T07:34:09.000Z",
+          "workflow_updated_at": "2026-03-11T09:25:55.000Z",
+          "workflow_state": "active",
+          "workflow_html_url": "https://github.com/iAmSomething/idol-song-app/blob/main/.github/workflows/weekly-kpop-scan.yml",
+          "parsed_schedule": {
+            "kind": "daily",
+            "minute": 0,
+            "hour": 0
+          },
+          "warmup_grace_hours": 12,
+          "first_expected_run_at": "2026-03-07T00:00:00.000Z",
+          "next_expected_run_at": "2026-03-12T00:00:00.000Z",
+          "warmup_deadline_at": "2026-03-07T12:00:00.000Z",
+          "expected_scheduled_runs_by_now": 5,
+          "observed_scheduled_runs": 0,
+          "missed_scheduled_windows": 5
+        }
       },
       "thresholds": {
         "passFailureRate": 0.1,
@@ -226,12 +249,12 @@
       "status": "fail",
       "observed": {
         "clean": false,
-        "generated_at": "2026-03-10",
+        "generated_at": "2026-03-11",
         "summary_lines": [
           "detail payload gate: pass (total 100.0%, pre-2024 100.0%)",
           "detail trusted gate: pass (total 100.0%, pre-2024 100.0%)",
-          "title-track resolved gate: fail (total 64.5%, pre-2024 62.0%)",
-          "canonical MV gate: fail (total 6.3%, pre-2024 3.3%)"
+          "title-track resolved gate: fail (total 67.8%, pre-2024 65.2%)",
+          "canonical MV gate: fail (total 8.6%, pre-2024 6.4%)"
         ]
       },
       "label": "historical_release_detail_coverage_report"
@@ -487,19 +510,21 @@
       "label": "critical_null_coverage"
     },
     "bundle_consistency": {
-      "status": "pass",
+      "status": "fail",
       "observed": {
-        "status": "pass",
+        "status": "fail",
         "expected_bundle_id": "post-sync-verification-57fe974c438e",
         "observed": {
           "parity_bundle": "post-sync-verification-57fe974c438e",
           "shadow_bundle": "post-sync-verification-57fe974c438e",
           "runtime_gate_bundle": null,
-          "historical_coverage_generated_at": "2026-03-10T00:00:00.000Z",
+          "historical_coverage_generated_at": "2026-03-11T00:00:00.000Z",
           "canonical_null_coverage_generated_at": "2026-03-11T08:30:30.464Z",
           "null_coverage_trend_generated_at": "2026-03-11T08:30:32.119Z"
         },
-        "mismatches": []
+        "mismatches": [
+          "historical coverage drift (2026-03-11T00:00:00.000Z)"
+        ]
       },
       "label": "report_bundle_metadata"
     }

--- a/backend/reports/worker_cadence_report.json
+++ b/backend/reports/worker_cadence_report.json
@@ -1,11 +1,11 @@
 {
-  "generated_at": "2026-03-11T08:30:28.469Z",
+  "generated_at": "2026-03-11T12:15:23.043Z",
   "repo": "iAmSomething/idol-song-app",
   "sample_limit": 12,
   "primary_path_key": "daily_upcoming",
   "summary_lines": [
-    "[primary] daily_upcoming: cadence=daily, status=no_scheduled_sample, scheduled_runs=0, failure_rate=n/a, last_success_age=n/a",
-    "[secondary] catalog_enrichment: cadence=weekly, status=no_scheduled_sample, scheduled_runs=0, failure_rate=n/a, last_success_age=n/a"
+    "[primary] daily_upcoming: cadence=daily, status=scheduled_evidence_missing, observed=0, expected_by_now=5, missed_windows=5",
+    "[secondary] catalog_enrichment: cadence=weekly, status=warming_up, first_due=2026-03-15T01:00:00.000Z, deadline=2026-03-16T01:00:00.000Z"
   ],
   "topology": {
     "daily_upcoming": {
@@ -40,16 +40,23 @@
         "pass_last_success_age_hours": 30,
         "review_last_success_age_hours": 48
       },
-      "cadence_status": "no_scheduled_sample",
+      "workflow_metadata": {
+        "created_at": "2026-03-06T16:34:09.000+09:00",
+        "updated_at": "2026-03-11T18:25:55.000+09:00",
+        "state": "active",
+        "html_url": "https://github.com/iAmSomething/idol-song-app/blob/main/.github/workflows/weekly-kpop-scan.yml"
+      },
+      "cadence_status": "scheduled_evidence_missing",
       "sample_limit": 12,
       "sample_window": {
-        "newest_created_at": "2026-03-11T08:05:17.000Z",
-        "oldest_created_at": "2026-03-11T06:12:53.000Z"
+        "newest_created_at": "2026-03-11T11:52:16.000Z",
+        "oldest_created_at": "2026-03-11T07:59:12.000Z"
       },
       "totals": {
         "all_runs": 12,
         "completed_runs": 12,
         "scheduled_runs": 0,
+        "scheduled_sampled_runs": 0,
         "manual_runs": 12,
         "successful_scheduled_runs": 0,
         "failed_scheduled_runs": 0,
@@ -67,63 +74,85 @@
         "avg_success_gap_hours": null,
         "max_success_gap_hours": null
       },
+      "scheduled_evidence": {
+        "status": "scheduled_evidence_missing",
+        "reason": "Expected scheduled run windows have elapsed without a recorded scheduled sample.",
+        "cadence_label": "daily",
+        "workflow_created_at": "2026-03-06T07:34:09.000Z",
+        "workflow_updated_at": "2026-03-11T09:25:55.000Z",
+        "workflow_state": "active",
+        "workflow_html_url": "https://github.com/iAmSomething/idol-song-app/blob/main/.github/workflows/weekly-kpop-scan.yml",
+        "parsed_schedule": {
+          "kind": "daily",
+          "minute": 0,
+          "hour": 0
+        },
+        "warmup_grace_hours": 12,
+        "first_expected_run_at": "2026-03-07T00:00:00.000Z",
+        "next_expected_run_at": "2026-03-12T00:00:00.000Z",
+        "warmup_deadline_at": "2026-03-07T12:00:00.000Z",
+        "expected_scheduled_runs_by_now": 5,
+        "observed_scheduled_runs": 0,
+        "missed_scheduled_windows": 5
+      },
       "latest_runs": [
         {
-          "database_id": 22942769208,
+          "database_id": 22951215642,
           "event": "push",
           "status": "completed",
           "conclusion": "failure",
-          "created_at": "2026-03-11T08:05:17.000Z",
-          "started_at": "2026-03-11T08:05:17.000Z",
-          "updated_at": "2026-03-11T08:05:17.000Z",
+          "created_at": "2026-03-11T11:52:16.000Z",
+          "started_at": "2026-03-11T11:52:16.000Z",
+          "updated_at": "2026-03-11T11:52:16.000Z",
           "duration_minutes": 0,
-          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22942769208"
+          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22951215642"
         },
         {
-          "database_id": 22942750912,
+          "database_id": 22951195021,
           "event": "push",
           "status": "completed",
           "conclusion": "failure",
-          "created_at": "2026-03-11T08:04:45.000Z",
-          "started_at": "2026-03-11T08:04:45.000Z",
-          "updated_at": "2026-03-11T08:04:45.000Z",
+          "created_at": "2026-03-11T11:51:41.000Z",
+          "started_at": "2026-03-11T11:51:41.000Z",
+          "updated_at": "2026-03-11T11:51:41.000Z",
           "duration_minutes": 0,
-          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22942750912"
+          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22951195021"
         },
         {
-          "database_id": 22942584170,
+          "database_id": 22948835485,
           "event": "push",
           "status": "completed",
           "conclusion": "failure",
-          "created_at": "2026-03-11T07:59:42.000Z",
-          "started_at": "2026-03-11T07:59:42.000Z",
-          "updated_at": "2026-03-11T07:59:42.000Z",
+          "created_at": "2026-03-11T10:47:46.000Z",
+          "started_at": "2026-03-11T10:47:46.000Z",
+          "updated_at": "2026-03-11T10:47:46.000Z",
           "duration_minutes": 0,
-          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22942584170"
+          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22948835485"
         },
         {
-          "database_id": 22942568709,
+          "database_id": 22948800261,
           "event": "push",
           "status": "completed",
           "conclusion": "failure",
-          "created_at": "2026-03-11T07:59:12.000Z",
-          "started_at": "2026-03-11T07:59:12.000Z",
-          "updated_at": "2026-03-11T07:59:12.000Z",
+          "created_at": "2026-03-11T10:46:50.000Z",
+          "started_at": "2026-03-11T10:46:50.000Z",
+          "updated_at": "2026-03-11T10:46:50.000Z",
           "duration_minutes": 0,
-          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22942568709"
+          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22948800261"
         },
         {
-          "database_id": 22941915194,
+          "database_id": 22945665409,
           "event": "push",
           "status": "completed",
           "conclusion": "failure",
-          "created_at": "2026-03-11T07:38:04.000Z",
-          "started_at": "2026-03-11T07:38:04.000Z",
-          "updated_at": "2026-03-11T07:38:04.000Z",
+          "created_at": "2026-03-11T09:25:55.000Z",
+          "started_at": "2026-03-11T09:25:55.000Z",
+          "updated_at": "2026-03-11T09:25:55.000Z",
           "duration_minutes": 0,
-          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22941915194"
+          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22945665409"
         }
-      ]
+      ],
+      "latest_scheduled_runs": []
     },
     "catalog_enrichment": {
       "workflow": "catalog-enrichment-refresh.yml",
@@ -154,17 +183,24 @@
         "pass_last_success_age_hours": 192,
         "review_last_success_age_hours": 240
       },
-      "cadence_status": "no_scheduled_sample",
+      "workflow_metadata": {
+        "created_at": "2026-03-11T16:14:52.000+09:00",
+        "updated_at": "2026-03-11T18:25:54.000+09:00",
+        "state": "active",
+        "html_url": "https://github.com/iAmSomething/idol-song-app/blob/main/.github/workflows/catalog-enrichment-refresh.yml"
+      },
+      "cadence_status": "warming_up",
       "sample_limit": 12,
       "sample_window": {
-        "newest_created_at": "2026-03-11T08:05:17.000Z",
-        "oldest_created_at": "2026-03-11T07:14:52.000Z"
+        "newest_created_at": "2026-03-11T11:52:16.000Z",
+        "oldest_created_at": "2026-03-11T07:59:12.000Z"
       },
       "totals": {
-        "all_runs": 8,
-        "completed_runs": 8,
+        "all_runs": 12,
+        "completed_runs": 12,
         "scheduled_runs": 0,
-        "manual_runs": 8,
+        "scheduled_sampled_runs": 0,
+        "manual_runs": 12,
         "successful_scheduled_runs": 0,
         "failed_scheduled_runs": 0,
         "scheduled_success_rate": null,
@@ -181,74 +217,98 @@
         "avg_success_gap_hours": null,
         "max_success_gap_hours": null
       },
+      "scheduled_evidence": {
+        "status": "warming_up",
+        "reason": "Workflow schedule is configured, but the first scheduled sample window is still in warm-up.",
+        "cadence_label": "weekly",
+        "workflow_created_at": "2026-03-11T07:14:52.000Z",
+        "workflow_updated_at": "2026-03-11T09:25:54.000Z",
+        "workflow_state": "active",
+        "workflow_html_url": "https://github.com/iAmSomething/idol-song-app/blob/main/.github/workflows/catalog-enrichment-refresh.yml",
+        "parsed_schedule": {
+          "kind": "weekly",
+          "minute": 0,
+          "hour": 1,
+          "weekday": 0
+        },
+        "warmup_grace_hours": 24,
+        "first_expected_run_at": "2026-03-15T01:00:00.000Z",
+        "next_expected_run_at": "2026-03-15T01:00:00.000Z",
+        "warmup_deadline_at": "2026-03-16T01:00:00.000Z",
+        "expected_scheduled_runs_by_now": 0,
+        "observed_scheduled_runs": 0,
+        "missed_scheduled_windows": 0
+      },
       "latest_runs": [
         {
-          "database_id": 22942769400,
+          "database_id": 22951215883,
           "event": "push",
           "status": "completed",
           "conclusion": "failure",
-          "created_at": "2026-03-11T08:05:17.000Z",
-          "started_at": "2026-03-11T08:05:17.000Z",
-          "updated_at": "2026-03-11T08:05:17.000Z",
+          "created_at": "2026-03-11T11:52:16.000Z",
+          "started_at": "2026-03-11T11:52:16.000Z",
+          "updated_at": "2026-03-11T11:52:16.000Z",
           "duration_minutes": 0,
-          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22942769400"
+          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22951215883"
         },
         {
-          "database_id": 22942751129,
+          "database_id": 22951194740,
           "event": "push",
           "status": "completed",
           "conclusion": "failure",
-          "created_at": "2026-03-11T08:04:46.000Z",
-          "started_at": "2026-03-11T08:04:46.000Z",
-          "updated_at": "2026-03-11T08:04:46.000Z",
+          "created_at": "2026-03-11T11:51:41.000Z",
+          "started_at": "2026-03-11T11:51:41.000Z",
+          "updated_at": "2026-03-11T11:51:41.000Z",
           "duration_minutes": 0,
-          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22942751129"
+          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22951194740"
         },
         {
-          "database_id": 22942584060,
+          "database_id": 22948835209,
           "event": "push",
           "status": "completed",
           "conclusion": "failure",
-          "created_at": "2026-03-11T07:59:42.000Z",
-          "started_at": "2026-03-11T07:59:42.000Z",
-          "updated_at": "2026-03-11T07:59:42.000Z",
+          "created_at": "2026-03-11T10:47:46.000Z",
+          "started_at": "2026-03-11T10:47:46.000Z",
+          "updated_at": "2026-03-11T10:47:46.000Z",
           "duration_minutes": 0,
-          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22942584060"
+          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22948835209"
         },
         {
-          "database_id": 22942568862,
+          "database_id": 22948800029,
           "event": "push",
           "status": "completed",
           "conclusion": "failure",
-          "created_at": "2026-03-11T07:59:12.000Z",
-          "started_at": "2026-03-11T07:59:12.000Z",
-          "updated_at": "2026-03-11T07:59:12.000Z",
+          "created_at": "2026-03-11T10:46:50.000Z",
+          "started_at": "2026-03-11T10:46:50.000Z",
+          "updated_at": "2026-03-11T10:46:50.000Z",
           "duration_minutes": 0,
-          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22942568862"
+          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22948800029"
         },
         {
-          "database_id": 22941915347,
+          "database_id": 22945665166,
           "event": "push",
           "status": "completed",
           "conclusion": "failure",
-          "created_at": "2026-03-11T07:38:04.000Z",
-          "started_at": "2026-03-11T07:38:04.000Z",
-          "updated_at": "2026-03-11T07:38:04.000Z",
+          "created_at": "2026-03-11T09:25:54.000Z",
+          "started_at": "2026-03-11T09:25:54.000Z",
+          "updated_at": "2026-03-11T09:25:54.000Z",
           "duration_minutes": 0,
-          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22941915347"
+          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22945665166"
         }
-      ]
+      ],
+      "latest_scheduled_runs": []
     }
   },
   "workflow": "weekly-kpop-scan.yml",
   "sample_window": {
-    "newest_created_at": "2026-03-11T08:05:17.000Z",
-    "oldest_created_at": "2026-03-11T06:12:53.000Z"
+    "newest_created_at": "2026-03-11T11:52:16.000Z",
+    "oldest_created_at": "2026-03-11T07:59:12.000Z"
   },
   "totals": {
     "all_runs": 12,
     "completed_runs": 12,
     "scheduled_runs": 0,
+    "scheduled_sampled_runs": 0,
     "manual_runs": 12,
     "successful_scheduled_runs": 0,
     "failed_scheduled_runs": 0,
@@ -266,61 +326,83 @@
     "avg_success_gap_hours": null,
     "max_success_gap_hours": null
   },
+  "scheduled_evidence": {
+    "status": "scheduled_evidence_missing",
+    "reason": "Expected scheduled run windows have elapsed without a recorded scheduled sample.",
+    "cadence_label": "daily",
+    "workflow_created_at": "2026-03-06T07:34:09.000Z",
+    "workflow_updated_at": "2026-03-11T09:25:55.000Z",
+    "workflow_state": "active",
+    "workflow_html_url": "https://github.com/iAmSomething/idol-song-app/blob/main/.github/workflows/weekly-kpop-scan.yml",
+    "parsed_schedule": {
+      "kind": "daily",
+      "minute": 0,
+      "hour": 0
+    },
+    "warmup_grace_hours": 12,
+    "first_expected_run_at": "2026-03-07T00:00:00.000Z",
+    "next_expected_run_at": "2026-03-12T00:00:00.000Z",
+    "warmup_deadline_at": "2026-03-07T12:00:00.000Z",
+    "expected_scheduled_runs_by_now": 5,
+    "observed_scheduled_runs": 0,
+    "missed_scheduled_windows": 5
+  },
   "latest_runs": [
     {
-      "database_id": 22942769208,
+      "database_id": 22951215642,
       "event": "push",
       "status": "completed",
       "conclusion": "failure",
-      "created_at": "2026-03-11T08:05:17.000Z",
-      "started_at": "2026-03-11T08:05:17.000Z",
-      "updated_at": "2026-03-11T08:05:17.000Z",
+      "created_at": "2026-03-11T11:52:16.000Z",
+      "started_at": "2026-03-11T11:52:16.000Z",
+      "updated_at": "2026-03-11T11:52:16.000Z",
       "duration_minutes": 0,
-      "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22942769208"
+      "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22951215642"
     },
     {
-      "database_id": 22942750912,
+      "database_id": 22951195021,
       "event": "push",
       "status": "completed",
       "conclusion": "failure",
-      "created_at": "2026-03-11T08:04:45.000Z",
-      "started_at": "2026-03-11T08:04:45.000Z",
-      "updated_at": "2026-03-11T08:04:45.000Z",
+      "created_at": "2026-03-11T11:51:41.000Z",
+      "started_at": "2026-03-11T11:51:41.000Z",
+      "updated_at": "2026-03-11T11:51:41.000Z",
       "duration_minutes": 0,
-      "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22942750912"
+      "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22951195021"
     },
     {
-      "database_id": 22942584170,
+      "database_id": 22948835485,
       "event": "push",
       "status": "completed",
       "conclusion": "failure",
-      "created_at": "2026-03-11T07:59:42.000Z",
-      "started_at": "2026-03-11T07:59:42.000Z",
-      "updated_at": "2026-03-11T07:59:42.000Z",
+      "created_at": "2026-03-11T10:47:46.000Z",
+      "started_at": "2026-03-11T10:47:46.000Z",
+      "updated_at": "2026-03-11T10:47:46.000Z",
       "duration_minutes": 0,
-      "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22942584170"
+      "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22948835485"
     },
     {
-      "database_id": 22942568709,
+      "database_id": 22948800261,
       "event": "push",
       "status": "completed",
       "conclusion": "failure",
-      "created_at": "2026-03-11T07:59:12.000Z",
-      "started_at": "2026-03-11T07:59:12.000Z",
-      "updated_at": "2026-03-11T07:59:12.000Z",
+      "created_at": "2026-03-11T10:46:50.000Z",
+      "started_at": "2026-03-11T10:46:50.000Z",
+      "updated_at": "2026-03-11T10:46:50.000Z",
       "duration_minutes": 0,
-      "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22942568709"
+      "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22948800261"
     },
     {
-      "database_id": 22941915194,
+      "database_id": 22945665409,
       "event": "push",
       "status": "completed",
       "conclusion": "failure",
-      "created_at": "2026-03-11T07:38:04.000Z",
-      "started_at": "2026-03-11T07:38:04.000Z",
-      "updated_at": "2026-03-11T07:38:04.000Z",
+      "created_at": "2026-03-11T09:25:55.000Z",
+      "started_at": "2026-03-11T09:25:55.000Z",
+      "updated_at": "2026-03-11T09:25:55.000Z",
       "duration_minutes": 0,
-      "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22941915194"
+      "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22945665409"
     }
-  ]
+  ],
+  "latest_scheduled_runs": []
 }

--- a/backend/scripts/build-runtime-gate-report.mjs
+++ b/backend/scripts/build-runtime-gate-report.mjs
@@ -210,6 +210,41 @@ function buildWorkerCadenceGate(cadenceReport) {
   const observedSource = primaryPath ?? cadenceReport;
   const failureRate = observedSource?.totals?.scheduled_failure_rate;
   const lastSuccessAgeHours = observedSource?.cadence?.last_success_age_hours;
+  const cadenceStatus = observedSource?.cadence_status ?? null;
+  const scheduledEvidence = observedSource?.scheduled_evidence ?? null;
+
+  if (cadenceStatus === 'warming_up') {
+    return {
+      status: 'needs_review',
+      observed: {
+        primary_path_key: primaryPathKey,
+        cadence_label: observedSource?.cadence_label ?? null,
+        scheduled_failure_rate: failureRate ?? null,
+        last_success_age_hours: lastSuccessAgeHours ?? null,
+        scheduled_runs: observedSource?.totals?.scheduled_runs ?? 0,
+        cadence_status: cadenceStatus,
+        scheduled_evidence: scheduledEvidence,
+      },
+      thresholds: GATE_THRESHOLDS.workerCadence,
+    };
+  }
+
+  if (cadenceStatus === 'scheduled_evidence_missing' || cadenceStatus === 'workflow_not_registered') {
+    return {
+      status: 'fail',
+      observed: {
+        primary_path_key: primaryPathKey,
+        cadence_label: observedSource?.cadence_label ?? null,
+        scheduled_failure_rate: failureRate ?? null,
+        last_success_age_hours: lastSuccessAgeHours ?? null,
+        scheduled_runs: observedSource?.totals?.scheduled_runs ?? 0,
+        cadence_status: cadenceStatus,
+        scheduled_evidence: scheduledEvidence,
+      },
+      thresholds: GATE_THRESHOLDS.workerCadence,
+    };
+  }
+
   const pass =
     typeof failureRate === 'number' &&
     typeof lastSuccessAgeHours === 'number' &&
@@ -229,7 +264,8 @@ function buildWorkerCadenceGate(cadenceReport) {
       scheduled_failure_rate: failureRate ?? null,
       last_success_age_hours: lastSuccessAgeHours ?? null,
       scheduled_runs: observedSource?.totals?.scheduled_runs ?? 0,
-      cadence_status: observedSource?.cadence_status ?? null,
+      cadence_status: cadenceStatus,
+      scheduled_evidence: scheduledEvidence,
     },
     thresholds: GATE_THRESHOLDS.workerCadence,
   };
@@ -357,7 +393,11 @@ async function main() {
     `api latency: ${runtimeChecks.api_latency.status} (worst p95=${runtimeChecks.api_latency.observed.worst_case_p95_ms ?? 'n/a'}ms)`,
     `api error rate: ${runtimeChecks.api_error_rate.status} (error rate=${runtimeChecks.api_error_rate.observed.overall_error_rate ?? 'n/a'})`,
     `projection freshness: ${runtimeChecks.projection_freshness.status} (lag=${runtimeChecks.projection_freshness.observed.lag_minutes ?? 'n/a'}m)`,
-    `worker cadence: ${runtimeChecks.worker_cadence.status} (failure rate=${runtimeChecks.worker_cadence.observed.scheduled_failure_rate ?? 'n/a'})`,
+    runtimeChecks.worker_cadence.observed.cadence_status === 'warming_up'
+      ? `worker cadence: ${runtimeChecks.worker_cadence.status} (cadence_status=warming_up, deadline=${runtimeChecks.worker_cadence.observed.scheduled_evidence?.warmup_deadline_at ?? 'n/a'})`
+      : runtimeChecks.worker_cadence.observed.cadence_status === 'scheduled_evidence_missing'
+        ? `worker cadence: ${runtimeChecks.worker_cadence.status} (cadence_status=scheduled_evidence_missing, missed_windows=${runtimeChecks.worker_cadence.observed.scheduled_evidence?.missed_scheduled_windows ?? 'n/a'})`
+        : `worker cadence: ${runtimeChecks.worker_cadence.status} (failure rate=${runtimeChecks.worker_cadence.observed.scheduled_failure_rate ?? 'n/a'})`,
     `parity dependency: ${dependencyChecks.parity.status}`,
     `shadow dependency: ${dependencyChecks.shadow.status}`,
     `historical catalog completeness dependency: ${dependencyChecks.historical_catalog_completeness.status}`,

--- a/backend/scripts/build-worker-cadence-report.mjs
+++ b/backend/scripts/build-worker-cadence-report.mjs
@@ -5,6 +5,8 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { promisify } from 'node:util';
 
+import { buildScheduledEvidenceSummary } from './lib/workerCadenceEvidence.mjs';
+
 const execFileAsync = promisify(execFile);
 const DEFAULT_LIMIT = 12;
 const DEFAULT_REPO = 'iAmSomething/idol-song-app';
@@ -172,21 +174,17 @@ function average(values) {
 
 async function fetchWorkflowRuns({ repo, workflow, limit }) {
   try {
-    const { stdout } = await execFileAsync('gh', [
-      'api',
-      `repos/${repo}/actions/workflows/${workflow}/runs?per_page=${limit}`,
-      '--jq',
-      '.workflow_runs',
-    ]);
+    const { stdout } = await execFileAsync('gh', ['api', `repos/${repo}/actions/workflows/${workflow}/runs?per_page=${limit}`]);
     return {
       workflow_registered: true,
-      runs: JSON.parse(stdout),
+      ...JSON.parse(stdout),
     };
   } catch (error) {
     const stderr = `${error?.stderr ?? ''}`;
     if (stderr.includes('404')) {
       return {
         workflow_registered: false,
+        total_count: 0,
         runs: [],
       };
     }
@@ -194,12 +192,57 @@ async function fetchWorkflowRuns({ repo, workflow, limit }) {
   }
 }
 
-function summarizeRuns(runs) {
-  const completedRuns = runs.filter((run) => run.status === 'completed');
-  const scheduledRuns = completedRuns.filter((run) => run.event === 'schedule');
+async function fetchScheduledWorkflowRuns({ repo, workflow, limit }) {
+  try {
+    const { stdout } = await execFileAsync('gh', [
+      'api',
+      `repos/${repo}/actions/workflows/${workflow}/runs?per_page=${limit}&event=schedule`,
+    ]);
+    return {
+      workflow_registered: true,
+      ...JSON.parse(stdout),
+    };
+  } catch (error) {
+    const stderr = `${error?.stderr ?? ''}`;
+    if (stderr.includes('404')) {
+      return {
+        workflow_registered: false,
+        total_count: 0,
+        runs: [],
+      };
+    }
+    throw error;
+  }
+}
+
+async function fetchWorkflowMetadata({ repo, workflow }) {
+  try {
+    const { stdout } = await execFileAsync('gh', ['api', `repos/${repo}/actions/workflows/${workflow}`]);
+    return {
+      workflow_registered: true,
+      ...JSON.parse(stdout),
+    };
+  } catch (error) {
+    const stderr = `${error?.stderr ?? ''}`;
+    if (stderr.includes('404')) {
+      return {
+        workflow_registered: false,
+        created_at: null,
+        updated_at: null,
+        state: null,
+        html_url: null,
+      };
+    }
+    throw error;
+  }
+}
+
+function summarizeRuns({ overallRuns, scheduledRuns, scheduledTotalCount }) {
+  const completedRuns = overallRuns.filter((run) => run.status === 'completed');
+  const completedScheduledRuns = scheduledRuns.filter((run) => run.status === 'completed');
   const manualRuns = completedRuns.filter((run) => run.event !== 'schedule');
-  const successRuns = scheduledRuns.filter((run) => run.conclusion === 'success');
-  const failureRuns = scheduledRuns.filter((run) => run.conclusion && run.conclusion !== 'success');
+  const successRuns = completedScheduledRuns.filter((run) => run.conclusion === 'success');
+  const failureRuns = completedScheduledRuns.filter((run) => run.conclusion && run.conclusion !== 'success');
   const durations = completedRuns
     .map((run) => minutesBetween(run.run_started_at ?? run.created_at, run.updated_at))
     .filter((value) => value !== null);
@@ -221,20 +264,21 @@ function summarizeRuns(runs) {
 
   return {
     sample_window: {
-      newest_created_at: runs[0] ? toIsoString(runs[0].created_at) : null,
-      oldest_created_at: runs.at(-1) ? toIsoString(runs.at(-1).created_at) : null,
+      newest_created_at: overallRuns[0] ? toIsoString(overallRuns[0].created_at) : null,
+      oldest_created_at: overallRuns.at(-1) ? toIsoString(overallRuns.at(-1).created_at) : null,
     },
     totals: {
-      all_runs: runs.length,
+      all_runs: overallRuns.length,
       completed_runs: completedRuns.length,
-      scheduled_runs: scheduledRuns.length,
+      scheduled_runs: scheduledTotalCount,
+      scheduled_sampled_runs: completedScheduledRuns.length,
       manual_runs: manualRuns.length,
       successful_scheduled_runs: successRuns.length,
       failed_scheduled_runs: failureRuns.length,
       scheduled_success_rate:
-        scheduledRuns.length === 0 ? null : Number((successRuns.length / scheduledRuns.length).toFixed(4)),
+        completedScheduledRuns.length === 0 ? null : Number((successRuns.length / completedScheduledRuns.length).toFixed(4)),
       scheduled_failure_rate:
-        scheduledRuns.length === 0 ? null : Number((failureRuns.length / scheduledRuns.length).toFixed(4)),
+        completedScheduledRuns.length === 0 ? null : Number((failureRuns.length / completedScheduledRuns.length).toFixed(4)),
     },
     duration_minutes: {
       avg: average(durations),
@@ -247,7 +291,18 @@ function summarizeRuns(runs) {
       avg_success_gap_hours: average(gapHours),
       max_success_gap_hours: gapHours.length ? Number(Math.max(...gapHours).toFixed(2)) : null,
     },
-    latest_runs: runs.slice(0, 5).map((run) => ({
+    latest_runs: overallRuns.slice(0, 5).map((run) => ({
+      database_id: run.id,
+      event: run.event,
+      status: run.status,
+      conclusion: run.conclusion,
+      created_at: toIsoString(run.created_at),
+      started_at: toIsoString(run.run_started_at ?? run.created_at),
+      updated_at: toIsoString(run.updated_at),
+      duration_minutes: minutesBetween(run.run_started_at ?? run.created_at, run.updated_at),
+      html_url: run.html_url ?? null,
+    })),
+    latest_scheduled_runs: scheduledRuns.slice(0, 5).map((run) => ({
       database_id: run.id,
       event: run.event,
       status: run.status,
@@ -261,9 +316,20 @@ function summarizeRuns(runs) {
   };
 }
 
-function buildPathReport(config, workflowData, sampleLimit) {
-  const summary = summarizeRuns(workflowData.runs);
+function buildPathReport(config, workflowData, scheduledWorkflowData, workflowMetadata, sampleLimit) {
+  const summary = summarizeRuns({
+    overallRuns: workflowData.workflow_runs ?? [],
+    scheduledRuns: scheduledWorkflowData.workflow_runs ?? [],
+    scheduledTotalCount: scheduledWorkflowData.total_count ?? 0,
+  });
   const lastSuccessAgeHours = summary.cadence.last_success_age_hours;
+  const scheduledEvidence = buildScheduledEvidenceSummary({
+    workflowRegistered: workflowData.workflow_registered && workflowMetadata.workflow_registered,
+    workflowMetadata,
+    cadenceLabel: config.cadence_label,
+    scheduleExpectation: config.schedule_expectation,
+    observedScheduledRuns: summary.totals.scheduled_runs,
+  });
 
   return {
     key: config.key,
@@ -276,12 +342,19 @@ function buildPathReport(config, workflowData, sampleLimit) {
     summary_artifacts: config.summary_artifacts,
     thresholds: config.thresholds,
     sample_limit: sampleLimit,
+    workflow_metadata: {
+      created_at: workflowMetadata.created_at ?? null,
+      updated_at: workflowMetadata.updated_at ?? null,
+      state: workflowMetadata.state ?? null,
+      html_url: workflowMetadata.html_url ?? null,
+    },
     ...summary,
+    scheduled_evidence: scheduledEvidence,
     cadence_status:
       !workflowData.workflow_registered
         ? 'workflow_not_registered'
         : summary.totals.scheduled_runs === 0
-          ? 'no_scheduled_sample'
+          ? scheduledEvidence.status
           : typeof lastSuccessAgeHours === 'number' &&
               lastSuccessAgeHours <= config.thresholds.pass_last_success_age_hours
             ? 'pass'
@@ -300,6 +373,12 @@ function buildSummaryLines(paths, primaryPathKey) {
       typeof entry.totals.scheduled_failure_rate === 'number' ? entry.totals.scheduled_failure_rate : 'n/a';
     const lastSuccessAge =
       typeof entry.cadence.last_success_age_hours === 'number' ? `${entry.cadence.last_success_age_hours}h` : 'n/a';
+    if (entry.cadence_status === 'warming_up') {
+      return `${prefix} ${entry.key}: cadence=${entry.cadence_label}, status=warming_up, first_due=${entry.scheduled_evidence.first_expected_run_at ?? 'n/a'}, deadline=${entry.scheduled_evidence.warmup_deadline_at ?? 'n/a'}`;
+    }
+    if (entry.cadence_status === 'scheduled_evidence_missing') {
+      return `${prefix} ${entry.key}: cadence=${entry.cadence_label}, status=scheduled_evidence_missing, observed=${entry.scheduled_evidence.observed_scheduled_runs}, expected_by_now=${entry.scheduled_evidence.expected_scheduled_runs_by_now}, missed_windows=${entry.scheduled_evidence.missed_scheduled_windows}`;
+    }
     return `${prefix} ${entry.key}: cadence=${entry.cadence_label}, status=${entry.cadence_status}, scheduled_runs=${scheduledRuns}, failure_rate=${failureRate}, last_success_age=${lastSuccessAge}`;
   });
 }
@@ -308,12 +387,23 @@ async function main() {
   const options = parseArgs(process.argv.slice(2));
   const pathReports = await Promise.all(
     options.workflowConfigs.map(async (config) => {
-      const workflowData = await fetchWorkflowRuns({
-        repo: options.repo,
-        workflow: config.workflow,
-        limit: options.limit,
-      });
-      return buildPathReport(config, workflowData, options.limit);
+      const [workflowData, scheduledWorkflowData, workflowMetadata] = await Promise.all([
+        fetchWorkflowRuns({
+          repo: options.repo,
+          workflow: config.workflow,
+          limit: options.limit,
+        }),
+        fetchScheduledWorkflowRuns({
+          repo: options.repo,
+          workflow: config.workflow,
+          limit: options.limit,
+        }),
+        fetchWorkflowMetadata({
+          repo: options.repo,
+          workflow: config.workflow,
+        }),
+      ]);
+      return buildPathReport(config, workflowData, scheduledWorkflowData, workflowMetadata, options.limit);
     }),
   );
 
@@ -334,13 +424,16 @@ async function main() {
         responsibilities: entry.responsibilities,
         summary_artifacts: entry.summary_artifacts,
         thresholds: entry.thresholds,
+        workflow_metadata: entry.workflow_metadata,
         cadence_status: entry.cadence_status,
         sample_limit: entry.sample_limit,
         sample_window: entry.sample_window,
         totals: entry.totals,
         duration_minutes: entry.duration_minutes,
         cadence: entry.cadence,
+        scheduled_evidence: entry.scheduled_evidence,
         latest_runs: entry.latest_runs,
+        latest_scheduled_runs: entry.latest_scheduled_runs,
       },
     ]),
   );
@@ -357,7 +450,9 @@ async function main() {
     totals: primaryPath.totals,
     duration_minutes: primaryPath.duration_minutes,
     cadence: primaryPath.cadence,
+    scheduled_evidence: primaryPath.scheduled_evidence,
     latest_runs: primaryPath.latest_runs,
+    latest_scheduled_runs: primaryPath.latest_scheduled_runs,
   };
 
   await mkdir(dirname(options.reportPath), { recursive: true });

--- a/backend/scripts/lib/workerCadenceEvidence.mjs
+++ b/backend/scripts/lib/workerCadenceEvidence.mjs
@@ -1,0 +1,176 @@
+const WARMUP_GRACE_HOURS_BY_CADENCE = {
+  daily: 12,
+  weekly: 24,
+  custom: 12,
+};
+
+function parseNumber(value) {
+  return /^\d+$/.test(String(value ?? '')) ? Number(value) : null;
+}
+
+function toDate(value) {
+  const parsed = new Date(value ?? '');
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function toIsoString(value) {
+  const parsed = value instanceof Date ? value : toDate(value);
+  return parsed ? parsed.toISOString() : null;
+}
+
+export function parseScheduleExpectation(cron) {
+  const parts = String(cron ?? '')
+    .trim()
+    .split(/\s+/);
+  if (parts.length !== 5) {
+    return null;
+  }
+
+  const [minuteToken, hourToken, dayOfMonthToken, monthToken, dayOfWeekToken] = parts;
+  const minute = parseNumber(minuteToken);
+  const hour = parseNumber(hourToken);
+  if (minute === null || hour === null || dayOfMonthToken !== '*' || monthToken !== '*') {
+    return null;
+  }
+
+  if (dayOfWeekToken === '*') {
+    return {
+      kind: 'daily',
+      minute,
+      hour,
+    };
+  }
+
+  const weekday = parseNumber(dayOfWeekToken);
+  if (weekday === null || weekday < 0 || weekday > 6) {
+    return null;
+  }
+
+  return {
+    kind: 'weekly',
+    minute,
+    hour,
+    weekday,
+  };
+}
+
+export function nextScheduledOccurrenceAfter(referenceValue, parsedSchedule) {
+  const reference = toDate(referenceValue);
+  if (!reference || !parsedSchedule) {
+    return null;
+  }
+
+  const candidate = new Date(reference.getTime());
+  candidate.setUTCSeconds(0, 0);
+  candidate.setUTCHours(parsedSchedule.hour, parsedSchedule.minute, 0, 0);
+
+  if (parsedSchedule.kind === 'daily') {
+    if (candidate <= reference) {
+      candidate.setUTCDate(candidate.getUTCDate() + 1);
+    }
+    return candidate;
+  }
+
+  if (parsedSchedule.kind === 'weekly') {
+    const currentWeekday = candidate.getUTCDay();
+    let dayOffset = parsedSchedule.weekday - currentWeekday;
+    if (dayOffset < 0 || (dayOffset === 0 && candidate <= reference)) {
+      dayOffset += 7;
+    }
+    candidate.setUTCDate(candidate.getUTCDate() + dayOffset);
+    return candidate;
+  }
+
+  return null;
+}
+
+export function countExpectedScheduledRunsByNow({
+  firstExpectedRunAt,
+  parsedSchedule,
+  now = new Date(),
+}) {
+  const firstExpected = toDate(firstExpectedRunAt);
+  const currentTime = toDate(now);
+  if (!firstExpected || !currentTime || !parsedSchedule || firstExpected > currentTime) {
+    return 0;
+  }
+
+  let count = 0;
+  let cursor = firstExpected;
+  const stepDays = parsedSchedule.kind === 'weekly' ? 7 : 1;
+
+  while (cursor <= currentTime) {
+    count += 1;
+    const next = new Date(cursor.getTime());
+    next.setUTCDate(next.getUTCDate() + stepDays);
+    cursor = next;
+  }
+
+  return count;
+}
+
+export function buildScheduledEvidenceSummary({
+  workflowRegistered,
+  workflowMetadata,
+  cadenceLabel,
+  scheduleExpectation,
+  observedScheduledRuns,
+  now = new Date(),
+}) {
+  const normalizedObservedRuns = Number.isInteger(observedScheduledRuns) && observedScheduledRuns > 0 ? observedScheduledRuns : 0;
+  const parsedSchedule = parseScheduleExpectation(scheduleExpectation);
+  const workflowCreatedAt = toDate(workflowMetadata?.created_at);
+  const nowDate = toDate(now);
+  const warmupGraceHours = WARMUP_GRACE_HOURS_BY_CADENCE[cadenceLabel] ?? WARMUP_GRACE_HOURS_BY_CADENCE.custom;
+  const firstExpectedRunAt =
+    workflowRegistered && workflowCreatedAt && parsedSchedule
+      ? nextScheduledOccurrenceAfter(workflowCreatedAt, parsedSchedule)
+      : null;
+  const nextExpectedRunAt =
+    workflowRegistered && nowDate && parsedSchedule ? nextScheduledOccurrenceAfter(nowDate, parsedSchedule) : null;
+  const warmupDeadlineAt =
+    firstExpectedRunAt !== null
+      ? new Date(firstExpectedRunAt.getTime() + warmupGraceHours * 60 * 60 * 1000)
+      : null;
+  const expectedScheduledRunsByNow = countExpectedScheduledRunsByNow({
+    firstExpectedRunAt,
+    parsedSchedule,
+    now: nowDate,
+  });
+  const missedScheduledWindows = Math.max(expectedScheduledRunsByNow - normalizedObservedRuns, 0);
+
+  let status = 'no_scheduled_sample';
+  let reason = 'No scheduled sample was found.';
+
+  if (!workflowRegistered) {
+    status = 'workflow_not_registered';
+    reason = 'Workflow is not registered in GitHub Actions.';
+  } else if (normalizedObservedRuns > 0) {
+    status = 'has_scheduled_evidence';
+    reason = 'Scheduled cadence evidence is present.';
+  } else if (warmupDeadlineAt && nowDate && nowDate <= warmupDeadlineAt) {
+    status = 'warming_up';
+    reason = 'Workflow schedule is configured, but the first scheduled sample window is still in warm-up.';
+  } else if (firstExpectedRunAt && expectedScheduledRunsByNow > 0) {
+    status = 'scheduled_evidence_missing';
+    reason = 'Expected scheduled run windows have elapsed without a recorded scheduled sample.';
+  }
+
+  return {
+    status,
+    reason,
+    cadence_label: cadenceLabel ?? null,
+    workflow_created_at: toIsoString(workflowCreatedAt),
+    workflow_updated_at: toIsoString(workflowMetadata?.updated_at),
+    workflow_state: workflowMetadata?.state ?? null,
+    workflow_html_url: workflowMetadata?.html_url ?? null,
+    parsed_schedule: parsedSchedule,
+    warmup_grace_hours: warmupGraceHours,
+    first_expected_run_at: toIsoString(firstExpectedRunAt),
+    next_expected_run_at: toIsoString(nextExpectedRunAt),
+    warmup_deadline_at: toIsoString(warmupDeadlineAt),
+    expected_scheduled_runs_by_now: expectedScheduledRunsByNow,
+    observed_scheduled_runs: normalizedObservedRuns,
+    missed_scheduled_windows: missedScheduledWindows,
+  };
+}

--- a/backend/scripts/lib/workerCadenceEvidence.test.mjs
+++ b/backend/scripts/lib/workerCadenceEvidence.test.mjs
@@ -1,0 +1,91 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildScheduledEvidenceSummary,
+  countExpectedScheduledRunsByNow,
+  nextScheduledOccurrenceAfter,
+  parseScheduleExpectation,
+} from './workerCadenceEvidence.mjs';
+
+test('parseScheduleExpectation supports daily and weekly cron schedules used by workers', () => {
+  assert.deepEqual(parseScheduleExpectation('0 0 * * *'), {
+    kind: 'daily',
+    minute: 0,
+    hour: 0,
+  });
+  assert.deepEqual(parseScheduleExpectation('0 1 * * 0'), {
+    kind: 'weekly',
+    minute: 0,
+    hour: 1,
+    weekday: 0,
+  });
+  assert.equal(parseScheduleExpectation('0 1 1 * *'), null);
+});
+
+test('nextScheduledOccurrenceAfter returns the next daily or weekly slot in UTC', () => {
+  const daily = parseScheduleExpectation('0 0 * * *');
+  const weekly = parseScheduleExpectation('0 1 * * 0');
+
+  assert.equal(
+    nextScheduledOccurrenceAfter('2026-03-06T07:34:09.000Z', daily)?.toISOString(),
+    '2026-03-07T00:00:00.000Z',
+  );
+  assert.equal(
+    nextScheduledOccurrenceAfter('2026-03-11T07:14:52.000Z', weekly)?.toISOString(),
+    '2026-03-15T01:00:00.000Z',
+  );
+});
+
+test('countExpectedScheduledRunsByNow counts elapsed schedule windows from the first due time', () => {
+  const daily = parseScheduleExpectation('0 0 * * *');
+  assert.equal(
+    countExpectedScheduledRunsByNow({
+      firstExpectedRunAt: '2026-03-07T00:00:00.000Z',
+      parsedSchedule: daily,
+      now: '2026-03-11T08:30:00.000Z',
+    }),
+    5,
+  );
+});
+
+test('buildScheduledEvidenceSummary marks daily cadence as missing after several missed windows', () => {
+  const summary = buildScheduledEvidenceSummary({
+    workflowRegistered: true,
+    workflowMetadata: {
+      created_at: '2026-03-06T07:34:09.000Z',
+      updated_at: '2026-03-11T09:25:55.000Z',
+      state: 'active',
+      html_url: 'https://github.com/example/weekly-kpop-scan',
+    },
+    cadenceLabel: 'daily',
+    scheduleExpectation: '0 0 * * *',
+    observedScheduledRuns: 0,
+    now: '2026-03-11T08:30:00.000Z',
+  });
+
+  assert.equal(summary.status, 'scheduled_evidence_missing');
+  assert.equal(summary.expected_scheduled_runs_by_now, 5);
+  assert.equal(summary.missed_scheduled_windows, 5);
+});
+
+test('buildScheduledEvidenceSummary keeps weekly cadence in warm-up before the first due window', () => {
+  const summary = buildScheduledEvidenceSummary({
+    workflowRegistered: true,
+    workflowMetadata: {
+      created_at: '2026-03-11T07:14:52.000Z',
+      updated_at: '2026-03-11T09:25:54.000Z',
+      state: 'active',
+      html_url: 'https://github.com/example/catalog-enrichment-refresh',
+    },
+    cadenceLabel: 'weekly',
+    scheduleExpectation: '0 1 * * 0',
+    observedScheduledRuns: 0,
+    now: '2026-03-11T08:30:00.000Z',
+  });
+
+  assert.equal(summary.status, 'warming_up');
+  assert.equal(summary.expected_scheduled_runs_by_now, 0);
+  assert.equal(summary.missed_scheduled_windows, 0);
+  assert.equal(summary.first_expected_run_at, '2026-03-15T01:00:00.000Z');
+});

--- a/docs/assets/distribution/backend_worker_cadence_warmup_local_2026-03-11.md
+++ b/docs/assets/distribution/backend_worker_cadence_warmup_local_2026-03-11.md
@@ -1,0 +1,45 @@
+# Backend Worker Cadence Warm-up Local Evidence
+
+- date: 2026-03-11
+- issue: #530
+- branch: `codex/dev/530-worker-cadence-warmup`
+
+## Commands
+
+```bash
+cd backend
+node --test ./scripts/lib/workerCadenceEvidence.test.mjs
+npm run worker:cadence
+npm run report:bundle -- --bundle-kind post-sync-verification --cadence-profile daily-upcoming
+npm run runtime:gate
+npm run migration:scorecard
+```
+
+## Observed worker cadence evidence
+
+- `daily_upcoming`
+  - `cadence_status=scheduled_evidence_missing`
+  - `first_expected_run_at=2026-03-07T00:00:00.000Z`
+  - `expected_scheduled_runs_by_now=5`
+  - `observed_scheduled_runs=0`
+  - `missed_scheduled_windows=5`
+- `catalog_enrichment`
+  - `cadence_status=warming_up`
+  - `first_expected_run_at=2026-03-15T01:00:00.000Z`
+  - `warmup_deadline_at=2026-03-16T01:00:00.000Z`
+  - `expected_scheduled_runs_by_now=0`
+
+## Runtime / readiness interpretation
+
+- `runtime_gate_report.json`
+  - worker cadence summary line: `worker cadence: fail (cadence_status=scheduled_evidence_missing, missed_windows=5)`
+- `migration_readiness_scorecard.json`
+  - backend runtime blocker reasons keep `worker_cadence=fail`
+  - previous null-style reading is gone; summary now points to `scheduled_evidence_missing`
+
+## Notes
+
+- This issue does not make runtime health pass.
+- It replaces the null-based cadence failure with schedule-aware evidence:
+  - warm-up when the first scheduled window has not matured
+  - explicit missing evidence when scheduled windows have elapsed without a sample

--- a/docs/specs/backend/migration-operations-runbook.md
+++ b/docs/specs/backend/migration-operations-runbook.md
@@ -134,6 +134,8 @@ cd ..
 - shadow clean이 아니면 cutover advance를 멈춘다.
 - runtime gate가 `fail`이면 refresh는 끝났더라도 cutover 근거로 쓰지 않는다.
 - migration readiness scorecard에서 blocker-grade category가 `fail`이면 milestone / cutover decision을 advance하지 않는다.
+- worker cadence가 `warming_up`면 first due / deadline을 보고 다음 scheduled sample을 기다린다.
+- worker cadence가 `scheduled_evidence_missing`면 `scheduled_runs=0` 자체가 아니라 "expected window를 놓쳤다"는 의미로 보고, workflow enablement / schedule delivery부터 확인한다.
 
 ## 6. Representative Refresh Path
 

--- a/docs/specs/backend/migration-runtime-gates.md
+++ b/docs/specs/backend/migration-runtime-gates.md
@@ -47,6 +47,15 @@ runtime gate는 아래 산출물을 기본 입력으로 사용한다.
 - `fail`
   - 해당 phase advance를 막는 상태
 
+worker cadence evidence에는 gate 상태와 별개로 아래 cadence status를 함께 남긴다.
+
+- `warming_up`
+  - workflow schedule은 설정됐지만, 첫 scheduled sample window가 아직 도래하지 않았거나 grace 안에 있다
+  - runtime gate에서는 `needs_review`로 해석한다
+- `scheduled_evidence_missing`
+  - 첫 scheduled sample window와 warm-up grace가 지난 뒤에도 scheduled sample이 기록되지 않았다
+  - runtime gate에서는 `fail`로 해석한다
+
 ## 5. Gate Definitions
 
 ### 5.1 API Latency
@@ -109,6 +118,9 @@ runtime gate는 아래 산출물을 기본 입력으로 사용한다.
 
 - `daily_upcoming` fast path와 `catalog_enrichment` slow path가 같이 기록된 `worker_cadence_report.json`
 - runtime gate는 `daily_upcoming` path를 freshness primary evidence로 사용
+- scheduled event 전용 sample
+- workflow metadata(`created_at`, `updated_at`, `state`, `html_url`)
+- expected scheduled window 계산값(`first_expected_run_at`, `expected_scheduled_runs_by_now`, `missed_scheduled_windows`)
 - scheduled run failure rate
 - last successful scheduled run age
 
@@ -123,6 +135,10 @@ runtime gate는 아래 산출물을 기본 입력으로 사용한다.
 - fast path는 daily cadence를 전제로 하므로, 마지막 성공 run이 하루를 크게 넘기면 freshness trust가 떨어진다
 - slow path는 historical enrichment / readiness evidence용으로 separate cadence를 가진다
 - preview에서는 cadence가 production보다 낮아도 되지만, rehearsal 직전에는 같은 순서로 한 번 이상 검증한다
+- scheduled sample이 0건이어도 바로 null-based fail로 보지 않는다
+  - 첫 scheduled run이 아직 오지 않았으면 `warming_up`
+  - expected scheduled window가 이미 여러 번 지났으면 `scheduled_evidence_missing`
+- `scheduled_evidence_missing`는 "evidence가 부족하다"가 아니라 "예상된 scheduled execution이 관측되지 않았다"는 운영 실패 신호다
 
 ### 5.5 Report Bundle Consistency
 


### PR DESCRIPTION
## Summary
- add schedule-aware cadence evidence for worker reports using workflow metadata and schedule-only samples
- classify zero-scheduled-sample cases as `warming_up` or `scheduled_evidence_missing` instead of raw null-based output
- feed the new cadence evidence into runtime gate/readiness reports and document the new semantics

## Verification
- cd backend && node --test ./scripts/lib/workerCadenceEvidence.test.mjs
- cd backend && npm run worker:cadence
- cd backend && npm run runtime:gate
- cd backend && npm run migration:scorecard
- git diff --cached --check

## Notes
- current evidence shows `daily_upcoming` is `scheduled_evidence_missing` with `missed_windows=5`
- current evidence shows `catalog_enrichment` is still `warming_up` until the first weekly scheduled window
