### PR TITLE
fix: provision stable preview backend url

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -19,6 +19,7 @@ on:
       - ".github/workflows/backend-deploy.yml"
 
 permissions:
+  actions: write
   contents: read
 
 jobs:
@@ -47,11 +48,26 @@ jobs:
         working-directory: backend
         run: npm ci
 
+      - name: Resolve preview backend public URL
+        id: resolve_preview_backend_public_url
+        working-directory: backend
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
+          RAILWAY_ENVIRONMENT_ID: ${{ vars.RAILWAY_ENVIRONMENT_ID }}
+          RAILWAY_SERVICE_ID: ${{ vars.RAILWAY_SERVICE_ID }}
+        run: >
+          npm run preview:url:sync --
+          --repo "${GITHUB_REPOSITORY}"
+          --github-environment preview
+          --report-path ./reports/preview_backend_public_url.json
+
       - name: Verify preview deploy environment contract
         working-directory: backend
         env:
           BACKEND_DEPLOY_TARGET: preview
-          BACKEND_PUBLIC_URL: ${{ vars.BACKEND_PUBLIC_URL }}
+          BACKEND_PUBLIC_URL: ${{ steps.resolve_preview_backend_public_url.outputs.backend_public_url }}
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
           RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
@@ -89,6 +105,14 @@ jobs:
           path: backend/reports/deploy_env_contract_preview.json
           if-no-files-found: warn
 
+      - name: Upload preview backend public URL report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-preview-public-url
+          path: backend/reports/preview_backend_public_url.json
+          if-no-files-found: warn
+
       - name: Deploy preview backend
         env:
           BACKEND_DEPLOY_TARGET: preview
@@ -101,13 +125,13 @@ jobs:
       - name: Run preview canonical fixture smoke checks
         working-directory: backend
         env:
-          BACKEND_PUBLIC_URL: ${{ vars.BACKEND_PUBLIC_URL }}
+          BACKEND_PUBLIC_URL: ${{ steps.resolve_preview_backend_public_url.outputs.backend_public_url }}
         run: npm run smoke:live -- --target preview --base-url "$BACKEND_PUBLIC_URL" --report-path ./reports/live_backend_smoke_preview.json
 
       - name: Build preview backend freshness handoff artifact
         working-directory: backend
         env:
-          BACKEND_PUBLIC_URL: ${{ vars.BACKEND_PUBLIC_URL }}
+          BACKEND_PUBLIC_URL: ${{ steps.resolve_preview_backend_public_url.outputs.backend_public_url }}
         run: npm run freshness:handoff -- --target preview --backend-public-url "$BACKEND_PUBLIC_URL" --report-path ./reports/backend_freshness_handoff_preview.json
 
       - name: Upload preview live smoke report

--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ npm run build
 - production backend는 `workflow_dispatch`에서 수동 승격
 - 두 경로 모두 backend `npm ci`, `npm run build`, `npm run test`를 선행한 뒤 Railway CLI deploy를 실행
 - GitHub Environment `preview`, `production`에 `RAILWAY_TOKEN`, `RAILWAY_PROJECT_ID`, `RAILWAY_ENVIRONMENT_ID`, `RAILWAY_SERVICE_ID`, `BACKEND_PUBLIC_URL`를 설정해야 함
+- preview deploy는 Railway provided domain을 resolve한 뒤 `preview/BACKEND_PUBLIC_URL`을 다시 동기화하고, 같은 URL로 live smoke와 freshness handoff를 검증함
 
 backend deploy topology와 rehearsal 규칙은 `docs/specs/backend/preview-staging-backend-path.md`, public read rate-limit 정책은 `docs/specs/backend/public-read-rate-limit-policy.md`, canonical live smoke fixture registry와 운영 entrypoint는 `backend/README.md`에 정리돼 있습니다.
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -249,7 +249,7 @@ cloudflared tunnel --url http://127.0.0.1:3213
 규칙:
 
 - tunnel은 임시 QA fallback일 뿐 production/preview deploy 대체가 아니다.
-- sign-off 기본 경로는 `https://api.idol-song-app.example.com` 같은 stable public preview backend다.
+- sign-off 기본 경로는 GitHub Environment `preview`의 `BACKEND_PUBLIC_URL`과 같은 stable public preview backend다.
 - debug metadata에서 `Backend target = Temporary tunnel backend`를 확인해야 한다.
 
 ## Backend Deploy Path
