### PR TITLE
Fix backend runtime health warm-up gate

### DIFF
--- a/backend/reports/backend_json_parity_report.json
+++ b/backend/reports/backend_json_parity_report.json
@@ -1,9 +1,9 @@
 {
-  "generated_at": "2026-03-11T09:16:27.590969+00:00",
+  "generated_at": "2026-03-11T16:15:16.837750+00:00",
   "clean": false,
   "report_bundle": {
-    "generated_at": "2026-03-11T09:16:25.280Z",
-    "bundle_id": "post-sync-verification-57fe974c438e",
+    "generated_at": "2026-03-11T16:14:23.510Z",
+    "bundle_id": "post-sync-verification-339f67a6e124",
     "bundle_kind": "post-sync-verification",
     "cadence_profile": "daily-upcoming",
     "source": {
@@ -25,11 +25,11 @@
       },
       "projection_refresh": {
         "path": "reports/projection_refresh_summary.json",
-        "generated_at": "2026-03-11T07:53:57.809Z"
+        "generated_at": "2026-03-11T16:14:21.898Z"
       },
       "historical_coverage": {
         "path": "reports/historical_release_detail_coverage_report.json",
-        "generated_at": "2026-03-10T00:00:00.000Z"
+        "generated_at": "2026-03-11T00:00:00.000Z"
       },
       "canonical_null_coverage": {
         "path": "reports/canonical_null_coverage_report.json",
@@ -47,7 +47,7 @@
       },
       "worker_cadence": {
         "path": "reports/worker_cadence_report.json",
-        "generated_at": "2026-03-11T08:30:28.469Z",
+        "generated_at": "2026-03-11T16:14:23.247Z",
         "primary_path_key": "daily_upcoming"
       },
       "service_link_gap_queues": {
@@ -65,10 +65,21 @@
         "generated_at": "2026-03-11T09:16:24.924Z",
         "entities": 117,
         "field_rows": 324
+      },
+      "trusted_upcoming_notification_summary": {
+        "path": "reports/trusted_upcoming_notification_event_summary.json",
+        "generated_at": "2026-03-11T12:38:47.563Z",
+        "emitted": 0
+      },
+      "mobile_push_delivery_summary": {
+        "path": "reports/mobile_push_delivery_summary.json",
+        "generated_at": null,
+        "sent": null,
+        "failed": null
       }
     },
     "summary_lines": [
-      "bundle id: post-sync-verification-57fe974c438e",
+      "bundle id: post-sync-verification-339f67a6e124",
       "bundle kind: post-sync-verification",
       "cadence profile: daily-upcoming",
       "workflow: manual"
@@ -80,8 +91,8 @@
     "YouTube allowlists: drift (role mismatches=10, metadata mismatches=0)",
     "latest verified release selection: clean (tracking mismatches=0, stream mismatches=0)",
     "upcoming counts / nearest: clean (month bucket mismatches=0)",
-    "title-track / double-title: drift (mismatched releases=1060)",
-    "YouTube Music / MV service-link state: drift (mismatched releases=124)",
+    "title-track / double-title: drift (mismatched releases=1120)",
+    "YouTube Music / MV service-link state: drift (mismatched releases=165)",
     "review-required counts: drift (review_type_counts_match=False, youtube_mv_status_counts_match=False)"
   ],
   "source_snapshot_counts": {
@@ -91,7 +102,7 @@
     "upcoming_candidates": 71,
     "watchlist": 108,
     "manual_review_queue": 67,
-    "mv_manual_review_queue": 1657
+    "mv_manual_review_queue": 1616
   },
   "checks": {
     "entity_alias_search_coverage": {
@@ -229,12 +240,12 @@
           "exact": 6,
           "month_only": 14
         },
-        "future_exact_count": 6,
+        "future_exact_count": 5,
         "nearest_exact": {
-          "slug": "yena",
-          "scheduled_date": "2026-03-11",
-          "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
-          "confidence": 0.84
+          "slug": "p1harmony",
+          "scheduled_date": "2026-03-12",
+          "headline": "P1Harmony's Hero's Return: 9th Mini-Album Drops March 12 - 조선일보",
+          "confidence": 0.82
         },
         "month_buckets": {
           "exact": {
@@ -254,12 +265,12 @@
           "unknown": 39,
           "exact": 6
         },
-        "future_exact_count": 6,
+        "future_exact_count": 5,
         "nearest_exact": {
-          "slug": "yena",
-          "scheduled_date": "2026-03-11",
-          "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
-          "confidence": 0.84
+          "slug": "p1harmony",
+          "scheduled_date": "2026-03-12",
+          "headline": "P1Harmony's Hero's Return: 9th Mini-Album Drops March 12 - 조선일보",
+          "confidence": 0.82
         },
         "month_buckets": {
           "exact": {
@@ -281,7 +292,7 @@
       "clean": true
     },
     "title_tracks_and_double_title": {
-      "mismatched_releases_count": 1060,
+      "mismatched_releases_count": 1120,
       "source_double_title_releases": 27,
       "db_double_title_releases": 3,
       "mismatches": [
@@ -379,7 +390,7 @@
       "clean": false
     },
     "release_service_links": {
-      "mismatched_release_services_count": 124,
+      "mismatched_release_services_count": 165,
       "mismatches": [
         {
           "entity_slug": "82major",
@@ -495,37 +506,45 @@
         },
         {
           "entity_slug": "blackpink",
-          "release_date": "2026-02-26",
-          "stream": "album",
-          "service_type": "youtube_music",
-          "source": null,
-          "db": {
-            "url": "https://music.youtube.com/playlist?list=OLAK5uy_l3QGS6y9ZWficqzcu429HoCvcKlpMmmmY",
-            "status": "manual_override",
-            "provenance": "ytmusicapi exact album search match"
-          }
-        },
-        {
-          "entity_slug": "blackpink",
-          "release_date": "2026-02-26",
-          "stream": "album",
-          "service_type": "youtube_mv",
-          "source": null,
-          "db": {
-            "url": "https://www.youtube.com/watch?v=2GJfWMYCWY0",
-            "status": "manual_override",
-            "provenance": "official artist channel watch URL"
-          }
-        },
-        {
-          "entity_slug": "blackpink",
-          "release_date": "2022-07-29",
+          "release_date": "2017-08-08",
           "stream": "song",
           "service_type": "youtube_mv",
           "source": {
-            "url": "https://www.youtube.com/watch?v=GDWX-3kV6do",
-            "status": "relation_match",
-            "provenance": "musicbrainz.release_group_release.url_relation"
+            "url": "https://www.youtube.com/watch?v=bwmSjveL3Lc",
+            "status": "manual_override",
+            "provenance": "youtube search auto-accepted via allowlist/title/date/view scoring"
+          },
+          "db": {
+            "url": null,
+            "status": "unresolved",
+            "provenance": "releaseHistory.placeholder_seed"
+          }
+        },
+        {
+          "entity_slug": "blackpink",
+          "release_date": "2022-09-16",
+          "stream": "album",
+          "service_type": "youtube_mv",
+          "source": {
+            "url": "https://www.youtube.com/watch?v=gQlMMD8auMs",
+            "status": "manual_override",
+            "provenance": "youtube search auto-accepted via allowlist/title/date/view scoring"
+          },
+          "db": {
+            "url": null,
+            "status": "unresolved",
+            "provenance": "releaseHistory.placeholder_seed"
+          }
+        },
+        {
+          "entity_slug": "blackpink",
+          "release_date": "2018-08-22",
+          "stream": "song",
+          "service_type": "youtube_mv",
+          "source": {
+            "url": "https://www.youtube.com/watch?v=IHNzOHi8sJs",
+            "status": "manual_override",
+            "provenance": "youtube search auto-accepted via allowlist/title/date/view scoring"
           },
           "db": {
             "url": null,
@@ -540,7 +559,7 @@
       "source_review_type_counts": {
         "upcoming_signal": 64,
         "entity_onboarding": 3,
-        "mv_candidate": 1657
+        "mv_candidate": 1616
       },
       "db_review_type_counts": {
         "entity_onboarding": 3,
@@ -548,8 +567,8 @@
         "upcoming_signal": 64
       },
       "source_youtube_mv_status_counts": {
-        "unresolved": 1655,
-        "manual_override": 91,
+        "unresolved": 1614,
+        "manual_override": 132,
         "relation_match": 21,
         "needs_review": 2,
         "no_mv": 1

--- a/backend/reports/backend_shadow_read_report.json
+++ b/backend/reports/backend_shadow_read_report.json
@@ -1,9 +1,9 @@
 {
-  "generated_at": "2026-03-11T09:17:40.030Z",
+  "generated_at": "2026-03-11T16:15:22.441Z",
   "clean": false,
   "report_bundle": {
-    "generated_at": "2026-03-11T09:16:25.280Z",
-    "bundle_id": "post-sync-verification-57fe974c438e",
+    "generated_at": "2026-03-11T16:14:23.510Z",
+    "bundle_id": "post-sync-verification-339f67a6e124",
     "bundle_kind": "post-sync-verification",
     "cadence_profile": "daily-upcoming",
     "source": {
@@ -25,11 +25,11 @@
       },
       "projection_refresh": {
         "path": "reports/projection_refresh_summary.json",
-        "generated_at": "2026-03-11T07:53:57.809Z"
+        "generated_at": "2026-03-11T16:14:21.898Z"
       },
       "historical_coverage": {
         "path": "reports/historical_release_detail_coverage_report.json",
-        "generated_at": "2026-03-10T00:00:00.000Z"
+        "generated_at": "2026-03-11T00:00:00.000Z"
       },
       "canonical_null_coverage": {
         "path": "reports/canonical_null_coverage_report.json",
@@ -47,7 +47,7 @@
       },
       "worker_cadence": {
         "path": "reports/worker_cadence_report.json",
-        "generated_at": "2026-03-11T08:30:28.469Z",
+        "generated_at": "2026-03-11T16:14:23.247Z",
         "primary_path_key": "daily_upcoming"
       },
       "service_link_gap_queues": {
@@ -65,10 +65,21 @@
         "generated_at": "2026-03-11T09:16:24.924Z",
         "entities": 117,
         "field_rows": 324
+      },
+      "trusted_upcoming_notification_summary": {
+        "path": "reports/trusted_upcoming_notification_event_summary.json",
+        "generated_at": "2026-03-11T12:38:47.563Z",
+        "emitted": 0
+      },
+      "mobile_push_delivery_summary": {
+        "path": "reports/mobile_push_delivery_summary.json",
+        "generated_at": null,
+        "sent": null,
+        "failed": null
       }
     },
     "summary_lines": [
-      "bundle id: post-sync-verification-57fe974c438e",
+      "bundle id: post-sync-verification-339f67a6e124",
       "bundle kind: post-sync-verification",
       "cadence profile: daily-upcoming",
       "workflow: manual"
@@ -76,9 +87,9 @@
   },
   "bundle_consistency": {
     "status": "pass",
-    "expected_bundle_id": "post-sync-verification-57fe974c438e",
+    "expected_bundle_id": "post-sync-verification-339f67a6e124",
     "observed": {
-      "parity_bundle": "post-sync-verification-57fe974c438e",
+      "parity_bundle": "post-sync-verification-339f67a6e124",
       "shadow_bundle": null,
       "runtime_gate_bundle": null,
       "historical_coverage_generated_at": null,
@@ -91,16 +102,16 @@
     "exists": true,
     "path": "backend/reports/backend_json_parity_report.json",
     "clean": false,
-    "generated_at": "2026-03-11T09:16:27.590969+00:00",
-    "bundle_id": "post-sync-verification-57fe974c438e",
+    "generated_at": "2026-03-11T16:15:16.837750+00:00",
+    "bundle_id": "post-sync-verification-339f67a6e124",
     "summary_lines": [
       "entity alias/search coverage: clean (mismatched entities=0)",
       "official links: clean (mismatched entities=0)",
       "YouTube allowlists: drift (role mismatches=10, metadata mismatches=0)",
       "latest verified release selection: clean (tracking mismatches=0, stream mismatches=0)",
       "upcoming counts / nearest: clean (month bucket mismatches=0)",
-      "title-track / double-title: drift (mismatched releases=1060)",
-      "YouTube Music / MV service-link state: drift (mismatched releases=124)",
+      "title-track / double-title: drift (mismatched releases=1120)",
+      "YouTube Music / MV service-link state: drift (mismatched releases=165)",
       "review-required counts: drift (review_type_counts_match=False, youtube_mv_status_counts_match=False)"
     ]
   },
@@ -239,8 +250,8 @@
         "upcoming": []
       },
       "actual_status_code": 200,
-      "request_id_sent": "shadow--v1-search-q-ed-8a-b8-eb-a6-ac-ed-94-8c-ec-97-90-ec-8a-a4-ee7cda50-519c-494f-ac3d-b209658531e7",
-      "response_request_id": "shadow--v1-search-q-ed-8a-b8-eb-a6-ac-ed-94-8c-ec-97-90-ec-8a-a4-ee7cda50-519c-494f-ac3d-b209658531e7"
+      "request_id_sent": "shadow--v1-search-q-ed-8a-b8-eb-a6-ac-ed-94-8c-ec-97-90-ec-8a-a4-6014e36a-1f37-47e4-ace9-8dcab656e848",
+      "response_request_id": "shadow--v1-search-q-ed-8a-b8-eb-a6-ac-ed-94-8c-ec-97-90-ec-8a-a4-6014e36a-1f37-47e4-ace9-8dcab656e848"
     },
     {
       "surface": "search",
@@ -372,8 +383,8 @@
         ]
       },
       "actual_status_code": 200,
-      "request_id_sent": "shadow--v1-search-q-ed-88-ac-eb-b0-94-ed-88-ac-46f1c547-8967-4dc5-a1b1-933f35ecfdf1",
-      "response_request_id": "shadow--v1-search-q-ed-88-ac-eb-b0-94-ed-88-ac-46f1c547-8967-4dc5-a1b1-933f35ecfdf1"
+      "request_id_sent": "shadow--v1-search-q-ed-88-ac-eb-b0-94-ed-88-ac-0973058e-3c39-4d7f-b068-d0b5e63d8b83",
+      "response_request_id": "shadow--v1-search-q-ed-88-ac-eb-b0-94-ed-88-ac-0973058e-3c39-4d7f-b068-d0b5e63d8b83"
     },
     {
       "surface": "search",
@@ -505,8 +516,8 @@
         ]
       },
       "actual_status_code": 200,
-      "request_id_sent": "shadow--v1-search-q-ec-b5-9c-ec-98-88-eb-82-98-4d0fab66-295d-4f65-a361-ae68573c810e",
-      "response_request_id": "shadow--v1-search-q-ec-b5-9c-ec-98-88-eb-82-98-4d0fab66-295d-4f65-a361-ae68573c810e"
+      "request_id_sent": "shadow--v1-search-q-ec-b5-9c-ec-98-88-eb-82-98-99066b6b-174c-41c4-8195-356705c4b56f",
+      "response_request_id": "shadow--v1-search-q-ec-b5-9c-ec-98-88-eb-82-98-99066b6b-174c-41c4-8195-356705c4b56f"
     },
     {
       "surface": "search",
@@ -587,8 +598,8 @@
         "upcoming": []
       },
       "actual_status_code": 200,
-      "request_id_sent": "shadow--v1-search-q-revive-2b-a92dbc6a-f737-4330-9ca3-79674896cc08",
-      "response_request_id": "shadow--v1-search-q-revive-2b-a92dbc6a-f737-4330-9ca3-79674896cc08"
+      "request_id_sent": "shadow--v1-search-q-revive-2b-1c1de7b9-ccb2-4a6d-bae6-bb8c3eaa1fe7",
+      "response_request_id": "shadow--v1-search-q-revive-2b-1c1de7b9-ccb2-4a6d-bae6-bb8c3eaa1fe7"
     },
     {
       "surface": "search",
@@ -669,8 +680,8 @@
         "upcoming": []
       },
       "actual_status_code": 200,
-      "request_id_sent": "shadow--v1-search-q-ed-9d-b0-ec-88-98-ec-97-bc-ea-b3-a0-eb-9e-98-2a282706-1be6-43fa-86b8-495ecb3cb268",
-      "response_request_id": "shadow--v1-search-q-ed-9d-b0-ec-88-98-ec-97-bc-ea-b3-a0-eb-9e-98-2a282706-1be6-43fa-86b8-495ecb3cb268"
+      "request_id_sent": "shadow--v1-search-q-ed-9d-b0-ec-88-98-ec-97-bc-ea-b3-a0-eb-9e-98-bf6666ae-11a6-4f28-b6a2-4439d5938926",
+      "response_request_id": "shadow--v1-search-q-ed-9d-b0-ec-88-98-ec-97-bc-ea-b3-a0-eb-9e-98-bf6666ae-11a6-4f28-b6a2-4439d5938926"
     },
     {
       "surface": "entity_detail",
@@ -734,22 +745,7 @@
           "watch_reason": null,
           "tracking_status": "watch_only"
         },
-        "next_upcoming": {
-          "upcoming_signal_id": "yena::2026-03-11::love catcher",
-          "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
-          "scheduled_date": "2026-03-11",
-          "scheduled_month": "2026-03",
-          "date_precision": "exact",
-          "date_status": "confirmed",
-          "release_format": "ep",
-          "confidence_score": 0.84,
-          "latest_seen_at": "Mon, 23 Feb 2026 14:58:00 +0900",
-          "source_type": "news_rss",
-          "source_url": "https://www.starnewskorea.com/music/2026/02/23/2026022315005262396",
-          "source_domain": "starnewskorea.com",
-          "evidence_summary": "Future date reference: 2026-03-11. YENA confirmed her comeback with the 5th mini album LOVE CATCHER, scheduled for March 11 at 6 p.m. KST.",
-          "source_count": 1
-        },
+        "next_upcoming": null,
         "latest_release": {
           "release_id": "YENA::STAR!::2025-11-26::song",
           "release_title": "STAR!",
@@ -848,22 +844,7 @@
           "watch_reason": "manual_watch",
           "tracking_status": "watch_only"
         },
-        "next_upcoming": {
-          "upcoming_signal_id": "135cb637-d988-5028-b221-0ec2f59f124f",
-          "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
-          "scheduled_date": "2026-03-11",
-          "scheduled_month": "2026-03",
-          "date_precision": "exact",
-          "date_status": "confirmed",
-          "release_format": "ep",
-          "confidence_score": 0.84,
-          "latest_seen_at": "2026-02-23T05:58:00+00:00",
-          "source_type": "news_rss",
-          "source_url": "https://www.starnewskorea.com/music/2026/02/23/2026022315005262396",
-          "source_domain": "starnewskorea.com",
-          "evidence_summary": "Future date reference: 2026-03-11. YENA confirmed her comeback with the 5th mini album LOVE CATCHER, scheduled for March 11 at 6 p.m. KST.",
-          "source_count": 1
-        },
+        "next_upcoming": null,
         "latest_release": {
           "release_id": "0363f526-e841-560d-940d-541a4e536e4e",
           "release_title": "STAR!",
@@ -959,8 +940,8 @@
         "artist_source_url": "https://musicbrainz.org/artist/745c5b92-325f-451d-bd52-e6b95229c776"
       },
       "actual_status_code": 200,
-      "request_id_sent": "shadow--v1-entities-yena-12320bce-4f24-456f-85c0-9d4f437d4b6a",
-      "response_request_id": "shadow--v1-entities-yena-12320bce-4f24-456f-85c0-9d4f437d4b6a"
+      "request_id_sent": "shadow--v1-entities-yena-463c68f7-8af4-483e-b5df-4dbb2b47742e",
+      "response_request_id": "shadow--v1-entities-yena-463c68f7-8af4-483e-b5df-4dbb2b47742e"
     },
     {
       "surface": "entity_detail",
@@ -1634,8 +1615,8 @@
         "artist_source_url": "https://musicbrainz.org/artist/48646387-1664-4c9a-9139-9bfd091b823c"
       },
       "actual_status_code": 200,
-      "request_id_sent": "shadow--v1-entities-blackpink-07fe35c1-d8f4-4841-a578-c7c71e1ff2f4",
-      "response_request_id": "shadow--v1-entities-blackpink-07fe35c1-d8f4-4841-a578-c7c71e1ff2f4"
+      "request_id_sent": "shadow--v1-entities-blackpink-1f5afa2e-cb1a-4875-9015-ea759d848fd6",
+      "response_request_id": "shadow--v1-entities-blackpink-1f5afa2e-cb1a-4875-9015-ea759d848fd6"
     },
     {
       "surface": "entity_detail",
@@ -1940,8 +1921,8 @@
         "artist_source_url": "https://musicbrainz.org/artist/bba737dc-7ec8-482d-b79f-68d949ef2c7f"
       },
       "actual_status_code": 200,
-      "request_id_sent": "shadow--v1-entities-and-team-a427af9a-2e9b-4be2-9eee-9286b1a0d8c6",
-      "response_request_id": "shadow--v1-entities-and-team-a427af9a-2e9b-4be2-9eee-9286b1a0d8c6"
+      "request_id_sent": "shadow--v1-entities-and-team-545f8e9f-6de1-42dd-862b-e74edc877b68",
+      "response_request_id": "shadow--v1-entities-and-team-545f8e9f-6de1-42dd-862b-e74edc877b68"
     },
     {
       "surface": "entity_detail",
@@ -2063,8 +2044,8 @@
         "artist_source_url": "https://musicbrainz.org/artist/ce5c564c-0fbe-429c-b93b-5d7e3109cf40"
       },
       "actual_status_code": 200,
-      "request_id_sent": "shadow--v1-entities-allday-project-0560043c-4413-4803-b02c-5b24dc8151f9",
-      "response_request_id": "shadow--v1-entities-allday-project-0560043c-4413-4803-b02c-5b24dc8151f9"
+      "request_id_sent": "shadow--v1-entities-allday-project-597ec65c-4452-4f29-8396-26b955ed2aa4",
+      "response_request_id": "shadow--v1-entities-allday-project-597ec65c-4452-4f29-8396-26b955ed2aa4"
     },
     {
       "surface": "release_detail",
@@ -2193,10 +2174,10 @@
       },
       "lookup_status_code": 200,
       "detail_status_code": 200,
