### PR TITLE
docs: audit remaining backend migration gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ scheduled automation도 cadence를 둘로 나눠서 운영한다.
 - prioritized service-link gap queues: `backend/reports/service_link_gap_queues.json`
 - title-track cohort gap queue: `backend/reports/title_track_gap_queue.json`
 - entity identity null workbench: `backend/reports/entity_identity_workbench.json`
+- parent backend gap audit report: `backend/reports/backend_gap_audit_report.json`, `backend/reports/backend_gap_audit_report.md`
 - report bundle metadata: `backend/reports/report_bundle_metadata.json`
 - backend freshness handoff artifact: `backend/reports/backend_freshness_handoff.json`
 - endpoint shadow-read report: `backend/reports/backend_shadow_read_report.json`

--- a/backend/README.md
+++ b/backend/README.md
@@ -580,6 +580,7 @@ scheduled workflow는 두 cadence로 나뉜다.
 - `npm run null:recheck`
 - `npm run null:trend`
 - `npm run gap:workbenches`
+- `npm run gap:audit`
 - `npm run report:bundle`
 - `python build_backend_json_parity_report.py`
 - `npm run shadow:verify`
@@ -727,6 +728,8 @@ npm run gap:workbenches
 - `backend/reports/entity_identity_field_queue.csv`
 - `backend/reports/trusted_upcoming_notification_event_summary.json`
 - `backend/reports/trusted_upcoming_operator_alert_report.md`
+- `backend/reports/backend_gap_audit_report.json`
+- `backend/reports/backend_gap_audit_report.md`
 
 이 report는 아래 topology를 함께 기록한다.
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,6 +18,7 @@
     "smoke:live": "node ./scripts/run-live-smoke-checks.mjs",
     "deploy:env:verify": "tsx ./scripts/verify-deploy-env-contract.ts",
     "report:bundle": "node ./scripts/build-report-bundle-metadata.mjs",
+    "gap:audit": "node ./scripts/build-backend-gap-audit-report.mjs",
     "freshness:handoff": "node ./scripts/build-backend-freshness-handoff.mjs",
     "migration:scorecard": "node ./scripts/build-migration-readiness-scorecard.mjs",
     "recovery:drill": "node ./scripts/run-backup-restore-drill.mjs",

