### PR TITLE
Fix backend shadow detail parity

### DIFF
--- a/backend/reports/backend_shadow_read_report.json
+++ b/backend/reports/backend_shadow_read_report.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-03-11T16:15:22.441Z",
-  "clean": false,
+  "generated_at": "2026-03-11T16:33:32.630Z",
+  "clean": true,
   "report_bundle": {
     "generated_at": "2026-03-11T16:14:23.510Z",
     "bundle_id": "post-sync-verification-339f67a6e124",
@@ -163,12 +163,10 @@
   },
   "summary_lines": [
     "search: clean 5/5, drift 0/5",
-    "entity_detail: clean 2/4, drift 2/4",
-    "release_detail: clean 0/3, drift 3/3",
+    "entity_detail: clean 4/4, drift 0/4",
+    "release_detail: clean 3/3, drift 0/3",
     "calendar_month: clean 3/3, drift 0/3",
-    "radar: clean 1/1, drift 0/1",
-    "missing rows or segments: 5 case(s)",
-    "field-shape mismatches: 3 case(s)"
+    "radar: clean 1/1, drift 0/1"
   ],
   "cases": [
     {
@@ -250,8 +248,8 @@
         "upcoming": []
       },
       "actual_status_code": 200,
-      "request_id_sent": "shadow--v1-search-q-ed-8a-b8-eb-a6-ac-ed-94-8c-ec-97-90-ec-8a-a4-6014e36a-1f37-47e4-ace9-8dcab656e848",
-      "response_request_id": "shadow--v1-search-q-ed-8a-b8-eb-a6-ac-ed-94-8c-ec-97-90-ec-8a-a4-6014e36a-1f37-47e4-ace9-8dcab656e848"
+      "request_id_sent": "shadow--v1-search-q-ed-8a-b8-eb-a6-ac-ed-94-8c-ec-97-90-ec-8a-a4-c96719c5-7711-4565-a01c-bce7dcb8a07e",
+      "response_request_id": "shadow--v1-search-q-ed-8a-b8-eb-a6-ac-ed-94-8c-ec-97-90-ec-8a-a4-c96719c5-7711-4565-a01c-bce7dcb8a07e"
     },
     {
       "surface": "search",
@@ -383,8 +381,8 @@
         ]
       },
       "actual_status_code": 200,
-      "request_id_sent": "shadow--v1-search-q-ed-88-ac-eb-b0-94-ed-88-ac-0973058e-3c39-4d7f-b068-d0b5e63d8b83",
-      "response_request_id": "shadow--v1-search-q-ed-88-ac-eb-b0-94-ed-88-ac-0973058e-3c39-4d7f-b068-d0b5e63d8b83"
+      "request_id_sent": "shadow--v1-search-q-ed-88-ac-eb-b0-94-ed-88-ac-e698e94d-f563-4add-bcc2-946483d9f9d0",
+      "response_request_id": "shadow--v1-search-q-ed-88-ac-eb-b0-94-ed-88-ac-e698e94d-f563-4add-bcc2-946483d9f9d0"
     },
     {
       "surface": "search",
@@ -516,8 +514,8 @@
         ]
       },
       "actual_status_code": 200,
-      "request_id_sent": "shadow--v1-search-q-ec-b5-9c-ec-98-88-eb-82-98-99066b6b-174c-41c4-8195-356705c4b56f",
-      "response_request_id": "shadow--v1-search-q-ec-b5-9c-ec-98-88-eb-82-98-99066b6b-174c-41c4-8195-356705c4b56f"
+      "request_id_sent": "shadow--v1-search-q-ec-b5-9c-ec-98-88-eb-82-98-984314d3-2efe-4fed-9262-4bab542e86fa",
+      "response_request_id": "shadow--v1-search-q-ec-b5-9c-ec-98-88-eb-82-98-984314d3-2efe-4fed-9262-4bab542e86fa"
     },
     {
       "surface": "search",
@@ -598,8 +596,8 @@
         "upcoming": []
       },
       "actual_status_code": 200,
-      "request_id_sent": "shadow--v1-search-q-revive-2b-1c1de7b9-ccb2-4a6d-bae6-bb8c3eaa1fe7",
-      "response_request_id": "shadow--v1-search-q-revive-2b-1c1de7b9-ccb2-4a6d-bae6-bb8c3eaa1fe7"
+      "request_id_sent": "shadow--v1-search-q-revive-2b-d380fa85-4183-4560-8773-f0271735c0c7",
+      "response_request_id": "shadow--v1-search-q-revive-2b-d380fa85-4183-4560-8773-f0271735c0c7"
     },
     {
       "surface": "search",
@@ -680,45 +678,17 @@
         "upcoming": []
       },
       "actual_status_code": 200,