@@ -281,9 +281,12 @@ GitHub Environment baseline:
 - variable: `RAILWAY_SERVICE_ID`
 - variable: `BACKEND_PUBLIC_URL`
 
+preview에서는 `BACKEND_PUBLIC_URL`을 수동 placeholder로 유지하지 않는다. deploy workflow가 Railway provided domain을 resolve한 뒤 preview environment variable을 같은 값으로 다시 써서 smoke / freshness handoff / mobile preview runtime이 모두 같은 stable public URL을 보게 한다.
+
 deploy helper는 아래 스크립트다.
 
 - `backend/scripts/deploy-backend.mjs`
+- `backend/scripts/provision-preview-backend-url.mjs`
 - `backend/scripts/run-live-smoke-checks.mjs`
 - `backend/scripts/verify-deploy-env-contract.ts`
 - `backend/fixtures/live_backend_smoke_fixtures.json`

--- a/backend/package.json
+++ b/backend/package.json
@@ -24,7 +24,8 @@
     "runtime:measure": "node ./scripts/measure-read-api-runtime.mjs",
     "worker:cadence": "node ./scripts/build-worker-cadence-report.mjs",
     "gap:workbenches": "node ./scripts/build-canonical-gap-workbenches.mjs",
-    "runtime:gate": "node ./scripts/build-runtime-gate-report.mjs"
+    "runtime:gate": "node ./scripts/build-runtime-gate-report.mjs",
+    "preview:url:sync": "node ./scripts/provision-preview-backend-url.mjs --target preview"
   },
   "dependencies": {
     "fastify": "^5.2.1",

--- a/backend/scripts/lib/previewBackendPublicUrl.mjs
+++ b/backend/scripts/lib/previewBackendPublicUrl.mjs
@@ -1,0 +1,100 @@
+function normalizeHttpsOrigin(value) {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const candidate = trimmed.startsWith('http://') || trimmed.startsWith('https://') ? trimmed : `https://${trimmed}`;
+
+  try {
+    const parsed = new URL(candidate);
+    if (parsed.protocol !== 'https:') {
+      return null;
+    }
+
+    return `${parsed.protocol}//${parsed.host}`;
+  } catch {
+    return null;
+  }
+}
+
+function collectUrlCandidates(value, bucket) {
+  if (typeof value === 'string') {
+    const normalized = normalizeHttpsOrigin(value);
+    if (normalized) {
+      bucket.push(normalized);
+    }
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      collectUrlCandidates(entry, bucket);
+    }
+    return;
+  }
+
+  if (value && typeof value === 'object') {
+    for (const nestedValue of Object.values(value)) {
+      collectUrlCandidates(nestedValue, bucket);
+    }
+  }
+}
+
+function extractTextCandidates(text) {
+  const bucket = [];
+  const matches = text.matchAll(/\bhttps:\/\/[a-zA-Z0-9.-]+\b|\b[a-zA-Z0-9.-]+\.up\.railway\.app\b/gu);
+  for (const match of matches) {
+    const normalized = normalizeHttpsOrigin(match[0]);
+    if (normalized) {
+      bucket.push(normalized);
+    }
+  }
+  return bucket;
+}
+
+export function extractBackendPublicUrlCandidates(rawOutput) {
+  const trimmed = rawOutput.trim();
+  if (!trimmed) {
+    return [];
+  }
+
+  const bucket = [];
+  try {
+    const parsed = JSON.parse(trimmed);
+    collectUrlCandidates(parsed, bucket);
+  } catch {
+    bucket.push(...extractTextCandidates(trimmed));
+  }
+
+  if (bucket.length === 0) {
+    bucket.push(...extractTextCandidates(trimmed));
+  }
+
+  return [...new Set(bucket)];
+}
+
+export function selectBackendPublicUrl(candidates, options = {}) {
+  const normalizedCandidates = [...new Set(candidates.map((value) => normalizeHttpsOrigin(value)).filter(Boolean))];
+  const productionUrl = options.productionUrl ? normalizeHttpsOrigin(options.productionUrl) : null;
+  const filtered = productionUrl
+    ? normalizedCandidates.filter((value) => value !== productionUrl)
+    : normalizedCandidates;
+
+  if (filtered.length === 0) {
+    return null;
+  }
+
+  const railwayProvided = filtered.filter((value) => value.includes('.up.railway.app'));
+  if (railwayProvided.length > 0) {
+    return railwayProvided[0];
+  }
+
+  return filtered[0];
+}
+
+export function urlsAreSameOrigin(left, right) {
+  const leftNormalized = normalizeHttpsOrigin(left);
+  const rightNormalized = normalizeHttpsOrigin(right);
+  return Boolean(leftNormalized && rightNormalized && leftNormalized === rightNormalized);
+}