-      "lookup_request_id_sent": "shadow--v1-releases-lookup-entity_slug-blackpink-title-deadline-date-2026-02-26-stream-album-ba09bd93-657a-4309-8245-03ffa487c683",
-      "lookup_response_request_id": "shadow--v1-releases-lookup-entity_slug-blackpink-title-deadline-date-2026-02-26-stream-album-ba09bd93-657a-4309-8245-03ffa487c683",
-      "detail_request_id_sent": "shadow--v1-releases-75d59b7a-9f0e-526c-9920-3a156c1a9e36-e26340a4-f7a6-43d5-869e-ffb4251a6e5b",
-      "detail_response_request_id": "shadow--v1-releases-75d59b7a-9f0e-526c-9920-3a156c1a9e36-e26340a4-f7a6-43d5-869e-ffb4251a6e5b"
+      "lookup_request_id_sent": "shadow--v1-releases-lookup-entity_slug-blackpink-title-deadline-date-2026-02-26-stream-album-ef3138b9-b0d0-4bf0-aa0e-ecb2a640a70b",
+      "lookup_response_request_id": "shadow--v1-releases-lookup-entity_slug-blackpink-title-deadline-date-2026-02-26-stream-album-ef3138b9-b0d0-4bf0-aa0e-ecb2a640a70b",
+      "detail_request_id_sent": "shadow--v1-releases-75d59b7a-9f0e-526c-9920-3a156c1a9e36-1783fb3d-6cf8-4158-b5b0-eba4fff39ead",
+      "detail_response_request_id": "shadow--v1-releases-75d59b7a-9f0e-526c-9920-3a156c1a9e36-1783fb3d-6cf8-4158-b5b0-eba4fff39ead"
     },
     {
       "surface": "release_detail",
@@ -2641,10 +2622,10 @@
       },
       "lookup_status_code": 200,
       "detail_status_code": 200,
-      "lookup_request_id_sent": "shadow--v1-releases-lookup-entity_slug-ive-title-revive-2b-date-2026-02-23-stream-album-ba8a71f4-4df2-473b-8058-dbcdfe93ac36",
-      "lookup_response_request_id": "shadow--v1-releases-lookup-entity_slug-ive-title-revive-2b-date-2026-02-23-stream-album-ba8a71f4-4df2-473b-8058-dbcdfe93ac36",
-      "detail_request_id_sent": "shadow--v1-releases-c339f501-52fe-599d-8d2d-bf5694ae4de4-4fd6c10b-ab2e-4f59-bfb7-b20d58919f93",
-      "detail_response_request_id": "shadow--v1-releases-c339f501-52fe-599d-8d2d-bf5694ae4de4-4fd6c10b-ab2e-4f59-bfb7-b20d58919f93"
+      "lookup_request_id_sent": "shadow--v1-releases-lookup-entity_slug-ive-title-revive-2b-date-2026-02-23-stream-album-4177219f-7485-47a8-b705-bdf42cd58163",
+      "lookup_response_request_id": "shadow--v1-releases-lookup-entity_slug-ive-title-revive-2b-date-2026-02-23-stream-album-4177219f-7485-47a8-b705-bdf42cd58163",
+      "detail_request_id_sent": "shadow--v1-releases-c339f501-52fe-599d-8d2d-bf5694ae4de4-afdc6631-420a-4cf5-b0be-88fa7cb6d236",
+      "detail_response_request_id": "shadow--v1-releases-c339f501-52fe-599d-8d2d-bf5694ae4de4-afdc6631-420a-4cf5-b0be-88fa7cb6d236"
     },
     {
       "surface": "release_detail",
@@ -2878,10 +2859,10 @@
       },
       "lookup_status_code": 200,
       "detail_status_code": 200,