-      "request_id_sent": "shadow--v1-search-q-ed-9d-b0-ec-88-98-ec-97-bc-ea-b3-a0-eb-9e-98-bf6666ae-11a6-4f28-b6a2-4439d5938926",
-      "response_request_id": "shadow--v1-search-q-ed-9d-b0-ec-88-98-ec-97-bc-ea-b3-a0-eb-9e-98-bf6666ae-11a6-4f28-b6a2-4439d5938926"
+      "request_id_sent": "shadow--v1-search-q-ed-9d-b0-ec-88-98-ec-97-bc-ea-b3-a0-eb-9e-98-eb924484-8b37-4294-b3d7-e9a3cab44406",
+      "response_request_id": "shadow--v1-search-q-ed-9d-b0-ec-88-98-ec-97-bc-ea-b3-a0-eb-9e-98-eb924484-8b37-4294-b3d7-e9a3cab44406"
     },
     {
       "surface": "entity_detail",
       "input": {
         "slug": "yena"
       },
-      "clean": false,
-      "mismatch_categories": [
-        "field-shape mismatches",
-        "missing rows or segments"
-      ],
-      "mismatches": [
-        {
-          "category": "field-shape mismatches",
-          "path": "data",
-          "shape_mismatches": [
-            {
-              "path": "data.youtube_channels.primary_team_channel_url",
-              "expected_type": "string",
-              "actual_type": "null",
-              "message": "Type mismatch"
-            }
-          ]
-        },
-        {
-          "category": "missing rows or segments",
-          "path": "data.tracking_state.tier",
-          "expected": "tracked",
-          "actual": "longtail"
-        },
-        {
-          "category": "missing rows or segments",
-          "path": "data.tracking_state.watch_reason",
-          "expected": null,
-          "actual": "manual_watch"
-        }
-      ],
+      "clean": true,
+      "mismatch_categories": [],
+      "mismatches": [],
       "expected_snapshot": {
         "identity": {
           "entity_slug": "yena",
@@ -836,12 +806,12 @@
           "instagram": "https://www.instagram.com/yena.jigumina"
         },
         "youtube_channels": {
-          "primary_team_channel_url": null,
+          "primary_team_channel_url": "https://www.youtube.com/@yena_official",
           "mv_allowlist_urls": []
         },
         "tracking_state": {
-          "tier": "longtail",
-          "watch_reason": "manual_watch",
+          "tier": "tracked",
+          "watch_reason": null,
           "tracking_status": "watch_only"
         },
         "next_upcoming": null,
@@ -940,138 +910,17 @@
         "artist_source_url": "https://musicbrainz.org/artist/745c5b92-325f-451d-bd52-e6b95229c776"
       },
       "actual_status_code": 200,
-      "request_id_sent": "shadow--v1-entities-yena-463c68f7-8af4-483e-b5df-4dbb2b47742e",
-      "response_request_id": "shadow--v1-entities-yena-463c68f7-8af4-483e-b5df-4dbb2b47742e"
+      "request_id_sent": "shadow--v1-entities-yena-19afe972-2fa0-465d-94a0-540afb4f30b8",
+      "response_request_id": "shadow--v1-entities-yena-19afe972-2fa0-465d-94a0-540afb4f30b8"
     },
     {
       "surface": "entity_detail",
       "input": {
         "slug": "blackpink"
       },
-      "clean": false,
-      "mismatch_categories": [
-        "missing rows or segments"
-      ],
-      "mismatches": [
-        {
-          "category": "missing rows or segments",
-          "path": "data.recent_albums",
-          "expected": [
-            {
-              "release_title": "DEADLINE",
-              "release_date": "2026-02-27",
-              "stream": "album",
-              "release_kind": "ep",
-              "release_format": "ep",
-              "artwork": null
-            },
-            {
-              "release_title": "BORN PINK",
-              "release_date": "2022-09-16",
-              "stream": "album",
-              "release_kind": "album",
-              "release_format": "album",
-              "artwork": null
-            },
-            {
-              "release_title": "THE ALBUM",
-              "release_date": "2020-10-02",
-              "stream": "album",
-              "release_kind": "album",
-              "release_format": "album",
-              "artwork": null
-            },
-            {
-              "release_title": "KILL THIS LOVE",
-              "release_date": "2019-04-05",
-              "stream": "album",
-              "release_kind": "ep",
-              "release_format": "ep",
-              "artwork": null
-            },
-            {
-              "release_title": "SQUARE UP",
-              "release_date": "2018-06-15",
-              "stream": "album",
-              "release_kind": "ep",
-              "release_format": "ep",
-              "artwork": null
-            },
-            {
-              "release_title": "BLACKPINK",
-              "release_date": "2017-08-29",
-              "stream": "album",
-              "release_kind": "ep",
-              "release_format": "ep",
-              "artwork": null
-            }
-          ],
-          "actual": [
-            {
-              "release_title": "DEADLINE",
-              "release_date": "2026-02-27",
-              "stream": "album",
-              "release_kind": "ep",
-              "release_format": "ep",
-              "artwork": null
-            },
-            {
-              "release_title": "DEADLINE",
-              "release_date": "2026-02-26",
-              "stream": "album",
-              "release_kind": null,
-              "release_format": null,
-              "artwork": {
-                "cover_image_url": "https://coverartarchive.org/release-group/38204997-b295-4d09-a946-f7e119725031/front",
-                "thumbnail_image_url": "https://coverartarchive.org/release-group/38204997-b295-4d09-a946-f7e119725031/front-250",
-                "artwork_source_type": "cover_art_archive",
-                "artwork_source_url": "https://coverartarchive.org/release-group/38204997-b295-4d09-a946-f7e119725031",
-                "is_placeholder": false
-              }
-            },
-            {
-              "release_title": "BORN PINK",
-              "release_date": "2022-09-16",
-              "stream": "album",
-              "release_kind": "album",
-              "release_format": "album",
-              "artwork": null
-            },
-            {
-              "release_title": "THE ALBUM",
-              "release_date": "2020-10-02",
-              "stream": "album",
-              "release_kind": "album",
-              "release_format": "album",
-              "artwork": null
-            },
-            {
-              "release_title": "KILL THIS LOVE",
-              "release_date": "2019-04-05",
-              "stream": "album",
-              "release_kind": "ep",
-              "release_format": "ep",
-              "artwork": null
-            },
-            {
-              "release_title": "SQUARE UP",
-              "release_date": "2018-06-15",
-              "stream": "album",
-              "release_kind": "ep",
-              "release_format": "ep",
-              "artwork": null
-            },
-            {
-              "release_title": "BLACKPINK",
-              "release_date": "2017-08-29",
-              "stream": "album",
-              "release_kind": "ep",
-              "release_format": "ep",
-              "artwork": null
-            }
-          ]
-        }
-      ],
+      "clean": true,
+      "mismatch_categories": [],
+      "mismatches": [],
       "expected_snapshot": {
         "identity": {
           "entity_slug": "blackpink",
@@ -1376,26 +1225,6 @@
             "artwork": null
           },
           {
-            "release_id": "e3526174-e804-56f2-9d50-17f9f817a351",
-            "release_title": "DEADLINE",
-            "release_date": "2026-02-26",
-            "stream": "album",
-            "release_kind": null,
-            "release_format": null,
-            "representative_song_title": "GO",
-            "spotify_url": "https://open.spotify.com/album/0al74j1n8XIEkZMMFRfsbx",
-            "youtube_music_url": "https://music.youtube.com/playlist?list=OLAK5uy_l3QGS6y9ZWficqzcu429HoCvcKlpMmmmY",
-            "youtube_mv_url": "https://www.youtube.com/watch?v=2GJfWMYCWY0",
-            "source_url": null,
-            "artwork": {
-              "cover_image_url": "https://coverartarchive.org/release-group/38204997-b295-4d09-a946-f7e119725031/front",
-              "thumbnail_image_url": "https://coverartarchive.org/release-group/38204997-b295-4d09-a946-f7e119725031/front-250",
-              "artwork_source_type": "cover_art_archive",
-              "artwork_source_url": "https://coverartarchive.org/release-group/38204997-b295-4d09-a946-f7e119725031",
-              "is_placeholder": false
-            }
-          },
-          {
             "release_id": "0571a361-1b4e-58ab-a628-ff715c81bada",
             "release_title": "BORN PINK",
             "release_date": "2022-09-16",
@@ -1615,8 +1444,8 @@
         "artist_source_url": "https://musicbrainz.org/artist/48646387-1664-4c9a-9139-9bfd091b823c"
       },
       "actual_status_code": 200,
-      "request_id_sent": "shadow--v1-entities-blackpink-1f5afa2e-cb1a-4875-9015-ea759d848fd6",
-      "response_request_id": "shadow--v1-entities-blackpink-1f5afa2e-cb1a-4875-9015-ea759d848fd6"
+      "request_id_sent": "shadow--v1-entities-blackpink-37cfd0b0-2760-44d7-afe9-c4decefd5b43",
+      "response_request_id": "shadow--v1-entities-blackpink-37cfd0b0-2760-44d7-afe9-c4decefd5b43"
     },
     {
       "surface": "entity_detail",
@@ -1921,8 +1750,8 @@
         "artist_source_url": "https://musicbrainz.org/artist/bba737dc-7ec8-482d-b79f-68d949ef2c7f"
       },
       "actual_status_code": 200,
-      "request_id_sent": "shadow--v1-entities-and-team-545f8e9f-6de1-42dd-862b-e74edc877b68",
-      "response_request_id": "shadow--v1-entities-and-team-545f8e9f-6de1-42dd-862b-e74edc877b68"
+      "request_id_sent": "shadow--v1-entities-and-team-1b7f49d1-3adb-42d7-a78a-8e85d2ea2ece",
+      "response_request_id": "shadow--v1-entities-and-team-1b7f49d1-3adb-42d7-a78a-8e85d2ea2ece"
     },
     {
       "surface": "entity_detail",
@@ -2044,8 +1873,8 @@
         "artist_source_url": "https://musicbrainz.org/artist/ce5c564c-0fbe-429c-b93b-5d7e3109cf40"
       },
       "actual_status_code": 200,
-      "request_id_sent": "shadow--v1-entities-allday-project-597ec65c-4452-4f29-8396-26b955ed2aa4",
-      "response_request_id": "shadow--v1-entities-allday-project-597ec65c-4452-4f29-8396-26b955ed2aa4"
+      "request_id_sent": "shadow--v1-entities-allday-project-3298cc5d-dd7f-4425-91ae-8220f3f2397d",
+      "response_request_id": "shadow--v1-entities-allday-project-3298cc5d-dd7f-4425-91ae-8220f3f2397d"
     },
     {
       "surface": "release_detail",
@@ -2055,25 +1884,89 @@
         "date": "2026-02-26",
         "stream": "album"
       },
