### PR TITLE
Add manual curation bundles for canonical null queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ scheduled automation도 cadence를 둘로 나눠서 운영한다.
 - prioritized service-link gap queues: `backend/reports/service_link_gap_queues.json`
 - title-track cohort gap queue: `backend/reports/title_track_gap_queue.json`
 - entity identity null workbench: `backend/reports/entity_identity_workbench.json`
+- manual curation bundle contract: `docs/specs/backend/manual-curation-bundle-contract.md`
 - parent backend gap audit report: `backend/reports/backend_gap_audit_report.json`, `backend/reports/backend_gap_audit_report.md`
 - report bundle metadata: `backend/reports/report_bundle_metadata.json`
 - backend freshness handoff artifact: `backend/reports/backend_freshness_handoff.json`

--- a/backend/README.md
+++ b/backend/README.md
@@ -580,6 +580,8 @@ scheduled workflow는 두 cadence로 나뉜다.
 - `npm run null:recheck`
 - `npm run null:trend`
 - `npm run gap:workbenches`
+- `npm run curation:export`
+- `npm run curation:import -- --dry-run`
 - `npm run gap:audit`
 - `npm run report:bundle`
 - `python build_backend_json_parity_report.py`
@@ -726,6 +728,9 @@ npm run gap:workbenches
 - `backend/reports/entity_identity_workbench.json`
 - `backend/reports/entity_identity_workbench_entities.csv`
 - `backend/reports/entity_identity_field_queue.csv`
+- `backend/reports/manual_curation_bundle_service_links.json`
+- `backend/reports/manual_curation_bundle_title_tracks.json`
+- `backend/reports/manual_curation_bundle_entity_identity.json`
 - `backend/reports/trusted_upcoming_notification_event_summary.json`
 - `backend/reports/trusted_upcoming_operator_alert_report.md`
 - `backend/reports/backend_gap_audit_report.json`
@@ -735,6 +740,44 @@ npm run gap:workbenches
 
 - `daily_upcoming`: current freshness primary path
 - `catalog_enrichment`: slower historical enrichment path
+
+### Manual curation bundle export/import
+
+gap workbench를 사람이 바로 curate할 수 있는 JSON bundle로 내보내려면:
+
+```bash
+cd backend
+npm run curation:export
+```
+
+기본 출력:
+
+- `backend/reports/manual_curation_bundle_service_links.json`
+- `backend/reports/manual_curation_bundle_title_tracks.json`
+- `backend/reports/manual_curation_bundle_entity_identity.json`
+
+curated bundle을 source-of-truth JSON으로 다시 흡수하려면:
+
+```bash
+cd backend
+npm run curation:import
+```
+
+검증만 하려면:
+
+```bash
+cd backend
+npm run curation:import -- --dry-run
+```
+
+import sink:
+
+- release/service/title metadata: `release_detail_overrides.json`
+- entity identity: `web/src/data/artistProfiles.json`
+
+reviewer trace contract는 아래 문서를 따른다.
+
+- `docs/specs/backend/manual-curation-bundle-contract.md`
 
 3. combined runtime gate report
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -25,6 +25,8 @@
     "runtime:measure": "node ./scripts/measure-read-api-runtime.mjs",
     "worker:cadence": "node ./scripts/build-worker-cadence-report.mjs",
     "gap:workbenches": "node ./scripts/build-canonical-gap-workbenches.mjs",
+    "curation:export": "node ./scripts/build-manual-curation-bundles.mjs",
+    "curation:import": "node ./scripts/import-manual-curation-bundles.mjs",
     "runtime:gate": "node ./scripts/build-runtime-gate-report.mjs",
     "preview:url:sync": "node ./scripts/provision-preview-backend-url.mjs --target preview"
   },