-      "lookup_request_id_sent": "shadow--v1-releases-lookup-entity_slug-qwer-title-ed-9d-b0-ec-88-98-ec-97-bc-ea-b3-a0-eb-9e-98-date-2025-10-06-stream-song-48bee426-f691-422b-83fc-fd48ba19bfd8",
-      "lookup_response_request_id": "shadow--v1-releases-lookup-entity_slug-qwer-title-ed-9d-b0-ec-88-98-ec-97-bc-ea-b3-a0-eb-9e-98-date-2025-10-06-stream-song-48bee426-f691-422b-83fc-fd48ba19bfd8",
-      "detail_request_id_sent": "shadow--v1-releases-d9a85b3d-ed19-51bb-a6c4-e5e538401b50-978ac683-1cc8-4a7b-adf3-c5a26eb3396d",
-      "detail_response_request_id": "shadow--v1-releases-d9a85b3d-ed19-51bb-a6c4-e5e538401b50-978ac683-1cc8-4a7b-adf3-c5a26eb3396d"
+      "lookup_request_id_sent": "shadow--v1-releases-lookup-entity_slug-qwer-title-ed-9d-b0-ec-88-98-ec-97-bc-ea-b3-a0-eb-9e-98-date-2025-10-06-stream-song-f2866422-ef37-4411-95cf-1990485361cb",
+      "lookup_response_request_id": "shadow--v1-releases-lookup-entity_slug-qwer-title-ed-9d-b0-ec-88-98-ec-97-bc-ea-b3-a0-eb-9e-98-date-2025-10-06-stream-song-f2866422-ef37-4411-95cf-1990485361cb",
+      "detail_request_id_sent": "shadow--v1-releases-d9a85b3d-ed19-51bb-a6c4-e5e538401b50-157672e7-53ea-4e54-9ff2-049810973a1d",
+      "detail_response_request_id": "shadow--v1-releases-d9a85b3d-ed19-51bb-a6c4-e5e538401b50-157672e7-53ea-4e54-9ff2-049810973a1d"
     },
     {
       "surface": "calendar_month",
@@ -2898,21 +2879,21 @@
           "month_only_upcoming_count": 4
         },
         "nearest_upcoming": {
-          "upcoming_signal_id": "yena::2026-03-11::love catcher",
-          "entity_slug": "yena",
-          "display_name": "YENA",
-          "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
-          "scheduled_date": "2026-03-11",
+          "upcoming_signal_id": "p1harmony::2026-03-12::march 12 future date reference 2026 03 12",
+          "entity_slug": "p1harmony",
+          "display_name": "P1Harmony",
+          "headline": "P1Harmony's Hero's Return: 9th Mini-Album Drops March 12 - 조선일보",
+          "scheduled_date": "2026-03-12",
           "scheduled_month": "2026-03",
           "date_precision": "exact",
           "date_status": "confirmed",
-          "confidence_score": 0.84,
+          "confidence_score": 0.82,
           "release_format": "ep",
-          "source_url": "https://www.starnewskorea.com/music/2026/02/23/2026022315005262396",
+          "source_url": "https://news.google.com/rss/articles/CBMijgFBVV95cUxOY1dvTzFyaVdpSEdaRVZDM1VmUlpqUk14S1VLVlFlZm5hODU5RDhFMjdCeXFoV2ZWeTZGb016cUJFZDFnQjF1S2FJeGdZb2FpOXZ4OXZaVUo0YTIwSmd1RlZMWmplU2JFcW4wZ0VQRHBiaGJiWlFIcDczNUQ4TEVyT0xrMk1ZM2NHdnVNVUxn?oc=5",
           "source_type": "news_rss",
-          "source_domain": "starnewskorea.com",
-          "evidence_summary": "Future date reference: 2026-03-11. YENA confirmed her comeback with the 5th mini album LOVE CATCHER, scheduled for March 11 at 6 p.m. KST.",
-          "source_count": 1
+          "source_domain": "news.google.com",
+          "evidence_summary": "Future date reference: 2026-03-12. P1Harmony's Hero's Return: 9th Mini-Album Drops March 12 조선일보",
+          "source_count": 4
         },
         "days": [
           {
@@ -3270,21 +3251,21 @@
           "month_only_upcoming_count": 4
         },
         "nearest_upcoming": {
-          "upcoming_signal_id": "135cb637-d988-5028-b221-0ec2f59f124f",
-          "entity_slug": "yena",
-          "display_name": "YENA",
-          "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
-          "scheduled_date": "2026-03-11",
+          "upcoming_signal_id": "909b6943-f6f5-5b45-a753-e625f9678735",
+          "entity_slug": "p1harmony",
+          "display_name": "P1Harmony",
+          "headline": "P1Harmony's Hero's Return: 9th Mini-Album Drops March 12 - 조선일보",
+          "scheduled_date": "2026-03-12",
           "scheduled_month": "2026-03",
           "date_precision": "exact",
           "date_status": "confirmed",
-          "confidence_score": 0.84,
+          "confidence_score": 0.82,
           "release_format": "ep",
-          "source_url": "https://www.starnewskorea.com/music/2026/02/23/2026022315005262396",
+          "source_url": "https://news.google.com/rss/articles/CBMijgFBVV95cUxOY1dvTzFyaVdpSEdaRVZDM1VmUlpqUk14S1VLVlFlZm5hODU5RDhFMjdCeXFoV2ZWeTZGb016cUJFZDFnQjF1S2FJeGdZb2FpOXZ4OXZaVUo0YTIwSmd1RlZMWmplU2JFcW4wZ0VQRHBiaGJiWlFIcDczNUQ4TEVyT0xrMk1ZM2NHdnVNVUxn?oc=5",
           "source_type": "news_rss",
-          "source_domain": "starnewskorea.com",
-          "evidence_summary": "Future date reference: 2026-03-11. YENA confirmed her comeback with the 5th mini album LOVE CATCHER, scheduled for March 11 at 6 p.m. KST.",
-          "source_count": 1
+          "source_domain": "news.google.com",
+          "evidence_summary": "Future date reference: 2026-03-12. P1Harmony's Hero's Return: 9th Mini-Album Drops March 12 조선일보",
+          "source_count": 4
         },
         "days": [
           {
@@ -3640,8 +3621,8 @@
         ]
       },
       "actual_status_code": 200,
-      "request_id_sent": "shadow--v1-calendar-month-month-2026-03-d5ba70c8-a9ee-4bdd-91e7-387c6c029a3b",
-      "response_request_id": "shadow--v1-calendar-month-month-2026-03-d5ba70c8-a9ee-4bdd-91e7-387c6c029a3b"
+      "request_id_sent": "shadow--v1-calendar-month-month-2026-03-942dc744-a3d4-49d7-a2de-80958d82d168",
+      "response_request_id": "shadow--v1-calendar-month-month-2026-03-942dc744-a3d4-49d7-a2de-80958d82d168"
     },
     {
       "surface": "calendar_month",
@@ -3658,21 +3639,21 @@
           "month_only_upcoming_count": 10
         },
         "nearest_upcoming": {
-          "upcoming_signal_id": "yena::2026-03-11::love catcher",
-          "entity_slug": "yena",
-          "display_name": "YENA",
-          "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
-          "scheduled_date": "2026-03-11",
+          "upcoming_signal_id": "p1harmony::2026-03-12::march 12 future date reference 2026 03 12",
+          "entity_slug": "p1harmony",
+          "display_name": "P1Harmony",
+          "headline": "P1Harmony's Hero's Return: 9th Mini-Album Drops March 12 - 조선일보",
+          "scheduled_date": "2026-03-12",
           "scheduled_month": "2026-03",
           "date_precision": "exact",
           "date_status": "confirmed",
-          "confidence_score": 0.84,
+          "confidence_score": 0.82,
           "release_format": "ep",
-          "source_url": "https://www.starnewskorea.com/music/2026/02/23/2026022315005262396",
+          "source_url": "https://news.google.com/rss/articles/CBMijgFBVV95cUxOY1dvTzFyaVdpSEdaRVZDM1VmUlpqUk14S1VLVlFlZm5hODU5RDhFMjdCeXFoV2ZWeTZGb016cUJFZDFnQjF1S2FJeGdZb2FpOXZ4OXZaVUo0YTIwSmd1RlZMWmplU2JFcW4wZ0VQRHBiaGJiWlFIcDczNUQ4TEVyT0xrMk1ZM2NHdnVNVUxn?oc=5",
           "source_type": "news_rss",
-          "source_domain": "starnewskorea.com",
-          "evidence_summary": "Future date reference: 2026-03-11. YENA confirmed her comeback with the 5th mini album LOVE CATCHER, scheduled for March 11 at 6 p.m. KST.",
-          "source_count": 1
+          "source_domain": "news.google.com",
+          "evidence_summary": "Future date reference: 2026-03-12. P1Harmony's Hero's Return: 9th Mini-Album Drops March 12 조선일보",
+          "source_count": 4
         },
         "days": [
           {
@@ -4099,21 +4080,21 @@
           "month_only_upcoming_count": 10
         },
         "nearest_upcoming": {
-          "upcoming_signal_id": "135cb637-d988-5028-b221-0ec2f59f124f",
-          "entity_slug": "yena",
-          "display_name": "YENA",
-          "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
-          "scheduled_date": "2026-03-11",
+          "upcoming_signal_id": "909b6943-f6f5-5b45-a753-e625f9678735",
+          "entity_slug": "p1harmony",
+          "display_name": "P1Harmony",
+          "headline": "P1Harmony's Hero's Return: 9th Mini-Album Drops March 12 - 조선일보",
+          "scheduled_date": "2026-03-12",
           "scheduled_month": "2026-03",
           "date_precision": "exact",
           "date_status": "confirmed",
-          "confidence_score": 0.84,
+          "confidence_score": 0.82,
           "release_format": "ep",
-          "source_url": "https://www.starnewskorea.com/music/2026/02/23/2026022315005262396",
+          "source_url": "https://news.google.com/rss/articles/CBMijgFBVV95cUxOY1dvTzFyaVdpSEdaRVZDM1VmUlpqUk14S1VLVlFlZm5hODU5RDhFMjdCeXFoV2ZWeTZGb016cUJFZDFnQjF1S2FJeGdZb2FpOXZ4OXZaVUo0YTIwSmd1RlZMWmplU2JFcW4wZ0VQRHBiaGJiWlFIcDczNUQ4TEVyT0xrMk1ZM2NHdnVNVUxn?oc=5",
           "source_type": "news_rss",
-          "source_domain": "starnewskorea.com",
-          "evidence_summary": "Future date reference: 2026-03-11. YENA confirmed her comeback with the 5th mini album LOVE CATCHER, scheduled for March 11 at 6 p.m. KST.",
-          "source_count": 1
+          "source_domain": "news.google.com",
+          "evidence_summary": "Future date reference: 2026-03-12. P1Harmony's Hero's Return: 9th Mini-Album Drops March 12 조선일보",
+          "source_count": 4
         },
         "days": [
           {
@@ -4544,8 +4525,8 @@
         ]
       },
       "actual_status_code": 200,
-      "request_id_sent": "shadow--v1-calendar-month-month-2026-04-dc59dc36-2995-4182-920d-fc775898caab",
-      "response_request_id": "shadow--v1-calendar-month-month-2026-04-dc59dc36-2995-4182-920d-fc775898caab"
+      "request_id_sent": "shadow--v1-calendar-month-month-2026-04-fec33bde-62d1-4a3f-9209-06cda1279334",
+      "response_request_id": "shadow--v1-calendar-month-month-2026-04-fec33bde-62d1-4a3f-9209-06cda1279334"
     },
     {
       "surface": "calendar_month",
@@ -4562,21 +4543,21 @@
           "month_only_upcoming_count": 0
         },
         "nearest_upcoming": {
-          "upcoming_signal_id": "yena::2026-03-11::love catcher",
-          "entity_slug": "yena",
-          "display_name": "YENA",
-          "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
-          "scheduled_date": "2026-03-11",
+          "upcoming_signal_id": "p1harmony::2026-03-12::march 12 future date reference 2026 03 12",
+          "entity_slug": "p1harmony",
+          "display_name": "P1Harmony",
+          "headline": "P1Harmony's Hero's Return: 9th Mini-Album Drops March 12 - 조선일보",
+          "scheduled_date": "2026-03-12",
           "scheduled_month": "2026-03",
           "date_precision": "exact",
           "date_status": "confirmed",
-          "confidence_score": 0.84,
+          "confidence_score": 0.82,
           "release_format": "ep",
-          "source_url": "https://www.starnewskorea.com/music/2026/02/23/2026022315005262396",
+          "source_url": "https://news.google.com/rss/articles/CBMijgFBVV95cUxOY1dvTzFyaVdpSEdaRVZDM1VmUlpqUk14S1VLVlFlZm5hODU5RDhFMjdCeXFoV2ZWeTZGb016cUJFZDFnQjF1S2FJeGdZb2FpOXZ4OXZaVUo0YTIwSmd1RlZMWmplU2JFcW4wZ0VQRHBiaGJiWlFIcDczNUQ4TEVyT0xrMk1ZM2NHdnVNVUxn?oc=5",
           "source_type": "news_rss",
-          "source_domain": "starnewskorea.com",
-          "evidence_summary": "Future date reference: 2026-03-11. YENA confirmed her comeback with the 5th mini album LOVE CATCHER, scheduled for March 11 at 6 p.m. KST.",
-          "source_count": 1
+          "source_domain": "news.google.com",
+          "evidence_summary": "Future date reference: 2026-03-12. P1Harmony's Hero's Return: 9th Mini-Album Drops March 12 조선일보",
+          "source_count": 4
         },
         "days": [
           {
@@ -4934,21 +4915,21 @@
           "month_only_upcoming_count": 0
         },
         "nearest_upcoming": {
-          "upcoming_signal_id": "135cb637-d988-5028-b221-0ec2f59f124f",
-          "entity_slug": "yena",
-          "display_name": "YENA",
-          "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
-          "scheduled_date": "2026-03-11",
+          "upcoming_signal_id": "909b6943-f6f5-5b45-a753-e625f9678735",
+          "entity_slug": "p1harmony",
+          "display_name": "P1Harmony",
+          "headline": "P1Harmony's Hero's Return: 9th Mini-Album Drops March 12 - 조선일보",
+          "scheduled_date": "2026-03-12",
           "scheduled_month": "2026-03",
           "date_precision": "exact",
           "date_status": "confirmed",
-          "confidence_score": 0.84,
+          "confidence_score": 0.82,
           "release_format": "ep",
-          "source_url": "https://www.starnewskorea.com/music/2026/02/23/2026022315005262396",
+          "source_url": "https://news.google.com/rss/articles/CBMijgFBVV95cUxOY1dvTzFyaVdpSEdaRVZDM1VmUlpqUk14S1VLVlFlZm5hODU5RDhFMjdCeXFoV2ZWeTZGb016cUJFZDFnQjF1S2FJeGdZb2FpOXZ4OXZaVUo0YTIwSmd1RlZMWmplU2JFcW4wZ0VQRHBiaGJiWlFIcDczNUQ4TEVyT0xrMk1ZM2NHdnVNVUxn?oc=5",
           "source_type": "news_rss",
-          "source_domain": "starnewskorea.com",
-          "evidence_summary": "Future date reference: 2026-03-11. YENA confirmed her comeback with the 5th mini album LOVE CATCHER, scheduled for March 11 at 6 p.m. KST.",
-          "source_count": 1
+          "source_domain": "news.google.com",
+          "evidence_summary": "Future date reference: 2026-03-12. P1Harmony's Hero's Return: 9th Mini-Album Drops March 12 조선일보",
+          "source_count": 4
         },
         "days": [
           {
@@ -5300,8 +5281,8 @@
         "scheduled_list": []
       },
       "actual_status_code": 200,
-      "request_id_sent": "shadow--v1-calendar-month-month-2025-10-3ac17eba-663a-4774-a286-342f04bc234c",
-      "response_request_id": "shadow--v1-calendar-month-month-2025-10-3ac17eba-663a-4774-a286-342f04bc234c"
+      "request_id_sent": "shadow--v1-calendar-month-month-2025-10-fa6c5bfe-021b-4403-84f5-830297bdfb9d",
+      "response_request_id": "shadow--v1-calendar-month-month-2025-10-fa6c5bfe-021b-4403-84f5-830297bdfb9d"
     },
     {
       "surface": "radar",
@@ -5313,28 +5294,17 @@
       "mismatches": [],
       "expected_snapshot": {
         "featured_upcoming": {
-          "upcoming_signal_id": "yena::2026-03-11::love catcher",
-          "entity_slug": "yena",
-          "display_name": "YENA",
-          "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
-          "scheduled_date": "2026-03-11",
+          "upcoming_signal_id": "p1harmony::2026-03-12::march 12 future date reference 2026 03 12",
+          "entity_slug": "p1harmony",
+          "display_name": "P1Harmony",
+          "headline": "P1Harmony's Hero's Return: 9th Mini-Album Drops March 12 - 조선일보",
+          "scheduled_date": "2026-03-12",
           "date_precision": "exact",
           "date_status": "confirmed",
-          "confidence_score": 0.84,
+          "confidence_score": 0.82,
           "release_format": "ep"
         },
         "weekly_upcoming": [
-          {
-            "upcoming_signal_id": "yena::2026-03-11::love catcher",
-            "entity_slug": "yena",
-            "display_name": "YENA",
-            "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
-            "scheduled_date": "2026-03-11",
-            "date_precision": "exact",
-            "date_status": "confirmed",
-            "confidence_score": 0.84,
-            "release_format": "ep"
-          },
           {
             "upcoming_signal_id": "p1harmony::2026-03-12::march 12 future date reference 2026 03 12",
             "entity_slug": "p1harmony",
@@ -5514,7 +5484,7 @@
               "stream": "song",
               "release_kind": "single"
             },
-            "gap_days": 1006,
+            "gap_days": 1007,
             "has_upcoming_signal": true,
             "latest_signal": {
               "upcoming_signal_id": "bts::undated::arirang",
@@ -5538,7 +5508,7 @@
               "stream": "album",
               "release_kind": "ep"
             },
-            "gap_days": 517,
+            "gap_days": 518,
             "has_upcoming_signal": true,
             "latest_signal": {
               "upcoming_signal_id": "ab6ix::2026-03::future month reference 2026 03 unveils",
@@ -5562,7 +5532,7 @@
               "stream": "song",
               "release_kind": "single"
             },
-            "gap_days": 1729,
+            "gap_days": 1730,
             "has_upcoming_signal": false,
             "latest_signal": null
           },
@@ -5576,7 +5546,7 @@
               "stream": "album",
               "release_kind": "ep"
             },
-            "gap_days": 1335,
+            "gap_days": 1336,
             "has_upcoming_signal": false,
             "latest_signal": null
           },
@@ -5590,7 +5560,7 @@
               "stream": "album",
               "release_kind": "ep"
             },