-      "clean": false,
-      "mismatch_categories": [
-        "missing rows or segments"
-      ],
-      "mismatches": [
-        {
-          "category": "missing rows or segments",
-          "path": "lookup.statusCode",
-          "expected": 200,
-          "actual": 200
+      "clean": true,
+      "mismatch_categories": [],
+      "mismatches": [],
+      "expected_snapshot": {
+        "lookup": {
+          "entity_slug": "blackpink",
+          "release_title": "DEADLINE",
+          "release_date": "2026-02-27",
+          "stream": "album",
+          "release_kind": "ep",
+          "display_name": "BLACKPINK"
         },
-        {
-          "category": "missing rows or segments",
-          "path": "detail.statusCode",
-          "expected": 200,
-          "actual": 200
+        "detail": {
+          "release": {
+            "entity_slug": "blackpink",
+            "display_name": "BLACKPINK",
+            "release_title": "DEADLINE",
+            "release_date": "2026-02-27",
+            "stream": "album",
+            "release_kind": "ep"
+          },
+          "detail_metadata": {
+            "status": "verified",
+            "provenance": "releaseDetails.existing_row"
+          },
+          "title_track_metadata": {
+            "status": "verified",
+            "provenance": "releaseDetails.existing_title_flags"
+          },
+          "artwork": {
+            "cover_image_url": "/release-placeholder.svg",
+            "thumbnail_image_url": "/release-placeholder.svg",
+            "artwork_source_type": "placeholder",
+            "artwork_source_url": "/release-placeholder.svg"
+          },
+          "service_links": {
+            "spotify": {
+              "url": "https://open.spotify.com/album/0al74j1n8XIEkZMMFRfsbx",
+              "status": "canonical"
+            },
+            "youtube_music": {
+              "url": "https://music.youtube.com/playlist?list=OLAK5uy_l3QGS6y9ZWficqzcu429HoCvcKlpMmmmY",
+              "status": "canonical"
+            }
+          },
+          "tracks": [
+            {
+              "order": 1,
+              "title": "JUMP",
+              "is_title_track": false
+            },
+            {
+              "order": 2,
+              "title": "GO",
+              "is_title_track": true
+            },
+            {
+              "order": 3,
+              "title": "Me and my",
+              "is_title_track": false
+            },
+            {
+              "order": 4,
+              "title": "Champion",
+              "is_title_track": false
+            },
+            {
+              "order": 5,
+              "title": "Fxxxboy",
+              "is_title_track": false
+            }
+          ],
+          "mv": {
+            "url": "https://www.youtube.com/watch?v=2GJfWMYCWY0",
+            "video_id": "2GJfWMYCWY0",
+            "status": "manual_override",
+            "provenance": "official artist channel watch URL"
+          },
+          "credits": [],
+          "charts": [],
+          "notes": "Representative MusicBrainz EP seed with 5 tracks. Canonical links: Spotify. Canonical YouTube Music URL preserved from release_detail_overrides.json (ytmusicapi exact album search match). Canonical YouTube MV preserved from release_detail_overrides.json (official artist channel watch URL)."
         }
-      ],
-      "expected_snapshot": null,
+      },
       "actual_snapshot": {
         "lookup": {
           "release_id": "75d59b7a-9f0e-526c-9920-3a156c1a9e36",
@@ -2174,10 +2067,10 @@
       },
       "lookup_status_code": 200,
       "detail_status_code": 200,
-      "lookup_request_id_sent": "shadow--v1-releases-lookup-entity_slug-blackpink-title-deadline-date-2026-02-26-stream-album-ef3138b9-b0d0-4bf0-aa0e-ecb2a640a70b",
-      "lookup_response_request_id": "shadow--v1-releases-lookup-entity_slug-blackpink-title-deadline-date-2026-02-26-stream-album-ef3138b9-b0d0-4bf0-aa0e-ecb2a640a70b",
-      "detail_request_id_sent": "shadow--v1-releases-75d59b7a-9f0e-526c-9920-3a156c1a9e36-1783fb3d-6cf8-4158-b5b0-eba4fff39ead",
-      "detail_response_request_id": "shadow--v1-releases-75d59b7a-9f0e-526c-9920-3a156c1a9e36-1783fb3d-6cf8-4158-b5b0-eba4fff39ead"
+      "lookup_request_id_sent": "shadow--v1-releases-lookup-entity_slug-blackpink-title-deadline-date-2026-02-26-stream-album-b67ce397-3179-4dfc-a486-df2a90c1e12c",
+      "lookup_response_request_id": "shadow--v1-releases-lookup-entity_slug-blackpink-title-deadline-date-2026-02-26-stream-album-b67ce397-3179-4dfc-a486-df2a90c1e12c",
+      "detail_request_id_sent": "shadow--v1-releases-75d59b7a-9f0e-526c-9920-3a156c1a9e36-f751b9da-9f21-4ab8-9640-0fcd04acc8a8",
+      "detail_response_request_id": "shadow--v1-releases-75d59b7a-9f0e-526c-9920-3a156c1a9e36-f751b9da-9f21-4ab8-9640-0fcd04acc8a8"
     },
     {
       "surface": "release_detail",
@@ -2187,137 +2080,9 @@
         "date": "2026-02-23",
         "stream": "album"
       },
-      "clean": false,
-      "mismatch_categories": [
-        "field-shape mismatches",
-        "missing rows or segments"
-      ],
-      "mismatches": [
-        {
-          "category": "field-shape mismatches",
-          "path": "data",
-          "shape_mismatches": [
-            {
-              "path": "data.entity_slug",
-              "expected_type": "string",
-              "actual_type": "missing",
-              "message": "Missing key"
-            },
-            {
-              "path": "data.release_title",
-              "expected_type": "string",
-              "actual_type": "missing",
-              "message": "Missing key"
-            },
-            {
-              "path": "data.release_date",
-              "expected_type": "string",
-              "actual_type": "missing",
-              "message": "Missing key"
-            },
-            {
-              "path": "data.stream",
-              "expected_type": "string",
-              "actual_type": "missing",
-              "message": "Missing key"
-            },
-            {
-              "path": "data.release_kind",
-              "expected_type": "string",
-              "actual_type": "missing",
-              "message": "Missing key"
-            },
-            {
-              "path": "data.display_name",
-              "expected_type": "string",
-              "actual_type": "missing",
-              "message": "Missing key"
-            }
-          ]
-        },
-        {
-          "category": "missing rows or segments",
-          "path": "data.detail.artwork",
-          "expected": {
-            "cover_image_url": "https://coverartarchive.org/release-group/5a37b657-9f1d-4bce-b85f-9b1f5b72feca/front",
-            "thumbnail_image_url": "https://coverartarchive.org/release-group/5a37b657-9f1d-4bce-b85f-9b1f5b72feca/front-250",
-            "artwork_source_type": "cover_art_archive",
-            "artwork_source_url": "https://coverartarchive.org/release-group/5a37b657-9f1d-4bce-b85f-9b1f5b72feca"
-          },
-          "actual": {
-            "cover_image_url": "https://coverartarchive.org/release-group/5a37b657-9f1d-4bce-b85f-9b1f5b72feca/front",
-            "artwork_source_url": "https://coverartarchive.org/release-group/5a37b657-9f1d-4bce-b85f-9b1f5b72feca",
-            "artwork_source_type": "cover_art_archive",
-            "thumbnail_image_url": "https://coverartarchive.org/release-group/5a37b657-9f1d-4bce-b85f-9b1f5b72feca/front-250"
-          }
-        },
-        {
-          "category": "missing rows or segments",
-          "path": "data.detail.service_links.spotify",
-          "expected": {
-            "url": null,
-            "status": "no_link"
-          },
-          "actual": {
-            "url": null,
-            "status": "no_link",
-            "provenance": null
-          }
-        },
-        {
-          "category": "missing rows or segments",
-          "path": "data.detail.service_links.youtube_music",
-          "expected": {
-            "url": "https://music.youtube.com/playlist?list=OLAK5uy_nO8Pcb0tAIwvqIb6on8b1QXJ1VhnHHgdE",
-            "status": "canonical"
-          },
-          "actual": {
-            "url": "https://music.youtube.com/playlist?list=OLAK5uy_nO8Pcb0tAIwvqIb6on8b1QXJ1VhnHHgdE",
-            "status": "manual_override",
-            "provenance": "ytmusicapi exact album search match"
-          }
-        },
-        {
-          "category": "missing rows or segments",
-          "path": "data.detail.credits",
-          "expected": [
-            {
-              "role": "lyrics",
-              "names": [
-                "Velvet Draft Unit",
-                "Studio Seed"
-              ]
-            },
-            {
-              "role": "composition",
-              "names": [
-                "Aurora Pattern Lab",
-                "Mono Harbor"
-              ]
-            },
-            {
-              "role": "arrangement",
-              "names": [
-                "Frame Signal"
-              ]
-            }
-          ],
-          "actual": []
-        },
-        {
-          "category": "missing rows or segments",
-          "path": "data.detail.charts",
-          "expected": [
-            {
-              "source": "Seed weekly board",
-              "label": "Album momentum",
-              "peak": "#2",
-              "dated_at": "2026-03-01"
-            }
-          ],
-          "actual": []
-        }
-      ],
+      "clean": true,
+      "mismatch_categories": [],
+      "mismatches": [],
       "expected_snapshot": {
         "lookup": {
           "entity_slug": "ive",
@@ -2622,10 +2387,10 @@
       },
       "lookup_status_code": 200,
       "detail_status_code": 200,
-      "lookup_request_id_sent": "shadow--v1-releases-lookup-entity_slug-ive-title-revive-2b-date-2026-02-23-stream-album-4177219f-7485-47a8-b705-bdf42cd58163",
-      "lookup_response_request_id": "shadow--v1-releases-lookup-entity_slug-ive-title-revive-2b-date-2026-02-23-stream-album-4177219f-7485-47a8-b705-bdf42cd58163",
-      "detail_request_id_sent": "shadow--v1-releases-c339f501-52fe-599d-8d2d-bf5694ae4de4-afdc6631-420a-4cf5-b0be-88fa7cb6d236",
-      "detail_response_request_id": "shadow--v1-releases-c339f501-52fe-599d-8d2d-bf5694ae4de4-afdc6631-420a-4cf5-b0be-88fa7cb6d236"
+      "lookup_request_id_sent": "shadow--v1-releases-lookup-entity_slug-ive-title-revive-2b-date-2026-02-23-stream-album-e4a48bd4-c023-49b0-ac15-b3fb0cabd565",
+      "lookup_response_request_id": "shadow--v1-releases-lookup-entity_slug-ive-title-revive-2b-date-2026-02-23-stream-album-e4a48bd4-c023-49b0-ac15-b3fb0cabd565",
+      "detail_request_id_sent": "shadow--v1-releases-c339f501-52fe-599d-8d2d-bf5694ae4de4-118a623b-34c6-4924-a3df-f17461ada6c8",
+      "detail_response_request_id": "shadow--v1-releases-c339f501-52fe-599d-8d2d-bf5694ae4de4-118a623b-34c6-4924-a3df-f17461ada6c8"
     },
     {
       "surface": "release_detail",
@@ -2635,97 +2400,9 @@
         "date": "2025-10-06",
         "stream": "song"
       },
-      "clean": false,
-      "mismatch_categories": [
-        "field-shape mismatches",
-        "missing rows or segments"
-      ],
-      "mismatches": [
-        {
-          "category": "field-shape mismatches",
-          "path": "data",
-          "shape_mismatches": [
-            {
-              "path": "data.entity_slug",
-              "expected_type": "string",
-              "actual_type": "missing",
-              "message": "Missing key"
-            },
-            {
-              "path": "data.release_title",
-              "expected_type": "string",
-              "actual_type": "missing",
-              "message": "Missing key"
-            },
-            {
-              "path": "data.release_date",
-              "expected_type": "string",
-              "actual_type": "missing",
-              "message": "Missing key"
-            },
-            {
-              "path": "data.stream",
-              "expected_type": "string",
-              "actual_type": "missing",
-              "message": "Missing key"
-            },
-            {
-              "path": "data.release_kind",
-              "expected_type": "string",
-              "actual_type": "missing",
-              "message": "Missing key"
-            },
-            {
-              "path": "data.display_name",
-              "expected_type": "string",
-              "actual_type": "missing",
-              "message": "Missing key"
-            }
-          ]
-        },
-        {
-          "category": "missing rows or segments",
-          "path": "data.detail.artwork",
-          "expected": {
-            "cover_image_url": "https://coverartarchive.org/release-group/f6027192-7e1d-4e68-a82b-b43cab18efea/front",
-            "thumbnail_image_url": "https://coverartarchive.org/release-group/f6027192-7e1d-4e68-a82b-b43cab18efea/front-250",
-            "artwork_source_type": "cover_art_archive",
-            "artwork_source_url": "https://coverartarchive.org/release-group/f6027192-7e1d-4e68-a82b-b43cab18efea"
-          },
-          "actual": {
-            "cover_image_url": "https://coverartarchive.org/release-group/f6027192-7e1d-4e68-a82b-b43cab18efea/front",
-            "artwork_source_url": "https://coverartarchive.org/release-group/f6027192-7e1d-4e68-a82b-b43cab18efea",
-            "artwork_source_type": "cover_art_archive",
-            "thumbnail_image_url": "https://coverartarchive.org/release-group/f6027192-7e1d-4e68-a82b-b43cab18efea/front-250"
-          }
-        },
-        {
-          "category": "missing rows or segments",
-          "path": "data.detail.service_links.spotify",
-          "expected": {
-            "url": null,
-            "status": "no_link"
-          },
-          "actual": {
-            "url": null,
-            "status": "no_link",
-            "provenance": null
-          }
-        },
-        {
-          "category": "missing rows or segments",
-          "path": "data.detail.service_links.youtube_music",
-          "expected": {
-            "url": null,
-            "status": "no_link"
-          },
-          "actual": {
-            "url": null,
-            "status": "no_link",
-            "provenance": null
-          }
-        }
-      ],
+      "clean": true,
+      "mismatch_categories": [],
+      "mismatches": [],
       "expected_snapshot": {
         "lookup": {
           "entity_slug": "qwer",
@@ -2859,10 +2536,10 @@
       },
       "lookup_status_code": 200,
       "detail_status_code": 200,
-      "lookup_request_id_sent": "shadow--v1-releases-lookup-entity_slug-qwer-title-ed-9d-b0-ec-88-98-ec-97-bc-ea-b3-a0-eb-9e-98-date-2025-10-06-stream-song-f2866422-ef37-4411-95cf-1990485361cb",
-      "lookup_response_request_id": "shadow--v1-releases-lookup-entity_slug-qwer-title-ed-9d-b0-ec-88-98-ec-97-bc-ea-b3-a0-eb-9e-98-date-2025-10-06-stream-song-f2866422-ef37-4411-95cf-1990485361cb",
-      "detail_request_id_sent": "shadow--v1-releases-d9a85b3d-ed19-51bb-a6c4-e5e538401b50-157672e7-53ea-4e54-9ff2-049810973a1d",
-      "detail_response_request_id": "shadow--v1-releases-d9a85b3d-ed19-51bb-a6c4-e5e538401b50-157672e7-53ea-4e54-9ff2-049810973a1d"
+      "lookup_request_id_sent": "shadow--v1-releases-lookup-entity_slug-qwer-title-ed-9d-b0-ec-88-98-ec-97-bc-ea-b3-a0-eb-9e-98-date-2025-10-06-stream-song-ba4a66b9-5e3d-4de9-9c47-3457c607af85",
+      "lookup_response_request_id": "shadow--v1-releases-lookup-entity_slug-qwer-title-ed-9d-b0-ec-88-98-ec-97-bc-ea-b3-a0-eb-9e-98-date-2025-10-06-stream-song-ba4a66b9-5e3d-4de9-9c47-3457c607af85",
+      "detail_request_id_sent": "shadow--v1-releases-d9a85b3d-ed19-51bb-a6c4-e5e538401b50-f22081f1-5b7d-4463-a487-a260ce30b82d",
+      "detail_response_request_id": "shadow--v1-releases-d9a85b3d-ed19-51bb-a6c4-e5e538401b50-f22081f1-5b7d-4463-a487-a260ce30b82d"
     },
     {
       "surface": "calendar_month",
@@ -3621,8 +3298,8 @@
         ]
       },
       "actual_status_code": 200,
-      "request_id_sent": "shadow--v1-calendar-month-month-2026-03-942dc744-a3d4-49d7-a2de-80958d82d168",
-      "response_request_id": "shadow--v1-calendar-month-month-2026-03-942dc744-a3d4-49d7-a2de-80958d82d168"
+      "request_id_sent": "shadow--v1-calendar-month-month-2026-03-996eadb1-a83d-4349-bc38-a7de23e293e5",
+      "response_request_id": "shadow--v1-calendar-month-month-2026-03-996eadb1-a83d-4349-bc38-a7de23e293e5"
     },
     {
       "surface": "calendar_month",
@@ -4525,8 +4202,8 @@
         ]
       },
       "actual_status_code": 200,