--- a/backend/scripts/build-manual-curation-bundles.mjs
+++ b/backend/scripts/build-manual-curation-bundles.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { buildManualCurationBundles, readJson, writeJson } from './lib/manualCurationBundles.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const BACKEND_DIR = path.resolve(__dirname, '..');
+
+const DEFAULT_SERVICE_LINK_GAP_PATH = path.join(BACKEND_DIR, 'reports', 'service_link_gap_queues.json');
+const DEFAULT_TITLE_TRACK_GAP_PATH = path.join(BACKEND_DIR, 'reports', 'title_track_gap_queue.json');
+const DEFAULT_ENTITY_IDENTITY_GAP_PATH = path.join(BACKEND_DIR, 'reports', 'entity_identity_workbench.json');
+
+const DEFAULT_SERVICE_LINK_BUNDLE_PATH = path.join(BACKEND_DIR, 'reports', 'manual_curation_bundle_service_links.json');
+const DEFAULT_TITLE_TRACK_BUNDLE_PATH = path.join(BACKEND_DIR, 'reports', 'manual_curation_bundle_title_tracks.json');
+const DEFAULT_ENTITY_IDENTITY_BUNDLE_PATH = path.join(BACKEND_DIR, 'reports', 'manual_curation_bundle_entity_identity.json');
+
+function parseArgs(argv) {
+  const options = {
+    serviceLinkGapPath: DEFAULT_SERVICE_LINK_GAP_PATH,
+    titleTrackGapPath: DEFAULT_TITLE_TRACK_GAP_PATH,
+    entityIdentityGapPath: DEFAULT_ENTITY_IDENTITY_GAP_PATH,
+    serviceLinkBundlePath: DEFAULT_SERVICE_LINK_BUNDLE_PATH,
+    titleTrackBundlePath: DEFAULT_TITLE_TRACK_BUNDLE_PATH,
+    entityIdentityBundlePath: DEFAULT_ENTITY_IDENTITY_BUNDLE_PATH,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const value = argv[index];
+    if (value === '--service-link-gap-path') {
+      options.serviceLinkGapPath = path.resolve(BACKEND_DIR, argv[index + 1] ?? '');
+      index += 1;
+      continue;
+    }
+    if (value === '--title-track-gap-path') {
+      options.titleTrackGapPath = path.resolve(BACKEND_DIR, argv[index + 1] ?? '');
+      index += 1;
+      continue;
+    }
+    if (value === '--entity-identity-gap-path') {
+      options.entityIdentityGapPath = path.resolve(BACKEND_DIR, argv[index + 1] ?? '');
+      index += 1;
+      continue;
+    }
+    if (value === '--service-link-bundle-path') {
+      options.serviceLinkBundlePath = path.resolve(BACKEND_DIR, argv[index + 1] ?? '');
+      index += 1;
+      continue;
+    }
+    if (value === '--title-track-bundle-path') {
+      options.titleTrackBundlePath = path.resolve(BACKEND_DIR, argv[index + 1] ?? '');
+      index += 1;
+      continue;
+    }
+    if (value === '--entity-identity-bundle-path') {
+      options.entityIdentityBundlePath = path.resolve(BACKEND_DIR, argv[index + 1] ?? '');
+      index += 1;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${value}`);
+  }
+
+  return options;
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const [serviceLinkGapQueues, titleTrackGapQueue, entityIdentityWorkbench] = await Promise.all([
+    readJson(options.serviceLinkGapPath),
+    readJson(options.titleTrackGapPath),
+    readJson(options.entityIdentityGapPath),
+  ]);
+
+  const bundles = buildManualCurationBundles({
+    serviceLinkGapQueues,
+    titleTrackGapQueue,
+    entityIdentityWorkbench,
+  });
+
+  await Promise.all([
+    writeJson(options.serviceLinkBundlePath, bundles.serviceLink),
+    writeJson(options.titleTrackBundlePath, bundles.titleTrack),
+    writeJson(options.entityIdentityBundlePath, bundles.entityIdentity),
+  ]);
+
+  const summary = {
+    generated_at: new Date().toISOString(),
+    service_link_bundle: {
+      path: path.relative(BACKEND_DIR, options.serviceLinkBundlePath),
+      rows: bundles.serviceLink.rows.length,
+    },
+    title_track_bundle: {
+      path: path.relative(BACKEND_DIR, options.titleTrackBundlePath),
+      rows: bundles.titleTrack.rows.length,
+    },
+    entity_identity_bundle: {
+      path: path.relative(BACKEND_DIR, options.entityIdentityBundlePath),
+      rows: bundles.entityIdentity.rows.length,
+    },
+  };
+
+  console.log(JSON.stringify(summary, null, 2));
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/backend/scripts/import-manual-curation-bundles.mjs
+++ b/backend/scripts/import-manual-curation-bundles.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { applyManualCurationImports, readJson, writeJson } from './lib/manualCurationBundles.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const BACKEND_DIR = path.resolve(__dirname, '..');
+const ROOT_DIR = path.resolve(BACKEND_DIR, '..');
+
+const DEFAULT_SERVICE_LINK_BUNDLE_PATH = path.join(BACKEND_DIR, 'reports', 'manual_curation_bundle_service_links.json');
+const DEFAULT_TITLE_TRACK_BUNDLE_PATH = path.join(BACKEND_DIR, 'reports', 'manual_curation_bundle_title_tracks.json');
+const DEFAULT_ENTITY_IDENTITY_BUNDLE_PATH = path.join(BACKEND_DIR, 'reports', 'manual_curation_bundle_entity_identity.json');
+const DEFAULT_RELEASE_DETAIL_OVERRIDES_PATH = path.join(ROOT_DIR, 'release_detail_overrides.json');
+const DEFAULT_ARTIST_PROFILES_PATH = path.join(ROOT_DIR, 'web', 'src', 'data', 'artistProfiles.json');
+const DEFAULT_SUMMARY_PATH = path.join(BACKEND_DIR, 'reports', 'manual_curation_bundle_import_summary.json');
+
+function parseArgs(argv) {
+  const options = {
+    serviceLinkBundlePath: DEFAULT_SERVICE_LINK_BUNDLE_PATH,
+    titleTrackBundlePath: DEFAULT_TITLE_TRACK_BUNDLE_PATH,
+    entityIdentityBundlePath: DEFAULT_ENTITY_IDENTITY_BUNDLE_PATH,
+    releaseDetailOverridesPath: DEFAULT_RELEASE_DETAIL_OVERRIDES_PATH,
+    artistProfilesPath: DEFAULT_ARTIST_PROFILES_PATH,
+    summaryPath: DEFAULT_SUMMARY_PATH,
+    dryRun: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const value = argv[index];
+    if (value === '--service-link-bundle-path') {
+      options.serviceLinkBundlePath = path.resolve(BACKEND_DIR, argv[index + 1] ?? '');
+      index += 1;
+      continue;
+    }
+    if (value === '--title-track-bundle-path') {
+      options.titleTrackBundlePath = path.resolve(BACKEND_DIR, argv[index + 1] ?? '');
+      index += 1;
+      continue;
+    }
+    if (value === '--entity-identity-bundle-path') {
+      options.entityIdentityBundlePath = path.resolve(BACKEND_DIR, argv[index + 1] ?? '');
+      index += 1;
+      continue;
+    }
+    if (value === '--release-detail-overrides-path') {
+      options.releaseDetailOverridesPath = path.resolve(ROOT_DIR, argv[index + 1] ?? '');
+      index += 1;
+      continue;
+    }
+    if (value === '--artist-profiles-path') {
+      options.artistProfilesPath = path.resolve(ROOT_DIR, argv[index + 1] ?? '');
+      index += 1;
+      continue;
+    }
+    if (value === '--summary-path') {
+      options.summaryPath = path.resolve(BACKEND_DIR, argv[index + 1] ?? '');
+      index += 1;
+      continue;
+    }
+    if (value === '--dry-run') {
+      options.dryRun = true;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${value}`);
+  }
+
+  return options;
+}
+
+async function readOptionalJson(filePath) {
+  try {
+    return await readJson(filePath);
+  } catch (error) {
+    if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
+      return null;
+    }
+    throw error;
+  }
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const [serviceLinkBundle, titleTrackBundle, entityIdentityBundle, releaseDetailOverrides, artistProfiles] = await Promise.all([
+    readOptionalJson(options.serviceLinkBundlePath),
+    readOptionalJson(options.titleTrackBundlePath),
+    readOptionalJson(options.entityIdentityBundlePath),
+    readJson(options.releaseDetailOverridesPath),
+    readJson(options.artistProfilesPath),
+  ]);
+
+  const result = applyManualCurationImports({
+    serviceLinkBundle,
+    titleTrackBundle,
+    entityIdentityBundle,
+    releaseDetailOverrides,
+    artistProfiles,
+  });
+
+  if (!options.dryRun) {
+    await Promise.all([
+      writeJson(options.releaseDetailOverridesPath, result.releaseDetailOverrides),
+      writeJson(options.artistProfilesPath, result.artistProfiles),
+    ]);
+  }
+
+  await writeJson(options.summaryPath, {
+    ...result.summary,
+    dry_run: options.dryRun,
+    service_link_bundle_path: serviceLinkBundle ? path.relative(BACKEND_DIR, options.serviceLinkBundlePath) : null,
+    title_track_bundle_path: titleTrackBundle ? path.relative(BACKEND_DIR, options.titleTrackBundlePath) : null,
+    entity_identity_bundle_path: entityIdentityBundle ? path.relative(BACKEND_DIR, options.entityIdentityBundlePath) : null,
+    release_detail_overrides_path: path.relative(ROOT_DIR, options.releaseDetailOverridesPath),
+    artist_profiles_path: path.relative(ROOT_DIR, options.artistProfilesPath),
+  });
+
+  console.log(
+    JSON.stringify(
+      {
+        ...result.summary,
+        dry_run: options.dryRun,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/backend/scripts/lib/manualCurationBundles.mjs
+++ b/backend/scripts/lib/manualCurationBundles.mjs
@@ -1,0 +1,734 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+export const MANUAL_CURATION_BUNDLE_VERSION = 1;
+
+export const SERVICE_LINK_DECISIONS = ['set_manual_override', 'mark_no_link', 'mark_review_needed', 'skip'];
+export const TITLE_TRACK_DECISIONS = ['set_manual_override', 'mark_review_needed', 'mark_unresolved', 'skip'];
+export const ENTITY_IDENTITY_DECISIONS = ['set_value', 'keep_unresolved', 'skip'];
+
+const IDENTITY_FIELD_MAP = {
+  'entities.representative_image': {
+    profileKey: 'representative_image_url',
+    sourceKey: 'representative_image_source',
+    valueType: 'url',
+  },
+  'entities.official_youtube': {
+    profileKey: 'official_youtube_url',
+    sourceKey: 'official_youtube_source',
+    valueType: 'url',
+  },
+  'entities.official_x': {
+    profileKey: 'official_x_url',
+    sourceKey: 'official_x_source',
+    valueType: 'url',
+  },
+  'entities.official_instagram': {
+    profileKey: 'official_instagram_url',
+    sourceKey: 'official_instagram_source',
+    valueType: 'url',
+  },
+  'entities.agency_name': {
+    profileKey: 'agency',
+    sourceKey: 'agency_source',
+    valueType: 'text',
+  },
+  'entities.debut_year': {
+    profileKey: 'debut_year',
+    sourceKey: 'debut_year_source',
+    valueType: 'integer',
+  },
+};
+
+const SERVICE_FIELD_MAP = {
+  spotify: {
+    urlKey: 'spotify_url',
+    statusKey: 'spotify_status',
+    provenanceKey: 'spotify_provenance',
+    reviewReasonKey: 'spotify_review_reason',
+    noLinkStatus: 'no_link',
+  },
+  youtube_music: {
+    urlKey: 'youtube_music_url',
+    statusKey: 'youtube_music_status',
+    provenanceKey: 'youtube_music_provenance',
+    reviewReasonKey: 'youtube_music_review_reason',
+    noLinkStatus: 'no_link',
+  },
+  youtube_mv: {
+    urlKey: 'youtube_video_url',
+    idKey: 'youtube_video_id',
+    statusKey: 'youtube_video_status',
+    provenanceKey: 'youtube_video_provenance',
+    reviewReasonKey: 'youtube_video_review_reason',
+    noLinkStatus: 'no_mv',
+  },
+};
+
+function toIsoString(value) {
+  const parsed = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return new Date().toISOString();
+  }
+  return parsed.toISOString();
+}
+
+function cleanString(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function normalizeOptionalText(value) {
+  const normalized = cleanString(value);
+  return normalized.length > 0 ? normalized : null;
+}
+
+function isValidHttpUrl(value) {
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function normalizeOptionalUrl(value) {
+  const normalized = normalizeOptionalText(value);
+  if (normalized === null) {
+    return null;
+  }
+  return isValidHttpUrl(normalized) ? normalized : null;
+}
+
+function normalizeTitleArray(value) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  const seen = new Set();
+  const results = [];
+  for (const item of value) {
+    const normalized = normalizeOptionalText(item);
+    if (normalized && !seen.has(normalized)) {
+      seen.add(normalized);
+      results.push(normalized);
+    }
+  }
+  return results;
+}
+
+function buildPendingCuration({ value = null, values = null } = {}) {
+  return {
+    decision: null,
+    value,
+    values,
+    provenance: null,
+    reviewer: null,
+    reviewed_at: null,
+    notes: null,
+  };
+}
+
+function buildBundleEnvelope({ fieldFamily, generatedAt, sourceArtifact, summaryCounts, allowedDecisions, rows }) {
+  return {
+    bundle_version: MANUAL_CURATION_BUNDLE_VERSION,
+    bundle_kind: 'manual_curation_bundle',
+    field_family: fieldFamily,
+    generated_at: toIsoString(generatedAt),
+    source_artifact: sourceArtifact,
+    allowed_decisions: allowedDecisions,
+    summary: summaryCounts,
+    rows,
+  };
+}
+
+function buildTraceEntry({ bundle, bundleRow, fieldFamilyKey, decision, value, values, provenance, reviewer, reviewedAt, notes }) {
+  return {
+    bundle_field_family: bundle.field_family,
+    bundle_version: bundle.bundle_version,
+    bundle_generated_at: bundle.generated_at,
+    bundle_row_key: bundleRow.bundle_row_key,
+    field_family_key: fieldFamilyKey,
+    decision,
+    value: value ?? null,
+    values: values ?? null,
+    provenance: provenance ?? null,
+    reviewer,
+    reviewed_at: reviewedAt,
+    notes: notes ?? null,
+    imported_at: new Date().toISOString(),
+  };
+}
+
+function ensureTraceArray(target) {
+  if (!Array.isArray(target.manual_curation_traces)) {
+    target.manual_curation_traces = [];
+  }
+  return target.manual_curation_traces;
+}
+
+function findOrCreateReleaseOverride(overrides, target) {
+  const existing = overrides.find(
+    (row) =>
+      row.group === target.group &&
+      row.release_title === target.release_title &&
+      row.release_date === target.release_date &&
+      row.stream === target.stream,
+  );
+  if (existing) {
+    return { row: existing, created: false };
+  }
+  const createdRow = {
+    group: target.group,
+    release_title: target.release_title,
+    release_date: target.release_date,
+    stream: target.stream,
+  };
+  overrides.push(createdRow);
+  return { row: createdRow, created: true };
+}
+
+function findEntityProfile(profiles, slug) {
+  return profiles.find((row) => row.slug === slug) ?? null;
+}
+
+function extractYoutubeVideoId(value) {
+  const normalized = normalizeOptionalText(value);
+  if (normalized === null) {
+    return null;
+  }
+  try {
+    const parsed = new URL(normalized);
+    if (parsed.hostname === 'youtu.be') {
+      return normalizeOptionalText(parsed.pathname.split('/').filter(Boolean)[0]);
+    }
+    if (parsed.hostname.endsWith('youtube.com')) {
+      if (parsed.pathname === '/watch') {
+        return normalizeOptionalText(parsed.searchParams.get('v'));
+      }
+      if (parsed.pathname.startsWith('/shorts/')) {
+        return normalizeOptionalText(parsed.pathname.split('/').filter(Boolean)[1]);
+      }
+      if (parsed.pathname.startsWith('/embed/')) {
+        return normalizeOptionalText(parsed.pathname.split('/').filter(Boolean)[1]);
+      }
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function buildServiceLinkBundle(serviceLinkGapQueues, generatedAt = new Date()) {
+  const rows = [];
+  for (const [serviceType, queueRows] of Object.entries(serviceLinkGapQueues.queues ?? {})) {
+    for (const row of queueRows) {
+      rows.push({
+        bundle_row_key: row.queue_key,
+        field_family_key: `release_service_links.${serviceType}`,
+        target: {
+          group: row.group,
+          slug: row.slug,
+          release_title: row.release_title,
+          release_date: row.release_date,
+          stream: row.stream,
+          service_type: serviceType,
+        },
+        context: {
+          entity_type: row.entity_type,
+          entity_tier: row.entity_tier,
+          priority_tier: row.priority_tier,
+          release_kind: row.release_kind,
+          release_cohort: row.release_cohort,
+          review_reason: row.review_reason,
+          recommended_action: row.recommended_action,
+          suggested_search_query: row.suggested_search_query,
+          mv_allowlist_urls: row.mv_allowlist_urls ?? [],
+        },
+        current_state: {
+          status: row.current_status,
+          url: normalizeOptionalUrl(row.current_url),
+          provenance: normalizeOptionalText(row.provenance),
+        },
+        curation: buildPendingCuration(),
+      });
+    }
+  }
+  return buildBundleEnvelope({
+    fieldFamily: 'service_link',
+    generatedAt,
+    sourceArtifact: 'backend/reports/service_link_gap_queues.json',
+    summaryCounts: serviceLinkGapQueues.counts ?? {},
+    allowedDecisions: SERVICE_LINK_DECISIONS,
+    rows,
+  });
+}
+
+function buildTitleTrackBundle(titleTrackGapQueue, generatedAt = new Date()) {
+  const rows = (titleTrackGapQueue.rows ?? []).map((row) => ({
+    bundle_row_key: row.queue_key,
+    field_family_key: 'release_detail.title_tracks',
+    target: {
+      group: row.group,
+      slug: row.slug,
+      release_title: row.release_title,
+      release_date: row.release_date,
+      stream: row.stream,
+    },
+    context: {
+      entity_type: row.entity_type,
+      entity_tier: row.entity_tier,
+      priority_tier: row.priority_tier,
+      release_kind: row.release_kind,
+      release_cohort: row.release_cohort,
+      track_titles: row.track_titles ?? [],
+      candidate_titles: row.candidate_titles ?? [],
+      candidate_sources: row.candidate_sources ?? [],
+      review_reason: row.review_reason,
+      recommended_action: row.recommended_action,
+      double_title_candidate: row.double_title_candidate ?? false,
+    },
+    current_state: {
+      status: row.title_track_status,
+      values: [],
+      provenance: null,
+    },
+    curation: buildPendingCuration({ values: [] }),
+  }));
+
+  return buildBundleEnvelope({
+    fieldFamily: 'title_track',
+    generatedAt,
+    sourceArtifact: 'backend/reports/title_track_gap_queue.json',
+    summaryCounts: titleTrackGapQueue.counts ?? {},
+    allowedDecisions: TITLE_TRACK_DECISIONS,
+    rows,
+  });
+}
+
+function buildEntityIdentityBundle(entityIdentityWorkbench, generatedAt = new Date()) {
+  const entityBySlug = new Map((entityIdentityWorkbench.entities ?? []).map((row) => [row.slug, row]));
+  const rows = (entityIdentityWorkbench.field_queue ?? []).map((row) => {
+    const entityRow = entityBySlug.get(row.slug) ?? null;
+    return {
+      bundle_row_key: row.queue_key,
+      field_family_key: row.field_family_key,
+      target: {
+        group: row.group,
+        slug: row.slug,
+        field_family_key: row.field_family_key,
+      },
+      context: {
+        entity_type: row.entity_type,
+        entity_tier: row.entity_tier,
+        priority_tier: row.priority_tier,
+        field_label: row.field_label,
+        latest_release_date: entityRow?.latest_release_date ?? null,
+        has_active_upcoming: entityRow?.has_active_upcoming ?? false,
+        identity_critical: row.identity_critical ?? false,
+        candidate_source_hints: row.candidate_source_hints ?? [],
+        entity_missing_fields: entityRow?.missing_fields ?? [],
+        recommended_action: row.recommended_action,
+      },
+      current_state: {
+        status: row.current_status,
+        value: null,
+        provenance: null,
+      },
+      curation: buildPendingCuration(),
+    };
+  });
+
+  return buildBundleEnvelope({
+    fieldFamily: 'entity_identity',
+    generatedAt,
+    sourceArtifact: 'backend/reports/entity_identity_workbench.json',
+    summaryCounts: entityIdentityWorkbench.counts ?? {},
+    allowedDecisions: ENTITY_IDENTITY_DECISIONS,
+    rows,
+  });
+}
+
+export function buildManualCurationBundles({
+  serviceLinkGapQueues,
+  titleTrackGapQueue,
+  entityIdentityWorkbench,
+  generatedAt = new Date(),
+}) {
+  return {
+    serviceLink: buildServiceLinkBundle(serviceLinkGapQueues, generatedAt),
+    titleTrack: buildTitleTrackBundle(titleTrackGapQueue, generatedAt),
+    entityIdentity: buildEntityIdentityBundle(entityIdentityWorkbench, generatedAt),
+  };
+}
+
+function assertBundleShape(bundle, expectedFamily) {
+  if (!bundle || bundle.bundle_kind !== 'manual_curation_bundle') {
+    throw new Error('Manual curation bundle payload is missing bundle_kind=manual_curation_bundle.');
+  }
+  if (bundle.bundle_version !== MANUAL_CURATION_BUNDLE_VERSION) {
+    throw new Error(
+      `Unsupported manual curation bundle version: ${String(bundle.bundle_version)} (expected ${String(
+        MANUAL_CURATION_BUNDLE_VERSION,
+      )}).`,
+    );
+  }
+  if (bundle.field_family !== expectedFamily) {
+    throw new Error(`Expected ${expectedFamily} bundle, received ${String(bundle.field_family)}.`);
+  }
+}
+
+function normalizeReviewedAt(value) {
+  const normalized = normalizeOptionalText(value);
+  if (normalized === null) {
+    return new Date().toISOString();
+  }
+  return toIsoString(normalized);
+}
+
+function applyServiceLinkDecision(overrides, bundle, row, summary) {
+  const curation = row.curation ?? {};
+  const decision = normalizeOptionalText(curation.decision);
+  if (decision === null || decision === 'skip') {
+    summary.service_link.skipped += 1;
+    return;
+  }
+  const reviewer = normalizeOptionalText(curation.reviewer);
+  if (reviewer === null) {
+    throw new Error(`service_link row ${row.bundle_row_key} is missing curation.reviewer.`);
+  }
+
+  const reviewedAt = normalizeReviewedAt(curation.reviewed_at);
+  const serviceType = row.target?.service_type;
+  const config = SERVICE_FIELD_MAP[serviceType];
+  if (!config) {
+    throw new Error(`Unsupported service type for row ${row.bundle_row_key}: ${String(serviceType)}`);
+  }
+
+  const { row: overrideRow, created } = findOrCreateReleaseOverride(overrides, row.target);
+  if (created) {
+    summary.release_detail_overrides.created_rows += 1;
+  }
+  const traces = ensureTraceArray(overrideRow);
+  const provenance = normalizeOptionalText(curation.provenance);
+  const notes = normalizeOptionalText(curation.notes);
+
+  if (decision === 'set_manual_override') {
+    const resolvedUrl = normalizeOptionalUrl(curation.value);
+    if (resolvedUrl === null) {
+      throw new Error(`service_link row ${row.bundle_row_key} requires a valid https url in curation.value.`);
+    }
+    overrideRow[config.urlKey] = resolvedUrl;
+    overrideRow[config.statusKey] = 'manual_override';
+    overrideRow[config.provenanceKey] = provenance;
+    delete overrideRow[config.reviewReasonKey];
+    if (config.idKey) {
+      const resolvedVideoId = extractYoutubeVideoId(resolvedUrl);
+      if (resolvedVideoId) {
+        overrideRow[config.idKey] = resolvedVideoId;
+      } else {
+        delete overrideRow[config.idKey];
+      }
+    }
+    summary.service_link.set_manual_override += 1;
+    traces.push(
+      buildTraceEntry({
+        bundle,
+        bundleRow: row,
+        fieldFamilyKey: row.field_family_key,
+        decision,
+        value: resolvedUrl,
+        provenance,
+        reviewer,
+        reviewedAt,
+        notes,
+      }),
+    );
+    return;
+  }
+
+  if (decision === 'mark_no_link') {
+    delete overrideRow[config.urlKey];
+    if (config.idKey) {
+      delete overrideRow[config.idKey];
+    }
+    overrideRow[config.statusKey] = config.noLinkStatus;
+    overrideRow[config.provenanceKey] = provenance;
+    delete overrideRow[config.reviewReasonKey];
+    summary.service_link.mark_no_link += 1;
+    traces.push(
+      buildTraceEntry({
+        bundle,
+        bundleRow: row,
+        fieldFamilyKey: row.field_family_key,
+        decision,
+        provenance,
+        reviewer,
+        reviewedAt,
+        notes,
+      }),
+    );
+    return;
+  }
+
+  if (decision === 'mark_review_needed') {
+    if (serviceType !== 'youtube_mv') {
+      throw new Error(`service_link row ${row.bundle_row_key} only supports mark_review_needed for youtube_mv.`);
+    }
+    delete overrideRow[config.urlKey];
+    if (config.idKey) {
+      delete overrideRow[config.idKey];
+    }
+    overrideRow[config.statusKey] = 'needs_review';
+    overrideRow[config.provenanceKey] = provenance;
+    overrideRow[config.reviewReasonKey] = notes ?? row.context?.review_reason ?? null;
+    summary.service_link.mark_review_needed += 1;
+    traces.push(
+      buildTraceEntry({
+        bundle,
+        bundleRow: row,
+        fieldFamilyKey: row.field_family_key,
+        decision,
+        provenance,
+        reviewer,
+        reviewedAt,
+        notes,
+      }),
+    );
+    return;
+  }
+
+  throw new Error(`Unsupported service_link decision for row ${row.bundle_row_key}: ${decision}`);
+}
+
+function applyTitleTrackDecision(overrides, bundle, row, summary) {
+  const curation = row.curation ?? {};
+  const decision = normalizeOptionalText(curation.decision);
+  if (decision === null || decision === 'skip') {
+    summary.title_track.skipped += 1;
+    return;
+  }
+  const reviewer = normalizeOptionalText(curation.reviewer);
+  if (reviewer === null) {
+    throw new Error(`title_track row ${row.bundle_row_key} is missing curation.reviewer.`);
+  }
+
+  const reviewedAt = normalizeReviewedAt(curation.reviewed_at);
+  const provenance = normalizeOptionalText(curation.provenance);
+  const notes = normalizeOptionalText(curation.notes);
+  const { row: overrideRow, created } = findOrCreateReleaseOverride(overrides, row.target);
+  if (created) {
+    summary.release_detail_overrides.created_rows += 1;
+  }
+  const traces = ensureTraceArray(overrideRow);
+
+  if (decision === 'set_manual_override') {
+    const titles = normalizeTitleArray(curation.values);
+    if (titles.length === 0) {
+      throw new Error(`title_track row ${row.bundle_row_key} requires curation.values with at least one title.`);
+    }
+    overrideRow.title_tracks = titles;
+    overrideRow.title_track_status = 'manual_override';
+    overrideRow.title_track_provenance = provenance;
+    delete overrideRow.title_track_review_reason;
+    summary.title_track.set_manual_override += 1;
+    traces.push(
+      buildTraceEntry({
+        bundle,
+        bundleRow: row,
+        fieldFamilyKey: row.field_family_key,
+        decision,
+        values: titles,
+        provenance,
+        reviewer,
+        reviewedAt,
+        notes,
+      }),
+    );
+    return;
+  }
+
+  if (decision === 'mark_review_needed' || decision === 'mark_unresolved') {
+    delete overrideRow.title_tracks;
+    overrideRow.title_track_status = decision === 'mark_review_needed' ? 'review' : 'unresolved';
+    overrideRow.title_track_provenance = provenance;
+    overrideRow.title_track_review_reason = notes ?? row.context?.review_reason ?? null;
+    if (decision === 'mark_review_needed') {
+      summary.title_track.mark_review_needed += 1;
+    } else {
+      summary.title_track.mark_unresolved += 1;
+    }
+    traces.push(
+      buildTraceEntry({
+        bundle,
+        bundleRow: row,
+        fieldFamilyKey: row.field_family_key,
+        decision,
+        provenance,
+        reviewer,
+        reviewedAt,
+        notes,
+      }),
+    );
+    return;
+  }
+
+  throw new Error(`Unsupported title_track decision for row ${row.bundle_row_key}: ${decision}`);
+}
+
+function coerceIdentityValue(fieldConfig, value, rowKey) {
+  if (fieldConfig.valueType === 'url') {
+    const normalized = normalizeOptionalUrl(value);
+    if (normalized === null) {
+      throw new Error(`entity_identity row ${rowKey} requires a valid https url in curation.value.`);
+    }
+    return normalized;
+  }
+  if (fieldConfig.valueType === 'integer') {
+    const numericValue = Number(value);
+    if (!Number.isInteger(numericValue) || numericValue < 1800 || numericValue > 2100) {
+      throw new Error(`entity_identity row ${rowKey} requires an integer debut year in curation.value.`);
+    }
+    return numericValue;
+  }
+  const normalized = normalizeOptionalText(value);
+  if (normalized === null) {
+    throw new Error(`entity_identity row ${rowKey} requires a non-empty curation.value.`);
+  }
+  return normalized;
+}
+
+function applyEntityIdentityDecision(artistProfiles, bundle, row, summary) {
+  const curation = row.curation ?? {};
+  const decision = normalizeOptionalText(curation.decision);
+  if (decision === null || decision === 'skip') {
+    summary.entity_identity.skipped += 1;
+    return;
+  }
+
+  const reviewer = normalizeOptionalText(curation.reviewer);
+  if (reviewer === null) {
+    throw new Error(`entity_identity row ${row.bundle_row_key} is missing curation.reviewer.`);
+  }
+  const reviewedAt = normalizeReviewedAt(curation.reviewed_at);
+  const provenance = normalizeOptionalText(curation.provenance);
+  const notes = normalizeOptionalText(curation.notes);
+
+  const profile = findEntityProfile(artistProfiles, row.target?.slug);
+  if (profile === null) {
+    throw new Error(`entity_identity row ${row.bundle_row_key} references unknown slug ${String(row.target?.slug)}.`);
+  }
+  const fieldConfig = IDENTITY_FIELD_MAP[row.field_family_key];
+  if (!fieldConfig) {
+    throw new Error(`Unsupported entity identity field: ${String(row.field_family_key)}`);
+  }
+  const traces = ensureTraceArray(profile);
+
+  if (decision === 'set_value') {
+    const coercedValue = coerceIdentityValue(fieldConfig, curation.value, row.bundle_row_key);
+    profile[fieldConfig.profileKey] = coercedValue;
+    if (fieldConfig.sourceKey) {
+      profile[fieldConfig.sourceKey] = provenance;
+    }
+    summary.entity_identity.set_value += 1;
+    traces.push(
+      buildTraceEntry({
+        bundle,
+        bundleRow: row,
+        fieldFamilyKey: row.field_family_key,
+        decision,
+        value: coercedValue,
+        provenance,
+        reviewer,
+        reviewedAt,
+        notes,
+      }),
+    );
+    return;
+  }
+
+  if (decision === 'keep_unresolved') {
+    summary.entity_identity.keep_unresolved += 1;
+    traces.push(
+      buildTraceEntry({
+        bundle,
+        bundleRow: row,
+        fieldFamilyKey: row.field_family_key,
+        decision,
+        provenance,
+        reviewer,
+        reviewedAt,
+        notes,
+      }),
+    );
+    return;
+  }
+
+  throw new Error(`Unsupported entity_identity decision for row ${row.bundle_row_key}: ${decision}`);
+}
+
+export function applyManualCurationImports({
+  serviceLinkBundle = null,
+  titleTrackBundle = null,
+  entityIdentityBundle = null,
+  releaseDetailOverrides,
+  artistProfiles,
+}) {
+  const summary = {
+    generated_at: new Date().toISOString(),
+    release_detail_overrides: {
+      created_rows: 0,
+    },
+    service_link: {
+      set_manual_override: 0,
+      mark_no_link: 0,
+      mark_review_needed: 0,
+      skipped: 0,
+    },
+    title_track: {
+      set_manual_override: 0,
+      mark_review_needed: 0,
+      mark_unresolved: 0,
+      skipped: 0,
+    },
+    entity_identity: {
+      set_value: 0,
+      keep_unresolved: 0,
+      skipped: 0,
+    },
+  };
+
+  if (serviceLinkBundle) {
+    assertBundleShape(serviceLinkBundle, 'service_link');
+    for (const row of serviceLinkBundle.rows ?? []) {
+      applyServiceLinkDecision(releaseDetailOverrides, serviceLinkBundle, row, summary);
+    }
+  }
+
+  if (titleTrackBundle) {
+    assertBundleShape(titleTrackBundle, 'title_track');
+    for (const row of titleTrackBundle.rows ?? []) {
+      applyTitleTrackDecision(releaseDetailOverrides, titleTrackBundle, row, summary);
+    }
+  }
+
+  if (entityIdentityBundle) {
+    assertBundleShape(entityIdentityBundle, 'entity_identity');
+    for (const row of entityIdentityBundle.rows ?? []) {
+      applyEntityIdentityDecision(artistProfiles, entityIdentityBundle, row, summary);
+    }
+  }
+
+  return {
+    releaseDetailOverrides,
+    artistProfiles,
+    summary,
+  };
+}
+
+export async function readJson(filePath) {
+  return JSON.parse(await readFile(filePath, 'utf8'));
+}
+
+export async function writeJson(filePath, payload) {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+}

--- a/backend/scripts/lib/manualCurationBundles.test.mjs
+++ b/backend/scripts/lib/manualCurationBundles.test.mjs
@@ -1,0 +1,314 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { applyManualCurationImports, buildManualCurationBundles } from './manualCurationBundles.mjs';
+
+test('buildManualCurationBundles exports service, title-track, and entity bundles with pending curation payloads', () => {
+  const bundles = buildManualCurationBundles({
+    serviceLinkGapQueues: {
+      counts: { spotify: { total: 1 }, youtube_music: { total: 0 }, youtube_mv: { total: 0 } },
+      queues: {
+        spotify: [
+          {
+            queue_key: 'release-1:spotify',
+            group: 'YENA',
+            slug: 'yena',
+            release_title: 'Blooming Wings',
+            release_date: '2026-03-11',
+            stream: 'song',
+            entity_type: 'solo',
+            entity_tier: 'core',
+            priority_tier: 'tier_1',
+            release_kind: 'single',
+            release_cohort: 'latest',
+            current_status: 'no_link',
+            current_url: '',
+            provenance: '',
+            review_reason: 'Missing Spotify url.',
+            recommended_action: 'Curate Spotify link.',
+            suggested_search_query: 'YENA Blooming Wings spotify',
+            mv_allowlist_urls: [],
+          },
+        ],
+        youtube_music: [],
+        youtube_mv: [],
+      },
+    },
+    titleTrackGapQueue: {
+      counts: { total: 1 },
+      rows: [
+        {
+          queue_key: 'release-1:title',
+          group: 'YENA',
+          slug: 'yena',
+          release_title: 'Blooming Wings',
+          release_date: '2026-03-11',
+          stream: 'song',
+          entity_type: 'solo',
+          entity_tier: 'core',
+          priority_tier: 'tier_1',
+          release_kind: 'single',
+          release_cohort: 'latest',
+          track_titles: ['Blooming Wings'],
+          candidate_titles: ['Blooming Wings'],
+          candidate_sources: ['release_title_substring'],
+          review_reason: 'Need explicit title-track confirmation.',
+          recommended_action: 'Confirm title track.',
+          double_title_candidate: false,
+          title_track_status: 'review',
+        },
+      ],
+    },
+    entityIdentityWorkbench: {
+      counts: { entities: 1, field_rows: 1 },
+      entities: [
+        {
+          slug: 'yena',
+          latest_release_date: '2026-03-11',
+          has_active_upcoming: true,
+          missing_fields: ['entities.official_youtube'],
+        },
+      ],
+      field_queue: [
+        {
+          queue_key: 'yena:entities.official_youtube',
+          group: 'YENA',
+          slug: 'yena',
+          entity_type: 'solo',
+          entity_tier: 'core',
+          priority_tier: 'tier_1',
+          field_family_key: 'entities.official_youtube',
+          field_label: 'Official YouTube',
+          identity_critical: true,
+          current_status: 'unresolved',
+          candidate_source_hints: ['artist_socials_structured.youtube_url'],
+          recommended_action: 'Curate official YouTube.',
+        },
+      ],
+    },
+    generatedAt: new Date('2026-03-12T00:00:00Z'),
+  });
+
+  assert.equal(bundles.serviceLink.bundle_version, 1);
+  assert.equal(bundles.serviceLink.rows[0].curation.decision, null);
+  assert.equal(bundles.titleTrack.rows[0].curation.values.length, 0);
+  assert.equal(bundles.entityIdentity.rows[0].field_family_key, 'entities.official_youtube');
+});
+
+test('applyManualCurationImports writes release override rows and reviewer traces', () => {
+  const releaseDetailOverrides = [];
+  const artistProfiles = [
+    {
+      slug: 'yena',
+      group: 'YENA',
+      display_name: 'YENA',
+      agency: '',
+      official_youtube_url: '',
+      official_x_url: '',
+      official_instagram_url: '',
+      representative_image_url: null,
+      representative_image_source: null,
+      search_aliases: ['최예나'],
+    },
+  ];
+
+  const serviceLinkBundle = {
+    bundle_version: 1,
+    bundle_kind: 'manual_curation_bundle',
+    field_family: 'service_link',
+    generated_at: '2026-03-12T00:00:00.000Z',
+    rows: [
+      {
+        bundle_row_key: 'release-1:spotify',
+        field_family_key: 'release_service_links.spotify',
+        target: {
+          group: 'YENA',
+          slug: 'yena',
+          release_title: 'Blooming Wings',
+          release_date: '2026-03-11',
+          stream: 'song',
+          service_type: 'spotify',
+        },
+        context: {},
+        current_state: { status: 'no_link', url: null, provenance: null },
+        curation: {
+          decision: 'set_manual_override',
+          value: 'https://open.spotify.com/album/example',
+          values: null,
+          provenance: 'manual curator verified canonical spotify album URL',
+          reviewer: 'gimtaehun',
+          reviewed_at: '2026-03-12T09:00:00+09:00',
+          notes: 'Spotify manual override.',
+        },
+      },
+    ],
+  };
+
+  const titleTrackBundle = {
+    bundle_version: 1,
+    bundle_kind: 'manual_curation_bundle',
+    field_family: 'title_track',
+    generated_at: '2026-03-12T00:00:00.000Z',
+    rows: [
+      {
+        bundle_row_key: 'release-1:title',
+        field_family_key: 'release_detail.title_tracks',
+        target: {
+          group: 'YENA',
+          slug: 'yena',
+          release_title: 'Blooming Wings',
+          release_date: '2026-03-11',
+          stream: 'song',
+        },
+        context: {},
+        current_state: { status: 'review', values: [], provenance: null },
+        curation: {
+          decision: 'set_manual_override',
+          value: null,
+          values: ['Blooming Wings'],
+          provenance: 'official teaser copy',
+          reviewer: 'gimtaehun',
+          reviewed_at: '2026-03-12T09:01:00+09:00',
+          notes: 'Single title track.',
+        },
+      },
+    ],
+  };
+
+  const entityIdentityBundle = {
+    bundle_version: 1,
+    bundle_kind: 'manual_curation_bundle',
+    field_family: 'entity_identity',
+    generated_at: '2026-03-12T00:00:00.000Z',
+    rows: [
+      {
+        bundle_row_key: 'yena:entities.official_youtube',
+        field_family_key: 'entities.official_youtube',
+        target: { group: 'YENA', slug: 'yena', field_family_key: 'entities.official_youtube' },
+        context: {},
+        current_state: { status: 'unresolved', value: null, provenance: null },
+        curation: {
+          decision: 'set_value',
+          value: 'https://www.youtube.com/@YENA_OFFICIAL',
+          values: null,
+          provenance: 'official youtube channel',
+          reviewer: 'gimtaehun',
+          reviewed_at: '2026-03-12T09:02:00+09:00',
+          notes: 'Official channel verified.',
+        },
+      },
+    ],
+  };
+
+  const result = applyManualCurationImports({
+    serviceLinkBundle,
+    titleTrackBundle,
+    entityIdentityBundle,
+    releaseDetailOverrides,
+    artistProfiles,
+  });
+
+  assert.equal(result.releaseDetailOverrides.length, 1);
+  assert.equal(result.releaseDetailOverrides[0].spotify_url, 'https://open.spotify.com/album/example');
+  assert.equal(result.releaseDetailOverrides[0].spotify_status, 'manual_override');
+  assert.deepEqual(result.releaseDetailOverrides[0].title_tracks, ['Blooming Wings']);
+  assert.equal(result.releaseDetailOverrides[0].manual_curation_traces.length, 2);
+  assert.equal(result.artistProfiles[0].official_youtube_url, 'https://www.youtube.com/@YENA_OFFICIAL');
+  assert.equal(result.artistProfiles[0].official_youtube_source, 'official youtube channel');
+  assert.equal(result.artistProfiles[0].manual_curation_traces.length, 1);
+  assert.equal(result.summary.service_link.set_manual_override, 1);
+  assert.equal(result.summary.title_track.set_manual_override, 1);
+  assert.equal(result.summary.entity_identity.set_value, 1);
+});
+
+test('applyManualCurationImports supports explicit no-link and unresolved identity decisions', () => {
+  const releaseDetailOverrides = [
+    {
+      group: 'YENA',
+      release_title: 'Blooming Wings',
+      release_date: '2026-03-11',
+      stream: 'song',
+      youtube_music_url: 'https://music.youtube.com/watch?v=old',
+    },
+  ];
+  const artistProfiles = [
+    {
+      slug: 'yena',
+      group: 'YENA',
+      display_name: 'YENA',
+      official_youtube_url: '',
+      official_x_url: '',
+      official_instagram_url: '',
+      search_aliases: [],
+    },
+  ];
+
+  const serviceLinkBundle = {
+    bundle_version: 1,
+    bundle_kind: 'manual_curation_bundle',
+    field_family: 'service_link',
+    generated_at: '2026-03-12T00:00:00.000Z',
+    rows: [
+      {
+        bundle_row_key: 'release-1:youtube_music',
+        field_family_key: 'release_service_links.youtube_music',
+        target: {
+          group: 'YENA',
+          slug: 'yena',
+          release_title: 'Blooming Wings',
+          release_date: '2026-03-11',
+          stream: 'song',
+          service_type: 'youtube_music',
+        },
+        context: {},
+        current_state: { status: 'no_link', url: null, provenance: null },
+        curation: {
+          decision: 'mark_no_link',
+          value: null,
+          values: null,
+          provenance: 'manual no-link verification',
+          reviewer: 'gimtaehun',
+          reviewed_at: '2026-03-12T09:00:00+09:00',
+          notes: 'No canonical YTM link.',
+        },
+      },
+    ],
+  };
+
+  const entityIdentityBundle = {
+    bundle_version: 1,
+    bundle_kind: 'manual_curation_bundle',
+    field_family: 'entity_identity',
+    generated_at: '2026-03-12T00:00:00.000Z',
+    rows: [
+      {
+        bundle_row_key: 'yena:entities.official_x',
+        field_family_key: 'entities.official_x',
+        target: { group: 'YENA', slug: 'yena', field_family_key: 'entities.official_x' },
+        context: {},
+        current_state: { status: 'unresolved', value: null, provenance: null },
+        curation: {
+          decision: 'keep_unresolved',
+          value: null,
+          values: null,
+          provenance: 'official account not yet opened',
+          reviewer: 'gimtaehun',
+          reviewed_at: '2026-03-12T09:05:00+09:00',
+          notes: 'Keep unresolved.',
+        },
+      },
+    ],
+  };
+
+  const result = applyManualCurationImports({
+    serviceLinkBundle,
+    entityIdentityBundle,
+    releaseDetailOverrides,
+    artistProfiles,
+  });
+
+  assert.equal(result.releaseDetailOverrides[0].youtube_music_status, 'no_link');
+  assert.equal(result.releaseDetailOverrides[0].youtube_music_url, undefined);
+  assert.equal(result.artistProfiles[0].official_x_url, '');
+  assert.equal(result.artistProfiles[0].manual_curation_traces[0].decision, 'keep_unresolved');
+});

--- a/build_backend_json_parity_report.py
+++ b/build_backend_json_parity_report.py
@@ -285,16 +285,36 @@ def build_source_service_link_map(group_to_slug: Dict[str, str]) -> Dict[str, Di
         override = overrides.get(key, {})
         service_rows = {}
 
-        spotify_url = normalize_url(row.get("spotify_url"))
+        spotify_url = normalize_url(override.get("spotify_url") or row.get("spotify_url"))
+        spotify_status = (
+            "manual_override"
+            if normalize_url(override.get("spotify_url"))
+            else optional_text(override.get("spotify_status"))
+            or ("canonical" if normalize_url(row.get("spotify_url")) else "no_link")
+        )
+        spotify_provenance = (
+            optional_text(override.get("spotify_provenance"))
+            or optional_text(override.get("provenance"))
+            or ("releaseDetails.spotify_url" if normalize_url(row.get("spotify_url")) else None)
+        )
         service_rows["spotify"] = {
             "url": spotify_url,
-            "status": "canonical" if spotify_url else "no_link",
-            "provenance": "releaseDetails.spotify_url" if spotify_url else None,
+            "status": spotify_status,
+            "provenance": spotify_provenance,
         }
 
         youtube_music_url = normalize_url(override.get("youtube_music_url") or row.get("youtube_music_url"))
-        youtube_music_status = "manual_override" if normalize_url(override.get("youtube_music_url")) else "canonical" if normalize_url(row.get("youtube_music_url")) else "no_link"
-        youtube_music_provenance = optional_text(override.get("provenance")) if normalize_url(override.get("youtube_music_url")) else "releaseDetails.youtube_music_url" if normalize_url(row.get("youtube_music_url")) else None
+        youtube_music_status = (
+            "manual_override"
+            if normalize_url(override.get("youtube_music_url"))
+            else optional_text(override.get("youtube_music_status"))
+            or ("canonical" if normalize_url(row.get("youtube_music_url")) else "no_link")
+        )
+        youtube_music_provenance = (
+            optional_text(override.get("youtube_music_provenance"))
+            or optional_text(override.get("provenance"))
+            or ("releaseDetails.youtube_music_url" if normalize_url(row.get("youtube_music_url")) else None)
+        )
         service_rows["youtube_music"] = {
             "url": youtube_music_url,
             "status": youtube_music_status,
@@ -343,21 +363,29 @@ def build_source_service_link_map(group_to_slug: Dict[str, str]) -> Dict[str, Di
                 best_match = row
                 best_distance = distance
 
-        spotify_url = normalize_url(best_match.get("spotify_url")) if best_match else None
+        spotify_url = normalize_url(override.get("spotify_url")) or (normalize_url(best_match.get("spotify_url")) if best_match else None)
+        spotify_status = (
+            "manual_override"
+            if normalize_url(override.get("spotify_url"))
+            else optional_text(override.get("spotify_status"))
+            or ("canonical" if best_match and normalize_url(best_match.get("spotify_url")) else "no_link")
+        )
+        spotify_provenance = (
+            optional_text(override.get("spotify_provenance"))
+            or optional_text(override.get("provenance"))
+            or ("releaseDetails.spotify_url" if best_match and normalize_url(best_match.get("spotify_url")) else None)
+        )
         youtube_music_url = normalize_url(override.get("youtube_music_url")) or (normalize_url(best_match.get("youtube_music_url")) if best_match else None)
         youtube_music_status = (
             "manual_override"
             if normalize_url(override.get("youtube_music_url"))
-            else "canonical"
-            if best_match and normalize_url(best_match.get("youtube_music_url"))
-            else "no_link"
+            else optional_text(override.get("youtube_music_status"))
+            or ("canonical" if best_match and normalize_url(best_match.get("youtube_music_url")) else "no_link")
         )
         youtube_music_provenance = (
-            optional_text(override.get("provenance"))
-            if normalize_url(override.get("youtube_music_url"))
-            else "releaseDetails.youtube_music_url"
-            if best_match and normalize_url(best_match.get("youtube_music_url"))
-            else None
+            optional_text(override.get("youtube_music_provenance"))
+            or optional_text(override.get("provenance"))
+            or ("releaseDetails.youtube_music_url" if best_match and normalize_url(best_match.get("youtube_music_url")) else None)
         )
 
         youtube_mv_url = normalize_url(override.get("youtube_video_url"))
@@ -381,8 +409,8 @@ def build_source_service_link_map(group_to_slug: Dict[str, str]) -> Dict[str, Di
         result[key] = {
             "spotify": {
                 "url": spotify_url,
-                "status": "canonical" if spotify_url else "no_link",
-                "provenance": "releaseDetails.spotify_url" if spotify_url else None,
+                "status": spotify_status,
+                "provenance": spotify_provenance,
             },
             "youtube_music": {
                 "url": youtube_music_url,

--- a/build_release_details_musicbrainz.py
+++ b/build_release_details_musicbrainz.py
@@ -793,13 +793,28 @@ def apply_detail_override(
             if detail_note not in detail["notes"]:
                 detail["notes"] += detail_note
 
+        spotify_url = optional_text(override.get("spotify_url"))
+        override_spotify_status = optional_text(override.get("spotify_status"))
+        if spotify_url:
+            detail["spotify_url"] = spotify_url
+            spotify_provenance = optional_text(override.get("spotify_provenance")) or optional_text(override.get("provenance"))
+            if spotify_provenance and spotify_provenance not in detail["notes"]:
+                detail["notes"] += f" Canonical Spotify URL preserved from release_detail_overrides.json ({spotify_provenance})."
+        elif override_spotify_status in {"no_link", "needs_review"}:
+            detail["spotify_url"] = None
+
         youtube_music_url = optional_text(override.get("youtube_music_url"))
+        override_youtube_music_status = optional_text(override.get("youtube_music_status"))
         if youtube_music_url:
             detail["youtube_music_url"] = youtube_music_url
+        elif override_youtube_music_status in {"no_link", "needs_review"}:
+            detail["youtube_music_url"] = None
 
-        provenance = optional_text(override.get("provenance"))
-        if provenance and provenance not in detail["notes"]:
+        provenance = optional_text(override.get("youtube_music_provenance")) or optional_text(override.get("provenance"))
+        if youtube_music_url and provenance and provenance not in detail["notes"]:
             detail["notes"] += f" Canonical YouTube Music URL preserved from release_detail_overrides.json ({provenance})."
+        elif override_youtube_music_status in {"no_link", "needs_review"} and provenance and provenance not in detail["notes"]:
+            detail["notes"] += f" YouTube Music curation status preserved from release_detail_overrides.json ({provenance})."
 
         youtube_video_url = optional_text(override.get("youtube_video_url"))
         youtube_video_id = optional_text(override.get("youtube_video_id"))
@@ -830,6 +845,8 @@ def apply_detail_override(
             )
 
     title_track_titles = override.get("title_tracks") if override else None
+    override_title_track_status = optional_text(override.get("title_track_status")) if override else None
+    override_title_track_review_reason = optional_text(override.get("title_track_review_reason")) if override else None
     existing_title_tracks = [track["title"] for track in detail.get("tracks", []) if track.get("is_title_track")]
     unique_existing_title_tracks = list(dict.fromkeys(existing_title_tracks))
     existing_title_tracks_are_ambiguous = (
@@ -854,6 +871,14 @@ def apply_detail_override(
                 for title in title_track_titles
             ],
             "reason": "Title-track metadata was supplied explicitly from release_detail_overrides.json.",
+        }
+    elif override_title_track_status in {TITLE_TRACK_STATUS_REVIEW, TITLE_TRACK_STATUS_UNRESOLVED, TITLE_TRACK_STATUS_NO_TRACKS}:
+        title_track_resolution = {
+            "status": override_title_track_status,
+            "selected_titles": [],
+            "candidates": [],
+            "reason": override_title_track_review_reason
+            or "Title-track manual curation kept this release unresolved.",
         }
     elif existing_title_tracks and not existing_title_tracks_are_ambiguous:
         title_track_resolution = {

--- a/docs/specs/backend/README.md
+++ b/docs/specs/backend/README.md
@@ -73,7 +73,10 @@
    - daily / weekly / monthly null hygiene cadence와 owner checklist
    - artifact handoff order, escalation rule, review ritual
    - service-link/title-track/entity-identity gap workbench artifact contract
-23. `trusted-upcoming-notification-events.md`
+23. `manual-curation-bundle-contract.md`
+   - gap workbench -> human curation -> source-of-truth re-absorb contract
+   - reviewer trace, field-family decision set, sink mapping
+24. `trusted-upcoming-notification-events.md`
    - trusted upcoming signal -> canonical notification event / operator alert contract
    - fingerprint, dedupe, destination, summary artifact 규칙
 
@@ -101,7 +104,8 @@
 20. `migration-readiness-scorecard.md`
 21. `canonical-null-hygiene-operating-model.md`
 22. `canonical-null-hygiene-cadence.md`
-23. `trusted-upcoming-notification-events.md`
+23. `manual-curation-bundle-contract.md`
+24. `trusted-upcoming-notification-events.md`
 
 ## 원칙
 

--- a/docs/specs/backend/manual-curation-bundle-contract.md
+++ b/docs/specs/backend/manual-curation-bundle-contract.md
@@ -1,0 +1,168 @@
+# Manual Curation Bundle Contract
+
+`#580` 범위의 manual curation bundle은 사람이 unresolved canonical null queue를 받아
+`release_detail_overrides.json` / `artistProfiles.json`에 다시 흡수할 수 있게 만드는
+thin export-import contract다.
+
+## 대상 field family
+
+1. `service_link`
+   - `release_service_links.spotify`
+   - `release_service_links.youtube_music`
+   - `release_service_links.youtube_mv`
+2. `title_track`
+   - `release_detail.title_tracks`
+3. `entity_identity`
+   - `entities.representative_image`
+   - `entities.official_youtube`
+   - `entities.official_x`
+   - `entities.official_instagram`
+   - `entities.agency_name`
+   - `entities.debut_year`
+
+## Export 입력
+
+- `backend/reports/service_link_gap_queues.json`
+- `backend/reports/title_track_gap_queue.json`
+- `backend/reports/entity_identity_workbench.json`
+
+## Export 출력
+
+- `backend/reports/manual_curation_bundle_service_links.json`
+- `backend/reports/manual_curation_bundle_title_tracks.json`
+- `backend/reports/manual_curation_bundle_entity_identity.json`
+
+## 공통 envelope
+
+```json
+{
+  "bundle_version": 1,
+  "bundle_kind": "manual_curation_bundle",
+  "field_family": "service_link",
+  "generated_at": "2026-03-12T00:00:00.000Z",
+  "source_artifact": "backend/reports/service_link_gap_queues.json",
+  "allowed_decisions": ["set_manual_override", "mark_no_link", "mark_review_needed", "skip"],
+  "summary": {},
+  "rows": []
+}
+```
+
+## 공통 row shape
+
+```json
+{
+  "bundle_row_key": "stable queue key",
+  "field_family_key": "release_service_links.youtube_mv",
+  "target": {},
+  "context": {},
+  "current_state": {},
+  "curation": {
+    "decision": null,
+    "value": null,
+    "values": null,
+    "provenance": null,
+    "reviewer": null,
+    "reviewed_at": null,
+    "notes": null
+  }
+}
+```
+
+## Decision contract
+
+### `service_link`
+
+- `set_manual_override`
+  - `curation.value`: canonical URL
+- `mark_no_link`
+  - explicit absence를 고정
+- `mark_review_needed`
+  - `youtube_mv`만 허용
+- `skip`
+
+Sink:
+
+- `release_detail_overrides.json`
+  - `spotify_url`, `spotify_status`, `spotify_provenance`
+  - `youtube_music_url`, `youtube_music_status`, `youtube_music_provenance`
+  - `youtube_video_url`, `youtube_video_id`, `youtube_video_status`, `youtube_video_provenance`
+
+### `title_track`
+
+- `set_manual_override`
+  - `curation.values`: selected title track array
+- `mark_review_needed`
+- `mark_unresolved`
+- `skip`
+
+Sink:
+
+- `release_detail_overrides.json`
+  - `title_tracks`
+  - `title_track_status`
+  - `title_track_provenance`
+  - `title_track_review_reason`
+
+### `entity_identity`
+
+- `set_value`
+  - `curation.value`: field value
+- `keep_unresolved`
+- `skip`
+
+Sink:
+
+- `web/src/data/artistProfiles.json`
+  - `representative_image_url`, `representative_image_source`
+  - `official_youtube_url`, `official_youtube_source`
+  - `official_x_url`, `official_x_source`
+  - `official_instagram_url`, `official_instagram_source`
+  - `agency`, `agency_source`
+  - `debut_year`, `debut_year_source`
+
+## Reviewer trace
+
+import가 실제 값을 흡수하면 target row에 `manual_curation_traces` array를 append한다.
+
+trace entry shape:
+
+```json
+{
+  "bundle_field_family": "service_link",
+  "bundle_version": 1,
+  "bundle_generated_at": "2026-03-12T00:00:00.000Z",
+  "bundle_row_key": "stable queue key",
+  "field_family_key": "release_service_links.youtube_music",
+  "decision": "set_manual_override",
+  "value": "https://music.youtube.com/...",
+  "values": null,
+  "provenance": "official platform url",
+  "reviewer": "gimtaehun",
+  "reviewed_at": "2026-03-12T09:00:00+09:00",
+  "notes": "manual verification",
+  "imported_at": "2026-03-12T00:05:00.000Z"
+}
+```
+
+## 실행 명령
+
+export:
+
+```bash
+cd backend
+npm run curation:export
+```
+
+import:
+
+```bash
+cd backend
+npm run curation:import
+```
+
+dry-run:
+
+```bash
+cd backend
+npm run curation:import -- --dry-run
+```

--- a/import_json_to_neon.py
+++ b/import_json_to_neon.py
@@ -535,17 +535,27 @@ def build_entity_rows(
                 "x_url": normalize_url(profile.get("official_x_url") or watchlist_row.get("x_url")),
                 "instagram_url": normalize_url(profile.get("official_instagram_url") or watchlist_row.get("instagram_url")),
                 "youtube_url": normalize_url(profile.get("official_youtube_url")),
-                "x_provenance": "artistProfiles.official_x_url"
+                "x_provenance": optional_text(profile.get("official_x_source"))
+                if normalize_url(profile.get("official_x_url")) and optional_text(profile.get("official_x_source"))
+                else "artistProfiles.official_x_url"
                 if normalize_url(profile.get("official_x_url"))
                 else "watchlist.x_url"
                 if normalize_url(watchlist_row.get("x_url"))
                 else None,
-                "instagram_provenance": "artistProfiles.official_instagram_url"
+                "instagram_provenance": optional_text(profile.get("official_instagram_source"))
+                if normalize_url(profile.get("official_instagram_url"))
+                and optional_text(profile.get("official_instagram_source"))
+                else "artistProfiles.official_instagram_url"
                 if normalize_url(profile.get("official_instagram_url"))
                 else "watchlist.instagram_url"
                 if normalize_url(watchlist_row.get("instagram_url"))
                 else None,
-                "youtube_provenance": "artistProfiles.official_youtube_url" if normalize_url(profile.get("official_youtube_url")) else None,
+                "youtube_provenance": optional_text(profile.get("official_youtube_source"))
+                if normalize_url(profile.get("official_youtube_url"))
+                and optional_text(profile.get("official_youtube_source"))
+                else "artistProfiles.official_youtube_url"
+                if normalize_url(profile.get("official_youtube_url"))
+                else None,
                 "artist_source_url": metadata.get("artist_source"),
             }
         )
@@ -1028,26 +1038,39 @@ def build_release_service_rows(
         if release_id is None:
             continue
 
+        spotify_url = normalize_url(override.get("spotify_url"))
+        spotify_status = optional_text(override.get("spotify_status"))
+        if spotify_url or spotify_status:
+            add_row(
+                release_id,
+                "spotify",
+                spotify_url,
+                "manual_override" if spotify_url else spotify_status,
+                optional_text(override.get("spotify_provenance")) or optional_text(override.get("provenance")),
+            )
+
         youtube_music_url = normalize_url(override.get("youtube_music_url"))
-        if youtube_music_url:
+        youtube_music_status = optional_text(override.get("youtube_music_status"))
+        if youtube_music_url or youtube_music_status:
             add_row(
                 release_id,
                 "youtube_music",
                 youtube_music_url,
-                "manual_override",
-                optional_text(override.get("provenance")),
+                "manual_override" if youtube_music_url else youtube_music_status,
+                optional_text(override.get("youtube_music_provenance")) or optional_text(override.get("provenance")),
             )
 
         youtube_video_url = normalize_url(override.get("youtube_video_url"))
         youtube_video_id = optional_text(override.get("youtube_video_id"))
+        youtube_video_status = optional_text(override.get("youtube_video_status"))
         if youtube_video_url is None and youtube_video_id:
             youtube_video_url = f"https://www.youtube.com/watch?v={youtube_video_id}"
-        if youtube_video_url or youtube_video_id:
+        if youtube_video_url or youtube_video_id or youtube_video_status:
             add_row(
                 release_id,
                 "youtube_mv",
                 youtube_video_url,
-                "manual_override",
+                "manual_override" if youtube_video_url or youtube_video_id else youtube_video_status,
                 optional_text(override.get("youtube_video_provenance")) or optional_text(override.get("provenance")),
             )
 


### PR DESCRIPTION
## Summary
- add export/import scripts for service-link, title-track, and entity-identity manual curation bundles
- preserve reviewer trace while importing into release_detail_overrides and artistProfiles
- extend release/service/entity provenance handling so imported decisions flow through existing pipelines

Closes #580