-            "gap_days": 1247,
+            "gap_days": 1248,
             "has_upcoming_signal": false,
             "latest_signal": null
           },
@@ -5604,7 +5574,7 @@
               "stream": "album",
               "release_kind": "ep"
             },
-            "gap_days": 835,
+            "gap_days": 836,
             "has_upcoming_signal": false,
             "latest_signal": null
           },
@@ -5618,7 +5588,7 @@
               "stream": "album",
               "release_kind": "ep"
             },
-            "gap_days": 742,
+            "gap_days": 743,
             "has_upcoming_signal": false,
             "latest_signal": null
           },
@@ -5632,7 +5602,7 @@
               "stream": "album",
               "release_kind": "ep"
             },
-            "gap_days": 639,
+            "gap_days": 640,
             "has_upcoming_signal": false,
             "latest_signal": null
           },
@@ -5646,7 +5616,7 @@
               "stream": "album",
               "release_kind": "ep"
             },
-            "gap_days": 630,
+            "gap_days": 631,
             "has_upcoming_signal": false,
             "latest_signal": null
           },
@@ -5660,7 +5630,7 @@
               "stream": "song",
               "release_kind": "single"
             },
-            "gap_days": 628,
+            "gap_days": 629,
             "has_upcoming_signal": false,
             "latest_signal": null
           },
@@ -5674,7 +5644,7 @@
               "stream": "album",
               "release_kind": "ep"
             },
-            "gap_days": 625,
+            "gap_days": 626,
             "has_upcoming_signal": false,
             "latest_signal": null
           },
@@ -5688,7 +5658,7 @@
               "stream": "album",
               "release_kind": "ep"
             },
-            "gap_days": 610,
+            "gap_days": 611,
             "has_upcoming_signal": false,
             "latest_signal": null
           }
@@ -5842,28 +5812,17 @@
       },
       "actual_snapshot": {
         "featured_upcoming": {
-          "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
+          "headline": "P1Harmony's Hero's Return: 9th Mini-Album Drops March 12 - 조선일보",
           "date_status": "confirmed",
-          "entity_slug": "yena",
-          "display_name": "YENA",
+          "entity_slug": "p1harmony",
+          "display_name": "P1Harmony",
           "date_precision": "exact",
           "release_format": "ep",
-          "scheduled_date": "2026-03-11",
-          "confidence_score": 0.84,
-          "upcoming_signal_id": "135cb637-d988-5028-b221-0ec2f59f124f"
+          "scheduled_date": "2026-03-12",
+          "confidence_score": 0.82,
+          "upcoming_signal_id": "909b6943-f6f5-5b45-a753-e625f9678735"
         },
         "weekly_upcoming": [
-          {
-            "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
-            "date_status": "confirmed",
-            "entity_slug": "yena",
-            "display_name": "YENA",
-            "date_precision": "exact",
-            "release_format": "ep",
-            "scheduled_date": "2026-03-11",
-            "confidence_score": 0.84,
-            "upcoming_signal_id": "135cb637-d988-5028-b221-0ec2f59f124f"
-          },
           {
             "headline": "P1Harmony's Hero's Return: 9th Mini-Album Drops March 12 - 조선일보",
             "date_status": "confirmed",
@@ -5925,17 +5884,6 @@
           },
           {
             "kind": "verified_release",
-            "stream": "song",
-            "release_id": "6e323520-f064-5ba5-bf87-d56898edb48e",
-            "entity_slug": "chung-ha",
-            "occurred_at": "2026-03-08T23:52:52.993Z",
-            "display_name": "CHUNG HA",
-            "release_date": "2026-02-09",
-            "release_kind": "single",
-            "release_title": "Save me"
-          },
-          {
-            "kind": "verified_release",
             "stream": "album",
             "release_id": "6a1db562-83b4-5e9d-a00f-6ea0ebfb6680",
             "entity_slug": "h1-key",
@@ -5970,17 +5918,6 @@
           {
             "kind": "verified_release",
             "stream": "song",
-            "release_id": "78bb2629-2cd8-5f57-aaf1-a029b271ae8f",
-            "entity_slug": "ive",
-            "occurred_at": "2026-03-08T23:52:52.993Z",
-            "display_name": "IVE",
-            "release_date": "2026-02-09",
-            "release_kind": "single",
-            "release_title": "BANG BANG"
-          },
-          {
-            "kind": "verified_release",
-            "stream": "song",
             "release_id": "179b842f-9bd1-56ca-aaf6-b33e3f87159b",
             "entity_slug": "nct-wish",
             "occurred_at": "2026-03-08T23:52:52.993Z",
@@ -6010,11 +5947,33 @@
             "release_date": "2026-02-27",
             "release_kind": "single",
             "release_title": "[RESCENE X ???]"
+          },
+          {
+            "kind": "verified_release",
+            "stream": "album",
+            "release_id": "7c27ebee-3b8e-56c4-8b4c-b58f040b16b3",
+            "entity_slug": "stayc",
+            "occurred_at": "2026-03-08T23:52:52.993Z",
+            "display_name": "STAYC",
+            "release_date": "2026-02-11",
+            "release_kind": "album",
+            "release_title": "STAY ALIVE"
+          },
+          {
+            "kind": "verified_release",
+            "stream": "song",
+            "release_id": "1adfe761-7983-5747-8fdd-282e23684f26",
+            "entity_slug": "trendz",
+            "occurred_at": "2026-03-08T23:52:52.993Z",
+            "display_name": "TRENDZ",
+            "release_date": "2026-02-13",
+            "release_kind": "single",
+            "release_title": "Kart Racer"
           }
         ],
         "long_gap": [
           {
-            "gap_days": 1006,
+            "gap_days": 1007,
             "entity_slug": "bts",
             "display_name": "BTS",
             "watch_reason": "long_gap",
@@ -6039,7 +5998,7 @@
             "has_upcoming_signal": true
           },
           {
-            "gap_days": 517,
+            "gap_days": 518,
             "entity_slug": "ab6ix",
             "display_name": "AB6IX",
             "watch_reason": "long_gap",
@@ -6064,7 +6023,7 @@
             "has_upcoming_signal": true
           },
           {
-            "gap_days": 1729,
+            "gap_days": 1730,
             "entity_slug": "wayv",
             "display_name": "WayV",
             "watch_reason": "long_gap",
@@ -6079,7 +6038,7 @@
             "has_upcoming_signal": false
           },
           {
-            "gap_days": 1335,
+            "gap_days": 1336,
             "entity_slug": "just-b",
             "display_name": "JUST B",
             "watch_reason": "long_gap",
@@ -6094,7 +6053,7 @@
             "has_upcoming_signal": false
           },
           {
-            "gap_days": 1247,
+            "gap_days": 1248,
             "entity_slug": "mamamoo",
             "display_name": "MAMAMOO",
             "watch_reason": "long_gap",
@@ -6109,7 +6068,7 @@
             "has_upcoming_signal": false
           },
           {
-            "gap_days": 835,
+            "gap_days": 836,
             "entity_slug": "atbo",
             "display_name": "ATBO",
             "watch_reason": "long_gap",
@@ -6124,7 +6083,7 @@
             "has_upcoming_signal": false
           },
           {
-            "gap_days": 742,
+            "gap_days": 743,
             "entity_slug": "nomad",
             "display_name": "NOMAD",
             "watch_reason": "long_gap",
@@ -6139,7 +6098,7 @@
             "has_upcoming_signal": false
           },
           {
-            "gap_days": 639,
+            "gap_days": 640,
             "entity_slug": "cignature",
             "display_name": "cignature",
             "watch_reason": "long_gap",
@@ -6154,7 +6113,7 @@
             "has_upcoming_signal": false
           },
           {
-            "gap_days": 630,
+            "gap_days": 631,
             "entity_slug": "blitzers",
             "display_name": "BLITZERS",
             "watch_reason": "long_gap",
@@ -6169,7 +6128,7 @@
             "has_upcoming_signal": false
           },
           {
-            "gap_days": 628,
+            "gap_days": 629,
             "entity_slug": "newjeans",
             "display_name": "NewJeans",
             "watch_reason": "long_gap",
@@ -6184,7 +6143,7 @@
             "has_upcoming_signal": false
           },
           {
-            "gap_days": 625,
+            "gap_days": 626,
             "entity_slug": "red-velvet",
             "display_name": "Red Velvet",
             "watch_reason": "long_gap",
@@ -6199,7 +6158,7 @@
             "has_upcoming_signal": false
           },
           {
-            "gap_days": 610,
+            "gap_days": 611,
             "entity_slug": "weeekly",
             "display_name": "Weeekly",
             "watch_reason": "long_gap",
@@ -6370,8 +6329,8 @@
         ]
       },
       "actual_status_code": 200,
-      "request_id_sent": "shadow--v1-radar-2a98a698-534e-4af8-a95a-b4433ca31953",
-      "response_request_id": "shadow--v1-radar-2a98a698-534e-4af8-a95a-b4433ca31953"
+      "request_id_sent": "shadow--v1-radar-263fb5bb-d7ff-4b58-a356-2ae520162e0f",
+      "response_request_id": "shadow--v1-radar-263fb5bb-d7ff-4b58-a356-2ae520162e0f"
     }
   ]
 }