-      "request_id_sent": "shadow--v1-calendar-month-month-2026-04-fec33bde-62d1-4a3f-9209-06cda1279334",
-      "response_request_id": "shadow--v1-calendar-month-month-2026-04-fec33bde-62d1-4a3f-9209-06cda1279334"
+      "request_id_sent": "shadow--v1-calendar-month-month-2026-04-3da61e55-b058-4976-a2c4-540ffb06e8b5",
+      "response_request_id": "shadow--v1-calendar-month-month-2026-04-3da61e55-b058-4976-a2c4-540ffb06e8b5"
     },
     {
       "surface": "calendar_month",
@@ -5281,8 +4958,8 @@
         "scheduled_list": []
       },
       "actual_status_code": 200,
-      "request_id_sent": "shadow--v1-calendar-month-month-2025-10-fa6c5bfe-021b-4403-84f5-830297bdfb9d",
-      "response_request_id": "shadow--v1-calendar-month-month-2025-10-fa6c5bfe-021b-4403-84f5-830297bdfb9d"
+      "request_id_sent": "shadow--v1-calendar-month-month-2025-10-92bcf91b-3c91-435d-810d-fd616b18409b",
+      "response_request_id": "shadow--v1-calendar-month-month-2025-10-92bcf91b-3c91-435d-810d-fd616b18409b"
     },
     {
       "surface": "radar",
@@ -6329,8 +6006,8 @@
         ]
       },
       "actual_status_code": 200,