--- a/backend/reports/backend_gap_audit_report.json
+++ b/backend/reports/backend_gap_audit_report.json
@@ -1,0 +1,986 @@
+{
+  "generated_at": "2026-03-11T15:10:28.264Z",
+  "parent_issue": {
+    "number": 529,
+    "url": "https://github.com/iAmSomething/idol-song-app/issues/529",
+    "audit_status": "audit_complete",
+    "closure_recommendation": "close_parent_keep_children_open"
+  },
+  "baseline_snapshot": {
+    "parent_issue_number": 529,
+    "parent_issue_url": "https://github.com/iAmSomething/idol-song-app/issues/529",
+    "readiness_score_percent": 59.9,
+    "latest_verified_release_selection_drift": 3,
+    "title_track_resolved_percent": 64.5,
+    "canonical_mv_percent": 6.3,
+    "allowlist_rows": 117,
+    "mv_source_channels_populated": 0,
+    "artist_profile_rows": 117,
+    "debut_year_populated": 8,
+    "representative_image_populated": 0
+  },
+  "current_snapshot": {
+    "readiness_score_percent": 56.3,
+    "readiness_status": "fail",
+    "latest_verified_release_selection_drift": 0,
+    "title_track_resolved_percent": 67.8,
+    "canonical_mv_percent": 8.6,
+    "allowlist_rows": 117,
+    "mv_source_channels_populated": 92,
+    "artist_profile_rows": 117,
+    "debut_year_populated": 8,
+    "representative_image_populated": 0,
+    "runtime_facing_duplicate_artifact_count": 4
+  },
+  "baseline_comparison": [
+    {
+      "key": "latest_verified_release_selection_drift",
+      "label": "Latest verified release selection drift count",
+      "baseline": 3,
+      "current": 0,
+      "delta": -3,
+      "status": "resolved"
+    },
+    {
+      "key": "title_track_resolved_percent",
+      "label": "Historical title-track resolved coverage (%)",
+      "baseline": 64.5,
+      "current": 67.8,
+      "delta": 3.3,
+      "status": "improved"
+    },
+    {
+      "key": "canonical_mv_percent",
+      "label": "Historical canonical MV coverage (%)",
+      "baseline": 6.3,
+      "current": 8.6,
+      "delta": 2.3,
+      "status": "improved"
+    },
+    {
+      "key": "mv_source_channels_populated",
+      "label": "Rows with mv_source_channels populated",
+      "baseline": 0,
+      "current": 92,
+      "delta": 92,
+      "status": "improved"
+    },
+    {
+      "key": "debut_year_populated",
+      "label": "Artist profiles with debut_year populated",
+      "baseline": 8,
+      "current": 8,
+      "delta": 0,
+      "status": "unchanged"
+    },
+    {
+      "key": "representative_image_populated",
+      "label": "Artist profiles with representative_image_url populated",
+      "baseline": 0,
+      "current": 0,
+      "delta": 0,
+      "status": "unchanged"
+    }
+  ],
+  "blocker_mapping": [
+    {
+      "key": "backend_runtime_health",
+      "label": "Backend runtime health",
+      "status": "fail",
+      "blocker_reasons": [
+        "projection_freshness=fail",
+        "worker_cadence=fail",
+        "stage_gate:shadow_to_web_cutover=fail",
+        "stage_gate:web_cutover_to_json_demotion=fail"
+      ],
+      "summary_lines": [
+        "api latency: needs_review (worst p95=1148.96ms)",
+        "api error rate: needs_review (error rate=0)",
+        "projection freshness: fail (lag=265.33m)",
+        "worker cadence: fail (cadence_status=scheduled_evidence_missing, missed_windows=5)",
+        "parity dependency: fail",
+        "shadow dependency: fail",
+        "historical catalog completeness dependency: fail",
+        "critical null coverage dependency: fail",
+        "bundle consistency: fail",
+        "shadow -> web cutover gate: fail",
+        "web cutover -> JSON demotion gate: fail"
+      ],
+      "issues": [
+        {
+          "number": 600,
+          "title": "Restore backend runtime-health cutover gate by clearing projection freshness lag and scheduled worker cadence evidence",
+          "url": "https://github.com/iAmSomething/idol-song-app/issues/600"
+        }
+      ]
+    },
+    {
+      "key": "backend_deploy_parity",
+      "label": "Backend deploy parity",
+      "status": "fail",
+      "blocker_reasons": [
+        "parity_clean=false (latest_verified_release_selection drift=0)"
+      ],
+      "summary_lines": [
+        "entity alias/search coverage: clean (mismatched entities=0)",
+        "official links: clean (mismatched entities=0)",
+        "YouTube allowlists: drift (role mismatches=10, metadata mismatches=0)",
+        "latest verified release selection: clean (tracking mismatches=0, stream mismatches=0)",
+        "upcoming counts / nearest: clean (month bucket mismatches=0)",
+        "title-track / double-title: drift (mismatched releases=1060)",
+        "YouTube Music / MV service-link state: drift (mismatched releases=124)",
+        "review-required counts: drift (review_type_counts_match=False, youtube_mv_status_counts_match=False)"
+      ],
+      "issues": [
+        {
+          "number": 602,
+          "title": "Resolve backend deploy parity drift for YouTube allowlists, title-track/service-link state, and review-required counts",
+          "url": "https://github.com/iAmSomething/idol-song-app/issues/602"
+        }
+      ]
+    },
+    {
+      "key": "web_backend_only_stability",
+      "label": "Web backend-only stability",
+      "status": "fail",
+      "blocker_reasons": [
+        "entity_detail clean_ratio=0.5",
+        "release_detail clean_ratio=0"
+      ],
+      "summary_lines": [
+        "search: clean 5/5, drift 0/5",
+        "entity_detail: clean 2/4, drift 2/4",
+        "release_detail: clean 0/3, drift 3/3",
+        "calendar_month: clean 3/3, drift 0/3",
+        "radar: clean 1/1, drift 0/1",
+        "missing rows or segments: 5 case(s)",
+        "field-shape mismatches: 3 case(s)"
+      ],
+      "issues": [
+        {
+          "number": 601,
+          "title": "Close remaining backend-only shadow drift on web entity detail and release detail surfaces",
+          "url": "https://github.com/iAmSomething/idol-song-app/issues/601"
+        }
+      ]
+    },
+    {
+      "key": "catalog_completeness",
+      "label": "Catalog completeness",
+      "status": "fail",
+      "blocker_reasons": [
+        "title_track_resolved overall=67.9 pre_2024=65.2",
+        "canonical_mv overall=8.6 pre_2024=6.4",
+        "releases.title_track latest 29.1% < 95.0%",
+        "release_service_links.youtube_mv latest 10.2% < 80.0%",
+        "entities.official_youtube latest 75.3% < 100.0%",
+        "entities.official_x latest 97.8% < 100.0%",
+        "entities.official_instagram latest 98.9% < 100.0%",
+        "releases.title_track recent 0.0% < 85.0%",
+        "release_service_links.youtube_mv recent 0.0% < 55.0%",
+        "entities.official_youtube recent 72.2% < 95.0%"
+      ],
+      "summary_lines": [
+        "detail payload coverage: 1770/1770 (100.0%), pre-2024 1153/1153 (100.0%)",
+        "detail trusted coverage: 1770/1770 (100.0%), pre-2024 1153/1153 (100.0%)",
+        "title-track resolved coverage: 1201/1770 (67.8%), pre-2024 752/1153 (65.2%), review queue 569",
+        "canonical MV coverage: 153/1770 (8.6%), pre-2024 74/1153 (6.4%), mv review 2",
+        "external acquisition pass: YTM attempted 113, resolved 0; MV attempted 56, resolved 0, review 2",
+        "youtube MV search pass: attempted 54, resolved 41, review 13, unresolved 1616, coverage lift +1",
+        "migration-critical first slice: title-track 18/18 (100.0%), canonical MV 18/18 (100.0%), gate pass",
+        "worst title-track cohort: 2021-2023 ep 31.4% / target 74.0%",
+        "worst canonical MV cohort: 2024+ single 15.4% / target 72.0%",
+        "release-detail null review queue: 1754 rows",
+        "historical catalog cutover gate: fail",
+        "migration_priority_slice rows=18/18 title_track=100 canonical_mv=100 gate=pass",
+        "critical null coverage gate=fail score=70.8"
+      ],
+      "issues": [
+        {
+          "number": 603,
+          "title": "Raise catalog completeness for title-track, MV, official-link, and visual metadata blocker cohorts",
+          "url": "https://github.com/iAmSomething/idol-song-app/issues/603"
+        },
+        {
+          "number": 538,
+          "title": "Integrate collected social links, agency names, and debut-year metadata into canonical entity data with provenance and review states",
+          "url": "https://github.com/iAmSomething/idol-song-app/issues/538"
+        },
+        {
+          "number": 539,
+          "title": "Backfill representative entity images and broaden release artwork coverage beyond the latest-snapshot subset",
+          "url": "https://github.com/iAmSomething/idol-song-app/issues/539"
+        },
+        {
+          "number": 580,
+          "title": "Define export-import manual curation bundles for unresolved canonical nulls across key field families",
+          "url": "https://github.com/iAmSomething/idol-song-app/issues/580"
+        }
+      ]
+    }
+  ],
+  "related_operational_followups": [
+    {
+      "number": 525,
+      "title": "[RN] Provision a stable public preview backend URL for external iPhone and Android device testing",
+      "url": "https://github.com/iAmSomething/idol-song-app/issues/525"
+    },
+    {
+      "number": 540,
+      "title": "Remove duplicate generated artifacts and define one canonical retention policy for runtime-facing JSON and pipeline scripts",
+      "url": "https://github.com/iAmSomething/idol-song-app/issues/540"
+    }
+  ],
+  "resolved_workstreams": [
+    {
+      "key": "latest_verified_release_selection",
+      "label": "Latest verified release selection drift cleared",
+      "issues": [
+        {
+          "number": 532,
+          "url": "https://github.com/iAmSomething/idol-song-app/issues/532"
+        }
+      ]
+    },
+    {
+      "key": "historical_release_enrichment_and_mv_allowlists",
+      "label": "Historical release enrichment and MV allowlist foundation landed",
+      "issues": [
+        {
+          "number": 534,
+          "url": "https://github.com/iAmSomething/idol-song-app/issues/534"
+        },
+        {
+          "number": 535,
+          "url": "https://github.com/iAmSomething/idol-song-app/issues/535"
+        },
+        {
+          "number": 536,
+          "url": "https://github.com/iAmSomething/idol-song-app/issues/536"
+        },
+        {
+          "number": 537,
+          "url": "https://github.com/iAmSomething/idol-song-app/issues/537"
+        },
+        {
+          "number": 591,
+          "url": "https://github.com/iAmSomething/idol-song-app/issues/591"
+        }
+      ]
+    },
+    {
+      "key": "trusted_upcoming_notification_runtime",
+      "label": "Trusted upcoming notification event and push runtime path landed",
+      "issues": [
+        {
+          "number": 554,
+          "url": "https://github.com/iAmSomething/idol-song-app/issues/554"
+        },
+        {
+          "number": 556,
+          "url": "https://github.com/iAmSomething/idol-song-app/issues/556"
+        },
+        {
+          "number": 557,
+          "url": "https://github.com/iAmSomething/idol-song-app/issues/557"
+        },
+        {
+          "number": 558,
+          "url": "https://github.com/iAmSomething/idol-song-app/issues/558"
+        },
+        {
+          "number": 559,
+          "url": "https://github.com/iAmSomething/idol-song-app/issues/559"
+        },
+        {
+          "number": 560,
+          "url": "https://github.com/iAmSomething/idol-song-app/issues/560"
+        },
+        {
+          "number": 561,
+          "url": "https://github.com/iAmSomething/idol-song-app/issues/561"
+        }
+      ]
+    },
+    {
+      "key": "null_hygiene_and_gap_workbenches",
+      "label": "Null hygiene cadence, workbench, and bundle reporting landed",
+      "issues": [
+        {
+          "number": 566,
+          "url": "https://github.com/iAmSomething/idol-song-app/issues/566"
+        },
+        {
+          "number": 567,
+          "url": "https://github.com/iAmSomething/idol-song-app/issues/567"
+        },
+        {
+          "number": 568,
+          "url": "https://github.com/iAmSomething/idol-song-app/issues/568"
+        },
+        {
+          "number": 569,
+          "url": "https://github.com/iAmSomething/idol-song-app/issues/569"
+        },
+        {
+          "number": 570,
+          "url": "https://github.com/iAmSomething/idol-song-app/issues/570"
+        },
+        {
+          "number": 571,
+          "url": "https://github.com/iAmSomething/idol-song-app/issues/571"
+        },
+        {
+          "number": 572,
+          "url": "https://github.com/iAmSomething/idol-song-app/issues/572"
+        },
+        {
+          "number": 573,
+          "url": "https://github.com/iAmSomething/idol-song-app/issues/573"
+        },
+        {
+          "number": 574,
+          "url": "https://github.com/iAmSomething/idol-song-app/issues/574"
+        },
+        {
+          "number": 575,
+          "url": "https://github.com/iAmSomething/idol-song-app/issues/575"
+        },
+        {
+          "number": 577,
+          "url": "https://github.com/iAmSomething/idol-song-app/issues/577"
+        },
+        {
+          "number": 578,
+          "url": "https://github.com/iAmSomething/idol-song-app/issues/578"
+        },
+        {
+          "number": 579,
+          "url": "https://github.com/iAmSomething/idol-song-app/issues/579"
+        },
+        {
+          "number": 582,
+          "url": "https://github.com/iAmSomething/idol-song-app/issues/582"
+        },
+        {
+          "number": 583,
+          "url": "https://github.com/iAmSomething/idol-song-app/issues/583"
+        }
+      ]
+    },
+    {
+      "key": "worker_cadence_gate_foundation",
+      "label": "Worker cadence / runtime gate semantics were added even though operational pass is still pending",
+      "issues": [
+        {
+          "number": 530,
+          "url": "https://github.com/iAmSomething/idol-song-app/issues/530"
+        }
+      ]
+    }
+  ],
+  "runtime_details": {
+    "projection_freshness": {
+      "status": "fail",
+      "observed": {
+        "projection_generated_at": "2026-03-11T07:53:57.809Z",
+        "lag_minutes": 265.33
+      },
+      "thresholds": {
+        "passLagMinutes": 20,
+        "reviewLagMinutes": 60
+      }
+    },
+    "worker_cadence": {
+      "status": "fail",
+      "observed": {
+        "primary_path_key": "daily_upcoming",
+        "cadence_label": "daily",
+        "scheduled_failure_rate": null,
+        "last_success_age_hours": null,
+        "scheduled_runs": 0,
+        "cadence_status": "scheduled_evidence_missing",
+        "scheduled_evidence": {
+          "status": "scheduled_evidence_missing",
+          "reason": "Expected scheduled run windows have elapsed without a recorded scheduled sample.",
+          "cadence_label": "daily",
+          "workflow_created_at": "2026-03-06T07:34:09.000Z",
+          "workflow_updated_at": "2026-03-11T09:25:55.000Z",
+          "workflow_state": "active",
+          "workflow_html_url": "https://github.com/iAmSomething/idol-song-app/blob/main/.github/workflows/weekly-kpop-scan.yml",
+          "parsed_schedule": {
+            "kind": "daily",
+            "minute": 0,
+            "hour": 0
+          },
+          "warmup_grace_hours": 12,
+          "first_expected_run_at": "2026-03-07T00:00:00.000Z",
+          "next_expected_run_at": "2026-03-12T00:00:00.000Z",
+          "warmup_deadline_at": "2026-03-07T12:00:00.000Z",
+          "expected_scheduled_runs_by_now": 5,
+          "observed_scheduled_runs": 0,
+          "missed_scheduled_windows": 5
+        }
+      },
+      "thresholds": {
+        "passFailureRate": 0.1,
+        "reviewFailureRate": 0.25,
+        "passLastSuccessAgeHours": 30,
+        "reviewLastSuccessAgeHours": 48
+      }
+    },
+    "stage_gates": {
+      "shadow_to_web_cutover": "fail",
+      "web_cutover_to_json_demotion": "fail"
+    },
+    "worker_cadence_summary": [
+      "[primary] daily_upcoming: cadence=daily, status=scheduled_evidence_missing, observed=0, expected_by_now=5, missed_windows=5",
+      "[secondary] catalog_enrichment: cadence=weekly, status=warming_up, first_due=2026-03-15T01:00:00.000Z, deadline=2026-03-16T01:00:00.000Z"
+    ]
+  },
+  "deploy_parity_details": {
+    "youtube_allowlists": {
+      "role_mismatches_count": 10,
+      "metadata_mismatches_count": 0,
+      "role_mismatches": [
+        {
+          "entity_slug": "chung-ha",
+          "missing_channel_roles": [
+            {
+              "url": "https://www.youtube.com/@CHUNGHA_OFFICIAL",
+              "role": "both"
+            }
+          ],
+          "extra_channel_roles": []
+        },
+        {
+          "entity_slug": "chuu",
+          "missing_channel_roles": [
+            {
+              "url": "https://www.youtube.com/@CHUUOfficial",
+              "role": "both"
+            }
+          ],
+          "extra_channel_roles": []
+        },
+        {
+          "entity_slug": "jeon-somi",
+          "missing_channel_roles": [
+            {
+              "url": "https://www.youtube.com/@JEONSOMIOFFICIAL",
+              "role": "both"
+            }
+          ],
+          "extra_channel_roles": []
+        },
+        {
+          "entity_slug": "kwon-eunbi",
+          "missing_channel_roles": [
+            {
+              "url": "https://www.youtube.com/@KWONEUNBI",
+              "role": "both"
+            }
+          ],
+          "extra_channel_roles": []
+        },
+        {
+          "entity_slug": "seventeen",
+          "missing_channel_roles": [
+            {
+              "url": "https://www.youtube.com/channel/UCfkXDY7vwkcJ8ddFGz8KusA",
+              "role": "mv_allowlist"
+            }
+          ],
+          "extra_channel_roles": []
+        },
+        {
+          "entity_slug": "tunexx",
+          "missing_channel_roles": [
+            {
+              "url": "https://www.youtube.com/@official_TUNEXX",
+              "role": "both"
+            }
+          ],
+          "extra_channel_roles": []
+        },
+        {
+          "entity_slug": "xlov",
+          "missing_channel_roles": [
+            {
+              "url": "https://www.youtube.com/@XLOV_official",
+              "role": "both"
+            }
+          ],
+          "extra_channel_roles": []
+        },
+        {
+          "entity_slug": "yena",
+          "missing_channel_roles": [
+            {
+              "url": "https://www.youtube.com/@yena_official",
+              "role": "both"
+            }
+          ],
+          "extra_channel_roles": []
+        },
+        {
+          "entity_slug": "yuju",
+          "missing_channel_roles": [
+            {
+              "url": "https://www.youtube.com/@YUJUofficial",
+              "role": "both"
+            }
+          ],
+          "extra_channel_roles": []
+        },
+        {
+          "entity_slug": "yves",
+          "missing_channel_roles": [
+            {
+              "url": "https://www.youtube.com/@YVES_OFFICIAL",
+              "role": "both"
+            }
+          ],
+          "extra_channel_roles": []
+        }
+      ],
+      "metadata_mismatches": [],
+      "clean": false
+    },
+    "latest_verified_release_selection": {
+      "tracking_mismatches_count": 0,
+      "tracking_mismatches": [],
+      "stream_mismatches_count": 0,
+      "stream_mismatches": [],
+      "clean": true
+    },
+    "title_tracks_and_double_title": {
+      "mismatched_releases_count": 1060,
+      "source_double_title_releases": 27,
+      "db_double_title_releases": 3,
+      "mismatches": [
+        {
+          "entity_slug": "82major",
+          "release_date": "2023-10-11",
+          "stream": "song",
+          "source_title_tracks": [
+            "Sure Thing"
+          ],
+          "db_title_tracks": []
+        },
+        {
+          "entity_slug": "82major",
+          "release_date": "2023-10-05",
+          "stream": "song",
+          "source_title_tracks": [
+            "Sure Thing"
+          ],
+          "db_title_tracks": []
+        },
+        {
+          "entity_slug": "8turn",
+          "release_date": "2025-08-21",
+          "stream": "song",
+          "source_title_tracks": [
+            "Electric Heart"
+          ],
+          "db_title_tracks": []
+        },
+        {
+          "entity_slug": "8turn",
+          "release_date": "2025-03-04",
+          "stream": "song",
+          "source_title_tracks": [
+            "LEGGO"
+          ],
+          "db_title_tracks": []
+        },
+        {
+          "entity_slug": "8turn",
+          "release_date": "2024-11-11",
+          "stream": "song",
+          "source_title_tracks": [
+            "You Are My Reason"
+          ],
+          "db_title_tracks": []
+        },
+        {
+          "entity_slug": "8turn",
+          "release_date": "2024-12-09",
+          "stream": "song",
+          "source_title_tracks": [
+            "Like a Friend"
+          ],
+          "db_title_tracks": []
+        },
+        {
+          "entity_slug": "ab6ix",
+          "release_date": "2022-08-24",
+          "stream": "song",
+          "source_title_tracks": [
+            "CHANCE"
+          ],
+          "db_title_tracks": []
+        },
+        {
+          "entity_slug": "ab6ix",
+          "release_date": "2023-05-10",
+          "stream": "song",
+          "source_title_tracks": [
+            "Fly Away"
+          ],
+          "db_title_tracks": []
+        },
+        {
+          "entity_slug": "ab6ix",
+          "release_date": "2020-11-02",
+          "stream": "album",
+          "source_title_tracks": [
+            "SALUTE"
+          ],
+          "db_title_tracks": []
+        },
+        {
+          "entity_slug": "ab6ix",
+          "release_date": "2023-11-24",
+          "stream": "song",
+          "source_title_tracks": [
+            "SIREN"
+          ],
+          "db_title_tracks": []
+        }
+      ],
+      "clean": false
+    },
+    "release_service_links": {
+      "mismatched_release_services_count": 124,
+      "mismatches": [
+        {
+          "entity_slug": "82major",
+          "release_date": "2024-11-15",
+          "stream": "album",
+          "service_type": "youtube_music",
+          "source": {
+            "url": "https://music.youtube.com/playlist?list=OLAK5uy_k1sIbCSXn34yi3_k1kdbhE3r24-du98ic",
+            "status": "canonical",
+            "provenance": "releaseDetails.youtube_music_url"
+          },
+          "db": {
+            "url": null,
+            "status": "no_link",
+            "provenance": null
+          }
+        },
+        {
+          "entity_slug": "8turn",
+          "release_date": "2025-03-04",
+          "stream": "song",
+          "service_type": "youtube_mv",
+          "source": {
+            "url": "https://www.youtube.com/watch?v=li5H5D3Jd70",
+            "status": "manual_override",
+            "provenance": "youtube search auto-accepted via allowlist/title/date/view scoring"
+          },
+          "db": {
+            "url": null,
+            "status": "unresolved",
+            "provenance": "releaseHistory.placeholder_seed"
+          }
+        },
+        {
+          "entity_slug": "aespa",
+          "release_date": "2025-06-27",
+          "stream": "song",
+          "service_type": "youtube_music",
+          "source": {
+            "url": "https://music.youtube.com/playlist?list=OLAK5uy_lylo1HjXQ3etth1Y_2psaHbhoyeNA49_w",
+            "status": "canonical",
+            "provenance": "releaseDetails.youtube_music_url"
+          },
+          "db": {
+            "url": null,
+            "status": "no_link",
+            "provenance": null
+          }
+        },
+        {
+          "entity_slug": "aespa",
+          "release_date": "2025-06-27",
+          "stream": "song",
+          "service_type": "youtube_mv",
+          "source": {
+            "url": "https://www.youtube.com/watch?v=M2WTUoy4y6E",
+            "status": "manual_override",
+            "provenance": "youtube search auto-accepted via allowlist/title/date/view scoring"
+          },
+          "db": {
+            "url": null,
+            "status": "unresolved",
+            "provenance": "releaseHistory.placeholder_seed"
+          }
+        },
+        {
+          "entity_slug": "aespa",
+          "release_date": "2021-10-05",
+          "stream": "album",
+          "service_type": "youtube_music",
+          "source": {
+            "url": "https://music.youtube.com/playlist?list=OLAK5uy_mAsOG3O5d13B9gcJ0_4JcpqbVlQKNyYzQ",
+            "status": "canonical",
+            "provenance": "releaseDetails.youtube_music_url"
+          },
+          "db": {
+            "url": null,
+            "status": "no_link",
+            "provenance": null
+          }
+        },
+        {
+          "entity_slug": "aespa",
+          "release_date": "2024-10-09",
+          "stream": "song",
+          "service_type": "youtube_music",
+          "source": {
+            "url": "https://music.youtube.com/playlist?list=OLAK5uy_mxuhlhhzPFDf4XF9zXA_fXmJQN8tqCUe4",
+            "status": "canonical",
+            "provenance": "releaseDetails.youtube_music_url"
+          },
+          "db": {
+            "url": null,
+            "status": "no_link",
+            "provenance": null
+          }
+        },
+        {
+          "entity_slug": "ateez",
+          "release_date": "2025-06-13",
+          "stream": "album",
+          "service_type": "youtube_music",
+          "source": {
+            "url": "https://music.youtube.com/playlist?list=OLAK5uy_lQnb6fzlcjYIWuQsQkVX-UucviuRkoyfE",
+            "status": "canonical",
+            "provenance": "releaseDetails.youtube_music_url"
+          },
+          "db": {
+            "url": null,
+            "status": "no_link",
+            "provenance": null
+          }
+        },
+        {
+          "entity_slug": "blackpink",
+          "release_date": "2026-02-26",
+          "stream": "album",
+          "service_type": "youtube_music",
+          "source": null,
+          "db": {
+            "url": "https://music.youtube.com/playlist?list=OLAK5uy_l3QGS6y9ZWficqzcu429HoCvcKlpMmmmY",
+            "status": "manual_override",
+            "provenance": "ytmusicapi exact album search match"
+          }
+        },
+        {
+          "entity_slug": "blackpink",
+          "release_date": "2026-02-26",
+          "stream": "album",
+          "service_type": "youtube_mv",
+          "source": null,
+          "db": {
+            "url": "https://www.youtube.com/watch?v=2GJfWMYCWY0",
+            "status": "manual_override",
+            "provenance": "official artist channel watch URL"
+          }
+        },
+        {
+          "entity_slug": "blackpink",
+          "release_date": "2022-07-29",
+          "stream": "song",
+          "service_type": "youtube_mv",
+          "source": {
+            "url": "https://www.youtube.com/watch?v=GDWX-3kV6do",
+            "status": "relation_match",
+            "provenance": "musicbrainz.release_group_release.url_relation"
+          },
+          "db": {
+            "url": null,
+            "status": "unresolved",
+            "provenance": "releaseHistory.placeholder_seed"
+          }
+        }
+      ],
+      "clean": false
+    },
+    "review_required_counts": {
+      "source_review_type_counts": {
+        "upcoming_signal": 64,
+        "entity_onboarding": 3,
+        "mv_candidate": 1657
+      },
+      "db_review_type_counts": {
+        "entity_onboarding": 3,
+        "mv_candidate": 39,
+        "upcoming_signal": 64
+      },
+      "source_youtube_mv_status_counts": {
+        "unresolved": 1655,
+        "manual_override": 91,
+        "relation_match": 21,
+        "needs_review": 2,
+        "no_mv": 1
+      },
+      "db_youtube_mv_status_counts": {
+        "unresolved": 1742,
+        "manual_override": 26,
+        "relation_match": 1,
+        "needs_review": 2
+      },
+      "review_type_counts_match": false,
+      "youtube_mv_status_counts_match": false,
+      "clean": false
+    }
+  },
+  "catalog_completeness_details": {
+    "cutover_gates": {
+      "thresholds": {
+        "detail_payload_total_min": 1,
+        "detail_payload_pre_2024_min": 1,
+        "detail_trusted_total_min": 0.85,
+        "detail_trusted_pre_2024_min": 0.5,
+        "title_track_resolved_total_min": 0.8,
+        "title_track_resolved_pre_2024_min": 0.6,
+        "canonical_mv_total_min": 0.65,
+        "canonical_mv_pre_2024_min": 0.35
+      },
+      "gates": {
+        "detail_payload": {
+          "status": "pass",
+          "observed_total": 1,
+          "observed_pre_2024": 1,
+          "threshold_total": 1,
+          "threshold_pre_2024": 1
+        },
+        "detail_trusted": {
+          "status": "pass",
+          "observed_total": 1,
+          "observed_pre_2024": 1,
+          "threshold_total": 0.85,
+          "threshold_pre_2024": 0.5
+        },
+        "title_track_resolved": {
+          "status": "fail",
+          "observed_total": 0.6785,
+          "observed_pre_2024": 0.6522,
+          "threshold_total": 0.8,
+          "threshold_pre_2024": 0.6
+        },
+        "canonical_mv": {
+          "status": "fail",
+          "observed_total": 0.0864,
+          "observed_pre_2024": 0.0642,
+          "threshold_total": 0.65,
+          "threshold_pre_2024": 0.35
+        }
+      },
+      "cutover_ready": false,
+      "cutover_status": "fail",
+      "generated_at": "2026-03-11",
+      "summary_lines": [
+        "detail payload gate: pass (total 100.0%, pre-2024 100.0%)",
+        "detail trusted gate: pass (total 100.0%, pre-2024 100.0%)",
+        "title-track resolved gate: fail (total 67.8%, pre-2024 65.2%)",
+        "canonical MV gate: fail (total 8.6%, pre-2024 6.4%)"
+      ]
+    },
+    "migration_priority_slice": {
+      "thresholds": {
+        "detail_payload_min": 1,
+        "detail_trusted_min": 1,
+        "title_track_resolved_min": 1,
+        "canonical_mv_min": 1
+      },
+      "gates": {
+        "detail_payload": {
+          "status": "pass",
+          "observed": 1,
+          "threshold": 1
+        },
+        "detail_trusted": {
+          "status": "pass",
+          "observed": 1,
+          "threshold": 1
+        },
+        "title_track_resolved": {
+          "status": "pass",
+          "observed": 1,
+          "threshold": 1
+        },
+        "canonical_mv": {
+          "status": "pass",
+          "observed": 1,
+          "threshold": 1
+        }
+      },
+      "cutover_ready": true,
+      "cutover_status": "pass",
+      "generated_at": "2026-03-11",
+      "summary_lines": [
+        "detail_payload gate: pass (100.0% vs 100.0%)",
+        "detail_trusted gate: pass (100.0% vs 100.0%)",
+        "title_track_resolved gate: pass (100.0% vs 100.0%)",
+        "canonical_mv gate: pass (100.0% vs 100.0%)"
+      ]
+    },
+    "null_field_families": [
+      {
+        "field_family_key": "release_service_links.youtube_mv",
+        "field_label": "YouTube MV Canonical Link",
+        "populated_records": 27,
+        "unresolved_records": 1744,
+        "effective_coverage_percent": 1.5
+      },
+      {
+        "field_family_key": "releases.title_track",
+        "field_label": "Title Track Resolution",
+        "populated_records": 77,
+        "unresolved_records": 1694,
+        "effective_coverage_percent": 4.3
+      },
+      {
+        "field_family_key": "entities.official_youtube",
+        "field_label": "Official YouTube",
+        "populated_records": 88,
+        "unresolved_records": 29,
+        "effective_coverage_percent": 75.2
+      },
+      {
+        "field_family_key": "entities.debut_year",
+        "field_label": "Debut Year",
+        "populated_records": 8,
+        "unresolved_records": 109,
+        "effective_coverage_percent": 6.8
+      },
+      {
+        "field_family_key": "entities.representative_image",
+        "field_label": "Representative Image",
+        "populated_records": 0,
+        "unresolved_records": 117,
+        "effective_coverage_percent": 0
+      }
+    ]
+  },
+  "runtime_facing_duplicate_artifacts": [
+    "build_release_details_musicbrainz 2.py",
+    "web/src/data/artistProfiles 2.json",
+    "web/src/data/releaseArtwork 2.json",
+    "web/src/data/releaseDetails 2.json"
+  ],
+  "summary_lines": [
+    "parent issue #529 audit status: audit_complete",
+    "current readiness score: 56.3% (fail)",
+    "baseline deltas: latest release drift 3 -> 0, title-track 64.5% -> 67.8%, canonical MV 6.3% -> 8.6%",
+    "allowlist progress: mv_source_channels 0/117 -> 92/117",
+    "entity metadata unchanged: debut_year 8/117, representative_image 0/117",
+    "runtime-facing duplicate artifacts still present: 4",
+    "direct blocker follow-ups: #600 backend runtime health, #601 web backend-only stability, #602 backend deploy parity, #603 catalog completeness"
+  ]
+}

