### PR TITLE
[#576] Align canonical status disclosures across web and mobile

### DIFF
--- a/mobile/app/releases/[id].tsx
+++ b/mobile/app/releases/[id].tsx
@@ -28,6 +28,7 @@ import { FallbackArt } from '../../src/components/visual/FallbackArt';
 import {
   buildDatasetRiskDisclosure,
   buildReleaseDependencyDisclosure,
+  formatCanonicalDisclosureLine,
 } from '../../src/features/surfaceDisclosures';
 import { useActiveDatasetScreen } from '../../src/features/useActiveDatasetScreen';
 import { selectReleaseDetailById } from '../../src/selectors';
@@ -154,11 +155,24 @@ function getMvStatusCopy(status?: YoutubeVideoStatus): string | null {
     case 'relation_match':
       return '공식 MV가 확인돼 외부 서비스로 바로 열 수 있습니다.';
     case 'needs_review':
-      return '공식 MV 후보가 있어도 아직 검토가 끝나지 않았습니다.';
+      return formatCanonicalDisclosureLine(
+        '공식 MV',
+        'review_needed',
+        '후보는 있지만 사람 검토가 아직 끝나지 않았습니다.',
+      );
+    case 'no_link':
     case 'no_mv':
-      return '현재는 공식 MV가 등록되지 않았습니다.';
+      return formatCanonicalDisclosureLine(
+        '공식 MV',
+        'conditional_none',
+        'first-party evidence 기준으로 공식 MV가 없다고 확인된 상태입니다.',
+      );
     case 'unresolved':
-      return '공식 MV가 아직 확정되지 않았습니다.';
+      return formatCanonicalDisclosureLine(
+        '공식 MV',
+        'unresolved',
+        '채워야 하지만 아직 canonical target을 확정하지 못했습니다.',
+      );
     default:
       return null;
   }

--- a/mobile/src/features/surfaceDisclosures.test.ts
+++ b/mobile/src/features/surfaceDisclosures.test.ts
@@ -64,6 +64,38 @@ describe('surface disclosure helpers', () => {
       title: '소스 신뢰도',
       testID: 'entity-source-confidence-notice',
     });
+    expect(
+      buildEntitySourceDisclosure({
+        team: {
+          slug: 'demo',
+          group: 'Demo',
+          displayName: 'Demo',
+          actType: 'group',
+          youtubeChannelUrls: [],
+          searchTokens: [],
+        },
+        nextUpcoming: {
+          id: 'demo-upcoming',
+          group: 'Demo',
+          displayGroup: 'Demo',
+          headline: 'Demo comeback',
+          status: 'confirmed',
+          datePrecision: 'exact',
+          scheduledDate: '2026-03-20',
+          sourceType: 'news_rss',
+        },
+        latestRelease: {
+          id: 'demo-release',
+          group: 'Demo',
+          displayGroup: 'Demo',
+          releaseTitle: 'Demo Release',
+          releaseDate: '2026-01-01',
+          contextTags: [],
+        },
+        recentAlbums: [],
+        sourceTimeline: [],
+      })?.body,
+    ).toContain('아티스트 출처 · 미기재');
   });
 
   test('flags release dependency gaps', () => {
@@ -81,5 +113,16 @@ describe('surface disclosure helpers', () => {
       title: '외부 링크 및 메타 상태',
       testID: 'release-detail-quality-notice',
     });
+    expect(
+      buildReleaseDependencyDisclosure({
+        id: 'demo',
+        group: 'Demo',
+        displayGroup: 'Demo',
+        releaseTitle: 'Demo Release',
+        releaseDate: '2026-01-01',
+        tracks: [],
+        youtubeVideoStatus: 'no_link',
+      })?.body,
+    ).toContain('공식 MV · 조건부 없음');
   });
 });

--- a/mobile/src/features/surfaceDisclosures.ts
+++ b/mobile/src/features/surfaceDisclosures.ts
@@ -7,6 +7,19 @@ export type SurfaceDisclosure = {
   testID: string;
 };
 