--- a/backend/scripts/lib/previewBackendPublicUrl.test.mjs
+++ b/backend/scripts/lib/previewBackendPublicUrl.test.mjs
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  extractBackendPublicUrlCandidates,
+  selectBackendPublicUrl,
+  urlsAreSameOrigin,
+} from './previewBackendPublicUrl.mjs';
+
+test('extractBackendPublicUrlCandidates reads provided railway domain JSON', () => {
+  const candidates = extractBackendPublicUrlCandidates(
+    JSON.stringify({
+      domain: 'idol-song-app-preview.up.railway.app',
+    }),
+  );
+
+  assert.deepEqual(candidates, ['https://idol-song-app-preview.up.railway.app']);
+});
+
+test('extractBackendPublicUrlCandidates finds nested URLs from status JSON', () => {
+  const candidates = extractBackendPublicUrlCandidates(
+    JSON.stringify({
+      project: {
+        services: [
+          {
+            domains: [
+              {
+                url: 'https://preview-api.idol-song-app.example.com',
+              },
+              {
+                hostname: 'idol-song-app-preview.up.railway.app',
+              },
+            ],
+          },
+        ],
+      },
+    }),
+  );
+
+  assert.deepEqual(candidates, [
+    'https://preview-api.idol-song-app.example.com',
+    'https://idol-song-app-preview.up.railway.app',
+  ]);
+});
+
+test('extractBackendPublicUrlCandidates falls back to plain-text parsing', () => {
+  const candidates = extractBackendPublicUrlCandidates(
+    'Generated domain: idol-song-app-preview.up.railway.app\n',
+  );
+
+  assert.deepEqual(candidates, ['https://idol-song-app-preview.up.railway.app']);
+});
+
+test('selectBackendPublicUrl prefers railway-provided domain and filters production URL', () => {
+  const selected = selectBackendPublicUrl(
+    [
+      'https://idol-song-app-production.up.railway.app',
+      'https://preview-api.idol-song-app.example.com',
+      'https://idol-song-app-preview.up.railway.app',
+    ],
+    {
+      productionUrl: 'https://idol-song-app-production.up.railway.app',
+    },
+  );
+
+  assert.equal(selected, 'https://idol-song-app-preview.up.railway.app');
+});
+
+test('urlsAreSameOrigin normalizes scheme and trailing slash', () => {
+  assert.equal(
+    urlsAreSameOrigin('https://idol-song-app-preview.up.railway.app/', 'idol-song-app-preview.up.railway.app'),
+    true,
+  );
+  assert.equal(
+    urlsAreSameOrigin('https://idol-song-app-preview.up.railway.app', 'https://idol-song-app-production.up.railway.app'),
+    false,
+  );
+});

