### PR TITLE
Add RN X reaction handoff for upcoming/news surfaces

### DIFF
--- a/mobile/app/(tabs)/calendar.tsx
+++ b/mobile/app/(tabs)/calendar.tsx
@@ -40,7 +40,11 @@ import {
   type CalendarViewMode,
 } from '../../src/features/routeState';
 import { useActiveDatasetScreen } from '../../src/features/useActiveDatasetScreen';
-import { selectCalendarMonthSnapshot } from '../../src/selectors';
+import {
+  createSelectorContext,
+  selectCalendarMonthSnapshot,
+  selectTeamSummaryBySlug,
+} from '../../src/selectors';
 import {
   MOBILE_COPY,
   resolveSourceLinkLabel,
@@ -60,8 +64,11 @@ import {
   trackFailureObserved,
 } from '../../src/services/analytics';
 import {
+  buildEntityCenteredXSearchQuery,
   describeServiceHandoffBehavior,
+  openXSearchHandoff,
   openServiceHandoff,
+  resolveXSearchHandoff,
   resolveServiceHandoff,
   type ServiceHandoffFailure,
   type ServiceHandoffResolution,
@@ -83,6 +90,7 @@ import type { SourceLinkRowItem } from '../../src/components/meta/SourceLinkRow'
 import type {
   CalendarMonthSnapshotModel,
   ReleaseSummaryModel,
+  TeamSummaryModel,
   UpcomingEventModel,
 } from '../../src/types';
 
@@ -253,6 +261,7 @@ export default function CalendarTabScreen() {
   const [reloadCount, setReloadCount] = useState(0);
   const [handoffFeedback, setHandoffFeedback] = useState<string | null>(null);
   const bundledProfiles = useMemo(() => cloneBundledDatasetFixture().artistProfiles, []);
+  const bundledSelectorContext = useMemo(() => createSelectorContext(cloneBundledDatasetFixture()), []);
   const loadBundledSnapshot = useCallback(async () => {
     const activeDataset = await loadActiveMobileDataset();
     return selectCalendarMonthSnapshot(activeDataset.dataset, activeMonth, todayIsoDate);
@@ -341,6 +350,19 @@ export default function CalendarTabScreen() {
 
     return entries;
   }, [bundledProfiles]);
+  const teamSummaryByGroup = useMemo(() => {
+    const entries = new Map<string, TeamSummaryModel>();
+
+    for (const profile of bundledProfiles) {
+      const team = selectTeamSummaryBySlug(bundledSelectorContext, profile.slug);
+      if (team) {
+        entries.set(profile.group, team);
+        entries.set(profile.slug, team);
+      }
+    }
+
+    return entries;
+  }, [bundledProfiles, bundledSelectorContext]);
 
   useEffect(() => {
     if (!filteredSnapshot) {
@@ -468,6 +490,68 @@ export default function CalendarTabScreen() {
       mode: result.mode,
       target: result.target,
     });
+    setHandoffFeedback(null);
+  }
+
+  function buildUpcomingXSearchQuery(event: UpcomingEventModel): {
+    query: string;
+    mode: 'entity_only' | 'release_backed';
+    entitySlug: string | null;
+  } {
+    const team = teamSummaryByGroup.get(event.group);
+    const query = buildEntityCenteredXSearchQuery({
+      displayName: team?.displayName ?? event.displayGroup,
+      searchTokens: team?.searchTokens ?? [],
+      releaseLabel: event.releaseLabel,
+    });
+
+    return {
+      query: query.query,
+      mode: query.mode,
+      entitySlug: team?.slug ?? groupSlugByGroup.get(event.group) ?? null,
+    };
+  }
+
+  async function handleUpcomingXReactionPress(event: UpcomingEventModel) {
+    const query = buildUpcomingXSearchQuery(event);
+    const handoff = resolveXSearchHandoff({
+      query: query.query,
+      mode: query.mode,
+    });
+
+    trackAnalyticsEvent('x_search_handoff_attempted', {
+      surface: 'calendar',
+      entitySlug: query.entitySlug,
+      mode: handoff.mode,
+    });
+
+    const result = await runWithPendingRouteResume(currentResumeTarget, () => openXSearchHandoff(handoff));
+    if (!result.ok) {
+      trackAnalyticsEvent('x_search_handoff_failed', {
+        surface: 'calendar',
+        entitySlug: query.entitySlug,
+        mode: result.mode,
+        failureCode: result.code,
+        retryable: result.feedback.retryable,
+      });
+      trackFailureObserved(
+        'calendar',
+        classifyServiceHandoffFailureCategory(result.code),
+        result.code,
+        result.feedback.retryable,
+      );
+      setHandoffFeedback(result.feedback.message);
+      return;
+    }
+
+    trackAnalyticsEvent(
+      result.target === 'app' ? 'x_search_handoff_opened_app' : 'x_search_handoff_opened_web',
+      {
+        surface: 'calendar',
+        entitySlug: query.entitySlug,
+        mode: result.mode,
+      },
+    );
     setHandoffFeedback(null);
   }
 
@@ -729,6 +813,11 @@ export default function CalendarTabScreen() {
         label: MOBILE_COPY.action.teamPage,
         onPress: () => openTeamDetailByGroup(event.group),
         testID: `${testPrefix}-primary-${event.id}`,
+      },
+      secondaryAction: {
+        label: MOBILE_COPY.action.viewOnX,
+        onPress: () => void handleUpcomingXReactionPress(event),
+        testID: `${testPrefix}-secondary-${event.id}`,
       },
       scheduledDate: formatUpcomingLabel(event),
       sourceLinks: buildUpcomingSourceLinks(event),

--- a/mobile/app/(tabs)/radar.tsx
+++ b/mobile/app/(tabs)/radar.tsx
@@ -36,10 +36,17 @@ import { adaptBackendRadarSnapshot } from '../../src/services/backendDisplayAdap
 import type { BackendReadClient } from '../../src/services/backendReadClient';
 import {
   classifyExternalLinkFailureCategory,
+  classifyServiceHandoffFailureCategory,
   trackAnalyticsEvent,
   trackFailureObserved,
 } from '../../src/services/analytics';
 import { openExternalLink, normalizeExternalLinkUrl } from '../../src/services/externalLinks';
+import {
+  buildEntityCenteredXSearchQuery,
+  describeXSearchHandoffBehavior,
+  openXSearchHandoff,
+  resolveXSearchHandoff,
+} from '../../src/services/handoff';
 import {
   runWithPendingRouteResume,
   type RouteResumeTarget,
@@ -83,6 +90,17 @@ function formatUpcomingDateLabel(item: RadarUpcomingCardModel): string {
   return formatUpcomingScheduleLabel({
     scheduledDate: item.upcoming.scheduledDate,
     scheduledMonth: item.upcoming.scheduledMonth,
+  });
+}
+
+function buildRadarXSearchQuery(input: {
+  team: TeamSummaryModel;
+  releaseLabel?: string | null;
+}): { query: string; mode: 'entity_only' | 'release_backed' } {
+  return buildEntityCenteredXSearchQuery({
+    displayName: input.team.displayName,
+    searchTokens: input.team.searchTokens,
+    releaseLabel: input.releaseLabel,
   });
 }
 
@@ -464,6 +482,49 @@ export default function RadarTabScreen() {
     setExternalLinkFeedback(null);
   }
 
+  async function handleXReactionOpen(input: {
+    team: TeamSummaryModel;
+    releaseLabel?: string | null;
+  }) {
+    const query = buildRadarXSearchQuery(input);
+    const handoff = resolveXSearchHandoff(query);
+
+    trackAnalyticsEvent('x_search_handoff_attempted', {
+      surface: 'radar',
+      entitySlug: input.team.slug,
+      mode: handoff.mode,
+    });
+
+    const result = await runWithPendingRouteResume(currentResumeTarget, () => openXSearchHandoff(handoff));
+    if (!result.ok) {
+      trackAnalyticsEvent('x_search_handoff_failed', {
+        surface: 'radar',
+        entitySlug: input.team.slug,
+        mode: result.mode,
+        failureCode: result.code,
+        retryable: result.feedback.retryable,
+      });
+      trackFailureObserved(
+        'radar',
+        classifyServiceHandoffFailureCategory(result.code),
+        result.code,
+        result.feedback.retryable,
+      );
+      setExternalLinkFeedback(result.feedback.message);
+      return;
+    }
+
+    trackAnalyticsEvent(
+      result.target === 'app' ? 'x_search_handoff_opened_app' : 'x_search_handoff_opened_web',
+      {
+        surface: 'radar',
+        entitySlug: input.team.slug,
+        mode: result.mode,
+      },
+    );
+    setExternalLinkFeedback(null);
+  }
+
   useEffect(() => {
     if (hasTrackedViewRef.current) {
       return;
@@ -646,6 +707,10 @@ export default function RadarTabScreen() {
         <RadarFeaturedSection
           item={featuredUpcoming}
           onOpenSource={handleSourceOpen}
+          onOpenXSearch={(item) => void handleXReactionOpen({
+            team: item.team,
+            releaseLabel: item.upcoming.releaseLabel,
+          })}
           onPressTeam={openTeamDetail}
           styles={styles}
         />
@@ -658,6 +723,10 @@ export default function RadarTabScreen() {
                 key={item.id}
                 item={item}
                 onOpenSource={handleSourceOpen}
+                onOpenXSearch={(entry) => void handleXReactionOpen({
+                  team: entry.team,
+                  releaseLabel: entry.upcoming.releaseLabel,
+                })}
                 onPressTeam={openTeamDetail}
                 styles={styles}
                 testID={`radar-weekly-card-${item.team.slug}`}
@@ -674,6 +743,10 @@ export default function RadarTabScreen() {
                 key={item.id}
                 item={item}
                 onOpenSource={handleSourceOpen}
+                onOpenXSearch={(entry) => void handleXReactionOpen({
+                  team: entry.team,
+                  releaseLabel: entry.releaseLabel ?? entry.headline,
+                })}
                 onPressTeam={openTeamDetail}
                 styles={styles}
               />
@@ -732,11 +805,13 @@ export default function RadarTabScreen() {
 function RadarFeaturedSection({
   item,
   onOpenSource,
+  onOpenXSearch,
   onPressTeam,
   styles,
 }: {
   item: RadarUpcomingCardModel | null;
   onOpenSource: (url?: string) => void;
+  onOpenXSearch: (item: RadarUpcomingCardModel) => void;
   onPressTeam: (
     slug: string,
     section: 'featured_upcoming' | 'weekly_upcoming' | 'change_feed' | 'long_gap' | 'rookie',
@@ -763,9 +838,18 @@ function RadarFeaturedSection({
           <Text style={styles.featuredMeta}>{formatUpcomingDateLabel(item)}</Text>
         <RadarActionRow
           onOpenSource={() => onOpenSource(item.sourceUrl)}
+          onPressSecondary={() => onOpenXSearch(item)}
           onPressPrimary={() => onPressTeam(item.team.slug, 'featured_upcoming')}
           primaryLabel={MOBILE_COPY.action.teamPage}
           primaryTestID="radar-featured-primary"
+          secondaryAccessibilityHint={describeXSearchHandoffBehavior(
+            resolveXSearchHandoff(buildRadarXSearchQuery({
+              team: item.team,
+              releaseLabel: item.upcoming.releaseLabel,
+            })),
+          )}
+          secondaryLabel={MOBILE_COPY.action.viewOnX}
+          secondaryTestID="radar-featured-x-search"
             sourceLabel={item.sourceLabel}
             sourceTestID="radar-featured-source"
             sourceUrl={item.sourceUrl}
@@ -798,12 +882,14 @@ function RadarSection({
 function RadarUpcomingSectionCard({
   item,
   onOpenSource,
+  onOpenXSearch,
   onPressTeam,
   styles,
   testID,
 }: {
   item: RadarUpcomingCardModel;
   onOpenSource: (url?: string) => void;
+  onOpenXSearch: (item: RadarUpcomingCardModel) => void;
   onPressTeam: (
     slug: string,
     section: 'featured_upcoming' | 'weekly_upcoming' | 'change_feed' | 'long_gap' | 'rookie',
@@ -840,9 +926,18 @@ function RadarUpcomingSectionCard({
         </Text>
         <RadarActionRow
           onOpenSource={() => onOpenSource(item.sourceUrl)}
+          onPressSecondary={() => onOpenXSearch(item)}
           onPressPrimary={() => onPressTeam(item.team.slug, 'weekly_upcoming')}
           primaryLabel={MOBILE_COPY.action.teamPage}
           primaryTestID={`${testID}-primary`}
+          secondaryAccessibilityHint={describeXSearchHandoffBehavior(
+            resolveXSearchHandoff(buildRadarXSearchQuery({
+              team: item.team,
+              releaseLabel: item.upcoming.releaseLabel,
+            })),
+          )}
+          secondaryLabel={MOBILE_COPY.action.viewOnX}
+          secondaryTestID={`${testID}-x-search`}
           sourceLabel={item.sourceLabel}
           sourceTestID={`${testID}-source`}
           sourceUrl={item.sourceUrl}
@@ -856,11 +951,13 @@ function RadarUpcomingSectionCard({
 function RadarChangeFeedCard({
   item,
   onOpenSource,
+  onOpenXSearch,
   onPressTeam,
   styles,
 }: {
   item: RadarChangeFeedItemModel;
   onOpenSource: (url?: string) => void;
+  onOpenXSearch: (item: RadarChangeFeedItemModel) => void;
   onPressTeam: (
     slug: string,
     section: 'featured_upcoming' | 'weekly_upcoming' | 'change_feed' | 'long_gap' | 'rookie',
@@ -892,9 +989,18 @@ function RadarChangeFeedCard({
         <Text style={styles.cardMetaStrong}>새 일정 · {item.nextScheduleLabel}</Text>
         <RadarActionRow
           onOpenSource={() => onOpenSource(item.sourceUrl)}
+          onPressSecondary={() => onOpenXSearch(item)}
           onPressPrimary={() => onPressTeam(item.team.slug, 'change_feed')}
           primaryLabel={MOBILE_COPY.action.teamPage}
           primaryTestID={`radar-change-primary-${item.team.slug}`}
+          secondaryAccessibilityHint={describeXSearchHandoffBehavior(
+            resolveXSearchHandoff(buildRadarXSearchQuery({
+              team: item.team,
+              releaseLabel: item.releaseLabel ?? item.headline,
+            })),
+          )}
+          secondaryLabel={MOBILE_COPY.action.viewOnX}
+          secondaryTestID={`radar-change-x-search-${item.team.slug}`}
           sourceLabel={item.sourceLabel}
           sourceTestID={`radar-change-source-${item.team.slug}`}
           sourceUrl={item.sourceUrl}
@@ -992,8 +1098,12 @@ function RadarRookieCard({
 function RadarActionRow({
   onOpenSource,
   onPressPrimary,
+  onPressSecondary,
   primaryLabel,
   primaryTestID,
+  secondaryAccessibilityHint,
+  secondaryLabel,
+  secondaryTestID,
   sourceLabel,
   sourceTestID,
   sourceUrl,
@@ -1001,8 +1111,12 @@ function RadarActionRow({
 }: {
   onOpenSource?: () => void;
   onPressPrimary: () => void;
+  onPressSecondary?: () => void;
   primaryLabel: string;
   primaryTestID?: string;
+  secondaryAccessibilityHint?: string;
+  secondaryLabel?: string;
+  secondaryTestID?: string;
   sourceLabel?: string;
   sourceTestID?: string;
   sourceUrl?: string;
@@ -1016,6 +1130,16 @@ function RadarActionRow({
         onPress={onPressPrimary}
         testID={primaryTestID}
       />
+      {secondaryLabel && onPressSecondary ? (
+        <ActionButton
+          accessibilityHint={secondaryAccessibilityHint}
+          accessibilityLabel={secondaryLabel}
+          label={secondaryLabel}
+          onPress={onPressSecondary}
+          testID={secondaryTestID}
+          tone="secondary"
+        />
+      ) : null}
       {sourceUrl && sourceLabel && onOpenSource ? (
         <ActionButton
           accessibilityLabel={sourceLabel}

--- a/mobile/app/(tabs)/search.tsx
+++ b/mobile/app/(tabs)/search.tsx
@@ -55,8 +55,12 @@ import {
 } from '../../src/services/analytics';
 import { openExternalLink, normalizeExternalLinkUrl } from '../../src/services/externalLinks';
 import {
+  buildEntityCenteredXSearchQuery,
   describeServiceHandoffBehavior,
+  describeXSearchHandoffBehavior,
+  openXSearchHandoff,
   openServiceHandoff,
+  resolveXSearchHandoff,
   resolveServiceHandoff,
   type MusicService,
 } from '../../src/services/handoff';
@@ -508,6 +512,25 @@ export default function SearchTabScreen() {
     openTeamDetail(slug);
   }
 
+  function buildUpcomingXSearchQuery(result: SearchUpcomingResultModel): {
+    query: string;
+    mode: 'entity_only' | 'release_backed';
+    entitySlug: string | null;
+  } {
+    const team = teamSummaryByGroup.get(result.upcoming.group);
+    const query = buildEntityCenteredXSearchQuery({
+      displayName: team?.displayName ?? result.upcoming.displayGroup,
+      searchTokens: team?.searchTokens ?? [],
+      releaseLabel: result.upcoming.releaseLabel,
+    });
+
+    return {
+      query: query.query,
+      mode: query.mode,
+      entitySlug: team?.slug ?? teamSlugByGroup.get(result.upcoming.group) ?? null,
+    };
+  }
+
   async function handleUpcomingSourcePress(result: SearchUpcomingResultModel) {
     const opened = await runWithPendingRouteResume(currentResumeTarget, () =>
       openExternalLink(normalizeExternalLinkUrl('source', result.upcoming.sourceUrl)),
@@ -531,6 +554,49 @@ export default function SearchTabScreen() {
       return;
     }
 
+    setHandoffFeedback(null);
+  }
+
+  async function handleUpcomingXReactionPress(result: SearchUpcomingResultModel) {
+    const query = buildUpcomingXSearchQuery(result);
+    const handoff = resolveXSearchHandoff({
+      query: query.query,
+      mode: query.mode,
+    });
+
+    trackAnalyticsEvent('x_search_handoff_attempted', {
+      surface: 'search',
+      entitySlug: query.entitySlug,
+      mode: handoff.mode,
+    });
+
+    const outcome = await runWithPendingRouteResume(currentResumeTarget, () => openXSearchHandoff(handoff));
+    if (!outcome.ok) {
+      trackAnalyticsEvent('x_search_handoff_failed', {
+        surface: 'search',
+        entitySlug: query.entitySlug,
+        mode: outcome.mode,
+        failureCode: outcome.code,
+        retryable: outcome.feedback.retryable,
+      });
+      trackFailureObserved(
+        'search',
+        classifyServiceHandoffFailureCategory(outcome.code),
+        outcome.code,
+        outcome.feedback.retryable,
+      );
+      setHandoffFeedback(outcome.feedback.message);
+      return;
+    }
+
+    trackAnalyticsEvent(
+      outcome.target === 'app' ? 'x_search_handoff_opened_app' : 'x_search_handoff_opened_web',
+      {
+        surface: 'search',
+        entitySlug: query.entitySlug,
+        mode: outcome.mode,
+      },
+    );
     setHandoffFeedback(null);
   }
 
@@ -1037,15 +1103,27 @@ export default function SearchTabScreen() {
                     />
                     <Text style={styles.resultMeta}>{formatUpcomingMeta(result)}</Text>
                   </Pressable>
-                  <View style={styles.resultSupplement}>
-                    <View style={styles.chipRow}>
-                      <View style={styles.resultChip}>
-                        <Text style={styles.resultChipLabel}>{resolveUpcomingMatchLabel(result.matchKind)}</Text>
+                    <View style={styles.resultSupplement}>
+                      <View style={styles.chipRow}>
+                        <View style={styles.resultChip}>
+                          <Text style={styles.resultChipLabel}>{resolveUpcomingMatchLabel(result.matchKind)}</Text>
+                        </View>
                       </View>
-                    </View>
-                    {result.upcoming.sourceUrl ? (
-                      <SourceLinkRow
-                        links={[
+                      <View style={styles.resultActionRow}>
+                        <ActionButton
+                          accessibilityHint={describeXSearchHandoffBehavior(
+                            resolveXSearchHandoff(buildUpcomingXSearchQuery(result)),
+                          )}
+                          accessibilityLabel={`${result.upcoming.displayGroup} X 반응 보기`}
+                          label={MOBILE_COPY.action.viewOnX}
+                          onPress={() => void handleUpcomingXReactionPress(result)}
+                          testID={`search-upcoming-x-search-${result.upcoming.id}`}
+                          tone="secondary"
+                        />
+                      </View>
+                      {result.upcoming.sourceUrl ? (
+                        <SourceLinkRow
+                          links={[
                           {
                             key: `${result.upcoming.id}-source`,
                             label: resolveSourceLinkLabel(result.upcoming.sourceType),
@@ -1207,6 +1285,11 @@ function createStyles(theme: ReturnType<typeof useAppTheme>) {
       opacity: 0.84,
     },
     resultSupplement: {
+      gap: theme.space[8],
+    },
+    resultActionRow: {
+      flexDirection: 'row',
+      flexWrap: 'wrap',
       gap: theme.space[8],
     },
     resultChip: {

--- a/mobile/app/artists/[slug].tsx
+++ b/mobile/app/artists/[slug].tsx
@@ -46,8 +46,12 @@ import {
 } from '../../src/services/analytics';
 import { openExternalLink, normalizeExternalLinkUrl } from '../../src/services/externalLinks';
 import {
+  buildEntityCenteredXSearchQuery,
   describeServiceHandoffBehavior,
+  describeXSearchHandoffBehavior,
+  openXSearchHandoff,
   openServiceHandoff,
+  resolveXSearchHandoff,
   resolveServiceHandoff,
   type ServiceHandoffFailure,
   type ServiceHandoffResolution,
@@ -399,6 +403,50 @@ export default function ArtistDetailScreen() {
     setHandoffFeedback(null);
   }
 
+  async function handleUpcomingXReaction(team: TeamSummaryModel, event: UpcomingEventModel) {
+    const query = buildEntityCenteredXSearchQuery({
+      displayName: team.displayName,
+      searchTokens: team.searchTokens,
+      releaseLabel: event.releaseLabel,
+    });
+    const handoff = resolveXSearchHandoff(query);
+
+    trackAnalyticsEvent('x_search_handoff_attempted', {
+      surface: 'entity_detail',
+      entitySlug: team.slug,
+      mode: handoff.mode,
+    });
+
+    const result = await runWithPendingRouteResume(currentResumeTarget, () => openXSearchHandoff(handoff));
+    if (!result.ok) {
+      trackAnalyticsEvent('x_search_handoff_failed', {
+        surface: 'entity_detail',
+        entitySlug: team.slug,
+        mode: result.mode,
+        failureCode: result.code,
+        retryable: result.feedback.retryable,
+      });
+      trackFailureObserved(
+        'entity_detail',
+        classifyServiceHandoffFailureCategory(result.code),
+        result.code,
+        result.feedback.retryable,
+      );
+      setHandoffFeedback(result.feedback.message);
+      return;
+    }
+
+    trackAnalyticsEvent(
+      result.target === 'app' ? 'x_search_handoff_opened_app' : 'x_search_handoff_opened_web',
+      {
+        surface: 'entity_detail',
+        entitySlug: team.slug,
+        mode: result.mode,
+      },
+    );
+    setHandoffFeedback(null);
+  }
+
   const screenTitle = snapshot?.team.displayName ?? slug ?? 'Team Detail';
 
   if (!slug) {
@@ -482,6 +530,15 @@ export default function ArtistDetailScreen() {
   const latestReleaseServiceButtons: EntityServiceButtonItem[] = snapshot.latestRelease
     ? buildLatestReleaseServiceButtons(snapshot.latestRelease)
     : [];
+  const nextUpcomingXHandoff = snapshot.nextUpcoming
+    ? resolveXSearchHandoff(
+        buildEntityCenteredXSearchQuery({
+          displayName: snapshot.team.displayName,
+          searchTokens: snapshot.team.searchTokens,
+          releaseLabel: snapshot.nextUpcoming.releaseLabel,
+        }),
+      )
+    : null;
 
   return (
     <ScrollView style={styles.screen} contentContainerStyle={scrollContentStyle}>
@@ -613,6 +670,14 @@ export default function ArtistDetailScreen() {
             <Text allowFontScaling maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.body} style={styles.primaryCardBody}>
               {snapshot.nextUpcoming.headline}
             </Text>
+            <ActionButton
+              accessibilityHint={describeXSearchHandoffBehavior(nextUpcomingXHandoff!)}
+              accessibilityLabel={`${snapshot.team.displayName} X 반응 보기`}
+              label={MOBILE_COPY.action.viewOnX}
+              onPress={() => void handleUpcomingXReaction(snapshot.team, snapshot.nextUpcoming!)}
+              testID="entity-next-upcoming-x-search"
+              tone="secondary"
+            />
             {snapshot.nextUpcoming.sourceUrl ? (
               <Pressable
                 accessibilityLabel={`${snapshot.team.displayName} 다음 컴백 출처 열기`}

--- a/mobile/src/components/upcoming/UpcomingEventRow.tsx
+++ b/mobile/src/components/upcoming/UpcomingEventRow.tsx
@@ -17,6 +17,7 @@ export interface UpcomingEventRowProps {
   confidenceChip?: string;
   headline: string;
   primaryAction: { label: string; onPress: () => void; testID?: string };
+  secondaryAction?: { label: string; onPress: () => void; testID?: string };
   scheduledDate?: string;
   sourceLinks?: SourceLinkRowItem[];
   statusChip?: string;
@@ -28,6 +29,7 @@ function UpcomingEventRowComponent({
   confidenceChip,
   headline,
   primaryAction,
+  secondaryAction,
   scheduledDate,
   sourceLinks = [],
   statusChip,
@@ -66,7 +68,10 @@ function UpcomingEventRowComponent({
           </View>
         ) : null}
       </View>
-      <ActionButton {...primaryAction} tone="primary" />
+      <View style={styles.actionColumn}>
+        <ActionButton {...primaryAction} fullWidth tone="primary" />
+        {secondaryAction ? <ActionButton {...secondaryAction} fullWidth tone="secondary" /> : null}
+      </View>
       {sourceLinks.length ? <SourceLinkRow links={sourceLinks} /> : null}
     </View>
   );
@@ -97,6 +102,9 @@ function createStyles(theme: MobileTheme) {
       flexDirection: 'row',
       flexWrap: 'wrap',
       gap: theme.space[4],
+    },
+    actionColumn: {
+      gap: theme.space[8],
     },
   });
 }

--- a/mobile/src/copy/mobileCopy.ts
+++ b/mobile/src/copy/mobileCopy.ts
@@ -17,6 +17,7 @@ export const MOBILE_COPY = {
     hideSourceTimeline: '소스 타임라인 접기',
     sourceView: '소스 보기',
     teamPage: '팀 페이지',
+    viewOnX: 'X에서 보기',
   },
   feedback: {
     errorTitle: '오류',

--- a/mobile/src/features/calendarControls.test.tsx
+++ b/mobile/src/features/calendarControls.test.tsx
@@ -5,6 +5,7 @@ import { Text } from 'react-native';
 
 import CalendarTabScreen from '../../app/(tabs)/calendar';
 import { trackAnalyticsEvent } from '../services/analytics';
+import { openXSearchHandoff } from '../services/handoff';
 import { MOBILE_TEXT_SCALE_LIMITS } from '../tokens/accessibility';
 
 jest.mock('expo-router', () => {
@@ -54,7 +55,16 @@ jest.mock('../services/analytics', () => {
     trackFailureObserved: jest.fn(),
   };
 });
+jest.mock('../services/handoff', () => {
+  const actual = jest.requireActual('../services/handoff') as typeof import('../services/handoff');
+
+  return {
+    ...actual,
+    openXSearchHandoff: jest.fn(),
+  };
+});
 const mockTrackAnalyticsEvent = jest.mocked(trackAnalyticsEvent);
+const mockOpenXSearchHandoff = jest.mocked(openXSearchHandoff);
 const mockUseWindowDimensions = jest.spyOn(ReactNative, 'useWindowDimensions');
 
 async function renderCalendarScreen() {
@@ -96,6 +106,13 @@ describe('calendar controls', () => {
     __mock.push.mockReset();
     __mock.setParams.mockReset();
     mockTrackAnalyticsEvent.mockClear();
+    mockOpenXSearchHandoff.mockReset();
+    mockOpenXSearchHandoff.mockResolvedValue({
+      ok: true,
+      mode: 'release_backed',
+      target: 'web',
+      openedUrl: 'https://x.com/search?q=YENA',
+    });
     mockUseWindowDimensions.mockReturnValue({
       fontScale: 1,
       height: 844,
@@ -222,6 +239,12 @@ describe('calendar controls', () => {
       tree.root.findByProps({ testID: 'calendar-day-2026-03-11' }).props.onPress();
     });
 
+    expect(
+      tree.root.findByProps({
+        testID: 'calendar-sheet-upcoming-secondary-yena--yena-confirms-a-march-11-comeback--2026-03-11--album',
+      }),
+    ).toBeDefined();
+
     await act(async () => {
       tree.root
         .findByProps({ testID: 'calendar-sheet-release-primary-yena--love-catcher--2026-03-11--album' })
@@ -234,6 +257,11 @@ describe('calendar controls', () => {
           testID: 'calendar-sheet-upcoming-primary-yena--yena-confirms-a-march-11-comeback--2026-03-11--album',
         })
         .props.onPress();
+      await tree.root
+        .findByProps({
+          testID: 'calendar-sheet-upcoming-secondary-yena--yena-confirms-a-march-11-comeback--2026-03-11--album',
+        })
+        .props.onPress();
     });
 
     expect(__mock.push).toHaveBeenCalledWith({
@@ -244,6 +272,7 @@ describe('calendar controls', () => {
       pathname: '/releases/[id]',
       params: { id: 'yena--love-catcher--2026-03-11--album' },
     });
+    expect(mockOpenXSearchHandoff).toHaveBeenCalled();
   });
 
   test('renders list mode with separated verified, exact, and month-only sections', async () => {

--- a/mobile/src/features/entityDetailScreen.test.tsx
+++ b/mobile/src/features/entityDetailScreen.test.tsx
@@ -3,6 +3,7 @@ import renderer, { act } from 'react-test-renderer';
 import { Text } from 'react-native';
 
 import ArtistDetailScreen from '../../app/artists/[slug]';
+import { openXSearchHandoff } from '../services/handoff';
 
 jest.mock('expo-router', () => {
   const useLocalSearchParams = jest.fn(() => ({ slug: 'yena' }));
@@ -29,6 +30,14 @@ jest.mock('expo-router', () => {
     },
   };
 });
+jest.mock('../services/handoff', () => {
+  const actual = jest.requireActual('../services/handoff') as typeof import('../services/handoff');
+
+  return {
+    ...actual,
+    openXSearchHandoff: jest.fn(),
+  };
+});
 
 const { __mock } = jest.requireMock('expo-router') as {
   __mock: {
@@ -36,6 +45,7 @@ const { __mock } = jest.requireMock('expo-router') as {
     useRouter: jest.Mock;
   };
 };
+const mockOpenXSearchHandoff = jest.mocked(openXSearchHandoff);
 
 async function renderArtistDetail() {
   let tree: renderer.ReactTestRenderer;
@@ -63,6 +73,13 @@ describe('mobile entity detail screen', () => {
       back: jest.fn(),
       push: jest.fn(),
     });
+    mockOpenXSearchHandoff.mockReset();
+    mockOpenXSearchHandoff.mockResolvedValue({
+      ok: true,
+      mode: 'release_backed',
+      target: 'web',
+      openedUrl: 'https://x.com/search?q=YENA',
+    });
   });
 
   test('renders populated entity detail sections for a tracked team', async () => {
@@ -83,6 +100,7 @@ describe('mobile entity detail screen', () => {
     );
     expect(tree.root.findByProps({ testID: 'entity-artist-source-link' })).toBeDefined();
     expect(tree.root.findByProps({ testID: 'entity-next-upcoming-card' })).toBeDefined();
+    expect(tree.root.findByProps({ testID: 'entity-next-upcoming-x-search' })).toBeDefined();
     expect(tree.root.findByProps({ testID: 'entity-latest-release-card' })).toBeDefined();
     expect(tree.root.findByProps({ testID: 'entity-latest-release-primary' })).toBeDefined();
     expect(tree.root.findByProps({ testID: 'entity-latest-release-service-spotify' })).toBeDefined();
@@ -99,11 +117,13 @@ describe('mobile entity detail screen', () => {
 
     await act(async () => {
       tree.root.findByProps({ testID: 'entity-detail-back' }).props.onPress();
+      await tree.root.findByProps({ testID: 'entity-next-upcoming-x-search' }).props.onPress();
       tree.root.findByProps({ testID: 'entity-latest-release-primary' }).props.onPress();
       tree.root.findByProps({ testID: 'entity-recent-album-single-card-yena--love-catcher--2026-03-11--album' }).props.onPress();
     });
 
     expect(back).toHaveBeenCalledTimes(1);
+    expect(mockOpenXSearchHandoff).toHaveBeenCalled();
     expect(push).toHaveBeenCalledWith({
       pathname: '/releases/[id]',
       params: { id: 'yena--love-catcher--2026-03-11--album' },

--- a/mobile/src/features/radarTab.test.tsx
+++ b/mobile/src/features/radarTab.test.tsx
@@ -9,6 +9,7 @@ import {
   loadActiveMobileDataset,
   type ActiveMobileDataset,
 } from '../services/activeDataset';
+import { openXSearchHandoff } from '../services/handoff';
 import { trackAnalyticsEvent, trackDatasetDegraded, trackDatasetLoadFailed } from '../services/analytics';
 import { cloneBundledDatasetFixture } from '../services/bundledDatasetFixture';
 import { createBundledDatasetSelection } from '../services/datasetSource';
@@ -81,6 +82,14 @@ jest.mock('../services/analytics', () => {
     trackFailureObserved: jest.fn(),
   };
 });
+jest.mock('../services/handoff', () => {
+  const actual = jest.requireActual('../services/handoff') as typeof import('../services/handoff');
+
+  return {
+    ...actual,
+    openXSearchHandoff: jest.fn(),
+  };
+});
 
 const { __mock } = jest.requireMock('expo-router') as {
   __mock: {
@@ -95,6 +104,7 @@ const mockSelectRadarSnapshot = jest.mocked(selectRadarSnapshot);
 const mockTrackAnalyticsEvent = jest.mocked(trackAnalyticsEvent);
 const mockTrackDatasetDegraded = jest.mocked(trackDatasetDegraded);
 const mockTrackDatasetLoadFailed = jest.mocked(trackDatasetLoadFailed);
+const mockOpenXSearchHandoff = jest.mocked(openXSearchHandoff);
 const runtimeModule = jest.requireMock('../config/runtime') as {
   getRuntimeConfigState: jest.Mock;
   getRuntimeConfig: jest.Mock;
@@ -180,6 +190,13 @@ describe('mobile radar tab', () => {
     mockTrackAnalyticsEvent.mockClear();
     mockTrackDatasetDegraded.mockClear();
     mockTrackDatasetLoadFailed.mockClear();
+    mockOpenXSearchHandoff.mockReset();
+    mockOpenXSearchHandoff.mockResolvedValue({
+      ok: true,
+      mode: 'release_backed',
+      target: 'app',
+      openedUrl: 'twitter://search?query=YENA',
+    });
     mockLoadActiveMobileDataset.mockResolvedValue(createSource());
 
     const actualSelectors = jest.requireActual('../selectors') as typeof import('../selectors');
@@ -195,11 +212,28 @@ describe('mobile radar tab', () => {
     expect(tree.root.findByProps({ testID: 'radar-featured-card' }).props.accessibilityLabel).toContain('YENA');
     expect(tree.root.findByProps({ testID: 'radar-weekly-card-yena' })).toBeDefined();
     expect(tree.root.findByProps({ testID: 'radar-change-card-p1harmony' })).toBeDefined();
+    expect(tree.root.findByProps({ testID: 'radar-featured-x-search' })).toBeDefined();
+    expect(tree.root.findByProps({ testID: 'radar-weekly-card-yena-x-search' })).toBeDefined();
+    expect(tree.root.findByProps({ testID: 'radar-change-x-search-p1harmony' })).toBeDefined();
     expect(tree.root.findByProps({ testID: 'radar-long-gap-card-weeekly' })).toBeDefined();
     expect(tree.root.findByProps({ testID: 'radar-rookie-card-atheart' })).toBeDefined();
     expect(tree.root.findAllByProps({ testID: 'radar-dataset-risk-notice' })).toHaveLength(0);
     expect(tree.root.findAllByProps({ testID: 'radar-partial-notice' })).toHaveLength(0);
     expect(mockTrackAnalyticsEvent).toHaveBeenCalledWith('radar_viewed', { enabledSections: 4 });
+
+    await act(async () => {
+      await tree.root.findByProps({ testID: 'radar-featured-x-search' }).props.onPress();
+    });
+
+    expect(mockOpenXSearchHandoff).toHaveBeenCalled();
+    expect(mockTrackAnalyticsEvent).toHaveBeenCalledWith(
+      'x_search_handoff_opened_app',
+      expect.objectContaining({
+        surface: 'radar',
+        entitySlug: 'yena',
+        mode: 'release_backed',
+      }),
+    );
   });
 
   test('shows a degraded-state notice while keeping usable cards visible', async () => {

--- a/mobile/src/features/searchTab.test.tsx
+++ b/mobile/src/features/searchTab.test.tsx
@@ -3,7 +3,7 @@ import { Text } from 'react-native';
 
 import SearchTabScreen from '../../app/(tabs)/search';
 import { trackAnalyticsEvent } from '../services/analytics';
-import { openServiceHandoff } from '../services/handoff';
+import { openServiceHandoff, openXSearchHandoff } from '../services/handoff';
 import { persistRecentQuery, readRecentQueries } from '../services/recentQueries';
 import { resetStorageAdapter, setStorageAdapter, type KeyValueStorageAdapter } from '../services/storage';
 
@@ -53,6 +53,7 @@ jest.mock('../services/handoff', () => {
   return {
     ...actual,
     openServiceHandoff: jest.fn(),
+    openXSearchHandoff: jest.fn(),
   };
 });
 
@@ -65,6 +66,7 @@ const { __mock } = jest.requireMock('expo-router') as {
 };
 const mockTrackAnalyticsEvent = jest.mocked(trackAnalyticsEvent);
 const mockOpenServiceHandoff = jest.mocked(openServiceHandoff);
+const mockOpenXSearchHandoff = jest.mocked(openXSearchHandoff);
 
 async function renderSearchScreen() {
   let tree: renderer.ReactTestRenderer;
@@ -90,12 +92,19 @@ describe('mobile search tab', () => {
     __mock.push.mockClear();
     mockTrackAnalyticsEvent.mockClear();
     mockOpenServiceHandoff.mockReset();
+    mockOpenXSearchHandoff.mockReset();
     mockOpenServiceHandoff.mockResolvedValue({
       ok: true,
       service: 'spotify',
       mode: 'canonical',
       target: 'primary',
       openedUrl: 'https://open.spotify.com/track/test',
+    });
+    mockOpenXSearchHandoff.mockResolvedValue({
+      ok: true,
+      mode: 'release_backed',
+      target: 'web',
+      openedUrl: 'https://x.com/search?q=YENA',
     });
   });
 
@@ -156,6 +165,11 @@ describe('mobile search tab', () => {
         testID: 'search-upcoming-result-yena--yena-confirms-a-march-11-comeback--2026-03-11--album',
       }),
     ).toBeDefined();
+    expect(
+      tree.root.findByProps({
+        testID: 'search-upcoming-x-search-yena--yena-confirms-a-march-11-comeback--2026-03-11--album',
+      }),
+    ).toBeDefined();
 
     await act(async () => {
       tree.root
@@ -169,6 +183,24 @@ describe('mobile search tab', () => {
       pathname: '/artists/[slug]',
       params: { slug: 'yena' },
     });
+
+    await act(async () => {
+      await tree.root
+        .findByProps({
+          testID: 'search-upcoming-x-search-yena--yena-confirms-a-march-11-comeback--2026-03-11--album',
+        })
+        .props.onPress();
+    });
+
+    expect(mockOpenXSearchHandoff).toHaveBeenCalled();
+    expect(mockTrackAnalyticsEvent).toHaveBeenCalledWith(
+      'x_search_handoff_opened_web',
+      expect.objectContaining({
+        surface: 'search',
+        entitySlug: 'yena',
+        mode: 'release_backed',
+      }),
+    );
 
     await act(async () => {
       await tree.root.findByProps({ testID: 'search-input' }).props.onSubmitEditing();

--- a/mobile/src/services/analytics.ts
+++ b/mobile/src/services/analytics.ts
@@ -139,6 +139,28 @@ export type AnalyticsEventMap = {
     target: ServiceHandoffTarget | null;
     failureCode: ServiceHandoffFailureCode | null;
   };
+  x_search_handoff_attempted: {
+    surface: AnalyticsSurface;
+    entitySlug: string | null;
+    mode: 'entity_only' | 'release_backed';
+  };
+  x_search_handoff_opened_app: {
+    surface: AnalyticsSurface;
+    entitySlug: string | null;
+    mode: 'entity_only' | 'release_backed';
+  };
+  x_search_handoff_opened_web: {
+    surface: AnalyticsSurface;
+    entitySlug: string | null;
+    mode: 'entity_only' | 'release_backed';
+  };
+  x_search_handoff_failed: {
+    surface: AnalyticsSurface;
+    entitySlug: string | null;
+    mode: 'entity_only' | 'release_backed';
+    failureCode: ServiceHandoffFailureCode;
+    retryable: boolean;
+  };
   dataset_degraded: {
     surface: AnalyticsSurface;
     activeSource: string;

--- a/mobile/src/services/handoff.test.ts
+++ b/mobile/src/services/handoff.test.ts
@@ -1,7 +1,12 @@
 import {
+  buildEntityCenteredXSearchQuery,
   buildServiceSearchFallbackUrl,
+  buildXSearchWebFallbackUrl,
   describeServiceHandoffBehavior,
+  describeXSearchHandoffBehavior,
+  openXSearchHandoff,
   openServiceHandoff,
+  resolveXSearchHandoff,
   resolveServiceHandoff,
   resolveServiceHandoffGroup,
   type HandoffLinkingAdapter,
@@ -31,6 +36,43 @@ describe('mobile external handoff service', () => {
     expect(buildServiceSearchFallbackUrl('youtubeMv', 'IVE REVIVE+')).toBe(
       'https://www.youtube.com/results?search_query=IVE%20REVIVE%2B%20official%20mv',
     );
+    expect(buildXSearchWebFallbackUrl('"아이브" OR IVE "REBEL HEART"')).toBe(
+      'https://x.com/search?q=%22%EC%95%84%EC%9D%B4%EB%B8%8C%22%20OR%20IVE%20%22REBEL%20HEART%22&src=typed_query',
+    );
+  });
+
+  test('builds alias-aware X queries from Korean, English, and representative aliases', () => {
+    expect(
+      buildEntityCenteredXSearchQuery({
+        displayName: 'LOONA',
+        searchTokens: ['이달의소녀', 'LOONA'],
+      }),
+    ).toEqual({
+      query: '"이달의소녀" OR LOONA',
+      mode: 'entity_only',
+    });
+
+    expect(
+      buildEntityCenteredXSearchQuery({
+        displayName: 'IVE',
+        searchTokens: ['아이브'],
+        releaseLabel: 'REBEL HEART',
+      }),
+    ).toEqual({
+      query: '"아이브" OR IVE "REBEL HEART"',
+      mode: 'release_backed',
+    });
+
+    expect(
+      buildEntityCenteredXSearchQuery({
+        displayName: 'Stray Kids',
+        searchTokens: ['스트레이 키즈', '스트레이키즈', '스키즈'],
+        releaseLabel: 'HOP',
+      }),
+    ).toEqual({
+      query: '"스트레이 키즈" OR "Stray Kids" OR "스키즈" HOP',
+      mode: 'release_backed',
+    });
   });
 
   test('prefers canonical service URLs when they are safe and supported', () => {
@@ -251,6 +293,107 @@ describe('mobile external handoff service', () => {
     );
     expect(describeServiceHandoffBehavior(unavailable)).toBe(
       '현재는 연결 가능한 앱 또는 검색 경로가 아직 준비되지 않았습니다.',
+    );
+  });
+
+  test('resolves X search handoff to app-first targets with web fallback', () => {
+    const handoff = resolveXSearchHandoff({
+      query: '"아이브" OR IVE "REBEL HEART"',
+      mode: 'release_backed',
+    });
+
+    if ('ok' in handoff) {
+      throw new Error('Expected an X handoff resolution.');
+    }
+
+    expect(handoff.mode).toBe('release_backed');
+    expect(handoff.appUrls).toEqual([
+      'twitter://search?query=%22%EC%95%84%EC%9D%B4%EB%B8%8C%22%20OR%20IVE%20%22REBEL%20HEART%22',
+      'x://search?query=%22%EC%95%84%EC%9D%B4%EB%B8%8C%22%20OR%20IVE%20%22REBEL%20HEART%22',
+    ]);
+    expect(handoff.webUrl).toBe(
+      'https://x.com/search?q=%22%EC%95%84%EC%9D%B4%EB%B8%8C%22%20OR%20IVE%20%22REBEL%20HEART%22&src=typed_query',
+    );
+  });
+
+  test('opens X app first and falls back to x.com when the app target is unavailable', async () => {
+    const handoff = resolveXSearchHandoff({
+      query: '"아이브" OR IVE "REBEL HEART"',
+      mode: 'release_backed',
+    });
+
+    const opened: string[] = [];
+    const appResult = await openXSearchHandoff(
+      handoff,
+      createLinkingAdapter({
+        canOpen: async (url) => url.startsWith('twitter://'),
+        open: async (url) => {
+          opened.push(url);
+        },
+      }),
+    );
+
+    expect(appResult).toEqual({
+      ok: true,
+      mode: 'release_backed',
+      target: 'app',
+      openedUrl: 'twitter://search?query=%22%EC%95%84%EC%9D%B4%EB%B8%8C%22%20OR%20IVE%20%22REBEL%20HEART%22',
+    });
+
+    opened.length = 0;
+    const webResult = await openXSearchHandoff(
+      handoff,
+      createLinkingAdapter({
+        canOpen: async (url) => url.startsWith('https://x.com/'),
+        open: async (url) => {
+          opened.push(url);
+        },
+      }),
+    );
+
+    expect(webResult).toEqual({
+      ok: true,
+      mode: 'release_backed',
+      target: 'web',
+      openedUrl:
+        'https://x.com/search?q=%22%EC%95%84%EC%9D%B4%EB%B8%8C%22%20OR%20IVE%20%22REBEL%20HEART%22&src=typed_query',
+    });
+  });
+
+  test('returns explicit unavailable or retryable failure states for X handoff', async () => {
+    const unavailable = resolveXSearchHandoff({
+      query: '   ',
+    });
+    expect(unavailable).toMatchObject({
+      ok: false,
+      code: 'handoff_unavailable',
+      feedback: {
+        retryable: false,
+        message: '지금은 열 수 있는 X 검색 경로가 없습니다.',
+      },
+    });
+
+    const retryable = await openXSearchHandoff(
+      resolveXSearchHandoff({
+        query: '"스트레이 키즈" OR "Stray Kids" OR "스키즈"',
+      }),
+      createLinkingAdapter({
+        canOpen: async () => false,
+      }),
+    );
+    expect(retryable).toMatchObject({
+      ok: false,
+      code: 'handoff_open_failed',
+      feedback: {
+        retryable: true,
+        message: 'X를 열지 못했습니다. 같은 화면에서 다시 시도해 주세요.',
+      },
+    });
+    if (retryable.ok) {
+      throw new Error('Expected the X search handoff to fail.');
+    }
+    expect(describeXSearchHandoffBehavior(retryable)).toBe(
+      'X 앱 연결에 실패해도 현재 화면을 유지한 채 다시 시도할 수 있습니다.',
     );
   });
 });

--- a/mobile/src/services/handoff.ts
+++ b/mobile/src/services/handoff.ts
@@ -4,6 +4,8 @@ export type MusicService = 'spotify' | 'youtubeMusic' | 'youtubeMv';
 export type ServiceHandoffMode = 'canonical' | 'searchFallback';
 export type ServiceHandoffTarget = 'primary' | 'browserFallback';
 export type ServiceHandoffFailureCode = 'handoff_unavailable' | 'handoff_open_failed';
+export type XSearchHandoffTarget = 'app' | 'web';
+export type XSearchQueryMode = 'entity_only' | 'release_backed';
 
 export type ServiceHandoffResolution = {
   service: MusicService;
@@ -40,6 +42,37 @@ export type ServiceHandoffSuccess = {
 
 export type ServiceHandoffResult = ServiceHandoffSuccess | ServiceHandoffFailure;
 
+export type XSearchHandoffResolution = {
+  query: string;
+  mode: XSearchQueryMode;
+  appUrls: string[];
+  webUrl: string;
+};
+
+export type XSearchHandoffFailure = {
+  ok: false;
+  code: ServiceHandoffFailureCode;
+  mode: XSearchQueryMode;
+  target: XSearchHandoffTarget | null;
+  attemptedUrl: string | null;
+  feedback: {
+    level: 'warning';
+    retryable: boolean;
+    message:
+      | '지금은 열 수 있는 X 검색 경로가 없습니다.'
+      | 'X를 열지 못했습니다. 같은 화면에서 다시 시도해 주세요.';
+  };
+};
+
+export type XSearchHandoffSuccess = {
+  ok: true;
+  mode: XSearchQueryMode;
+  target: XSearchHandoffTarget;
+  openedUrl: string;
+};
+
+export type XSearchHandoffResult = XSearchHandoffSuccess | XSearchHandoffFailure;
+
 export type HandoffLinkingAdapter = {
   canOpenURL(url: string): Promise<boolean>;
   openURL(url: string): Promise<unknown>;
@@ -62,6 +95,12 @@ function isServiceHandoffFailure(
   return 'ok' in handoff;
 }
 
+function isXSearchHandoffFailure(
+  handoff: XSearchHandoffResolution | XSearchHandoffFailure,
+): handoff is XSearchHandoffFailure {
+  return 'ok' in handoff;
+}
+
 const CANONICAL_HOSTS: Record<MusicService, Set<string>> = {
   spotify: new Set(['open.spotify.com']),
   youtubeMusic: new Set(['music.youtube.com']),
@@ -70,6 +109,67 @@ const CANONICAL_HOSTS: Record<MusicService, Set<string>> = {
 
 function normalizeQuery(query: string): string {
   return query.trim().replace(/\s+/g, ' ');
+}
+
+function normalizeEntitySearchToken(value: string): string {
+  return normalizeQuery(value).replace(/^["']+|["']+$/g, '');
+}
+
+function canonicalizeSearchToken(value: string): string {
+  return normalizeEntitySearchToken(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9가-힣]+/g, '');
+}
+
+function containsHangul(value: string): boolean {
+  return /[가-힣]/.test(value);
+}
+
+function containsLatin(value: string): boolean {
+  return /[A-Za-z]/.test(value);
+}
+
+function formatXSearchToken(value: string): string {
+  const normalized = normalizeEntitySearchToken(value);
+  if (!normalized) {
+    return '';
+  }
+
+  if (/[^A-Za-z0-9_-]/.test(normalized) || containsHangul(normalized)) {
+    return `"${normalized}"`;
+  }
+
+  return normalized;
+}
+
+function pushUniqueSearchToken(collection: string[], token: string): void {
+  const normalized = normalizeEntitySearchToken(token);
+  if (!normalized) {
+    return;
+  }
+
+  const canonical = canonicalizeSearchToken(normalized);
+  if (!canonical) {
+    return;
+  }
+
+  if (collection.some((existing) => canonicalizeSearchToken(existing) === canonical)) {
+    return;
+  }
+
+  collection.push(normalized);
+}
+
+function isRedundantReleaseSearchToken(
+  token: string,
+  entityTokens: string[],
+): boolean {
+  const canonical = canonicalizeSearchToken(token);
+  if (!canonical) {
+    return true;
+  }
+
+  return entityTokens.some((entityToken) => canonicalizeSearchToken(entityToken) === canonical);
 }
 
 function tryParseUrl(value: string | null | undefined): URL | null {
@@ -126,6 +226,67 @@ export function buildServiceSearchFallbackUrl(service: MusicService, query: stri
   }
 
   return `https://www.youtube.com/results?search_query=${encodeURIComponent(`${normalizedQuery} official mv`)}`;
+}
+
+export function buildXSearchWebFallbackUrl(query: string): string {
+  return `https://x.com/search?q=${encodeURIComponent(normalizeQuery(query))}&src=typed_query`;
+}
+
+export function buildEntityCenteredXSearchQuery(input: {
+  displayName: string;
+  searchTokens?: string[];
+  releaseLabel?: string | null;
+}): { query: string; mode: XSearchQueryMode } {
+  const orderedEntityTokens: string[] = [];
+  pushUniqueSearchToken(orderedEntityTokens, input.displayName);
+
+  for (const token of input.searchTokens ?? []) {
+    pushUniqueSearchToken(orderedEntityTokens, token);
+  }
+
+  const selectedEntityTokens: string[] = [];
+  const koreanToken = orderedEntityTokens.find(containsHangul);
+  const englishToken = orderedEntityTokens.find(containsLatin);
+  const representativeAlias = orderedEntityTokens.find((token) => {
+    const canonical = canonicalizeSearchToken(token);
+    return (
+      canonical &&
+      canonical !== canonicalizeSearchToken(koreanToken ?? '') &&
+      canonical !== canonicalizeSearchToken(englishToken ?? '')
+    );
+  });
+
+  if (koreanToken) {
+    pushUniqueSearchToken(selectedEntityTokens, koreanToken);
+  }
+  if (englishToken) {
+    pushUniqueSearchToken(selectedEntityTokens, englishToken);
+  }
+  if (representativeAlias) {
+    pushUniqueSearchToken(selectedEntityTokens, representativeAlias);
+  }
+  if (selectedEntityTokens.length === 0) {
+    pushUniqueSearchToken(selectedEntityTokens, input.displayName);
+  }
+
+  const releaseLabel = normalizeEntitySearchToken(input.releaseLabel ?? '');
+  const mode: XSearchQueryMode =
+    releaseLabel && !isRedundantReleaseSearchToken(releaseLabel, selectedEntityTokens)
+      ? 'release_backed'
+      : 'entity_only';
+
+  const entityClause = selectedEntityTokens.map(formatXSearchToken).filter(Boolean).join(' OR ');
+  if (mode === 'release_backed') {
+    return {
+      query: normalizeQuery(`${entityClause} ${formatXSearchToken(releaseLabel)}`),
+      mode,
+    };
+  }
+
+  return {
+    query: entityClause,
+    mode,
+  };
 }
 
 export function normalizeCanonicalServiceUrl(service: MusicService, value: string | null | undefined): string | null {
@@ -203,6 +364,41 @@ export function resolveServiceHandoff(input: {
   };
 }
 
+export function resolveXSearchHandoff(input: {
+  query: string;
+  mode?: XSearchQueryMode;
+}): XSearchHandoffResolution | XSearchHandoffFailure {
+  const query = normalizeQuery(input.query);
+  const mode = input.mode ?? 'entity_only';
+
+  if (!query) {
+    return {
+      ok: false,
+      code: 'handoff_unavailable',
+      mode,
+      target: null,
+      attemptedUrl: null,
+      feedback: {
+        level: 'warning',
+        retryable: false,
+        message: '지금은 열 수 있는 X 검색 경로가 없습니다.',
+      },
+    };
+  }
+
+  const encodedQuery = encodeURIComponent(query);
+
+  return {
+    query,
+    mode,
+    appUrls: [
+      `twitter://search?query=${encodedQuery}`,
+      `x://search?query=${encodedQuery}`,
+    ],
+    webUrl: buildXSearchWebFallbackUrl(query),
+  };
+}
+
 export async function openServiceHandoff(
   handoff: ServiceHandoffResolution | ServiceHandoffFailure,
   adapter: HandoffLinkingAdapter = DEFAULT_LINKING_ADAPTER,
@@ -258,6 +454,52 @@ export async function openServiceHandoff(
   };
 }
 
+export async function openXSearchHandoff(
+  handoff: XSearchHandoffResolution | XSearchHandoffFailure,
+  adapter: HandoffLinkingAdapter = DEFAULT_LINKING_ADAPTER,
+): Promise<XSearchHandoffResult> {
+  if (isXSearchHandoffFailure(handoff)) {
+    return handoff;
+  }
+
+  const attempts: { target: XSearchHandoffTarget; url: string }[] = [
+    ...handoff.appUrls.map((url) => ({ target: 'app' as const, url })),
+    { target: 'web' as const, url: handoff.webUrl },
+  ];
+
+  for (const attempt of attempts) {
+    try {
+      const canOpen = await adapter.canOpenURL(attempt.url);
+      if (!canOpen) {
+        continue;
+      }
+
+      await adapter.openURL(attempt.url);
+      return {
+        ok: true,
+        mode: handoff.mode,
+        target: attempt.target,
+        openedUrl: attempt.url,
+      };
+    } catch {
+      continue;
+    }
+  }
+
+  return {
+    ok: false,
+    code: 'handoff_open_failed',
+    mode: handoff.mode,
+    target: 'web',
+    attemptedUrl: handoff.webUrl,
+    feedback: {
+      level: 'warning',
+      retryable: true,
+      message: 'X를 열지 못했습니다. 같은 화면에서 다시 시도해 주세요.',
+    },
+  };
+}
+
 export function describeServiceHandoffBehavior(
   handoff: ServiceHandoffResolution | ServiceHandoffFailure,
 ): string {
@@ -276,6 +518,20 @@ export function describeServiceHandoffBehavior(
   }
 
   return `${serviceLabel} 설치 여부와 관계없이 검색 결과로 엽니다.`;
+}
+
+export function describeXSearchHandoffBehavior(
+  handoff: XSearchHandoffResolution | XSearchHandoffFailure,
+): string {
+  if (isXSearchHandoffFailure(handoff)) {
+    if (handoff.code === 'handoff_unavailable') {
+      return '현재는 X 검색으로 연결할 수 있는 엔티티 키워드가 아직 준비되지 않았습니다.';
+    }
+
+    return 'X 앱 연결에 실패해도 현재 화면을 유지한 채 다시 시도할 수 있습니다.';
+  }
+
+  return 'X 앱이 있으면 앱으로, 없으면 x.com 검색 결과로 엽니다.';
 }
 
 export function resolveServiceHandoffGroup(input: {


### PR DESCRIPTION
## Summary
- add alias-aware X search query generation and app-first/web-fallback handoff helpers
- wire X reaction CTAs into search, calendar, radar, and team detail upcoming surfaces
- add regression tests for query snapshots, handoff behavior, and RN surface CTA flows

## Verification
- cd mobile && npm test -- --runInBand src/services/handoff.test.ts src/features/searchTab.test.tsx src/features/calendarControls.test.tsx src/features/radarTab.test.tsx src/features/entityDetailScreen.test.tsx
- cd mobile && ./node_modules/.bin/tsc --noEmit --pretty false
- cd mobile && npm run lint
- git diff --check

Closes #563
Closes #564
Closes #565