--- a/backend/reports/backend_gap_audit_report.md
+++ b/backend/reports/backend_gap_audit_report.md
@@ -1,0 +1,97 @@
+# Backend Gap Audit Report
+
+- generated_at: 2026-03-11T15:10:28.264Z
+- parent_issue: #529
+- closure_recommendation: close_parent_keep_children_open
+
+## Summary
+
+- parent issue #529 audit status: audit_complete
+- current readiness score: 56.3% (fail)
+- baseline deltas: latest release drift 3 -> 0, title-track 64.5% -> 67.8%, canonical MV 6.3% -> 8.6%
+- allowlist progress: mv_source_channels 0/117 -> 92/117
+- entity metadata unchanged: debut_year 8/117, representative_image 0/117
+- runtime-facing duplicate artifacts still present: 4
+- direct blocker follow-ups: #600 backend runtime health, #601 web backend-only stability, #602 backend deploy parity, #603 catalog completeness
+
+## Baseline vs Current
+
+| Metric | Baseline | Current | Status |
+| --- | ---: | ---: | --- |
+| Latest verified release selection drift count | 3 | 0 | resolved |
+| Historical title-track resolved coverage (%) | 64.5 | 67.8 | improved |
+| Historical canonical MV coverage (%) | 6.3 | 8.6 | improved |
+| Rows with mv_source_channels populated | 0 | 92 | improved |
+| Artist profiles with debut_year populated | 8 | 8 | unchanged |
+| Artist profiles with representative_image_url populated | 0 | 0 | unchanged |
+
+## Blocker Mapping
+
+### Backend runtime health
+
+- status: fail
+- blocker_reason: projection_freshness=fail
+- blocker_reason: worker_cadence=fail
+- blocker_reason: stage_gate:shadow_to_web_cutover=fail
+- blocker_reason: stage_gate:web_cutover_to_json_demotion=fail
+- follow_up: [#600](https://github.com/iAmSomething/idol-song-app/issues/600) Restore backend runtime-health cutover gate by clearing projection freshness lag and scheduled worker cadence evidence
+
+### Backend deploy parity
+
+- status: fail
+- blocker_reason: parity_clean=false (latest_verified_release_selection drift=0)
+- follow_up: [#602](https://github.com/iAmSomething/idol-song-app/issues/602) Resolve backend deploy parity drift for YouTube allowlists, title-track/service-link state, and review-required counts
+
+### Web backend-only stability
+
+- status: fail
+- blocker_reason: entity_detail clean_ratio=0.5
+- blocker_reason: release_detail clean_ratio=0
+- follow_up: [#601](https://github.com/iAmSomething/idol-song-app/issues/601) Close remaining backend-only shadow drift on web entity detail and release detail surfaces
+
+### Catalog completeness
+
+- status: fail
+- blocker_reason: title_track_resolved overall=67.9 pre_2024=65.2
+- blocker_reason: canonical_mv overall=8.6 pre_2024=6.4
+- blocker_reason: releases.title_track latest 29.1% < 95.0%
+- blocker_reason: release_service_links.youtube_mv latest 10.2% < 80.0%
+- blocker_reason: entities.official_youtube latest 75.3% < 100.0%
+- blocker_reason: entities.official_x latest 97.8% < 100.0%
+- blocker_reason: entities.official_instagram latest 98.9% < 100.0%
+- blocker_reason: releases.title_track recent 0.0% < 85.0%
+- blocker_reason: release_service_links.youtube_mv recent 0.0% < 55.0%
+- blocker_reason: entities.official_youtube recent 72.2% < 95.0%
+- follow_up: [#603](https://github.com/iAmSomething/idol-song-app/issues/603) Raise catalog completeness for title-track, MV, official-link, and visual metadata blocker cohorts
+- follow_up: [#538](https://github.com/iAmSomething/idol-song-app/issues/538) Integrate collected social links, agency names, and debut-year metadata into canonical entity data with provenance and review states
+- follow_up: [#539](https://github.com/iAmSomething/idol-song-app/issues/539) Backfill representative entity images and broaden release artwork coverage beyond the latest-snapshot subset
+- follow_up: [#580](https://github.com/iAmSomething/idol-song-app/issues/580) Define export-import manual curation bundles for unresolved canonical nulls across key field families
+
+## Related Operational Follow-ups
+
+- [#525](https://github.com/iAmSomething/idol-song-app/issues/525) [RN] Provision a stable public preview backend URL for external iPhone and Android device testing
+- [#540](https://github.com/iAmSomething/idol-song-app/issues/540) Remove duplicate generated artifacts and define one canonical retention policy for runtime-facing JSON and pipeline scripts
+
+## Resolved Workstreams
+
+- Latest verified release selection drift cleared: #532
+- Historical release enrichment and MV allowlist foundation landed: #534, #535, #536, #537, #591
+- Trusted upcoming notification event and push runtime path landed: #554, #556, #557, #558, #559, #560, #561
+- Null hygiene cadence, workbench, and bundle reporting landed: #566, #567, #568, #569, #570, #571, #572, #573, #574, #575, #577, #578, #579, #582, #583
+- Worker cadence / runtime gate semantics were added even though operational pass is still pending: #530
+
+## Runtime-facing Duplicate Artifacts
+
+- build_release_details_musicbrainz 2.py
+- web/src/data/artistProfiles 2.json
+- web/src/data/releaseArtwork 2.json
+- web/src/data/releaseDetails 2.json
+
+## Null Hygiene Snapshot
+
+- YouTube MV Canonical Link: coverage 1.5%, unresolved 1744
+- Title Track Resolution: coverage 4.3%, unresolved 1694
+- Official YouTube: coverage 75.2%, unresolved 29
+- Debut Year: coverage 6.8%, unresolved 109
+- Representative Image: coverage 0%, unresolved 117
+

--- a/backend/scripts/build-backend-gap-audit-report.mjs
+++ b/backend/scripts/build-backend-gap-audit-report.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+
+import { existsSync } from 'node:fs';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { buildBackendGapAuditReport, renderBackendGapAuditMarkdown } from './lib/backendGapAudit.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const BACKEND_DIR = path.resolve(__dirname, '..');
+const REPO_DIR = path.resolve(BACKEND_DIR, '..');
+
+const DEFAULT_JSON_REPORT_PATH = path.join(BACKEND_DIR, 'reports', 'backend_gap_audit_report.json');
+const DEFAULT_MARKDOWN_REPORT_PATH = path.join(BACKEND_DIR, 'reports', 'backend_gap_audit_report.md');
+const DEFAULT_SCORECARD_PATH = path.join(BACKEND_DIR, 'reports', 'migration_readiness_scorecard.json');
+const DEFAULT_RUNTIME_GATE_PATH = path.join(BACKEND_DIR, 'reports', 'runtime_gate_report.json');
+const DEFAULT_PARITY_PATH = path.join(BACKEND_DIR, 'reports', 'backend_json_parity_report.json');
+const DEFAULT_HISTORICAL_COVERAGE_PATH = path.join(
+  BACKEND_DIR,
+  'reports',
+  'historical_release_detail_coverage_report.json',
+);
+const DEFAULT_NULL_COVERAGE_PATH = path.join(BACKEND_DIR, 'reports', 'canonical_null_coverage_report.json');
+const DEFAULT_WORKER_CADENCE_PATH = path.join(BACKEND_DIR, 'reports', 'worker_cadence_report.json');
+const DEFAULT_ALLOWLIST_PATH = path.join(REPO_DIR, 'web', 'src', 'data', 'youtubeChannelAllowlists.json');
+const DEFAULT_ARTIST_PROFILES_PATH = path.join(REPO_DIR, 'web', 'src', 'data', 'artistProfiles.json');
+
+function parseArgs(argv) {
+  const options = {
+    jsonReportPath: DEFAULT_JSON_REPORT_PATH,
+    markdownReportPath: DEFAULT_MARKDOWN_REPORT_PATH,
+    scorecardPath: DEFAULT_SCORECARD_PATH,
+    runtimeGatePath: DEFAULT_RUNTIME_GATE_PATH,
+    parityPath: DEFAULT_PARITY_PATH,
+    historicalCoveragePath: DEFAULT_HISTORICAL_COVERAGE_PATH,
+    nullCoveragePath: DEFAULT_NULL_COVERAGE_PATH,
+    workerCadencePath: DEFAULT_WORKER_CADENCE_PATH,
+    allowlistPath: DEFAULT_ALLOWLIST_PATH,
+    artistProfilesPath: DEFAULT_ARTIST_PROFILES_PATH,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const value = argv[index];
+    if (value === '--json-report-path') {
+      options.jsonReportPath = path.resolve(BACKEND_DIR, argv[index + 1] ?? '');
+      index += 1;
+      continue;
+    }
+    if (value === '--markdown-report-path') {
+      options.markdownReportPath = path.resolve(BACKEND_DIR, argv[index + 1] ?? '');
+      index += 1;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${value}`);
+  }
+
+  return options;
+}
+
+async function readJson(filePath) {
+  const raw = await readFile(filePath, 'utf8');
+  return JSON.parse(raw);
+}
+
+function collectRuntimeFacingDuplicateArtifacts() {
+  const candidates = [
+    path.join(REPO_DIR, 'build_release_details_musicbrainz 2.py'),
+    path.join(REPO_DIR, 'web', 'src', 'data', 'artistProfiles 2.json'),
+    path.join(REPO_DIR, 'web', 'src', 'data', 'releaseArtwork 2.json'),
+    path.join(REPO_DIR, 'web', 'src', 'data', 'releaseDetails 2.json'),
+  ];
+
+  return candidates
+    .filter((filePath) => Boolean(filePath) && existsSync(filePath))
+    .map((filePath) => path.relative(REPO_DIR, filePath));
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const [
+    scorecard,
+    runtimeGate,
+    parityReport,
+    historicalCoverageReport,
+    nullCoverageReport,
+    workerCadenceReport,
+    allowlistRows,
+    artistProfiles,
+  ] = await Promise.all([
+    readJson(options.scorecardPath),
+    readJson(options.runtimeGatePath),
+    readJson(options.parityPath),
+    readJson(options.historicalCoveragePath),
+    readJson(options.nullCoveragePath),
+    readJson(options.workerCadencePath),
+    readJson(options.allowlistPath),
+    readJson(options.artistProfilesPath),
+  ]);
+
+  const report = buildBackendGapAuditReport({
+    scorecard,
+    runtimeGate,
+    parityReport,
+    historicalCoverageReport,
+    nullCoverageReport,
+    workerCadenceReport,
+    allowlistRows,
+    artistProfiles,
+    runtimeFacingDuplicateArtifacts: collectRuntimeFacingDuplicateArtifacts(),
+  });
+  const markdown = renderBackendGapAuditMarkdown(report);
+
+  await mkdir(path.dirname(options.jsonReportPath), { recursive: true });
+  await mkdir(path.dirname(options.markdownReportPath), { recursive: true });
+  await writeFile(options.jsonReportPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+  await writeFile(options.markdownReportPath, markdown, 'utf8');
+
+  console.log(
+    JSON.stringify({
+      status: 'ok',
+      parent_issue: report.parent_issue.number,
+      closure_recommendation: report.parent_issue.closure_recommendation,
+      direct_blocker_followups: report.blocker_mapping.flatMap((entry) => entry.issues.map((issue) => issue.number)),
+      runtime_facing_duplicate_artifact_count: report.current_snapshot.runtime_facing_duplicate_artifact_count,
+      json_report_path: path.relative(REPO_DIR, options.jsonReportPath),
+      markdown_report_path: path.relative(REPO_DIR, options.markdownReportPath),
+    }),
+  );
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/backend/scripts/lib/backendGapAudit.mjs
+++ b/backend/scripts/lib/backendGapAudit.mjs
@@ -1,0 +1,396 @@
+const ISSUE_BASELINE = {
+  parent_issue_number: 529,
+  parent_issue_url: 'https://github.com/iAmSomething/idol-song-app/issues/529',
+  readiness_score_percent: 59.9,
+  latest_verified_release_selection_drift: 3,
+  title_track_resolved_percent: 64.5,
+  canonical_mv_percent: 6.3,
+  allowlist_rows: 117,
+  mv_source_channels_populated: 0,
+  artist_profile_rows: 117,
+  debut_year_populated: 8,
+  representative_image_populated: 0,
+};
+
+const DIRECT_BLOCKER_FOLLOWUPS = [
+  {
+    key: 'backend_runtime_health',
+    issues: [
+      {
+        number: 600,
+        title: 'Restore backend runtime-health cutover gate by clearing projection freshness lag and scheduled worker cadence evidence',
+      },
+    ],
+  },
+  {
+    key: 'backend_deploy_parity',
+    issues: [
+      {
+        number: 602,
+        title: 'Resolve backend deploy parity drift for YouTube allowlists, title-track/service-link state, and review-required counts',
+      },
+    ],
+  },
+  {
+    key: 'web_backend_only_stability',
+    issues: [
+      {
+        number: 601,
+        title: 'Close remaining backend-only shadow drift on web entity detail and release detail surfaces',
+      },
+    ],
+  },
+  {
+    key: 'catalog_completeness',
+    issues: [
+      {
+        number: 603,
+        title: 'Raise catalog completeness for title-track, MV, official-link, and visual metadata blocker cohorts',
+      },
+      {
+        number: 538,
+        title: 'Integrate collected social links, agency names, and debut-year metadata into canonical entity data with provenance and review states',
+      },
+      {
+        number: 539,
+        title: 'Backfill representative entity images and broaden release artwork coverage beyond the latest-snapshot subset',
+      },
+      {
+        number: 580,
+        title: 'Define export-import manual curation bundles for unresolved canonical nulls across key field families',
+      },
+    ],
+  },
+];
+
+const RELATED_OPERATIONAL_FOLLOWUPS = [
+  {
+    number: 525,
+    title: '[RN] Provision a stable public preview backend URL for external iPhone and Android device testing',
+  },
+  {
+    number: 540,
+    title: 'Remove duplicate generated artifacts and define one canonical retention policy for runtime-facing JSON and pipeline scripts',
+  },
+];
+
+const RESOLVED_WORKSTREAMS = [
+  {
+    key: 'latest_verified_release_selection',
+    label: 'Latest verified release selection drift cleared',
+    issues: [532],
+  },
+  {
+    key: 'historical_release_enrichment_and_mv_allowlists',
+    label: 'Historical release enrichment and MV allowlist foundation landed',
+    issues: [534, 535, 536, 537, 591],
+  },
+  {
+    key: 'trusted_upcoming_notification_runtime',
+    label: 'Trusted upcoming notification event and push runtime path landed',
+    issues: [554, 556, 557, 558, 559, 560, 561],
+  },
+  {
+    key: 'null_hygiene_and_gap_workbenches',
+    label: 'Null hygiene cadence, workbench, and bundle reporting landed',
+    issues: [566, 567, 568, 569, 570, 571, 572, 573, 574, 575, 577, 578, 579, 582, 583],
+  },
+  {
+    key: 'worker_cadence_gate_foundation',
+    label: 'Worker cadence / runtime gate semantics were added even though operational pass is still pending',
+    issues: [530],
+  },
+];
+
+function formatIssueUrl(number) {
+  return `https://github.com/iAmSomething/idol-song-app/issues/${number}`;
+}
+
+function roundToOneDecimal(value) {
+  return Number(Number(value).toFixed(1));
+}
+
+function ratioToPercent(value) {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return null;
+  }
+  return roundToOneDecimal(value * 100);
+}
+
+function findCategory(scorecard, key) {
+  return scorecard.categories.find((category) => category.key === key) ?? null;
+}
+
+function findField(fieldSummary, key) {
+  return fieldSummary.find((entry) => entry.field_family_key === key) ?? null;
+}
+
+function buildIssueEntries(entries) {
+  return entries.map((entry) => ({
+    ...entry,
+    url: formatIssueUrl(entry.number),
+  }));
+}
+
+function compareMetric({ key, label, baseline, current }) {
+  let status = 'unchanged';
+  if (typeof baseline === 'number' && typeof current === 'number') {
+    if (current === baseline) {
+      status = 'unchanged';
+    } else if (current > baseline) {
+      status = 'improved';
+    } else {
+      status = 'regressed';
+    }
+  }
+  if (key === 'latest_verified_release_selection_drift') {
+    if (current === 0 && baseline > 0) {
+      status = 'resolved';
+    } else if (current < baseline) {
+      status = 'improved';
+    }
+  }
+  if (key === 'representative_image_populated' && current === baseline) {
+    status = 'unchanged';
+  }
+  return {
+    key,
+    label,
+    baseline,
+    current,
+    delta:
+      typeof baseline === 'number' && typeof current === 'number'
+        ? roundToOneDecimal(current - baseline)
+        : null,
+    status,
+  };
+}
+
+export function buildBackendGapAuditReport({
+  scorecard,
+  runtimeGate,
+  parityReport,
+  historicalCoverageReport,
+  nullCoverageReport,
+  workerCadenceReport,
+  allowlistRows,
+  artistProfiles,
+  runtimeFacingDuplicateArtifacts,
+}) {
+  const runtimeCategory = findCategory(scorecard, 'backend_runtime_health');
+  const parityCategory = findCategory(scorecard, 'backend_deploy_parity');
+  const webCategory = findCategory(scorecard, 'web_backend_only_stability');
+  const catalogCategory = findCategory(scorecard, 'catalog_completeness');
+
+  const runtimeChecks = runtimeGate.runtime_checks ?? {};
+  const stageGates = runtimeGate.stage_gates ?? {};
+  const parityChecks = parityReport.checks ?? {};
+  const historicalCutoverGates = historicalCoverageReport.cutover_gates?.gates ?? {};
+  const nullFieldSummary = nullCoverageReport.field_family_summary ?? [];
+
+  const currentSnapshot = {
+    readiness_score_percent: scorecard.overall?.score_percent ?? null,
+    readiness_status: scorecard.overall?.status ?? null,
+    latest_verified_release_selection_drift:
+      parityChecks.latest_verified_release_selection?.stream_mismatches_count ?? null,
+    title_track_resolved_percent: ratioToPercent(historicalCutoverGates.title_track_resolved?.observed_total ?? null),
+    canonical_mv_percent: ratioToPercent(historicalCutoverGates.canonical_mv?.observed_total ?? null),
+    allowlist_rows: allowlistRows.length,
+    mv_source_channels_populated: allowlistRows.filter((row) => Array.isArray(row.mv_source_channels) && row.mv_source_channels.length > 0).length,
+    artist_profile_rows: artistProfiles.length,
+    debut_year_populated: artistProfiles.filter((row) => row.debut_year !== null && row.debut_year !== undefined && String(row.debut_year).trim() !== '').length,
+    representative_image_populated: artistProfiles.filter((row) => typeof row.representative_image_url === 'string' && row.representative_image_url.trim().length > 0).length,
+    runtime_facing_duplicate_artifact_count: runtimeFacingDuplicateArtifacts.length,
+  };
+
+  const baselineComparison = [
+    compareMetric({
+      key: 'latest_verified_release_selection_drift',
+      label: 'Latest verified release selection drift count',
+      baseline: ISSUE_BASELINE.latest_verified_release_selection_drift,
+      current: currentSnapshot.latest_verified_release_selection_drift,
+    }),
+    compareMetric({
+      key: 'title_track_resolved_percent',
+      label: 'Historical title-track resolved coverage (%)',
+      baseline: ISSUE_BASELINE.title_track_resolved_percent,
+      current: currentSnapshot.title_track_resolved_percent,
+    }),
+    compareMetric({
+      key: 'canonical_mv_percent',
+      label: 'Historical canonical MV coverage (%)',
+      baseline: ISSUE_BASELINE.canonical_mv_percent,
+      current: currentSnapshot.canonical_mv_percent,
+    }),
+    compareMetric({
+      key: 'mv_source_channels_populated',
+      label: 'Rows with mv_source_channels populated',
+      baseline: ISSUE_BASELINE.mv_source_channels_populated,
+      current: currentSnapshot.mv_source_channels_populated,
+    }),
+    compareMetric({
+      key: 'debut_year_populated',
+      label: 'Artist profiles with debut_year populated',
+      baseline: ISSUE_BASELINE.debut_year_populated,
+      current: currentSnapshot.debut_year_populated,
+    }),
+    compareMetric({
+      key: 'representative_image_populated',
+      label: 'Artist profiles with representative_image_url populated',
+      baseline: ISSUE_BASELINE.representative_image_populated,
+      current: currentSnapshot.representative_image_populated,
+    }),
+  ];
+
+  const blockerMapping = DIRECT_BLOCKER_FOLLOWUPS.map((followup) => {
+    const category =
+      followup.key === 'backend_runtime_health'
+        ? runtimeCategory
+        : followup.key === 'backend_deploy_parity'
+          ? parityCategory
+          : followup.key === 'web_backend_only_stability'
+            ? webCategory
+            : catalogCategory;
+    return {
+      key: followup.key,
+      label: category?.label ?? followup.key,
+      status: category?.status ?? null,
+      blocker_reasons: category?.blocker_reasons ?? [],
+      summary_lines: category?.summary_lines ?? [],
+      issues: buildIssueEntries(followup.issues),
+    };
+  });
+
+  const nullFieldFamilies = ['release_service_links.youtube_mv', 'releases.title_track', 'entities.official_youtube', 'entities.debut_year', 'entities.representative_image']
+    .map((key) => findField(nullFieldSummary, key))
+    .filter(Boolean)
+    .map((entry) => ({
+      field_family_key: entry.field_family_key,
+      field_label: entry.field_label,
+      populated_records: entry.populated_records,
+      unresolved_records: entry.unresolved_records,
+      effective_coverage_percent: ratioToPercent(entry.effective_coverage_ratio),
+    }));
+
+  const auditStatus = blockerMapping.every((entry) => entry.issues.length > 0) ? 'audit_complete' : 'audit_incomplete';
+
+  const summaryLines = [
+    `parent issue #${ISSUE_BASELINE.parent_issue_number} audit status: ${auditStatus}`,
+    `current readiness score: ${currentSnapshot.readiness_score_percent}% (${currentSnapshot.readiness_status})`,
+    `baseline deltas: latest release drift ${ISSUE_BASELINE.latest_verified_release_selection_drift} -> ${currentSnapshot.latest_verified_release_selection_drift}, title-track ${ISSUE_BASELINE.title_track_resolved_percent}% -> ${currentSnapshot.title_track_resolved_percent}%, canonical MV ${ISSUE_BASELINE.canonical_mv_percent}% -> ${currentSnapshot.canonical_mv_percent}%`,
+    `allowlist progress: mv_source_channels ${ISSUE_BASELINE.mv_source_channels_populated}/${ISSUE_BASELINE.allowlist_rows} -> ${currentSnapshot.mv_source_channels_populated}/${currentSnapshot.allowlist_rows}`,
+    `entity metadata unchanged: debut_year ${currentSnapshot.debut_year_populated}/${currentSnapshot.artist_profile_rows}, representative_image ${currentSnapshot.representative_image_populated}/${currentSnapshot.artist_profile_rows}`,
+    `runtime-facing duplicate artifacts still present: ${currentSnapshot.runtime_facing_duplicate_artifact_count}`,
+    'direct blocker follow-ups: #600 backend runtime health, #601 web backend-only stability, #602 backend deploy parity, #603 catalog completeness',
+  ];
+
+  return {
+    generated_at: new Date().toISOString(),
+    parent_issue: {
+      number: ISSUE_BASELINE.parent_issue_number,
+      url: ISSUE_BASELINE.parent_issue_url,
+      audit_status: auditStatus,
+      closure_recommendation: auditStatus === 'audit_complete' ? 'close_parent_keep_children_open' : 'keep_open',
+    },
+    baseline_snapshot: ISSUE_BASELINE,
+    current_snapshot: currentSnapshot,
+    baseline_comparison: baselineComparison,
+    blocker_mapping: blockerMapping,
+    related_operational_followups: buildIssueEntries(RELATED_OPERATIONAL_FOLLOWUPS),
+    resolved_workstreams: RESOLVED_WORKSTREAMS.map((entry) => ({
+      key: entry.key,
+      label: entry.label,
+      issues: entry.issues.map((number) => ({
+        number,
+        url: formatIssueUrl(number),
+      })),
+    })),
+    runtime_details: {
+      projection_freshness: runtimeChecks.projection_freshness ?? null,
+      worker_cadence: runtimeChecks.worker_cadence ?? null,
+      stage_gates: stageGates,
+      worker_cadence_summary: workerCadenceReport.summary_lines ?? [],
+    },
+    deploy_parity_details: {
+      youtube_allowlists: parityChecks.youtube_allowlists ?? null,
+      latest_verified_release_selection: parityChecks.latest_verified_release_selection ?? null,
+      title_tracks_and_double_title: parityChecks.title_tracks_and_double_title ?? null,
+      release_service_links: parityChecks.release_service_links ?? null,
+      review_required_counts: parityChecks.review_required_counts ?? null,
+    },
+    catalog_completeness_details: {
+      cutover_gates: historicalCoverageReport.cutover_gates ?? null,
+      migration_priority_slice: historicalCoverageReport.migration_priority_slice?.gates ?? null,
+      null_field_families: nullFieldFamilies,
+    },
+    runtime_facing_duplicate_artifacts: runtimeFacingDuplicateArtifacts,
+    summary_lines: summaryLines,
+  };
+}
+
+export function renderBackendGapAuditMarkdown(report) {
+  const lines = [
+    '# Backend Gap Audit Report',
+    '',
+    `- generated_at: ${report.generated_at}`,
+    `- parent_issue: #${report.parent_issue.number}`,
+    `- closure_recommendation: ${report.parent_issue.closure_recommendation}`,
+    '',
+    '## Summary',
+    '',
+    ...report.summary_lines.map((line) => `- ${line}`),
+    '',
+    '## Baseline vs Current',
+    '',
+    '| Metric | Baseline | Current | Status |',
+    '| --- | ---: | ---: | --- |',
+    ...report.baseline_comparison.map(
+      (entry) => `| ${entry.label} | ${entry.baseline} | ${entry.current} | ${entry.status} |`,
+    ),
+    '',
+    '## Blocker Mapping',
+    '',
+  ];
+
+  for (const blocker of report.blocker_mapping) {
+    lines.push(`### ${blocker.label}`);
+    lines.push('');
+    lines.push(`- status: ${blocker.status}`);
+    for (const reason of blocker.blocker_reasons) {
+      lines.push(`- blocker_reason: ${reason}`);
+    }
+    for (const issue of blocker.issues) {
+      lines.push(`- follow_up: [#${issue.number}](${issue.url}) ${issue.title}`);
+    }
+    lines.push('');
+  }
+
+  lines.push('## Related Operational Follow-ups');
+  lines.push('');
+  for (const issue of report.related_operational_followups) {
+    lines.push(`- [#${issue.number}](${issue.url}) ${issue.title}`);
+  }
+  lines.push('');
+  lines.push('## Resolved Workstreams');
+  lines.push('');
+  for (const item of report.resolved_workstreams) {
+    lines.push(`- ${item.label}: ${item.issues.map((issue) => `#${issue.number}`).join(', ')}`);
+  }
+  lines.push('');
+  lines.push('## Runtime-facing Duplicate Artifacts');
+  lines.push('');
+  for (const item of report.runtime_facing_duplicate_artifacts) {
+    lines.push(`- ${item}`);
+  }
+  lines.push('');
+  lines.push('## Null Hygiene Snapshot');
+  lines.push('');
+  for (const item of report.catalog_completeness_details.null_field_families) {
+    lines.push(
+      `- ${item.field_label}: coverage ${item.effective_coverage_percent}%, unresolved ${item.unresolved_records}`,
+    );
+  }
+  lines.push('');
+
+  return `${lines.join('\n')}\n`;
+}

--- a/backend/scripts/lib/backendGapAudit.test.mjs
+++ b/backend/scripts/lib/backendGapAudit.test.mjs
@@ -1,0 +1,163 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildBackendGapAuditReport, renderBackendGapAuditMarkdown } from './backendGapAudit.mjs';
+
+test('buildBackendGapAuditReport maps blockers and baseline deltas', () => {
+  const report = buildBackendGapAuditReport({
+    scorecard: {
+      overall: { score_percent: 56.3, status: 'fail' },
+      categories: [
+        {
+          key: 'backend_runtime_health',
+          label: 'Backend runtime health',
+          status: 'fail',
+          blocker_reasons: ['projection_freshness=fail'],
+          summary_lines: [],
+        },
+        {
+          key: 'backend_deploy_parity',
+          label: 'Backend deploy parity',
+          status: 'fail',
+          blocker_reasons: ['parity_clean=false'],
+          summary_lines: [],
+        },
+        {
+          key: 'web_backend_only_stability',
+          label: 'Web backend-only stability',
+          status: 'fail',
+          blocker_reasons: ['entity_detail clean_ratio=0.5'],
+          summary_lines: [],
+        },
+        {
+          key: 'catalog_completeness',
+          label: 'Catalog completeness',
+          status: 'fail',
+          blocker_reasons: ['title_track_resolved overall=67.9'],
+          summary_lines: [],
+        },
+      ],
+    },
+    runtimeGate: {
+      runtime_checks: {
+        projection_freshness: { status: 'fail' },
+        worker_cadence: { status: 'fail' },
+      },
+      stage_gates: { shadow_to_web_cutover: 'fail' },
+    },
+    parityReport: {
+      checks: {
+        latest_verified_release_selection: { stream_mismatches_count: 0 },
+        youtube_allowlists: { clean: false },
+        title_tracks_and_double_title: { clean: false },
+        release_service_links: { clean: false },
+        review_required_counts: { clean: false },
+      },
+    },
+    historicalCoverageReport: {
+      cutover_gates: {
+        gates: {
+          title_track_resolved: { observed_total: 0.6785 },
+          canonical_mv: { observed_total: 0.0864 },
+        },
+      },
+      migration_priority_slice: { gates: { cutover_status: 'pass' } },
+    },
+    nullCoverageReport: {
+      field_family_summary: [
+        {
+          field_family_key: 'entities.representative_image',
+          field_label: 'Representative Image',
+          populated_records: 0,
+          unresolved_records: 117,
+          effective_coverage_ratio: 0,
+        },
+        {
+          field_family_key: 'release_service_links.youtube_mv',
+          field_label: 'YouTube MV Canonical Link',
+          populated_records: 27,
+          unresolved_records: 1744,
+          effective_coverage_ratio: 0.0152,
+        },
+      ],
+    },
+    workerCadenceReport: {
+      summary_lines: ['[primary] daily_upcoming: cadence=daily, status=scheduled_evidence_missing'],
+    },
+    allowlistRows: [
+      { mv_source_channels: [{ channel_url: 'https://www.youtube.com/@one' }] },
+      { mv_source_channels: [] },
+    ],
+    artistProfiles: [
+      { debut_year: 2024, representative_image_url: '' },
+      { debut_year: '', representative_image_url: '' },
+    ],
+    runtimeFacingDuplicateArtifacts: ['web/src/data/releaseDetails 2.json'],
+  });
+
+  assert.equal(report.parent_issue.number, 529);
+  assert.equal(report.baseline_comparison[0].status, 'resolved');
+  assert.equal(report.current_snapshot.mv_source_channels_populated, 1);
+  assert.equal(report.blocker_mapping[0].issues[0].number, 600);
+  assert.equal(report.related_operational_followups[0].number, 525);
+});
+
+test('renderBackendGapAuditMarkdown renders blocker follow-up links', () => {
+  const markdown = renderBackendGapAuditMarkdown({
+    generated_at: '2026-03-11T00:00:00.000Z',
+    parent_issue: {
+      number: 529,
+      closure_recommendation: 'close_parent_keep_children_open',
+    },
+    summary_lines: ['parent issue #529 audit status: audit_complete'],
+    baseline_comparison: [
+      {
+        label: 'Latest verified release selection drift count',
+        baseline: 3,
+        current: 0,
+        status: 'resolved',
+      },
+    ],
+    blocker_mapping: [
+      {
+        label: 'Backend runtime health',
+        status: 'fail',
+        blocker_reasons: ['projection_freshness=fail'],
+        issues: [
+          {
+            number: 600,
+            url: 'https://github.com/iAmSomething/idol-song-app/issues/600',
+            title: 'Runtime health follow-up',
+          },
+        ],
+      },
+    ],
+    related_operational_followups: [
+      {
+        number: 525,
+        url: 'https://github.com/iAmSomething/idol-song-app/issues/525',
+        title: 'Preview backend URL',
+      },
+    ],
+    resolved_workstreams: [
+      {
+        label: 'Latest verified release selection drift cleared',
+        issues: [{ number: 532 }],
+      },
+    ],
+    runtime_facing_duplicate_artifacts: ['web/src/data/releaseDetails 2.json'],
+    catalog_completeness_details: {
+      null_field_families: [
+        {
+          field_label: 'Representative Image',
+          effective_coverage_percent: 0,
+          unresolved_records: 117,
+        },
+      ],
+    },
+  });
+
+  assert.match(markdown, /# Backend Gap Audit Report/);
+  assert.match(markdown, /\[#600\]\(https:\/\/github.com\/iAmSomething\/idol-song-app\/issues\/600\)/);
+  assert.match(markdown, /Latest verified release selection drift cleared: #532/);
+});

--- a/docs/assets/distribution/backend_gap_audit_parent_529_local_2026-03-11.md
+++ b/docs/assets/distribution/backend_gap_audit_parent_529_local_2026-03-11.md
@@ -1,0 +1,40 @@
+# Backend Gap Audit Parent #529 Local Evidence (2026-03-11)
+
+## Commands
+
+```bash
+cd backend
+node --test ./scripts/lib/backendGapAudit.test.mjs
+npm run gap:audit
+npm run build
+
+cd ..
+git diff --check
+```
+
+## Result
+
+- `backend/reports/backend_gap_audit_report.json`
+- `backend/reports/backend_gap_audit_report.md`
+
+## Snapshot
+
+- closure recommendation: `close_parent_keep_children_open`
+- direct blocker follow-ups:
+  - `#600` backend runtime health
+  - `#601` web backend-only stability
+  - `#602` backend deploy parity
+  - `#603` catalog completeness
+- related operational follow-ups:
+  - `#525` stable public preview backend URL
+  - `#540` duplicate runtime-facing artifact retention policy
+
+## Key Deltas vs #529 Baseline
+
+- latest verified release selection drift: `3 -> 0`
+- historical title-track resolved coverage: `64.5% -> 67.8%`
+- historical canonical MV coverage: `6.3% -> 8.6%`
+- `mv_source_channels` populated rows: `0/117 -> 92/117`
+- `debut_year` populated rows: `8/117 -> 8/117`
+- `representative_image_url` populated rows: `0/117 -> 0/117`
+- runtime-facing duplicate artifacts still present: `4`


### PR DESCRIPTION
## Summary
- add a backend gap-audit report generator for parent issue `#529`
- generate repo-tracked JSON/Markdown audit artifacts with current blocker mapping
- split the remaining blocker categories into direct follow-up issues `#600`, `#601`, `#602`, `#603`

## Verification
- `cd backend && node --test ./scripts/lib/backendGapAudit.test.mjs`
- `cd backend && npm run gap:audit`
- `cd backend && npm run build`
- `git diff --check`

Closes #529