--- a/backend/scripts/provision-preview-backend-url.mjs
+++ b/backend/scripts/provision-preview-backend-url.mjs
@@ -1,0 +1,269 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+import {
+  extractBackendPublicUrlCandidates,
+  selectBackendPublicUrl,
+  urlsAreSameOrigin,
+} from './lib/previewBackendPublicUrl.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const BACKEND_DIR = path.resolve(__dirname, '..');
+const REPORTS_DIR = path.resolve(BACKEND_DIR, 'reports');
+
+function parseArgs(argv) {
+  const options = {
+    githubEnvironment: 'preview',
+    repo: process.env.GITHUB_REPOSITORY?.trim() ?? '',
+    reportPath: path.resolve(REPORTS_DIR, 'preview_backend_public_url.json'),
+    target: 'preview',
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const nextValue = argv[index + 1];
+
+    if (arg === '--github-environment' && nextValue) {
+      options.githubEnvironment = nextValue;
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--repo' && nextValue) {
+      options.repo = nextValue;
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--report-path' && nextValue) {
+      options.reportPath = path.resolve(BACKEND_DIR, nextValue);
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--target' && nextValue) {
+      options.target = nextValue;
+      index += 1;
+      continue;
+    }
+  }
+
+  if (options.target !== 'preview') {
+    throw new Error(`Unsupported target: ${options.target}`);
+  }
+
+  if (!options.repo) {
+    throw new Error('Missing required argument: --repo <owner/repo>');
+  }
+
+  return options;
+}
+
+function requireEnv(name) {
+  const value = process.env[name]?.trim();
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+function appendStepSummary(line) {
+  if (!process.env.GITHUB_STEP_SUMMARY) {
+    return Promise.resolve();
+  }
+
+  return fs.appendFile(process.env.GITHUB_STEP_SUMMARY, `${line}\n`);
+}
+
+function writeGithubOutput(key, value) {
+  if (!process.env.GITHUB_OUTPUT) {
+    return Promise.resolve();
+  }
+
+  return fs.appendFile(process.env.GITHUB_OUTPUT, `${key}=${value}\n`);
+}
+
+function runCommand(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: BACKEND_DIR,
+      env: {
+        ...process.env,
+        ...options.env,
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+
+    child.on('error', reject);
+    child.on('exit', (code, signal) => {
+      if (signal) {
+        reject(new Error(`Command terminated by signal: ${signal}`));
+        return;
+      }
+
+      if (code !== 0) {
+        const reason = stderr.trim().length > 0 ? stderr.trim() : stdout.trim() || `Command failed with exit code ${code}`;
+        reject(new Error(reason));
+        return;
+      }
+
+      resolve({
+        stdout,
+        stderr,
+      });
+    });
+  });
+}
+
+async function readProductionPublicUrl(repo) {
+  try {
+    const result = await runCommand(
+      'gh',
+      ['variable', 'get', 'BACKEND_PUBLIC_URL', '--env', 'production', '--repo', repo],
+      { env: { GH_TOKEN: requireEnv('GH_TOKEN') } },
+    );
+    return result.stdout.trim();
+  } catch {
+    return null;
+  }
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const railwayToken = requireEnv('RAILWAY_TOKEN');
+  const projectId = requireEnv('RAILWAY_PROJECT_ID');
+  const environmentId = requireEnv('RAILWAY_ENVIRONMENT_ID');
+  const serviceId = requireEnv('RAILWAY_SERVICE_ID');
+  const ghToken = requireEnv('GH_TOKEN');
+
+  const report = {
+    target: options.target,
+    github_environment: options.githubEnvironment,
+    repo: options.repo,
+    generated_at: new Date().toISOString(),
+    checks: [],
+    railway_outputs: {},
+    backend_public_url: null,
+    production_public_url: null,
+  };
+
+  await runCommand(
+    'npx',
+    [
+      '-y',
+      '@railway/cli',
+      'link',
+      '--project',
+      projectId,
+      '--environment',
+      environmentId,
+      '--service',
+      serviceId,
+    ],
+    {
+      env: { RAILWAY_TOKEN: railwayToken },
+    },
+  );
+
+  const candidates = [];
+
+  try {
+    const domainResult = await runCommand(
+      'npx',
+      ['-y', '@railway/cli', 'domain', '--service', serviceId, '--json'],
+      {
+        env: { RAILWAY_TOKEN: railwayToken },
+      },
+    );
+    report.railway_outputs.domain_json = domainResult.stdout.trim();
+    candidates.push(...extractBackendPublicUrlCandidates(domainResult.stdout));
+    report.checks.push({
+      key: 'railway-domain-json',
+      status: 'pass',
+      candidate_count: candidates.length,
+    });
+  } catch (error) {
+    report.checks.push({
+      key: 'railway-domain-json',
+      status: 'warn',
+      reason: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  const statusResult = await runCommand(
+    'npx',
+    ['-y', '@railway/cli', 'status', '--json'],
+    {
+      env: { RAILWAY_TOKEN: railwayToken },
+    },
+  );
+  report.railway_outputs.status_json = statusResult.stdout.trim();
+  candidates.push(...extractBackendPublicUrlCandidates(statusResult.stdout));
+
+  const productionPublicUrl = await readProductionPublicUrl(options.repo);
+  report.production_public_url = productionPublicUrl;
+
+  const backendPublicUrl = selectBackendPublicUrl(candidates, {
+    productionUrl: productionPublicUrl,
+  });
+
+  if (!backendPublicUrl) {
+    throw new Error('Unable to resolve a preview backend public URL from Railway CLI output');
+  }
+
+  if (productionPublicUrl && urlsAreSameOrigin(backendPublicUrl, productionPublicUrl)) {
+    throw new Error(`Resolved preview backend URL matches production URL: ${backendPublicUrl}`);
+  }
+
+  await runCommand(
+    'gh',
+    [
+      'variable',
+      'set',
+      'BACKEND_PUBLIC_URL',
+      '--env',
+      options.githubEnvironment,
+      '--repo',
+      options.repo,
+      '--body',
+      backendPublicUrl,
+    ],
+    {
+      env: { GH_TOKEN: ghToken },
+    },
+  );
+
+  report.backend_public_url = backendPublicUrl;
+  report.checks.push({
+    key: 'github-variable-sync',
+    status: 'pass',
+    variable: 'BACKEND_PUBLIC_URL',
+  });
+
+  await fs.mkdir(path.dirname(options.reportPath), { recursive: true });
+  await fs.writeFile(options.reportPath, `${JSON.stringify(report, null, 2)}\n`);
+  await appendStepSummary(`- preview backend public URL: ${backendPublicUrl}`);
+  await writeGithubOutput('backend_public_url', backendPublicUrl);
+
+  console.log(`preview backend public url: ${backendPublicUrl}`);
+}
+
+main().catch(async (error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/docs/specs/mobile/configuration-environment-spec.md
+++ b/docs/specs/mobile/configuration-environment-spec.md
@@ -56,6 +56,8 @@
 ## 7.2 Public preview backend and tunnel fallback
 - external iPhone/Android QA의 기본 경로는 stable public preview backend다.
 - mobile preview 예시 env는 `mobile/.env.preview.example`를 기준으로 둔다.
+- stable preview backend의 source of truth는 GitHub Environment `preview`의 `BACKEND_PUBLIC_URL`이다.
+- preview backend deploy workflow는 Railway provided domain을 resolve한 뒤 같은 값을 `BACKEND_PUBLIC_URL`에 다시 동기화해야 한다.
 - debug metadata에서는 최소 아래를 확인 가능해야 한다.
   - active API base URL
   - active API host

--- a/docs/specs/mobile/ios-preview-signing-personal-team.md
+++ b/docs/specs/mobile/ios-preview-signing-personal-team.md
@@ -51,8 +51,9 @@ PRODUCT_BUNDLE_IDENTIFIER = com.example.idolsongapp.preview
 cd mobile
 export EXPO_IOS_APPLE_TEAM_ID=ABCDE12345
 export EXPO_IOS_BUNDLE_IDENTIFIER=com.example.idolsongapp.preview
-EXPO_PUBLIC_API_BASE_URL=https://api.idol-song-app.example.com npm run config:preview
-EXPO_PUBLIC_API_BASE_URL=https://api.idol-song-app.example.com npm run qa:preview:ios:sim
+export EXPO_PUBLIC_API_BASE_URL="$(gh variable get BACKEND_PUBLIC_URL --env preview --repo iAmSomething/idol-song-app)"
+npm run config:preview
+npm run qa:preview:ios:sim
 ```
 
 실제 iPhone으로 설치할 때는 `expo run:ios --device <device name>` 또는 Xcode Run을 사용한다.

--- a/mobile/.env.preview.example
+++ b/mobile/.env.preview.example
@@ -1,7 +1,7 @@
 APP_ENV=preview
 
 # Stable public preview backend for external device QA
-EXPO_PUBLIC_API_BASE_URL=https://api.idol-song-app.example.com
+EXPO_PUBLIC_API_BASE_URL=https://<preview-backend-public-url>
 EXPO_PUBLIC_EXPO_PROJECT_ID=
 
 # Optional metadata

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -134,8 +134,8 @@ preview QA runtime용 native prebuild / simulator 실행:
 
 ```bash
 cd mobile
-EXPO_PUBLIC_API_BASE_URL=https://api.idol-song-app.example.com npm run qa:preview:ios:prebuild
-EXPO_PUBLIC_API_BASE_URL=https://api.idol-song-app.example.com npm run qa:preview:ios:sim
+EXPO_PUBLIC_API_BASE_URL="$(gh variable get BACKEND_PUBLIC_URL --env preview --repo iAmSomething/idol-song-app)" npm run qa:preview:ios:prebuild
+EXPO_PUBLIC_API_BASE_URL="$(gh variable get BACKEND_PUBLIC_URL --env preview --repo iAmSomething/idol-song-app)" npm run qa:preview:ios:sim
 ```
 
 personal Apple team으로 iOS preview signing override를 준비하려면:
@@ -161,8 +161,8 @@ Android 쪽 native prebuild baseline:
 
 ```bash
 cd mobile
-EXPO_PUBLIC_API_BASE_URL=https://api.idol-song-app.example.com npm run qa:preview:android:prebuild
-EXPO_PUBLIC_API_BASE_URL=https://api.idol-song-app.example.com npm run qa:preview:android:emu
+EXPO_PUBLIC_API_BASE_URL="$(gh variable get BACKEND_PUBLIC_URL --env preview --repo iAmSomething/idol-song-app)" npm run qa:preview:android:prebuild
+EXPO_PUBLIC_API_BASE_URL="$(gh variable get BACKEND_PUBLIC_URL --env preview --repo iAmSomething/idol-song-app)" npm run qa:preview:android:emu
 ```
 
 Android preview QA rerun을 emulator 안정화 설정과 함께 준비하려면:
@@ -171,7 +171,7 @@ Android preview QA rerun을 emulator 안정화 설정과 함께 준비하려면:
 cd mobile
 npm run qa:preview:android:avd:prepare
 npm run qa:preview:android:avd:launch
-EXPO_PUBLIC_API_BASE_URL=https://api.idol-song-app.example.com npm run qa:preview:android:emu
+EXPO_PUBLIC_API_BASE_URL="$(gh variable get BACKEND_PUBLIC_URL --env preview --repo iAmSomething/idol-song-app)" npm run qa:preview:android:emu
 ```
 
 참고:
@@ -228,14 +228,15 @@ iPhone / Android 외부 기기 QA minimum steps:
 
 1. 같은 Wi-Fi 또는 reachability 가능한 네트워크에 host machine과 device를 둔다.
 2. `mobile/.env.preview.example`을 `.env`로 복사한다.
-3. `npm run config:preview`로 `EXPO_PUBLIC_API_BASE_URL`이 `https://api.idol-song-app.example.com`로 잡히는지 확인한다.
-4. 같은 출력에서 `services.expoProjectId`도 비어 있지 않은지 확인한다.
-5. 앱 안 `알림` 진입점에서 권한 요청과 등록 상태를 바로 확인할 수 있다.
-6. preview dev client를 열고 Expo CLI가 보여주는 QR 또는 deep link로 runtime에 붙는다.
-7. hidden debug route `idolsongapp-preview://debug/metadata`에서 아래 값을 확인한다.
+3. `gh variable get BACKEND_PUBLIC_URL --env preview --repo iAmSomething/idol-song-app`로 stable preview URL을 확인하고 `.env`에 같은 값을 넣는다.
+4. `npm run config:preview`로 `EXPO_PUBLIC_API_BASE_URL`이 preview GitHub Environment의 `BACKEND_PUBLIC_URL`과 같은지 확인한다.
+5. 같은 출력에서 `services.expoProjectId`도 비어 있지 않은지 확인한다.
+6. 앱 안 `알림` 진입점에서 권한 요청과 등록 상태를 바로 확인할 수 있다.
+7. preview dev client를 열고 Expo CLI가 보여주는 QR 또는 deep link로 runtime에 붙는다.
+8. hidden debug route `idolsongapp-preview://debug/metadata`에서 아래 값을 확인한다.
    - `Backend target = Public preview backend`
-   - `API base URL = https://api.idol-song-app.example.com`
-   - `API host = api.idol-song-app.example.com`
+   - `API base URL = <preview BACKEND_PUBLIC_URL>`
+   - `API host = <preview host>`
 
 ## temporary tunnel fallback
 
@@ -262,7 +263,7 @@ APP_ENV=preview npx expo start --dev-client --host tunnel --port 8082
 
 tunnel fallback 규칙:
 
-- 정식 sign-off / distribution 기본 경로로 쓰지 않는다.
+- 정식 sign-off / distribution 기본 경로는 GitHub Environment `preview`의 `BACKEND_PUBLIC_URL`과 같은 stable public preview backend다.
 - backend target이 tunnel이면 debug metadata에서 `Backend target = Temporary tunnel backend`가 보여야 한다.
 - tunnel은 속도/안정성/도메인 수명이 불안정하므로 regression spot-check 용도로만 쓴다.
 

--- a/mobile/scripts/prepare-ios-preview-signing.sh
+++ b/mobile/scripts/prepare-ios-preview-signing.sh
@@ -66,6 +66,7 @@ Prepared iOS signing override:
 Next steps:
   export EXPO_IOS_APPLE_TEAM_ID=$TEAM_ID
   export EXPO_IOS_BUNDLE_IDENTIFIER=$BUNDLE_ID
-  EXPO_PUBLIC_API_BASE_URL=https://api.idol-song-app.example.com npm run config:preview
-  EXPO_PUBLIC_API_BASE_URL=https://api.idol-song-app.example.com npm run qa:preview:ios:sim
+  export EXPO_PUBLIC_API_BASE_URL="$(gh variable get BACKEND_PUBLIC_URL --env preview --repo iAmSomething/idol-song-app)"
+  npm run config:preview
+  npm run qa:preview:ios:sim
 EOF

--- a/mobile/src/config/debugMetadata.test.ts
+++ b/mobile/src/config/debugMetadata.test.ts
@@ -103,7 +103,7 @@ describe('debug metadata helpers', () => {
           ...previewRuntimeConfig,
           services: {
             ...previewRuntimeConfig.services,
-            apiBaseUrl: 'https://api.idol-song-app.example.com',
+            apiBaseUrl: 'https://idol-song-app-preview.up.railway.app',
           },
         },
       }).backendTargetLabel,
@@ -121,6 +121,19 @@ describe('debug metadata helpers', () => {
         },
       }).backendTargetLabel,
     ).toBe('Temporary tunnel backend');
+
+    expect(
+      getDebugMetadata({
+        ...previewRuntimeState,
+        config: {
+          ...previewRuntimeConfig,
+          services: {
+            ...previewRuntimeConfig.services,
+            apiBaseUrl: 'https://idol-song-app-production.up.railway.app',
+          },
+        },
+      }).backendTargetLabel,
+    ).toBe('Custom backend target');
   });
 
   test('keeps the metadata surface unavailable for production profile', () => {

--- a/mobile/src/config/debugMetadata.ts
+++ b/mobile/src/config/debugMetadata.ts
@@ -27,7 +27,7 @@ export type MobileDebugMetadata = {
   latestAnalyticsEvent: string | null;
 };
 
-const PUBLIC_PREVIEW_API_HOST = 'api.idol-song-app.example.com';
+const LEGACY_PUBLIC_PREVIEW_API_HOST = 'api.idol-song-app.example.com';
 const TUNNEL_API_HOST_SUFFIXES = ['trycloudflare.com', 'ngrok-free.app', 'ngrok.io', 'loca.lt'] as const;
 
 function getBackendTargetLabel(apiBaseUrl: string | null): MobileDebugMetadata['backendTargetLabel'] {
@@ -36,12 +36,16 @@ function getBackendTargetLabel(apiBaseUrl: string | null): MobileDebugMetadata['
   }
 
   const host = new URL(apiBaseUrl).host;
-  if (host === PUBLIC_PREVIEW_API_HOST) {
+  if (TUNNEL_API_HOST_SUFFIXES.some((suffix) => host === suffix || host.endsWith(`.${suffix}`))) {
+    return 'Temporary tunnel backend';
+  }
+
+  if (host === LEGACY_PUBLIC_PREVIEW_API_HOST) {
     return 'Public preview backend';
   }
 
-  if (TUNNEL_API_HOST_SUFFIXES.some((suffix) => host === suffix || host.endsWith(`.${suffix}`))) {
-    return 'Temporary tunnel backend';
+  if (host.endsWith('.up.railway.app') && !host.includes('production')) {
+    return 'Public preview backend';
   }
 
   return 'Custom backend target';


### PR DESCRIPTION
## Summary\n- provision and sync a stable Railway-backed preview backend URL before preview smoke runs\n- switch mobile preview docs and debug metadata to use the real preview backend identity instead of a production-like placeholder\n- keep preview runtime clearly distinct from production in debug metadata and docs\n\nCloses #525