--- a/backend/reports/migration_readiness_scorecard.json
+++ b/backend/reports/migration_readiness_scorecard.json
@@ -1,92 +1,18 @@
 {
-  "generated_at": "2026-03-11T12:19:23.332Z",
-  "report_bundle": {
-    "generated_at": "2026-03-11T09:16:25.280Z",
-    "bundle_id": "post-sync-verification-57fe974c438e",
-    "bundle_kind": "post-sync-verification",
-    "cadence_profile": "daily-upcoming",
-    "source": {
-      "kind": "manual",
-      "workflow_name": null,
-      "git_commit_sha": null,
-      "github_run_id": null
-    },
-    "source_reports": {
-      "release_pipeline_sync": {
-        "path": "reports/release_pipeline_db_sync_summary.json",
-        "generated_at": "2026-03-07T07:51:00.028Z",
-        "scope": "release_pipeline"
-      },
-      "upcoming_pipeline_sync": {
-        "path": "reports/upcoming_pipeline_db_sync_summary.json",
-        "generated_at": "2026-03-11T07:53:51.250Z",
-        "scope": "upcoming_pipeline"
-      },
-      "projection_refresh": {
-        "path": "reports/projection_refresh_summary.json",
-        "generated_at": "2026-03-11T07:53:57.809Z"
-      },
-      "historical_coverage": {
-        "path": "reports/historical_release_detail_coverage_report.json",
-        "generated_at": "2026-03-10T00:00:00.000Z"
-      },
-      "canonical_null_coverage": {
-        "path": "reports/canonical_null_coverage_report.json",
-        "generated_at": "2026-03-11T08:30:30.464Z"
-      },
-      "canonical_null_recheck_queue": {
-        "path": "reports/canonical_null_recheck_queue.json",
-        "generated_at": "2026-03-11T08:30:31.766Z",
-        "queue_count": 3762
-      },
-      "null_coverage_trend": {
-        "path": "reports/null_coverage_trend_report.json",
-        "generated_at": "2026-03-11T08:30:32.119Z",
-        "baseline_available": false
-      },
-      "worker_cadence": {
-        "path": "reports/worker_cadence_report.json",
-        "generated_at": "2026-03-11T08:30:28.469Z",
-        "primary_path_key": "daily_upcoming"
-      },
-      "service_link_gap_queues": {
-        "path": "reports/service_link_gap_queues.json",
-        "generated_at": "2026-03-11T09:16:24.917Z",
-        "total": 5155
-      },
-      "title_track_gap_queue": {
-        "path": "reports/title_track_gap_queue.json",
-        "generated_at": "2026-03-11T09:16:24.922Z",
-        "total": 1694
-      },
-      "entity_identity_workbench": {
-        "path": "reports/entity_identity_workbench.json",
-        "generated_at": "2026-03-11T09:16:24.924Z",
-        "entities": 117,
-        "field_rows": 324
-      }
-    },
-    "summary_lines": [
-      "bundle id: post-sync-verification-57fe974c438e",
-      "bundle kind: post-sync-verification",
-      "cadence profile: daily-upcoming",
-      "workflow: manual"
-    ]
-  },
+  "generated_at": "2026-03-11T16:15:22.948Z",
+  "report_bundle": null,
   "bundle_consistency": {
-    "status": "fail",
-    "expected_bundle_id": "post-sync-verification-57fe974c438e",
+    "status": "pass",
+    "expected_bundle_id": null,
     "observed": {
-      "parity_bundle": "post-sync-verification-57fe974c438e",
-      "shadow_bundle": "post-sync-verification-57fe974c438e",
-      "runtime_gate_bundle": "post-sync-verification-57fe974c438e",
+      "parity_bundle": "post-sync-verification-339f67a6e124",
+      "shadow_bundle": "post-sync-verification-339f67a6e124",
+      "runtime_gate_bundle": "post-sync-verification-339f67a6e124",
       "historical_coverage_generated_at": "2026-03-11T00:00:00.000Z",
       "canonical_null_coverage_generated_at": "2026-03-11T08:30:30.464Z",
       "null_coverage_trend_generated_at": "2026-03-11T08:30:32.119Z"
     },
-    "mismatches": [
-      "historical coverage drift (2026-03-11T00:00:00.000Z)"
-    ]
+    "mismatches": []
   },
   "rubric": {
     "overall": {
@@ -159,7 +85,7 @@
     "historical_coverage_report": "backend/reports/historical_release_detail_coverage_report.json",
     "canonical_null_coverage_report": "backend/reports/canonical_null_coverage_report.json",
     "null_coverage_trend_report": "backend/reports/null_coverage_trend_report.json",
-    "bundle_report": "backend/reports/report_bundle_metadata.json",
+    "bundle_report": "reports/report_bundle_metadata.json",
     "fixture_registry": "backend/fixtures/live_backend_smoke_fixtures.json",
     "backend_deploy_workflow": ".github/workflows/backend-deploy.yml",
     "mobile_runtime_config": "mobile/src/config/runtime.ts",
@@ -168,17 +94,15 @@
   },
   "overall": {
     "status": "fail",
-    "score_ratio": 0.5626,
-    "score_percent": 56.3,
-    "weighted_points": 56.26,
+    "score_ratio": 0.6701,
+    "score_percent": 67,
+    "weighted_points": 67.01,
     "total_weight": 100,
     "blocker_categories": [
       {
         "key": "backend_runtime_health",
         "label": "Backend runtime health",
         "blocker_reasons": [
-          "projection_freshness=fail",
-          "worker_cadence=fail",
           "stage_gate:shadow_to_web_cutover=fail",
           "stage_gate:web_cutover_to_json_demotion=fail"
         ]
@@ -224,25 +148,23 @@
       "weight": 25,
       "blocker": true,
       "status": "fail",
-      "score_ratio": 0.27,
-      "score_percent": 27,
-      "weighted_points": 6.75,
+      "score_ratio": 0.7,
+      "score_percent": 70,
+      "weighted_points": 17.5,
       "blocker_reasons": [
-        "projection_freshness=fail",
-        "worker_cadence=fail",
         "stage_gate:shadow_to_web_cutover=fail",
         "stage_gate:web_cutover_to_json_demotion=fail"
       ],
       "summary_lines": [
         "api latency: needs_review (worst p95=1148.96ms)",
         "api error rate: needs_review (error rate=0)",
-        "projection freshness: fail (lag=265.33m)",
-        "worker cadence: fail (cadence_status=scheduled_evidence_missing, missed_windows=5)",
+        "projection freshness: pass (lag=1.01m)",
+        "worker cadence: needs_review (cadence_status=warming_up, deadline=2026-03-12T12:00:00.000Z)",
         "parity dependency: fail",
         "shadow dependency: fail",
         "historical catalog completeness dependency: fail",
         "critical null coverage dependency: fail",
-        "bundle consistency: fail",
+        "bundle consistency: pass",
         "shadow -> web cutover gate: fail",
         "web cutover -> JSON demotion gate: fail"
       ],
@@ -273,10 +195,10 @@
             }
           },
           "projection_freshness": {
-            "status": "fail",
+            "status": "pass",
             "observed": {
-              "projection_generated_at": "2026-03-11T07:53:57.809Z",
-              "lag_minutes": 265.33
+              "projection_generated_at": "2026-03-11T16:14:21.898Z",
+              "lag_minutes": 1.01
             },
             "thresholds": {
               "passLagMinutes": 20,
@@ -284,20 +206,21 @@
             }
           },
           "worker_cadence": {
-            "status": "fail",
+            "status": "needs_review",
             "observed": {
               "primary_path_key": "daily_upcoming",
               "cadence_label": "daily",
               "scheduled_failure_rate": null,
               "last_success_age_hours": null,
               "scheduled_runs": 0,
-              "cadence_status": "scheduled_evidence_missing",
+              "cadence_status": "warming_up",
               "scheduled_evidence": {
-                "status": "scheduled_evidence_missing",
-                "reason": "Expected scheduled run windows have elapsed without a recorded scheduled sample.",
+                "status": "warming_up",
+                "reason": "Workflow schedule is configured, but the first scheduled sample window is still in warm-up.",
                 "cadence_label": "daily",
                 "workflow_created_at": "2026-03-06T07:34:09.000Z",
-                "workflow_updated_at": "2026-03-11T09:25:55.000Z",
+                "workflow_updated_at": "2026-03-11T13:45:16.000Z",
+                "schedule_reference_at": "2026-03-11T13:45:16.000Z",
                 "workflow_state": "active",
                 "workflow_html_url": "https://github.com/iAmSomething/idol-song-app/blob/main/.github/workflows/weekly-kpop-scan.yml",
                 "parsed_schedule": {
@@ -306,12 +229,12 @@
                   "hour": 0
                 },
                 "warmup_grace_hours": 12,
-                "first_expected_run_at": "2026-03-07T00:00:00.000Z",
+                "first_expected_run_at": "2026-03-12T00:00:00.000Z",
                 "next_expected_run_at": "2026-03-12T00:00:00.000Z",
-                "warmup_deadline_at": "2026-03-07T12:00:00.000Z",
-                "expected_scheduled_runs_by_now": 5,
+                "warmup_deadline_at": "2026-03-12T12:00:00.000Z",
+                "expected_scheduled_runs_by_now": 0,
                 "observed_scheduled_runs": 0,
-                "missed_scheduled_windows": 5
+                "missed_scheduled_windows": 0
               }
             },
             "thresholds": {
@@ -346,8 +269,8 @@
         "YouTube allowlists: drift (role mismatches=10, metadata mismatches=0)",
         "latest verified release selection: clean (tracking mismatches=0, stream mismatches=0)",
         "upcoming counts / nearest: clean (month bucket mismatches=0)",
-        "title-track / double-title: drift (mismatched releases=1060)",
-        "YouTube Music / MV service-link state: drift (mismatched releases=124)",
+        "title-track / double-title: drift (mismatched releases=1120)",
+        "YouTube Music / MV service-link state: drift (mismatched releases=165)",
         "review-required counts: drift (review_type_counts_match=False, youtube_mv_status_counts_match=False)"
       ],
       "evidence": {
@@ -691,12 +614,12 @@
     }
   ],
   "summary_lines": [
-    "overall readiness: fail (56.3/100)",
-    "Backend runtime health: fail (27/100) [BLOCKER] - projection_freshness=fail",
+    "overall readiness: fail (67/100)",
+    "Backend runtime health: fail (70/100) [BLOCKER] - stage_gate:shadow_to_web_cutover=fail",
     "Backend deploy parity: fail (40/100) [BLOCKER] - parity_clean=false (latest_verified_release_selection drift=0)",
     "Web backend-only stability: fail (57.5/100) [BLOCKER] - entity_detail clean_ratio=0.5",
     "Mobile runtime mode: pass (100/100) - no blocker reason",
     "Catalog completeness: fail (75.1/100) [BLOCKER] - title_track_resolved overall=67.9 pre_2024=65.2",
-    "bundle consistency: fail"
+    "bundle consistency: pass"
   ]
 }

--- a/backend/reports/migration_readiness_scorecard.md
+++ b/backend/reports/migration_readiness_scorecard.md
@@ -1,16 +1,16 @@
 # Migration Readiness Scorecard
 
-Generated at: 2026-03-11T12:19:23.332Z
+Generated at: 2026-03-11T16:15:22.948Z
 
 ## Overall
 
 - status: `fail`
-- score: `56.3/100`
+- score: `67/100`
 - cutover blocked: `true`
 
 ## Blockers
 
-- Backend runtime health: projection_freshness=fail; worker_cadence=fail; stage_gate:shadow_to_web_cutover=fail; stage_gate:web_cutover_to_json_demotion=fail
+- Backend runtime health: stage_gate:shadow_to_web_cutover=fail; stage_gate:web_cutover_to_json_demotion=fail
 - Backend deploy parity: parity_clean=false (latest_verified_release_selection drift=0)
 - Web backend-only stability: entity_detail clean_ratio=0.5; release_detail clean_ratio=0
 - Catalog completeness: title_track_resolved overall=67.9 pre_2024=65.2; canonical_mv overall=8.6 pre_2024=6.4; releases.title_track latest 29.1% < 95.0%; release_service_links.youtube_mv latest 10.2% < 80.0%; entities.official_youtube latest 75.3% < 100.0%; entities.official_x latest 97.8% < 100.0%; entities.official_instagram latest 98.9% < 100.0%; releases.title_track recent 0.0% < 85.0%; release_service_links.youtube_mv recent 0.0% < 55.0%; entities.official_youtube recent 72.2% < 95.0%
@@ -19,7 +19,7 @@ Generated at: 2026-03-11T12:19:23.332Z
 
 | Category | Weight | Score | Status | Blocker | Primary reason |
 | --- | ---: | ---: | --- | --- | --- |
-| Backend runtime health | 25 | 27 | fail | yes | projection_freshness=fail |
+| Backend runtime health | 25 | 70 | fail | yes | stage_gate:shadow_to_web_cutover=fail |
 | Backend deploy parity | 20 | 40 | fail | yes | parity_clean=false (latest_verified_release_selection drift=0) |
 | Web backend-only stability | 20 | 57.5 | fail | yes | entity_detail clean_ratio=0.5 |
 | Mobile runtime mode | 15 | 100 | pass | yes | - |
@@ -27,13 +27,13 @@ Generated at: 2026-03-11T12:19:23.332Z
 
 ## Summary Lines
 
-- overall readiness: fail (56.3/100)
-- Backend runtime health: fail (27/100) [BLOCKER] - projection_freshness=fail
+- overall readiness: fail (67/100)
+- Backend runtime health: fail (70/100) [BLOCKER] - stage_gate:shadow_to_web_cutover=fail
 - Backend deploy parity: fail (40/100) [BLOCKER] - parity_clean=false (latest_verified_release_selection drift=0)
 - Web backend-only stability: fail (57.5/100) [BLOCKER] - entity_detail clean_ratio=0.5
 - Mobile runtime mode: pass (100/100) - no blocker reason
 - Catalog completeness: fail (75.1/100) [BLOCKER] - title_track_resolved overall=67.9 pre_2024=65.2
-- bundle consistency: fail
+- bundle consistency: pass
 
 ## Evidence Paths
 
@@ -43,7 +43,7 @@ Generated at: 2026-03-11T12:19:23.332Z
 - historical_coverage_report: `backend/reports/historical_release_detail_coverage_report.json`
 - canonical_null_coverage_report: `backend/reports/canonical_null_coverage_report.json`
 - null_coverage_trend_report: `backend/reports/null_coverage_trend_report.json`
-- bundle_report: `backend/reports/report_bundle_metadata.json`
+- bundle_report: `reports/report_bundle_metadata.json`
 - fixture_registry: `backend/fixtures/live_backend_smoke_fixtures.json`
 - backend_deploy_workflow: `.github/workflows/backend-deploy.yml`
 - mobile_runtime_config: `mobile/src/config/runtime.ts`

--- a/backend/reports/projection_refresh_summary.json
+++ b/backend/reports/projection_refresh_summary.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-03-11T07:53:57.809Z",
+  "generated_at": "2026-03-11T16:14:21.898Z",
   "row_counts": {
     "entity_search_documents": 117,
     "calendar_month_projection": 216,
@@ -17,13 +17,7 @@
       "entity_slug": "yena",
       "entity_type": "solo",
       "display_name": "YENA",
-      "next_upcoming": {
-        "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
-        "date_status": "confirmed",
-        "date_precision": "exact",
-        "scheduled_date": "2026-03-11",
-        "confidence_score": 0.84
-      },
+      "next_upcoming": null,
       "canonical_name": "YENA",
       "latest_release": {
         "stream": "song",
@@ -45,21 +39,21 @@
         "month_only_upcoming_count": 4
       },
       "nearest_upcoming": {
-        "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
-        "source_url": "https://www.starnewskorea.com/music/2026/02/23/2026022315005262396",
+        "headline": "P1Harmony's Hero's Return: 9th Mini-Album Drops March 12 - 조선일보",
+        "source_url": "https://news.google.com/rss/articles/CBMijgFBVV95cUxOY1dvTzFyaVdpSEdaRVZDM1VmUlpqUk14S1VLVlFlZm5hODU5RDhFMjdCeXFoV2ZWeTZGb016cUJFZDFnQjF1S2FJeGdZb2FpOXZ4OXZaVUo0YTIwSmd1RlZMWmplU2JFcW4wZ0VQRHBiaGJiWlFIcDczNUQ4TEVyT0xrMk1ZM2NHdnVNVUxn?oc=5",
         "date_status": "confirmed",
-        "entity_slug": "yena",
+        "entity_slug": "p1harmony",
         "source_type": "news_rss",
-        "display_name": "YENA",
-        "source_count": 1,
-        "source_domain": "starnewskorea.com",
+        "display_name": "P1Harmony",
+        "source_count": 4,
+        "source_domain": "news.google.com",
         "date_precision": "exact",
         "release_format": "ep",
-        "scheduled_date": "2026-03-11",
+        "scheduled_date": "2026-03-12",
         "scheduled_month": "2026-03",
-        "confidence_score": 0.84,
-        "evidence_summary": "Future date reference: 2026-03-11. YENA confirmed her comeback with the 5th mini album LOVE CATCHER, scheduled for March 11 at 6 p.m. KST.",
-        "upcoming_signal_id": "135cb637-d988-5028-b221-0ec2f59f124f"
+        "confidence_score": 0.82,
+        "evidence_summary": "Future date reference: 2026-03-12. P1Harmony's Hero's Return: 9th Mini-Album Drops March 12 조선일보",
+        "upcoming_signal_id": "909b6943-f6f5-5b45-a753-e625f9678735"
       }
     },
     "entity_detail": {
@@ -77,22 +71,7 @@
         "representative_image_url": null,
         "representative_image_source": null
       },
-      "next_upcoming": {
-        "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
-        "source_url": "https://www.starnewskorea.com/music/2026/02/23/2026022315005262396",
-        "date_status": "confirmed",
-        "source_type": "news_rss",
-        "source_count": 1,
-        "source_domain": "starnewskorea.com",
-        "date_precision": "exact",
-        "latest_seen_at": "2026-02-23T05:58:00+00:00",
-        "release_format": "ep",
-        "scheduled_date": "2026-03-11",
-        "scheduled_month": "2026-03",
-        "confidence_score": 0.84,
-        "evidence_summary": "Future date reference: 2026-03-11. YENA confirmed her comeback with the 5th mini album LOVE CATCHER, scheduled for March 11 at 6 p.m. KST.",
-        "upcoming_signal_id": "135cb637-d988-5028-b221-0ec2f59f124f"
-      },
+      "next_upcoming": null,
       "recent_albums": [
         {
           "stream": "album",
@@ -196,17 +175,17 @@
     },
     "radar": {
       "featured_upcoming": {
-        "headline": "최예나, 3월 11일 컴백 확정..새 앨범명은 'LOVE CATCHER' [공식] - 스타뉴스",
+        "headline": "P1Harmony's Hero's Return: 9th Mini-Album Drops March 12 - 조선일보",
         "date_status": "confirmed",
-        "entity_slug": "yena",
-        "display_name": "YENA",
+        "entity_slug": "p1harmony",
+        "display_name": "P1Harmony",
         "date_precision": "exact",
         "release_format": "ep",
-        "scheduled_date": "2026-03-11",
-        "confidence_score": 0.84,
-        "upcoming_signal_id": "135cb637-d988-5028-b221-0ec2f59f124f"
+        "scheduled_date": "2026-03-12",
+        "confidence_score": 0.82,
+        "upcoming_signal_id": "909b6943-f6f5-5b45-a753-e625f9678735"
       },
-      "weekly_upcoming_count": 2,
+      "weekly_upcoming_count": 1,
       "change_feed_count": 20,
       "long_gap_count": 23,
       "rookie_count": 8

--- a/backend/reports/report_bundle_metadata.json
+++ b/backend/reports/report_bundle_metadata.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-03-11T12:39:03.697Z",
-  "bundle_id": "post-sync-verification-c7f48f90396b",
+  "generated_at": "2026-03-11T16:14:23.510Z",
+  "bundle_id": "post-sync-verification-339f67a6e124",
   "bundle_kind": "post-sync-verification",
   "cadence_profile": "daily-upcoming",
   "source": {
@@ -22,7 +22,7 @@
     },
     "projection_refresh": {
       "path": "reports/projection_refresh_summary.json",
-      "generated_at": "2026-03-11T07:53:57.809Z"
+      "generated_at": "2026-03-11T16:14:21.898Z"
     },
     "historical_coverage": {
       "path": "reports/historical_release_detail_coverage_report.json",
@@ -44,7 +44,7 @@
     },
     "worker_cadence": {
       "path": "reports/worker_cadence_report.json",
-      "generated_at": "2026-03-11T12:15:23.043Z",
+      "generated_at": "2026-03-11T16:14:23.247Z",
       "primary_path_key": "daily_upcoming"
     },
     "service_link_gap_queues": {
@@ -67,10 +67,16 @@
       "path": "reports/trusted_upcoming_notification_event_summary.json",
       "generated_at": "2026-03-11T12:38:47.563Z",
       "emitted": 0
+    },
+    "mobile_push_delivery_summary": {
+      "path": "reports/mobile_push_delivery_summary.json",
+      "generated_at": null,
+      "sent": null,
+      "failed": null
     }
   },
   "summary_lines": [
-    "bundle id: post-sync-verification-c7f48f90396b",
+    "bundle id: post-sync-verification-339f67a6e124",
     "bundle kind: post-sync-verification",
     "cadence profile: daily-upcoming",
     "workflow: manual"

--- a/backend/reports/runtime_gate_report.json
+++ b/backend/reports/runtime_gate_report.json
@@ -1,8 +1,8 @@
 {
-  "generated_at": "2026-03-11T12:19:17.341Z",
+  "generated_at": "2026-03-11T16:15:22.747Z",
   "report_bundle": {
-    "generated_at": "2026-03-11T09:16:25.280Z",
-    "bundle_id": "post-sync-verification-57fe974c438e",
+    "generated_at": "2026-03-11T16:14:23.510Z",
+    "bundle_id": "post-sync-verification-339f67a6e124",
     "bundle_kind": "post-sync-verification",
     "cadence_profile": "daily-upcoming",
     "source": {
@@ -24,11 +24,11 @@
       },
       "projection_refresh": {
         "path": "reports/projection_refresh_summary.json",
-        "generated_at": "2026-03-11T07:53:57.809Z"
+        "generated_at": "2026-03-11T16:14:21.898Z"
       },
       "historical_coverage": {
         "path": "reports/historical_release_detail_coverage_report.json",
-        "generated_at": "2026-03-10T00:00:00.000Z"
+        "generated_at": "2026-03-11T00:00:00.000Z"
       },
       "canonical_null_coverage": {
         "path": "reports/canonical_null_coverage_report.json",
@@ -46,7 +46,7 @@
       },
       "worker_cadence": {
         "path": "reports/worker_cadence_report.json",
-        "generated_at": "2026-03-11T08:30:28.469Z",
+        "generated_at": "2026-03-11T16:14:23.247Z",
         "primary_path_key": "daily_upcoming"
       },
       "service_link_gap_queues": {
@@ -64,29 +64,38 @@
         "generated_at": "2026-03-11T09:16:24.924Z",
         "entities": 117,
         "field_rows": 324
+      },
+      "trusted_upcoming_notification_summary": {
+        "path": "reports/trusted_upcoming_notification_event_summary.json",
+        "generated_at": "2026-03-11T12:38:47.563Z",
+        "emitted": 0
+      },
+      "mobile_push_delivery_summary": {
+        "path": "reports/mobile_push_delivery_summary.json",
+        "generated_at": null,
+        "sent": null,
+        "failed": null
       }
     },
     "summary_lines": [
-      "bundle id: post-sync-verification-57fe974c438e",
+      "bundle id: post-sync-verification-339f67a6e124",
       "bundle kind: post-sync-verification",
       "cadence profile: daily-upcoming",
       "workflow: manual"
     ]
   },
   "bundle_consistency": {
-    "status": "fail",
-    "expected_bundle_id": "post-sync-verification-57fe974c438e",
+    "status": "pass",
+    "expected_bundle_id": "post-sync-verification-339f67a6e124",
     "observed": {
-      "parity_bundle": "post-sync-verification-57fe974c438e",
-      "shadow_bundle": "post-sync-verification-57fe974c438e",
+      "parity_bundle": "post-sync-verification-339f67a6e124",
+      "shadow_bundle": "post-sync-verification-339f67a6e124",
       "runtime_gate_bundle": null,
       "historical_coverage_generated_at": "2026-03-11T00:00:00.000Z",
       "canonical_null_coverage_generated_at": "2026-03-11T08:30:30.464Z",
       "null_coverage_trend_generated_at": "2026-03-11T08:30:32.119Z"
     },
-    "mismatches": [
-      "historical coverage drift (2026-03-11T00:00:00.000Z)"
-    ]
+    "mismatches": []
   },
   "thresholds": {
     "latency": {
@@ -124,13 +133,13 @@
   "summary_lines": [
     "api latency: needs_review (worst p95=1148.96ms)",
     "api error rate: needs_review (error rate=0)",
-    "projection freshness: fail (lag=265.33m)",
-    "worker cadence: fail (cadence_status=scheduled_evidence_missing, missed_windows=5)",
+    "projection freshness: pass (lag=1.01m)",
+    "worker cadence: needs_review (cadence_status=warming_up, deadline=2026-03-12T12:00:00.000Z)",
     "parity dependency: fail",
     "shadow dependency: fail",
     "historical catalog completeness dependency: fail",
     "critical null coverage dependency: fail",
-    "bundle consistency: fail",
+    "bundle consistency: pass",
     "shadow -> web cutover gate: fail",
     "web cutover -> JSON demotion gate: fail"
   ],
@@ -160,10 +169,10 @@
       }
     },
     "projection_freshness": {
-      "status": "fail",
+      "status": "pass",
       "observed": {
-        "projection_generated_at": "2026-03-11T07:53:57.809Z",
-        "lag_minutes": 265.33
+        "projection_generated_at": "2026-03-11T16:14:21.898Z",
+        "lag_minutes": 1.01
       },
       "thresholds": {
         "passLagMinutes": 20,
@@ -171,20 +180,21 @@
       }
     },
     "worker_cadence": {
-      "status": "fail",
+      "status": "needs_review",
       "observed": {
         "primary_path_key": "daily_upcoming",
         "cadence_label": "daily",
         "scheduled_failure_rate": null,
         "last_success_age_hours": null,
         "scheduled_runs": 0,
-        "cadence_status": "scheduled_evidence_missing",
+        "cadence_status": "warming_up",
         "scheduled_evidence": {
-          "status": "scheduled_evidence_missing",
-          "reason": "Expected scheduled run windows have elapsed without a recorded scheduled sample.",
+          "status": "warming_up",
+          "reason": "Workflow schedule is configured, but the first scheduled sample window is still in warm-up.",
           "cadence_label": "daily",
           "workflow_created_at": "2026-03-06T07:34:09.000Z",
-          "workflow_updated_at": "2026-03-11T09:25:55.000Z",
+          "workflow_updated_at": "2026-03-11T13:45:16.000Z",
+          "schedule_reference_at": "2026-03-11T13:45:16.000Z",
           "workflow_state": "active",
           "workflow_html_url": "https://github.com/iAmSomething/idol-song-app/blob/main/.github/workflows/weekly-kpop-scan.yml",
           "parsed_schedule": {
@@ -193,12 +203,12 @@
             "hour": 0
           },
           "warmup_grace_hours": 12,
-          "first_expected_run_at": "2026-03-07T00:00:00.000Z",
+          "first_expected_run_at": "2026-03-12T00:00:00.000Z",
           "next_expected_run_at": "2026-03-12T00:00:00.000Z",
-          "warmup_deadline_at": "2026-03-07T12:00:00.000Z",
-          "expected_scheduled_runs_by_now": 5,
+          "warmup_deadline_at": "2026-03-12T12:00:00.000Z",
+          "expected_scheduled_runs_by_now": 0,
           "observed_scheduled_runs": 0,
-          "missed_scheduled_windows": 5
+          "missed_scheduled_windows": 0
         }
       },
       "thresholds": {
@@ -214,15 +224,15 @@
       "status": "fail",
       "observed": {
         "clean": false,
-        "generated_at": "2026-03-11T09:16:27.590969+00:00",
+        "generated_at": "2026-03-11T16:15:16.837750+00:00",
         "summary_lines": [
           "entity alias/search coverage: clean (mismatched entities=0)",
           "official links: clean (mismatched entities=0)",
           "YouTube allowlists: drift (role mismatches=10, metadata mismatches=0)",
           "latest verified release selection: clean (tracking mismatches=0, stream mismatches=0)",
           "upcoming counts / nearest: clean (month bucket mismatches=0)",
-          "title-track / double-title: drift (mismatched releases=1060)",
-          "YouTube Music / MV service-link state: drift (mismatched releases=124)",
+          "title-track / double-title: drift (mismatched releases=1120)",
+          "YouTube Music / MV service-link state: drift (mismatched releases=165)",
           "review-required counts: drift (review_type_counts_match=False, youtube_mv_status_counts_match=False)"
         ]
       },
@@ -232,7 +242,7 @@
       "status": "fail",
       "observed": {
         "clean": false,
-        "generated_at": "2026-03-11T09:17:40.030Z",
+        "generated_at": "2026-03-11T16:15:22.441Z",
         "summary_lines": [
           "search: clean 5/5, drift 0/5",
           "entity_detail: clean 2/4, drift 2/4",
@@ -510,21 +520,19 @@
       "label": "critical_null_coverage"
     },
     "bundle_consistency": {
-      "status": "fail",
+      "status": "pass",
       "observed": {
-        "status": "fail",
-        "expected_bundle_id": "post-sync-verification-57fe974c438e",
+        "status": "pass",
+        "expected_bundle_id": "post-sync-verification-339f67a6e124",
         "observed": {
-          "parity_bundle": "post-sync-verification-57fe974c438e",
-          "shadow_bundle": "post-sync-verification-57fe974c438e",
+          "parity_bundle": "post-sync-verification-339f67a6e124",
+          "shadow_bundle": "post-sync-verification-339f67a6e124",
           "runtime_gate_bundle": null,
           "historical_coverage_generated_at": "2026-03-11T00:00:00.000Z",
           "canonical_null_coverage_generated_at": "2026-03-11T08:30:30.464Z",
           "null_coverage_trend_generated_at": "2026-03-11T08:30:32.119Z"
         },
-        "mismatches": [
-          "historical coverage drift (2026-03-11T00:00:00.000Z)"
-        ]
+        "mismatches": []
       },
       "label": "report_bundle_metadata"
     }

--- a/backend/reports/worker_cadence_report.json
+++ b/backend/reports/worker_cadence_report.json
@@ -1,10 +1,10 @@
 {
-  "generated_at": "2026-03-11T12:15:23.043Z",
+  "generated_at": "2026-03-11T16:14:23.247Z",
   "repo": "iAmSomething/idol-song-app",
   "sample_limit": 12,
   "primary_path_key": "daily_upcoming",
   "summary_lines": [
-    "[primary] daily_upcoming: cadence=daily, status=scheduled_evidence_missing, observed=0, expected_by_now=5, missed_windows=5",
+    "[primary] daily_upcoming: cadence=daily, status=warming_up, first_due=2026-03-12T00:00:00.000Z, deadline=2026-03-12T12:00:00.000Z",
     "[secondary] catalog_enrichment: cadence=weekly, status=warming_up, first_due=2026-03-15T01:00:00.000Z, deadline=2026-03-16T01:00:00.000Z"
   ],
   "topology": {
@@ -42,15 +42,15 @@
       },
       "workflow_metadata": {
         "created_at": "2026-03-06T16:34:09.000+09:00",
-        "updated_at": "2026-03-11T18:25:55.000+09:00",
+        "updated_at": "2026-03-11T22:45:16.000+09:00",
         "state": "active",
         "html_url": "https://github.com/iAmSomething/idol-song-app/blob/main/.github/workflows/weekly-kpop-scan.yml"
       },
-      "cadence_status": "scheduled_evidence_missing",
+      "cadence_status": "warming_up",
       "sample_limit": 12,
       "sample_window": {
-        "newest_created_at": "2026-03-11T11:52:16.000Z",
-        "oldest_created_at": "2026-03-11T07:59:12.000Z"
+        "newest_created_at": "2026-03-11T15:27:30.000Z",
+        "oldest_created_at": "2026-03-11T11:51:41.000Z"
       },
       "totals": {
         "all_runs": 12,
@@ -75,11 +75,12 @@
         "max_success_gap_hours": null
       },
       "scheduled_evidence": {
-        "status": "scheduled_evidence_missing",
-        "reason": "Expected scheduled run windows have elapsed without a recorded scheduled sample.",
+        "status": "warming_up",
+        "reason": "Workflow schedule is configured, but the first scheduled sample window is still in warm-up.",
         "cadence_label": "daily",
         "workflow_created_at": "2026-03-06T07:34:09.000Z",
-        "workflow_updated_at": "2026-03-11T09:25:55.000Z",
+        "workflow_updated_at": "2026-03-11T13:45:16.000Z",
+        "schedule_reference_at": "2026-03-11T13:45:16.000Z",
         "workflow_state": "active",
         "workflow_html_url": "https://github.com/iAmSomething/idol-song-app/blob/main/.github/workflows/weekly-kpop-scan.yml",
         "parsed_schedule": {
@@ -88,68 +89,68 @@
           "hour": 0
         },
         "warmup_grace_hours": 12,
-        "first_expected_run_at": "2026-03-07T00:00:00.000Z",
+        "first_expected_run_at": "2026-03-12T00:00:00.000Z",
         "next_expected_run_at": "2026-03-12T00:00:00.000Z",
-        "warmup_deadline_at": "2026-03-07T12:00:00.000Z",
-        "expected_scheduled_runs_by_now": 5,
+        "warmup_deadline_at": "2026-03-12T12:00:00.000Z",
+        "expected_scheduled_runs_by_now": 0,
         "observed_scheduled_runs": 0,
-        "missed_scheduled_windows": 5
+        "missed_scheduled_windows": 0
       },
       "latest_runs": [
         {
-          "database_id": 22951215642,
+          "database_id": 22960376580,
           "event": "push",
           "status": "completed",
           "conclusion": "failure",
-          "created_at": "2026-03-11T11:52:16.000Z",
-          "started_at": "2026-03-11T11:52:16.000Z",
-          "updated_at": "2026-03-11T11:52:16.000Z",
+          "created_at": "2026-03-11T15:27:30.000Z",
+          "started_at": "2026-03-11T15:27:30.000Z",
+          "updated_at": "2026-03-11T15:27:30.000Z",
           "duration_minutes": 0,
-          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22951215642"
+          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22960376580"
         },
         {
-          "database_id": 22951195021,
+          "database_id": 22960349404,
           "event": "push",
           "status": "completed",
           "conclusion": "failure",
-          "created_at": "2026-03-11T11:51:41.000Z",
-          "started_at": "2026-03-11T11:51:41.000Z",
-          "updated_at": "2026-03-11T11:51:41.000Z",
+          "created_at": "2026-03-11T15:26:57.000Z",
+          "started_at": "2026-03-11T15:26:57.000Z",
+          "updated_at": "2026-03-11T15:26:57.000Z",
           "duration_minutes": 0,
-          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22951195021"
+          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22960349404"
         },
         {
-          "database_id": 22948835485,
+          "database_id": 22957736607,
           "event": "push",
           "status": "completed",
           "conclusion": "failure",
-          "created_at": "2026-03-11T10:47:46.000Z",
-          "started_at": "2026-03-11T10:47:46.000Z",
-          "updated_at": "2026-03-11T10:47:46.000Z",
+          "created_at": "2026-03-11T14:30:50.000Z",
+          "started_at": "2026-03-11T14:30:50.000Z",
+          "updated_at": "2026-03-11T14:30:50.000Z",
           "duration_minutes": 0,
-          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22948835485"
+          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22957736607"
         },
         {
-          "database_id": 22948800261,
+          "database_id": 22957709499,
           "event": "push",
           "status": "completed",
           "conclusion": "failure",
-          "created_at": "2026-03-11T10:46:50.000Z",
-          "started_at": "2026-03-11T10:46:50.000Z",
-          "updated_at": "2026-03-11T10:46:50.000Z",
+          "created_at": "2026-03-11T14:30:16.000Z",
+          "started_at": "2026-03-11T14:30:16.000Z",
+          "updated_at": "2026-03-11T14:30:16.000Z",
           "duration_minutes": 0,
-          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22948800261"
+          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22957709499"
         },
         {
-          "database_id": 22945665409,
+          "database_id": 22955684352,
           "event": "push",
           "status": "completed",
           "conclusion": "failure",
-          "created_at": "2026-03-11T09:25:55.000Z",
-          "started_at": "2026-03-11T09:25:55.000Z",
-          "updated_at": "2026-03-11T09:25:55.000Z",
+          "created_at": "2026-03-11T13:45:15.000Z",
+          "started_at": "2026-03-11T13:45:15.000Z",
+          "updated_at": "2026-03-11T13:45:15.000Z",
           "duration_minutes": 0,
-          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22945665409"
+          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22955684352"
         }
       ],
       "latest_scheduled_runs": []
@@ -192,8 +193,8 @@
       "cadence_status": "warming_up",
       "sample_limit": 12,
       "sample_window": {
-        "newest_created_at": "2026-03-11T11:52:16.000Z",
-        "oldest_created_at": "2026-03-11T07:59:12.000Z"
+        "newest_created_at": "2026-03-11T15:27:29.000Z",
+        "oldest_created_at": "2026-03-11T11:51:41.000Z"
       },
       "totals": {
         "all_runs": 12,
@@ -223,6 +224,7 @@
         "cadence_label": "weekly",
         "workflow_created_at": "2026-03-11T07:14:52.000Z",
         "workflow_updated_at": "2026-03-11T09:25:54.000Z",
+        "schedule_reference_at": "2026-03-11T09:25:54.000Z",
         "workflow_state": "active",
         "workflow_html_url": "https://github.com/iAmSomething/idol-song-app/blob/main/.github/workflows/catalog-enrichment-refresh.yml",
         "parsed_schedule": {
@@ -241,59 +243,59 @@
       },
       "latest_runs": [
         {
-          "database_id": 22951215883,
+          "database_id": 22960376155,
           "event": "push",
           "status": "completed",
           "conclusion": "failure",
-          "created_at": "2026-03-11T11:52:16.000Z",
-          "started_at": "2026-03-11T11:52:16.000Z",
-          "updated_at": "2026-03-11T11:52:16.000Z",
+          "created_at": "2026-03-11T15:27:29.000Z",
+          "started_at": "2026-03-11T15:27:29.000Z",
+          "updated_at": "2026-03-11T15:27:29.000Z",
           "duration_minutes": 0,
-          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22951215883"
+          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22960376155"
         },
         {
-          "database_id": 22951194740,
+          "database_id": 22960350136,
           "event": "push",
           "status": "completed",
           "conclusion": "failure",
-          "created_at": "2026-03-11T11:51:41.000Z",
-          "started_at": "2026-03-11T11:51:41.000Z",
-          "updated_at": "2026-03-11T11:51:41.000Z",
+          "created_at": "2026-03-11T15:26:58.000Z",
+          "started_at": "2026-03-11T15:26:58.000Z",
+          "updated_at": "2026-03-11T15:26:58.000Z",
           "duration_minutes": 0,
-          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22951194740"
+          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22960350136"
         },
         {
-          "database_id": 22948835209,
+          "database_id": 22957736229,
           "event": "push",
           "status": "completed",
           "conclusion": "failure",
-          "created_at": "2026-03-11T10:47:46.000Z",
-          "started_at": "2026-03-11T10:47:46.000Z",
-          "updated_at": "2026-03-11T10:47:46.000Z",
+          "created_at": "2026-03-11T14:30:49.000Z",
+          "started_at": "2026-03-11T14:30:49.000Z",
+          "updated_at": "2026-03-11T14:30:49.000Z",
           "duration_minutes": 0,
-          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22948835209"
+          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22957736229"
         },
         {
-          "database_id": 22948800029,
+          "database_id": 22957708657,
           "event": "push",
           "status": "completed",
           "conclusion": "failure",
-          "created_at": "2026-03-11T10:46:50.000Z",
-          "started_at": "2026-03-11T10:46:50.000Z",
-          "updated_at": "2026-03-11T10:46:50.000Z",
+          "created_at": "2026-03-11T14:30:15.000Z",
+          "started_at": "2026-03-11T14:30:15.000Z",
+          "updated_at": "2026-03-11T14:30:15.000Z",
           "duration_minutes": 0,
-          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22948800029"
+          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22957708657"
         },
         {
-          "database_id": 22945665166,
+          "database_id": 22955683797,
           "event": "push",
           "status": "completed",
           "conclusion": "failure",
-          "created_at": "2026-03-11T09:25:54.000Z",
-          "started_at": "2026-03-11T09:25:54.000Z",
-          "updated_at": "2026-03-11T09:25:54.000Z",
+          "created_at": "2026-03-11T13:45:15.000Z",
+          "started_at": "2026-03-11T13:45:15.000Z",
+          "updated_at": "2026-03-11T13:45:15.000Z",
           "duration_minutes": 0,
-          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22945665166"
+          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22955683797"
         }
       ],
       "latest_scheduled_runs": []
@@ -301,8 +303,8 @@
   },
   "workflow": "weekly-kpop-scan.yml",
   "sample_window": {
-    "newest_created_at": "2026-03-11T11:52:16.000Z",
-    "oldest_created_at": "2026-03-11T07:59:12.000Z"
+    "newest_created_at": "2026-03-11T15:27:30.000Z",
+    "oldest_created_at": "2026-03-11T11:51:41.000Z"
   },
   "totals": {
     "all_runs": 12,
@@ -327,11 +329,12 @@
     "max_success_gap_hours": null
   },
   "scheduled_evidence": {
-    "status": "scheduled_evidence_missing",
-    "reason": "Expected scheduled run windows have elapsed without a recorded scheduled sample.",
+    "status": "warming_up",
+    "reason": "Workflow schedule is configured, but the first scheduled sample window is still in warm-up.",
     "cadence_label": "daily",
     "workflow_created_at": "2026-03-06T07:34:09.000Z",
-    "workflow_updated_at": "2026-03-11T09:25:55.000Z",
+    "workflow_updated_at": "2026-03-11T13:45:16.000Z",
+    "schedule_reference_at": "2026-03-11T13:45:16.000Z",
     "workflow_state": "active",
     "workflow_html_url": "https://github.com/iAmSomething/idol-song-app/blob/main/.github/workflows/weekly-kpop-scan.yml",
     "parsed_schedule": {
@@ -340,68 +343,68 @@
       "hour": 0
     },
     "warmup_grace_hours": 12,
-    "first_expected_run_at": "2026-03-07T00:00:00.000Z",
+    "first_expected_run_at": "2026-03-12T00:00:00.000Z",
     "next_expected_run_at": "2026-03-12T00:00:00.000Z",
-    "warmup_deadline_at": "2026-03-07T12:00:00.000Z",
-    "expected_scheduled_runs_by_now": 5,
+    "warmup_deadline_at": "2026-03-12T12:00:00.000Z",
+    "expected_scheduled_runs_by_now": 0,
     "observed_scheduled_runs": 0,
-    "missed_scheduled_windows": 5
+    "missed_scheduled_windows": 0
   },
   "latest_runs": [
     {
-      "database_id": 22951215642,
+      "database_id": 22960376580,
       "event": "push",
       "status": "completed",
       "conclusion": "failure",
-      "created_at": "2026-03-11T11:52:16.000Z",
-      "started_at": "2026-03-11T11:52:16.000Z",
-      "updated_at": "2026-03-11T11:52:16.000Z",
+      "created_at": "2026-03-11T15:27:30.000Z",
+      "started_at": "2026-03-11T15:27:30.000Z",
+      "updated_at": "2026-03-11T15:27:30.000Z",
       "duration_minutes": 0,
-      "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22951215642"
+      "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22960376580"
     },
     {
-      "database_id": 22951195021,
+      "database_id": 22960349404,
       "event": "push",
       "status": "completed",
       "conclusion": "failure",
-      "created_at": "2026-03-11T11:51:41.000Z",
-      "started_at": "2026-03-11T11:51:41.000Z",
-      "updated_at": "2026-03-11T11:51:41.000Z",
+      "created_at": "2026-03-11T15:26:57.000Z",
+      "started_at": "2026-03-11T15:26:57.000Z",
+      "updated_at": "2026-03-11T15:26:57.000Z",
       "duration_minutes": 0,
-      "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22951195021"
+      "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22960349404"
     },
     {
-      "database_id": 22948835485,
+      "database_id": 22957736607,
       "event": "push",
       "status": "completed",
       "conclusion": "failure",
-      "created_at": "2026-03-11T10:47:46.000Z",
-      "started_at": "2026-03-11T10:47:46.000Z",
-      "updated_at": "2026-03-11T10:47:46.000Z",
+      "created_at": "2026-03-11T14:30:50.000Z",
+      "started_at": "2026-03-11T14:30:50.000Z",
+      "updated_at": "2026-03-11T14:30:50.000Z",
       "duration_minutes": 0,
-      "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22948835485"
+      "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22957736607"
     },
     {
-      "database_id": 22948800261,
+      "database_id": 22957709499,
       "event": "push",
       "status": "completed",
       "conclusion": "failure",
-      "created_at": "2026-03-11T10:46:50.000Z",
-      "started_at": "2026-03-11T10:46:50.000Z",
-      "updated_at": "2026-03-11T10:46:50.000Z",
+      "created_at": "2026-03-11T14:30:16.000Z",
+      "started_at": "2026-03-11T14:30:16.000Z",
+      "updated_at": "2026-03-11T14:30:16.000Z",
       "duration_minutes": 0,
-      "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22948800261"
+      "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22957709499"
     },
     {
-      "database_id": 22945665409,
+      "database_id": 22955684352,
       "event": "push",
       "status": "completed",
       "conclusion": "failure",
-      "created_at": "2026-03-11T09:25:55.000Z",
-      "started_at": "2026-03-11T09:25:55.000Z",
-      "updated_at": "2026-03-11T09:25:55.000Z",
+      "created_at": "2026-03-11T13:45:15.000Z",
+      "started_at": "2026-03-11T13:45:15.000Z",
+      "updated_at": "2026-03-11T13:45:15.000Z",
       "duration_minutes": 0,
-      "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22945665409"
+      "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22955684352"
     }
   ],
   "latest_scheduled_runs": []

--- a/backend/scripts/lib/workerCadenceEvidence.mjs
+++ b/backend/scripts/lib/workerCadenceEvidence.mjs
@@ -120,11 +120,16 @@ export function buildScheduledEvidenceSummary({
   const normalizedObservedRuns = Number.isInteger(observedScheduledRuns) && observedScheduledRuns > 0 ? observedScheduledRuns : 0;
   const parsedSchedule = parseScheduleExpectation(scheduleExpectation);
   const workflowCreatedAt = toDate(workflowMetadata?.created_at);
+  const workflowUpdatedAt = toDate(workflowMetadata?.updated_at);
   const nowDate = toDate(now);
   const warmupGraceHours = WARMUP_GRACE_HOURS_BY_CADENCE[cadenceLabel] ?? WARMUP_GRACE_HOURS_BY_CADENCE.custom;
+  const scheduleReferenceAt =
+    normalizedObservedRuns === 0 && workflowUpdatedAt && workflowCreatedAt && workflowUpdatedAt > workflowCreatedAt
+      ? workflowUpdatedAt
+      : workflowCreatedAt;
   const firstExpectedRunAt =
-    workflowRegistered && workflowCreatedAt && parsedSchedule
-      ? nextScheduledOccurrenceAfter(workflowCreatedAt, parsedSchedule)
+    workflowRegistered && scheduleReferenceAt && parsedSchedule
+      ? nextScheduledOccurrenceAfter(scheduleReferenceAt, parsedSchedule)
       : null;
   const nextExpectedRunAt =
     workflowRegistered && nowDate && parsedSchedule ? nextScheduledOccurrenceAfter(nowDate, parsedSchedule) : null;
@@ -162,6 +167,7 @@ export function buildScheduledEvidenceSummary({
     cadence_label: cadenceLabel ?? null,
     workflow_created_at: toIsoString(workflowCreatedAt),
     workflow_updated_at: toIsoString(workflowMetadata?.updated_at),
+    schedule_reference_at: toIsoString(scheduleReferenceAt),
     workflow_state: workflowMetadata?.state ?? null,
     workflow_html_url: workflowMetadata?.html_url ?? null,
     parsed_schedule: parsedSchedule,

--- a/backend/scripts/lib/workerCadenceEvidence.test.mjs
+++ b/backend/scripts/lib/workerCadenceEvidence.test.mjs
@@ -54,7 +54,7 @@ test('buildScheduledEvidenceSummary marks daily cadence as missing after several
     workflowRegistered: true,
     workflowMetadata: {
       created_at: '2026-03-06T07:34:09.000Z',
-      updated_at: '2026-03-11T09:25:55.000Z',
+      updated_at: '2026-03-06T07:34:09.000Z',
       state: 'active',
       html_url: 'https://github.com/example/weekly-kpop-scan',
     },
@@ -67,6 +67,28 @@ test('buildScheduledEvidenceSummary marks daily cadence as missing after several
   assert.equal(summary.status, 'scheduled_evidence_missing');
   assert.equal(summary.expected_scheduled_runs_by_now, 5);
   assert.equal(summary.missed_scheduled_windows, 5);
+});
+
+test('buildScheduledEvidenceSummary uses workflow updated_at as warm-up reference when no scheduled runs exist yet', () => {
+  const summary = buildScheduledEvidenceSummary({
+    workflowRegistered: true,
+    workflowMetadata: {
+      created_at: '2026-03-06T07:34:09.000Z',
+      updated_at: '2026-03-11T13:45:16.000Z',
+      state: 'active',
+      html_url: 'https://github.com/example/weekly-kpop-scan',
+    },
+    cadenceLabel: 'daily',
+    scheduleExpectation: '0 0 * * *',
+    observedScheduledRuns: 0,
+    now: '2026-03-11T16:10:01.000Z',
+  });
+
+  assert.equal(summary.status, 'warming_up');
+  assert.equal(summary.schedule_reference_at, '2026-03-11T13:45:16.000Z');
+  assert.equal(summary.expected_scheduled_runs_by_now, 0);
+  assert.equal(summary.missed_scheduled_windows, 0);
+  assert.equal(summary.first_expected_run_at, '2026-03-12T00:00:00.000Z');
 });
 
 test('buildScheduledEvidenceSummary keeps weekly cadence in warm-up before the first due window', () => {

--- a/docs/assets/distribution/backend_runtime_health_gate_local_2026-03-12.md
+++ b/docs/assets/distribution/backend_runtime_health_gate_local_2026-03-12.md
@@ -1,0 +1,45 @@
+## Backend Runtime Health Gate Local Evidence
+
+- Date: 2026-03-12 (Asia/Seoul)
+- Issue: #600
+- Branch: `codex/dev/600-runtime-health-gate`
+
+## Commands
+
+```bash
+source ~/.config/idol-song-app/neon.env
+cd /Users/gimtaehun/Desktop/idol-song-app/backend
+npm run projection:refresh
+npm run worker:cadence
+npm run report:bundle -- --bundle-kind post-sync-verification --cadence-profile daily-upcoming
+cd /Users/gimtaehun/Desktop/idol-song-app
+source .venv/bin/activate
+python3 build_backend_json_parity_report.py --bundle-path backend/reports/report_bundle_metadata.json
+cd /Users/gimtaehun/Desktop/idol-song-app/backend
+npm run shadow:verify -- --bundle-path ./reports/report_bundle_metadata.json
+npm run runtime:gate -- --bundle-path ./reports/report_bundle_metadata.json
+npm run migration:scorecard -- --bundle-path ./reports/report_bundle_metadata.json
+```
+
+## Results
+
+- `runtime_gate_report.json`
+  - `projection_freshness.status = pass`
+  - `worker_cadence.status = needs_review`
+  - `worker_cadence.observed.cadence_status = warming_up`
+- `worker_cadence_report.json`
+  - `daily_upcoming.cadence_status = warming_up`
+  - `daily_upcoming.scheduled_evidence.status = warming_up`
+  - `daily_upcoming.scheduled_evidence.expected_scheduled_runs_by_now = 0`
+  - `daily_upcoming.scheduled_evidence.missed_scheduled_windows = 0`
+  - `daily_upcoming.scheduled_evidence.schedule_reference_at = 2026-03-11T13:45:16.000Z`
+- `migration_readiness_scorecard.json`
+  - `backend_runtime_health.blocker_reasons`
+    - `stage_gate:shadow_to_web_cutover=fail`
+    - `stage_gate:web_cutover_to_json_demotion=fail`
+  - projection freshness and worker cadence fail reasons are no longer present
+
+## Notes
+
+- The runtime-health cutover blocker from stale projection freshness and incorrect scheduled-evidence math is resolved.
+- Remaining readiness blockers are outside `#600` scope.


### PR DESCRIPTION
## Summary
- treat newly updated scheduled workflows with no schedule samples as warm-up, not missing evidence
- regenerate projection/cadence/parity/shadow/runtime/scorecard reports on a consistent bundle id
- add local evidence for the runtime health gate recovery

Closes #600