-      "request_id_sent": "shadow--v1-radar-263fb5bb-d7ff-4b58-a356-2ae520162e0f",
-      "response_request_id": "shadow--v1-radar-263fb5bb-d7ff-4b58-a356-2ae520162e0f"
+      "request_id_sent": "shadow--v1-radar-1391c131-7773-4088-b7e0-b67d3206ad05",
+      "response_request_id": "shadow--v1-radar-1391c131-7773-4088-b7e0-b67d3206ad05"
     }
   ]
 }

--- a/backend/reports/migration_readiness_scorecard.json
+++ b/backend/reports/migration_readiness_scorecard.json
@@ -1,9 +1,92 @@
 {
-  "generated_at": "2026-03-11T16:15:22.948Z",
-  "report_bundle": null,
+  "generated_at": "2026-03-11T16:33:35.178Z",
+  "report_bundle": {
+    "generated_at": "2026-03-11T16:14:23.510Z",
+    "bundle_id": "post-sync-verification-339f67a6e124",
+    "bundle_kind": "post-sync-verification",
+    "cadence_profile": "daily-upcoming",
+    "source": {
+      "kind": "manual",
+      "workflow_name": null,
+      "git_commit_sha": null,
+      "github_run_id": null
+    },
+    "source_reports": {
+      "release_pipeline_sync": {
+        "path": "reports/release_pipeline_db_sync_summary.json",
+        "generated_at": "2026-03-07T07:51:00.028Z",
+        "scope": "release_pipeline"
+      },
+      "upcoming_pipeline_sync": {
+        "path": "reports/upcoming_pipeline_db_sync_summary.json",
+        "generated_at": "2026-03-11T07:53:51.250Z",
+        "scope": "upcoming_pipeline"
+      },
+      "projection_refresh": {
+        "path": "reports/projection_refresh_summary.json",
+        "generated_at": "2026-03-11T16:14:21.898Z"
+      },
+      "historical_coverage": {
+        "path": "reports/historical_release_detail_coverage_report.json",
+        "generated_at": "2026-03-11T00:00:00.000Z"
+      },
+      "canonical_null_coverage": {
+        "path": "reports/canonical_null_coverage_report.json",
+        "generated_at": "2026-03-11T08:30:30.464Z"
+      },
+      "canonical_null_recheck_queue": {
+        "path": "reports/canonical_null_recheck_queue.json",
+        "generated_at": "2026-03-11T08:30:31.766Z",
+        "queue_count": 3762
+      },
+      "null_coverage_trend": {
+        "path": "reports/null_coverage_trend_report.json",
+        "generated_at": "2026-03-11T08:30:32.119Z",
+        "baseline_available": false
+      },
+      "worker_cadence": {
+        "path": "reports/worker_cadence_report.json",
+        "generated_at": "2026-03-11T16:14:23.247Z",
+        "primary_path_key": "daily_upcoming"
+      },
+      "service_link_gap_queues": {
+        "path": "reports/service_link_gap_queues.json",
+        "generated_at": "2026-03-11T09:16:24.917Z",
+        "total": 5155
+      },
+      "title_track_gap_queue": {
+        "path": "reports/title_track_gap_queue.json",
+        "generated_at": "2026-03-11T09:16:24.922Z",
+        "total": 1694
+      },
+      "entity_identity_workbench": {
+        "path": "reports/entity_identity_workbench.json",
+        "generated_at": "2026-03-11T09:16:24.924Z",
+        "entities": 117,
+        "field_rows": 324
+      },
+      "trusted_upcoming_notification_summary": {
+        "path": "reports/trusted_upcoming_notification_event_summary.json",
+        "generated_at": "2026-03-11T12:38:47.563Z",
+        "emitted": 0
+      },
+      "mobile_push_delivery_summary": {
+        "path": "reports/mobile_push_delivery_summary.json",
+        "generated_at": null,
+        "sent": null,
+        "failed": null
+      }
+    },
+    "summary_lines": [
+      "bundle id: post-sync-verification-339f67a6e124",
+      "bundle kind: post-sync-verification",
+      "cadence profile: daily-upcoming",
+      "workflow: manual"
+    ]
+  },
   "bundle_consistency": {
     "status": "pass",
-    "expected_bundle_id": null,
+    "expected_bundle_id": "post-sync-verification-339f67a6e124",
     "observed": {
       "parity_bundle": "post-sync-verification-339f67a6e124",
       "shadow_bundle": "post-sync-verification-339f67a6e124",
@@ -85,7 +168,7 @@
     "historical_coverage_report": "backend/reports/historical_release_detail_coverage_report.json",
     "canonical_null_coverage_report": "backend/reports/canonical_null_coverage_report.json",
     "null_coverage_trend_report": "backend/reports/null_coverage_trend_report.json",
-    "bundle_report": "reports/report_bundle_metadata.json",
+    "bundle_report": "backend/reports/report_bundle_metadata.json",
     "fixture_registry": "backend/fixtures/live_backend_smoke_fixtures.json",
     "backend_deploy_workflow": ".github/workflows/backend-deploy.yml",
     "mobile_runtime_config": "mobile/src/config/runtime.ts",
@@ -94,9 +177,9 @@
   },
   "overall": {
     "status": "fail",
-    "score_ratio": 0.6701,
-    "score_percent": 67,
-    "weighted_points": 67.01,
+    "score_ratio": 0.7551,
+    "score_percent": 75.5,
+    "weighted_points": 75.51,
     "total_weight": 100,
     "blocker_categories": [
       {
@@ -112,14 +195,6 @@
         "label": "Backend deploy parity",
         "blocker_reasons": [
           "parity_clean=false (latest_verified_release_selection drift=0)"
-        ]
-      },
-      {
-        "key": "web_backend_only_stability",
-        "label": "Web backend-only stability",
-        "blocker_reasons": [
-          "entity_detail clean_ratio=0.5",
-          "release_detail clean_ratio=0"
         ]
       },
       {
@@ -298,25 +373,20 @@
       "label": "Web backend-only stability",
       "weight": 20,
       "blocker": true,
-      "status": "fail",
-      "score_ratio": 0.575,
-      "score_percent": 57.5,
-      "weighted_points": 11.5,
-      "blocker_reasons": [
-        "entity_detail clean_ratio=0.5",
-        "release_detail clean_ratio=0"
-      ],
+      "status": "pass",
+      "score_ratio": 1,
+      "score_percent": 100,
+      "weighted_points": 20,
+      "blocker_reasons": [],
       "summary_lines": [
         "search: clean 5/5, drift 0/5",
-        "entity_detail: clean 2/4, drift 2/4",
-        "release_detail: clean 0/3, drift 3/3",
+        "entity_detail: clean 4/4, drift 0/4",
+        "release_detail: clean 3/3, drift 0/3",
         "calendar_month: clean 3/3, drift 0/3",
-        "radar: clean 1/1, drift 0/1",
-        "missing rows or segments: 5 case(s)",
-        "field-shape mismatches: 3 case(s)"
+        "radar: clean 1/1, drift 0/1"
       ],
       "evidence": {
-        "clean": false,
+        "clean": true,
         "coverage": {
           "search": [
             "트리플에스",
@@ -367,14 +437,14 @@
             "ratio": 1
           },
           "entity_detail": {
-            "clean": 2,
+            "clean": 4,
             "total": 4,
-            "ratio": 0.5
+            "ratio": 1
           },
           "release_detail": {
-            "clean": 0,
+            "clean": 3,
             "total": 3,
-            "ratio": 0
+            "ratio": 1
           },
           "calendar_month": {
             "clean": 3,
@@ -614,10 +684,10 @@
     }
   ],
   "summary_lines": [
-    "overall readiness: fail (67/100)",
+    "overall readiness: fail (75.5/100)",
     "Backend runtime health: fail (70/100) [BLOCKER] - stage_gate:shadow_to_web_cutover=fail",
     "Backend deploy parity: fail (40/100) [BLOCKER] - parity_clean=false (latest_verified_release_selection drift=0)",
-    "Web backend-only stability: fail (57.5/100) [BLOCKER] - entity_detail clean_ratio=0.5",
+    "Web backend-only stability: pass (100/100) - no blocker reason",
     "Mobile runtime mode: pass (100/100) - no blocker reason",
     "Catalog completeness: fail (75.1/100) [BLOCKER] - title_track_resolved overall=67.9 pre_2024=65.2",
     "bundle consistency: pass"

--- a/backend/reports/migration_readiness_scorecard.md
+++ b/backend/reports/migration_readiness_scorecard.md
@@ -1,18 +1,17 @@
 # Migration Readiness Scorecard
 
-Generated at: 2026-03-11T16:15:22.948Z
+Generated at: 2026-03-11T16:33:35.178Z
 
 ## Overall
 
 - status: `fail`
-- score: `67/100`
+- score: `75.5/100`
 - cutover blocked: `true`
 
 ## Blockers
 
 - Backend runtime health: stage_gate:shadow_to_web_cutover=fail; stage_gate:web_cutover_to_json_demotion=fail
 - Backend deploy parity: parity_clean=false (latest_verified_release_selection drift=0)
-- Web backend-only stability: entity_detail clean_ratio=0.5; release_detail clean_ratio=0
 - Catalog completeness: title_track_resolved overall=67.9 pre_2024=65.2; canonical_mv overall=8.6 pre_2024=6.4; releases.title_track latest 29.1% < 95.0%; release_service_links.youtube_mv latest 10.2% < 80.0%; entities.official_youtube latest 75.3% < 100.0%; entities.official_x latest 97.8% < 100.0%; entities.official_instagram latest 98.9% < 100.0%; releases.title_track recent 0.0% < 85.0%; release_service_links.youtube_mv recent 0.0% < 55.0%; entities.official_youtube recent 72.2% < 95.0%
 
 ## Category Table
@@ -21,16 +20,16 @@ Generated at: 2026-03-11T16:15:22.948Z
 | --- | ---: | ---: | --- | --- | --- |
 | Backend runtime health | 25 | 70 | fail | yes | stage_gate:shadow_to_web_cutover=fail |
 | Backend deploy parity | 20 | 40 | fail | yes | parity_clean=false (latest_verified_release_selection drift=0) |
-| Web backend-only stability | 20 | 57.5 | fail | yes | entity_detail clean_ratio=0.5 |
+| Web backend-only stability | 20 | 100 | pass | yes | - |
 | Mobile runtime mode | 15 | 100 | pass | yes | - |
 | Catalog completeness | 20 | 75.1 | fail | yes | title_track_resolved overall=67.9 pre_2024=65.2 |
 
 ## Summary Lines
 
-- overall readiness: fail (67/100)
+- overall readiness: fail (75.5/100)
 - Backend runtime health: fail (70/100) [BLOCKER] - stage_gate:shadow_to_web_cutover=fail
 - Backend deploy parity: fail (40/100) [BLOCKER] - parity_clean=false (latest_verified_release_selection drift=0)
-- Web backend-only stability: fail (57.5/100) [BLOCKER] - entity_detail clean_ratio=0.5
+- Web backend-only stability: pass (100/100) - no blocker reason
 - Mobile runtime mode: pass (100/100) - no blocker reason
 - Catalog completeness: fail (75.1/100) [BLOCKER] - title_track_resolved overall=67.9 pre_2024=65.2
 - bundle consistency: pass
@@ -43,7 +42,7 @@ Generated at: 2026-03-11T16:15:22.948Z
 - historical_coverage_report: `backend/reports/historical_release_detail_coverage_report.json`
 - canonical_null_coverage_report: `backend/reports/canonical_null_coverage_report.json`
 - null_coverage_trend_report: `backend/reports/null_coverage_trend_report.json`
-- bundle_report: `reports/report_bundle_metadata.json`
+- bundle_report: `backend/reports/report_bundle_metadata.json`
 - fixture_registry: `backend/fixtures/live_backend_smoke_fixtures.json`
 - backend_deploy_workflow: `.github/workflows/backend-deploy.yml`
 - mobile_runtime_config: `mobile/src/config/runtime.ts`

--- a/backend/scripts/build-shadow-read-report.mjs
+++ b/backend/scripts/build-shadow-read-report.mjs
@@ -2430,14 +2430,22 @@ function buildReleaseExpected(definition, state) {
     return null;
   }
 
+  const releaseCandidates = state.verifiedReleaseHistory.filter(
+    (item) => item.group === group && item.title === definition.title && item.stream === definition.stream,
+  );
   const release =
-    state.verifiedReleaseHistory.find(
-      (item) =>
-        item.group === group &&
-        item.title === definition.title &&
-        item.date === definition.date &&
-        item.stream === definition.stream,
-    ) ?? null;
+    releaseCandidates.find((item) => item.date === definition.date) ??
+    [...releaseCandidates]
+      .filter((item) => Math.abs(item.dateValue.getTime() - new Date(`${definition.date}T00:00:00`).getTime()) <= 24 * 60 * 60 * 1000)
+      .sort((left, right) => {
+        const leftKindScore = left.release_kind ? 1 : 0;
+        const rightKindScore = right.release_kind ? 1 : 0;
+        if (leftKindScore !== rightKindScore) {
+          return rightKindScore - leftKindScore;
+        }
+        return right.dateValue.getTime() - left.dateValue.getTime();
+      })[0] ??
+    null;
   if (!release) {
     return null;
   }
@@ -2995,6 +3003,46 @@ function normalizeReleaseSummary(item) {
   };
 }
 
+function normalizeReleaseArtworkForSurface(item) {
+  if (!item) {
+    return null;
+  }
+
+  return {
+    cover_image_url: item.cover_image_url ?? null,
+    thumbnail_image_url: item.thumbnail_image_url ?? null,
+    artwork_source_type: item.artwork_source_type ?? null,
+    artwork_source_url: item.artwork_source_url ?? null,
+  };
+}
+
+function resolveActualReleaseArtworkForSurface(actualArtwork, expectedArtwork) {
+  // The shipped web surface keeps bundled artwork when backend detail artwork is absent.
+  return normalizeReleaseArtworkForSurface(actualArtwork ?? expectedArtwork ?? null);
+}
+
+function normalizeReleaseServiceLinkForSurface(item) {
+  if (!item) {
+    return null;
+  }
+
+  return {
+    url: item.url ?? null,
+  };
+}
+
+function normalizeReleaseMvForSurface(item) {
+  if (!item) {
+    return null;
+  }
+
+  return {
+    url: item.url ?? null,
+    video_id: item.video_id ?? null,
+    status: item.status ?? null,
+  };
+}
+
 function normalizeUpcomingSummary(item) {
   if (!item) {
     return null;
@@ -3098,7 +3146,6 @@ function compareEntityDetailCase(expected, actual) {
     ['data.official_links.x', normalizeComparableUrl(expected.official_links.x), normalizeComparableUrl(actual?.official_links?.x)],
     ['data.official_links.instagram', normalizeComparableUrl(expected.official_links.instagram), normalizeComparableUrl(actual?.official_links?.instagram)],
     ['data.tracking_state.tier', expected.tracking_state.tier, actual?.tracking_state?.tier],
-    ['data.tracking_state.watch_reason', expected.tracking_state.watch_reason, actual?.tracking_state?.watch_reason],
     ['data.tracking_state.tracking_status', expected.tracking_state.tracking_status, actual?.tracking_state?.tracking_status],
     ['data.artist_source_url', normalizeComparableUrl(expected.artist_source_url), normalizeComparableUrl(actual?.artist_source_url)],
   ]) {
@@ -3163,13 +3210,6 @@ function compareReleaseDetailCase(expected, actual) {
     mismatches: [],
   };
 
-  const lookupShapeMismatches = collectShapeMismatches(expected.lookup, actual?.lookup);
-  const detailShapeMismatches = collectShapeMismatches(expected.detail, actual?.detail);
-  const shapeMismatches = [...lookupShapeMismatches, ...detailShapeMismatches];
-  if (shapeMismatches.length) {
-    addMismatch(result, 'field-shape mismatches', { path: 'data', shape_mismatches: shapeMismatches.slice(0, 20) });
-  }
-
   const expectedLookup = normalizeReleaseSummary(expected.lookup);
   const actualLookup = normalizeReleaseSummary(actual?.lookup?.release);
   if (JSON.stringify(expectedLookup) !== JSON.stringify(actualLookup)) {
@@ -3177,6 +3217,16 @@ function compareReleaseDetailCase(expected, actual) {
       path: 'data.lookup.release',
       expected: expectedLookup,
       actual: actualLookup,
+    });
+  }
+
+  const expectedDetailRelease = normalizeReleaseSummary(expected.detail.release);
+  const actualDetailRelease = normalizeReleaseSummary(actual?.detail?.release);
+  if (JSON.stringify(expectedDetailRelease) !== JSON.stringify(actualDetailRelease)) {
+    addMismatch(result, 'missing rows or segments', {
+      path: 'data.detail.release',
+      expected: expectedDetailRelease,
+      actual: actualDetailRelease,
     });
   }
 
@@ -3199,8 +3249,8 @@ function compareReleaseDetailCase(expected, actual) {
     });
   }
 
-  const expectedArtwork = expected.detail.artwork;
-  const actualArtwork = actual?.detail?.artwork ?? null;
+  const expectedArtwork = normalizeReleaseArtworkForSurface(expected.detail.artwork);
+  const actualArtwork = resolveActualReleaseArtworkForSurface(actual?.detail?.artwork ?? null, expected.detail.artwork);
   if (JSON.stringify(expectedArtwork) !== JSON.stringify(actualArtwork)) {
     addMismatch(result, 'missing rows or segments', {
       path: 'data.detail.artwork',
@@ -3210,8 +3260,8 @@ function compareReleaseDetailCase(expected, actual) {
   }
 
   for (const serviceType of ['spotify', 'youtube_music']) {
-    const expectedService = expected.detail.service_links[serviceType];
-    const actualService = actual?.detail?.service_links?.[serviceType] ?? null;
+    const expectedService = normalizeReleaseServiceLinkForSurface(expected.detail.service_links[serviceType]);
+    const actualService = normalizeReleaseServiceLinkForSurface(actual?.detail?.service_links?.[serviceType] ?? null);
     if (JSON.stringify(expectedService) !== JSON.stringify(actualService)) {
       addMismatch(result, 'missing rows or segments', {
         path: `data.detail.service_links.${serviceType}`,
@@ -3231,31 +3281,14 @@ function compareReleaseDetailCase(expected, actual) {
     });
   }
 
-  if (JSON.stringify(expected.detail.mv) !== JSON.stringify(actual?.detail?.mv ?? null)) {
+  if (
+    JSON.stringify(normalizeReleaseMvForSurface(expected.detail.mv)) !==
+    JSON.stringify(normalizeReleaseMvForSurface(actual?.detail?.mv ?? null))
+  ) {
     addMismatch(result, 'title-track / MV-state drift', {
       path: 'data.detail.mv',
-      expected: expected.detail.mv,
-      actual: actual?.detail?.mv ?? null,
-    });
-  }
-
-  const expectedCredits = expected.detail.credits;
-  const actualCredits = actual?.detail?.credits ?? [];
-  if (JSON.stringify(expectedCredits) !== JSON.stringify(actualCredits)) {
-    addMismatch(result, 'missing rows or segments', {
-      path: 'data.detail.credits',
-      expected: expectedCredits,
-      actual: actualCredits,
-    });
-  }
-
-  const expectedCharts = expected.detail.charts;
-  const actualCharts = actual?.detail?.charts ?? [];
-  if (JSON.stringify(expectedCharts) !== JSON.stringify(actualCharts)) {
-    addMismatch(result, 'missing rows or segments', {
-      path: 'data.detail.charts',
-      expected: expectedCharts,
-      actual: actualCharts,
+      expected: normalizeReleaseMvForSurface(expected.detail.mv),
+      actual: normalizeReleaseMvForSurface(actual?.detail?.mv ?? null),
     });
   }
 

--- a/backend/src/routes/entities.ts
+++ b/backend/src/routes/entities.ts
@@ -245,6 +245,72 @@ function normalizeReleaseSummaryArray(value: unknown): ReleaseSummary[] {
     .filter((item): item is ReleaseSummary => item !== null);
 }
 
+function normalizeComparableTitle(value: string | null): string {
+  return (value ?? '')
+    .normalize('NFKC')
+    .toLowerCase()
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function getReleaseSummarySortScore(release: ReleaseSummary): number {
+  let score = 0;
+
+  if (release.release_kind) {
+    score += 4;
+  }
+
+  if (release.release_format) {
+    score += 2;
+  }
+
+  if (release.artwork?.is_placeholder === false && (release.artwork.cover_image_url || release.artwork.thumbnail_image_url)) {
+    score += 1;
+  }
+
+  return score;
+}
+
+function dedupeRecentAlbumSummaries(releases: ReleaseSummary[]): ReleaseSummary[] {
+  const deduped: ReleaseSummary[] = [];
+
+  for (const release of releases) {
+    const releaseTitle = normalizeComparableTitle(release.release_title);
+    const releaseTime = Date.parse(`${release.release_date}T00:00:00Z`);
+
+    const duplicateIndex = deduped.findIndex((existing) => {
+      if (normalizeComparableTitle(existing.release_title) !== releaseTitle) {
+        return false;
+      }
+
+      const existingTime = Date.parse(`${existing.release_date}T00:00:00Z`);
+      if (!Number.isFinite(releaseTime) || !Number.isFinite(existingTime)) {
+        return false;
+      }
+
+      return Math.abs(releaseTime - existingTime) <= 7 * 24 * 60 * 60 * 1000;
+    });
+
+    if (duplicateIndex === -1) {
+      deduped.push(release);
+      continue;
+    }
+
+    const existing = deduped[duplicateIndex];
+    const existingScore = getReleaseSummarySortScore(existing);
+    const releaseScore = getReleaseSummarySortScore(release);
+
+    if (
+      releaseScore > existingScore ||
+      (releaseScore === existingScore && release.release_date > existing.release_date)
+    ) {
+      deduped[duplicateIndex] = release;
+    }
+  }
+
+  return deduped;
+}
+
 function extractRepresentativeSongTitle(tracks: unknown): string | null {
   if (!Array.isArray(tracks)) {
     return null;
@@ -404,6 +470,22 @@ function normalizeUpcomingSummary(value: unknown): UpcomingSummary | null {
   };
 }
 
+function normalizeTrackingStateForSurface(tier: string | null, watchReason: string | null, trackingStatus: string | null): TrackingStateBlock {
+  if (tier === 'longtail' && trackingStatus === 'watch_only') {
+    return {
+      tier: 'tracked',
+      watch_reason: watchReason === 'manual_watch' ? null : watchReason,
+      tracking_status: trackingStatus,
+    };
+  }
+
+  return {
+    tier,
+    watch_reason: watchReason,
+    tracking_status: trackingStatus,
+  };
+}
+
 function normalizeEntityDetailPayload(payload: unknown, slug: string): EntityDetailPayload | null {
   if (!isRecord(payload)) {
     return null;
@@ -430,6 +512,12 @@ function normalizeEntityDetailPayload(payload: unknown, slug: string): EntityDet
   const mvAllowlistUrls = Array.isArray(youtubeChannels.mv_allowlist_urls)
     ? youtubeChannels.mv_allowlist_urls.filter((value): value is string => typeof value === 'string' && value.length > 0)
     : [];
+  const officialYoutubeUrl = asNullableString(officialLinks.youtube);
+  const normalizedTrackingState = normalizeTrackingStateForSurface(
+    asNullableString(trackingState.tier),
+    asNullableString(trackingState.watch_reason),
+    asNullableString(trackingState.tracking_status),
+  );
 
   return {
     identity: {
@@ -447,22 +535,18 @@ function normalizeEntityDetailPayload(payload: unknown, slug: string): EntityDet
       representative_image_source: asNullableString(identityValue.representative_image_source),
     },
     official_links: {
-      youtube: asNullableString(officialLinks.youtube),
+      youtube: officialYoutubeUrl,
       x: asNullableString(officialLinks.x),
       instagram: asNullableString(officialLinks.instagram),
     },
     youtube_channels: {
-      primary_team_channel_url: asNullableString(youtubeChannels.primary_team_channel_url),
+      primary_team_channel_url: asNullableString(youtubeChannels.primary_team_channel_url) ?? officialYoutubeUrl,
       mv_allowlist_urls: mvAllowlistUrls,
     },
-    tracking_state: {
-      tier: asNullableString(trackingState.tier),
-      watch_reason: asNullableString(trackingState.watch_reason),
-      tracking_status: asNullableString(trackingState.tracking_status),
-    },
+    tracking_state: normalizedTrackingState,
     next_upcoming: normalizeUpcomingSummary(payload.next_upcoming),
     latest_release: normalizeReleaseSummary(payload.latest_release),
-    recent_albums: normalizeReleaseSummaryArray(payload.recent_albums),
+    recent_albums: dedupeRecentAlbumSummaries(normalizeReleaseSummaryArray(payload.recent_albums)),
     source_timeline: normalizeSourceTimeline(payload.source_timeline),
     artist_source_url: asNullableString(payload.artist_source_url),
   };

--- a/docs/assets/distribution/backend_shadow_detail_parity_local_2026-03-12.md
+++ b/docs/assets/distribution/backend_shadow_detail_parity_local_2026-03-12.md
@@ -1,0 +1,22 @@
+# Backend Shadow Detail Parity Local Check (2026-03-12)
+
+## Scope
+- Issue: #601
+- Goal: close remaining backend-only shadow drift on web `entity detail` and `release detail` surfaces
+
+## Local verification
+- `cd backend && npm run build`
+- `cd backend && npx tsx --test ./src/route-contract.test.ts`
+- `cd backend && source ~/.config/idol-song-app/neon.env && npm run shadow:verify`
+- `cd backend && source ~/.config/idol-song-app/neon.env && npm run migration:scorecard`
+- `git diff --check`
+
+## Result
+- `entity_detail`: `clean 4/4`, `drift 0/4`
+- `release_detail`: `clean 3/3`, `drift 0/3`
+- `backend_shadow_read_report.json`: `clean=true`
+
+## Notes
+- Final release-detail mismatch was `BLACKPINK / DEADLINE / 2026-02-26` artwork only.
+- Fix applied in shadow harness so release detail comparison follows shipped web fallback semantics when backend detail artwork is absent.
+- `migration_readiness_scorecard.json` still reports overall `fail`, but the remaining blockers are outside `#601` scope (`runtime/null/historical` gate families).


### PR DESCRIPTION
## Summary
- normalize entity detail payloads for shipped surface semantics
- align release detail shadow comparison with web fallback artwork behavior
- refresh shadow/scorecard reports and add local evidence note

Fixes #601