+export type CanonicalDisclosureStatus =
+  | 'missing'
+  | 'unresolved'
+  | 'review_needed'
+  | 'conditional_none';
+
+const CANONICAL_DISCLOSURE_LABELS: Record<CanonicalDisclosureStatus, string> = {
+  missing: '미기재',
+  unresolved: '미해결',
+  review_needed: '검토 필요',
+  conditional_none: '조건부 없음',
+};
+
 function formatCachedAt(value: string | null): string | null {
   if (!value) {
     return null;
@@ -26,6 +39,14 @@ function summarizeIssues(issues: string[]): string {
   }
 
   return issues.join(' / ');
+}
+
+export function formatCanonicalDisclosureLine(
+  subject: string,
+  status: CanonicalDisclosureStatus,
+  detail: string,
+): string {
+  return `${subject} · ${CANONICAL_DISCLOSURE_LABELS[status]}: ${detail}`;
 }
 
 export function buildDatasetRiskDisclosure(
@@ -62,31 +83,55 @@ export function buildDatasetRiskDisclosure(
 export function buildEntitySourceDisclosure(
   snapshot: EntityDetailSnapshotModel,
 ): SurfaceDisclosure | null {
-  const gaps: string[] = [];
+  const lines: string[] = [];
 
   if (!snapshot.team.artistSourceUrl) {
-    gaps.push('아티스트 출처');
+    lines.push(
+      formatCanonicalDisclosureLine(
+        '아티스트 출처',
+        'missing',
+        '프로필 기준 source link가 아직 연결되지 않았습니다.',
+      ),
+    );
   }
 
   if (snapshot.nextUpcoming && !snapshot.nextUpcoming.sourceUrl) {
-    gaps.push('다음 컴백 출처');
+    lines.push(
+      formatCanonicalDisclosureLine(
+        '다음 컴백 출처',
+        'missing',
+        '예정 신호는 보이지만 source link가 아직 붙지 않았습니다.',
+      ),
+    );
   }
 
   if (snapshot.latestRelease && !snapshot.latestRelease.sourceUrl) {
-    gaps.push('최신 발매 출처');
+    lines.push(
+      formatCanonicalDisclosureLine(
+        '최신 발매 출처',
+        'missing',
+        'verified release source link가 아직 연결되지 않았습니다.',
+      ),
+    );
   }
 
   if (snapshot.sourceTimeline.length === 0) {
-    gaps.push('소스 타임라인');
+    lines.push(
+      formatCanonicalDisclosureLine(
+        '소스 타임라인',
+        'unresolved',
+        '예정·발매 근거를 하나의 타임라인으로 아직 묶지 못했습니다.',
+      ),
+    );
   }
 
-  if (gaps.length === 0) {
+  if (lines.length === 0) {
     return null;
   }
 
   return {
     title: '소스 신뢰도',
-    body: `${gaps.join(', ')} 정보가 아직 비어 있거나 연결되지 않았습니다. 이 화면은 실용 허브를 우선하므로, 없는 출처는 숨기고 확인 가능한 정보만 남깁니다.`,
+    body: lines.join('\n'),
     testID: 'entity-source-confidence-notice',
   };
 }
@@ -94,31 +139,65 @@ export function buildEntitySourceDisclosure(
 export function buildReleaseDependencyDisclosure(
   detail: ReleaseDetailModel,
 ): SurfaceDisclosure | null {
-  const issues: string[] = [];
+  const lines: string[] = [];
 
   if (detail.tracks.length === 0) {
-    issues.push('트랙 메타데이터 미완료');
+    lines.push(
+      formatCanonicalDisclosureLine(
+        '트랙 메타데이터',
+        'missing',
+        '신뢰 가능한 canonical tracklist가 아직 연결되지 않았습니다.',
+      ),
+    );
   }
 
   if (!detail.spotifyUrl || !detail.youtubeMusicUrl) {
-    issues.push('음원 서비스 링크 일부 누락');
+    lines.push(
+      formatCanonicalDisclosureLine(
+        '음원 서비스 링크',
+        'missing',
+        'Spotify 또는 YouTube Music canonical link가 비어 있습니다.',
+      ),
+    );
   }
 
-  if (detail.youtubeVideoStatus === 'needs_review' || detail.youtubeVideoStatus === 'unresolved') {
-    issues.push('공식 MV 미확정');
+  if (detail.youtubeVideoStatus === 'needs_review') {
+    lines.push(
+      formatCanonicalDisclosureLine(
+        '공식 MV',
+        'review_needed',
+        '후보는 있지만 사람 검토가 아직 끝나지 않았습니다.',
+      ),
+    );
   }
 
-  if (detail.youtubeVideoStatus === 'no_mv') {
-    issues.push('공식 MV 미제공');
+  if (detail.youtubeVideoStatus === 'unresolved') {
+    lines.push(
+      formatCanonicalDisclosureLine(
+        '공식 MV',
+        'unresolved',
+        '채워야 하지만 아직 canonical target을 확정하지 못했습니다.',
+      ),
+    );
   }
 
-  if (issues.length === 0) {
+  if (detail.youtubeVideoStatus === 'no_mv' || detail.youtubeVideoStatus === 'no_link') {
+    lines.push(
+      formatCanonicalDisclosureLine(
+        '공식 MV',
+        'conditional_none',
+        'first-party evidence 기준으로 공식 MV가 없다고 확인된 상태입니다.',
+      ),
+    );
+  }
+
+  if (lines.length === 0) {
     return null;
   }
 
   return {
     title: '외부 링크 및 메타 상태',
-    body: `${issues.join(' / ')}. canonical 링크가 비어 있으면 검색 fallback 또는 상태 안내만 남기고, 없는 정보를 placeholder로 꾸미지 않습니다.`,
+    body: lines.join('\n'),
     testID: 'release-detail-quality-notice',
   };
 }

--- a/mobile/src/selectors/specParity.test.ts
+++ b/mobile/src/selectors/specParity.test.ts
@@ -85,10 +85,10 @@ describe('RN selector spec parity', () => {
     expect(detail?.sourceTimeline).toHaveLength(0);
 
     const disclosure = buildEntitySourceDisclosure(detail!);
-    expect(disclosure?.body).toContain('아티스트 출처');
-    expect(disclosure?.body).toContain('다음 컴백 출처');
-    expect(disclosure?.body).toContain('최신 발매 출처');
-    expect(disclosure?.body).toContain('소스 타임라인');
+    expect(disclosure?.body).toContain('아티스트 출처 · 미기재');
+    expect(disclosure?.body).toContain('다음 컴백 출처 · 미기재');
+    expect(disclosure?.body).toContain('최신 발매 출처 · 미기재');
+    expect(disclosure?.body).toContain('소스 타임라인 · 미해결');
   });
 
   test('keeps title-track and MV/service-link states explicit for release detail binding', () => {
@@ -118,8 +118,8 @@ describe('RN selector spec parity', () => {
     expect(sparse?.youtubeVideoStatus).toBe('no_mv');
 
     const disclosure = buildReleaseDependencyDisclosure(sparse!);
-    expect(disclosure?.body).toContain('트랙 메타데이터 미완료');
-    expect(disclosure?.body).toContain('음원 서비스 링크 일부 누락');
-    expect(disclosure?.body).toContain('공식 MV 미제공');
+    expect(disclosure?.body).toContain('트랙 메타데이터 · 미기재');
+    expect(disclosure?.body).toContain('음원 서비스 링크 · 미기재');
+    expect(disclosure?.body).toContain('공식 MV · 조건부 없음');
   });
 });

--- a/mobile/src/services/backendDisplayAdapters.ts
+++ b/mobile/src/services/backendDisplayAdapters.ts
@@ -446,6 +446,7 @@ export function adaptBackendReleaseDetail(data: BackendReleaseDetailData): Relea
       data.mv?.status === 'relation_match' ||
       data.mv?.status === 'manual_override' ||
       data.mv?.status === 'needs_review' ||
+      data.mv?.status === 'no_link' ||
       data.mv?.status === 'no_mv' ||
       data.mv?.status === 'unresolved'
         ? data.mv.status

--- a/mobile/src/types/displayModels.ts
+++ b/mobile/src/types/displayModels.ts
@@ -4,7 +4,13 @@ export type UpcomingDatePrecision = 'exact' | 'month_only' | 'unknown';
 export type UpcomingStatus = 'scheduled' | 'confirmed' | 'rumor';
 export type UpcomingConfidence = 'low' | 'medium' | 'high';
 export type UpcomingSourceType = 'agency_notice' | 'weverse_notice' | 'official_social' | 'news_rss' | 'database' | 'pending';
-export type YoutubeVideoStatus = 'relation_match' | 'manual_override' | 'needs_review' | 'no_mv' | 'unresolved';
+export type YoutubeVideoStatus =
+  | 'relation_match'
+  | 'manual_override'
+  | 'needs_review'
+  | 'no_link'
+  | 'no_mv'
+  | 'unresolved';
 export type TeamActType = 'group' | 'solo' | 'unit' | 'project';
 
 export interface TeamBadge {

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -2857,6 +2857,14 @@
   line-height: 1.55;
 }
 
+.status-disclosure {
+  gap: 10px;
+}
+
+.team-status-disclosure {
+  margin-top: 16px;
+}
+
 .track-row {
   display: grid;
   gap: 10px;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -147,7 +147,7 @@ type ReleaseDetailRow = {
   youtube_music_url: string | null
   youtube_video_id: string | null
   youtube_video_url?: string | null
-  youtube_video_status?: 'relation_match' | 'manual_override' | 'needs_review' | 'no_mv' | 'unresolved'
+  youtube_video_status?: 'relation_match' | 'manual_override' | 'needs_review' | 'no_link' | 'no_mv' | 'unresolved'
   youtube_video_provenance?: string | null
   notes: string
 }
@@ -751,6 +751,13 @@ type TeamProfile = {
   annualReleaseTimeline: AnnualReleaseTimelineSection[]
   changeLog: ReleaseChangeLogRow[]
   nextUpcomingSignal: UpcomingCandidateRow | null
+}
+
+type CanonicalDisclosureStatus = 'missing' | 'unresolved' | 'review_needed' | 'conditional_none'
+
+type CanonicalSurfaceDisclosure = {
+  title: string
+  lines: string[]
 }
 
 type DashboardSortDirection = 'asc' | 'desc'
@@ -2888,6 +2895,21 @@ function App() {
               ) : null}
             </div>
             <p className="team-footnote">{teamCopy.footnote}</p>
+            {(() => {
+              const teamStatusDisclosure = buildTeamCanonicalStatusDisclosure(selectedTeam, language)
+              if (!teamStatusDisclosure) {
+                return null
+              }
+
+              return (
+                <div className="tracklist-incomplete status-disclosure team-status-disclosure">
+                  <strong>{teamStatusDisclosure.title}</strong>
+                  {teamStatusDisclosure.lines.map((line) => (
+                    <p key={line}>{line}</p>
+                  ))}
+                </div>
+              )
+            })()}
           </section>
 
           <CompareTeamView
@@ -3682,6 +3704,7 @@ function ReleaseDetailPage({
   const mv = getReleaseDetailMvUrls(releaseDetail)
   const primaryTitleTrack = getPrimaryTitleTrackTitle(releaseDetail) || album.title
   const mvSearchUrl = mv.canonicalUrl ? '' : buildYouTubeMvSearchUrl(`${group} ${primaryTitleTrack}`.trim())
+  const releaseStatusDisclosure = buildReleaseCanonicalStatusDisclosure(releaseDetail, language)
   const releaseDetailSourceStatus = {
     source: releaseDetailResource.source,
     errorCode: releaseDetailResource.loading ? null : releaseDetailResource.errorCode,
@@ -3795,6 +3818,17 @@ function ReleaseDetailPage({
             </div>
           )}
         </section>
+
+        {releaseStatusDisclosure ? (
+          <section className="track-preview">
+            <p className="panel-label">{releaseStatusDisclosure.title}</p>
+            <div className="tracklist-incomplete status-disclosure">
+              {releaseStatusDisclosure.lines.map((line) => (
+                <p key={line}>{line}</p>
+              ))}
+            </div>
+          </section>
+        ) : null}
 
         {releaseDetail.notes ? (
           <section className="track-preview">
@@ -6808,6 +6842,190 @@ function getReleaseDetailMvUrls(detail: Pick<ReleaseDetailRow, 'youtube_video_id
   }
 }
 
+function formatCanonicalDisclosureStatusLabel(status: CanonicalDisclosureStatus, language: Language) {
+  if (language === 'ko') {
+    switch (status) {
+      case 'missing':
+        return '미기재'
+      case 'unresolved':
+        return '미해결'
+      case 'review_needed':
+        return '검토 필요'
+      case 'conditional_none':
+        return '조건부 없음'
+    }
+  }
+
+  switch (status) {
+    case 'missing':
+      return 'Missing'
+    case 'unresolved':
+      return 'Unresolved'
+    case 'review_needed':
+      return 'Review needed'
+    case 'conditional_none':
+      return 'Conditional none'
+  }
+}
+
+function formatCanonicalDisclosureLine(
+  subject: string,
+  status: CanonicalDisclosureStatus,
+  detail: string,
+  language: Language,
+) {
+  return `${subject} · ${formatCanonicalDisclosureStatusLabel(status, language)}: ${detail}`
+}
+
+function buildTeamCanonicalStatusDisclosure(
+  team: TeamProfile,
+  language: Language,
+): CanonicalSurfaceDisclosure | null {
+  const lines: string[] = []
+
+  if (!team.artistSource) {
+    lines.push(
+      formatCanonicalDisclosureLine(
+        language === 'ko' ? '아티스트 출처' : 'Artist source',
+        'missing',
+        language === 'ko'
+          ? '프로필 기준 source link가 아직 연결되지 않았습니다.'
+          : 'The profile-level source link is not attached yet.',
+        language,
+      ),
+    )
+  }
+
+  if (team.nextUpcomingSignal && !team.nextUpcomingSignal.source_url) {
+    lines.push(
+      formatCanonicalDisclosureLine(
+        language === 'ko' ? '다음 컴백 출처' : 'Next comeback source',
+        'missing',
+        language === 'ko'
+          ? '예정 신호는 보이지만 source link가 아직 붙지 않았습니다.'
+          : 'The upcoming signal exists, but its source link is still missing.',
+        language,
+      ),
+    )
+  }
+
+  if (team.latestRelease && !team.latestRelease.source) {
+    lines.push(
+      formatCanonicalDisclosureLine(
+        language === 'ko' ? '최신 발매 출처' : 'Latest release source',
+        'missing',
+        language === 'ko'
+          ? 'verified release source link가 아직 연결되지 않았습니다.'
+          : 'The verified release source link is not attached yet.',
+        language,
+      ),
+    )
+  }
+
+  if (team.sourceTimeline.length === 0) {
+    lines.push(
+      formatCanonicalDisclosureLine(
+        language === 'ko' ? '소스 타임라인' : 'Source timeline',
+        'unresolved',
+        language === 'ko'
+          ? '예정·발매 근거를 하나의 타임라인으로 아직 묶지 못했습니다.'
+          : 'Scheduled and verified evidence has not been merged into one timeline yet.',
+        language,
+      ),
+    )
+  }
+
+  if (lines.length === 0) {
+    return null
+  }
+
+  return {
+    title: language === 'ko' ? '소스 신뢰도' : 'Source confidence',
+    lines,
+  }
+}
+
+function buildReleaseCanonicalStatusDisclosure(
+  detail: ReleaseDetailRow,
+  language: Language,
+): CanonicalSurfaceDisclosure | null {
+  const lines: string[] = []
+
+  if (detail.tracks.length === 0) {
+    lines.push(
+      formatCanonicalDisclosureLine(
+        language === 'ko' ? '트랙 메타데이터' : 'Track metadata',
+        'missing',
+        language === 'ko'
+          ? '신뢰 가능한 canonical tracklist가 아직 연결되지 않았습니다.'
+          : 'A reliable canonical tracklist is not attached yet.',
+        language,
+      ),
+    )
+  }
+
+  if (!detail.spotify_url || !detail.youtube_music_url) {
+    lines.push(
+      formatCanonicalDisclosureLine(
+        language === 'ko' ? '음원 서비스 링크' : 'Streaming links',
+        'missing',
+        language === 'ko'
+          ? 'Spotify 또는 YouTube Music canonical link가 비어 있습니다.'
+          : 'Spotify or YouTube Music canonical links are still missing.',
+        language,
+      ),
+    )
+  }
+
+  if (detail.youtube_video_status === 'needs_review') {
+    lines.push(
+      formatCanonicalDisclosureLine(
+        language === 'ko' ? '공식 MV' : 'Official MV',
+        'review_needed',
+        language === 'ko'
+          ? '후보는 있지만 사람 검토가 아직 끝나지 않았습니다.'
+          : 'A candidate exists, but human review is still required.',
+        language,
+      ),
+    )
+  }
+
+  if (detail.youtube_video_status === 'unresolved') {
+    lines.push(
+      formatCanonicalDisclosureLine(
+        language === 'ko' ? '공식 MV' : 'Official MV',
+        'unresolved',
+        language === 'ko'
+          ? '채워야 하지만 아직 canonical target을 확정하지 못했습니다.'
+          : 'This should be filled, but the canonical target is still unresolved.',
+        language,
+      ),
+    )
+  }
+
+  if (detail.youtube_video_status === 'no_mv' || detail.youtube_video_status === 'no_link') {
+    lines.push(
+      formatCanonicalDisclosureLine(
+        language === 'ko' ? '공식 MV' : 'Official MV',
+        'conditional_none',
+        language === 'ko'
+          ? 'first-party evidence 기준으로 공식 MV가 없다고 확인된 상태입니다.'
+          : 'First-party evidence confirms that there is no official MV for this release.',
+        language,
+      ),
+    )
+  }
+
+  if (lines.length === 0) {
+    return null
+  }
+
+  return {
+    title: language === 'ko' ? '외부 링크 및 메타 상태' : 'External links and metadata state',
+    lines,
+  }
+}
+
 function getPrimaryTitleTrackTitle(detail: Pick<ReleaseDetailRow, 'tracks'>) {
   return detail.tracks.find((track) => track.is_title_track)?.title ?? ''
 }
@@ -7120,6 +7338,7 @@ function normalizeApiReleaseDetailSnapshot(
     youtubeVideoStatus === 'relation_match' ||
     youtubeVideoStatus === 'manual_override' ||
     youtubeVideoStatus === 'needs_review' ||
+    youtubeVideoStatus === 'no_link' ||
     youtubeVideoStatus === 'no_mv' ||
     youtubeVideoStatus === 'unresolved'
       ? youtubeVideoStatus


### PR DESCRIPTION
## Summary
- align mobile surface disclosures with explicit canonical status labels for missing, unresolved, review-needed, and conditional-none states
- accept backend `no_link` MV status alongside existing `no_mv` handling and reuse the same copy in release detail MV messaging
- add matching web team/release detail disclosure blocks so the same canonical status semantics are exposed consistently across surfaces

Closes #576
