### PR TITLE
Fix runtime artifact retention scanner coverage

### DIFF
--- a/backend/reports/backend_gap_audit_report.json
+++ b/backend/reports/backend_gap_audit_report.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-03-11T18:25:43.631Z",
+  "generated_at": "2026-03-11T18:31:21.281Z",
   "parent_issue": {
     "number": 529,
     "url": "https://github.com/iAmSomething/idol-song-app/issues/529",

--- a/backend/reports/backend_gap_audit_report.md
+++ b/backend/reports/backend_gap_audit_report.md
@@ -1,6 +1,6 @@
 # Backend Gap Audit Report
 
-- generated_at: 2026-03-11T18:25:43.631Z
+- generated_at: 2026-03-11T18:31:21.281Z
 - parent_issue: #529
 - closure_recommendation: close_parent_keep_children_open
 

--- a/backend/reports/runtime_artifact_retention_report.json
+++ b/backend/reports/runtime_artifact_retention_report.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-03-11T18:26:28.738Z",
+  "generated_at": "2026-03-11T18:31:21.148Z",
   "retention_policy_version": "v1",
   "scope": {
     "directories": [
@@ -11,7 +11,7 @@
   },
   "summary_lines": [
     "runtime-facing canonical groups: 3",
-    "runtime-facing canonical files: 26",
+    "runtime-facing canonical files: 29",
     "duplicate files detected: 0",
     "retention status: canonical only"
   ],
@@ -19,7 +19,7 @@
     {
       "key": "repo_root_pipeline_scripts",
       "label": "Repo root pipeline scripts",
-      "canonical_count": 9,
+      "canonical_count": 10,
       "duplicate_count": 0,
       "canonical_paths": [
         "build_release_details_musicbrainz.py",
@@ -29,6 +29,7 @@
         "build_release_rollup_from_history.py",
         "build_tracking_watchlist.py",
         "scan_upcoming_candidates.py",
+        "hydrate_release_windows.py",
         "build_canonical_entity_metadata.py",
         "build_release_artwork_catalog.py"
       ],
@@ -38,11 +39,12 @@
     {
       "key": "repo_root_runtime_data",
       "label": "Repo root runtime-facing generated data",
-      "canonical_count": 9,
+      "canonical_count": 10,
       "duplicate_count": 0,
       "canonical_paths": [
         "tracking_watchlist.json",
         "upcoming_release_candidates.json",
+        "upcoming_release_candidates.csv",
         "manual_review_queue.json",
         "manual_review_queue.csv",
         "canonical_entity_metadata.json",
@@ -57,7 +59,7 @@
     {
       "key": "web_runtime_data_exports",
       "label": "Web runtime data exports",
-      "canonical_count": 8,
+      "canonical_count": 9,
       "duplicate_count": 0,
       "canonical_paths": [
         "web/src/data/artistProfiles.json",
@@ -65,6 +67,7 @@
         "web/src/data/releaseDetails.json",
         "web/src/data/releaseHistory.json",
         "web/src/data/releases.json",
+        "web/src/data/unresolved.json",
         "web/src/data/upcomingCandidates.json",
         "web/src/data/watchlist.json",
         "web/src/data/youtubeChannelAllowlists.json"

--- a/backend/reports/runtime_artifact_retention_report.md
+++ b/backend/reports/runtime_artifact_retention_report.md
@@ -1,12 +1,12 @@
 # Runtime Artifact Retention Report
 
-- generated_at: 2026-03-11T18:26:28.738Z
+- generated_at: 2026-03-11T18:31:21.148Z
 - retention_policy_version: v1
 
 ## Summary
 
 - runtime-facing canonical groups: 3
-- runtime-facing canonical files: 26
+- runtime-facing canonical files: 29
 - duplicate files detected: 0
 - retention status: canonical only
 
@@ -18,7 +18,7 @@
 
 ### Repo root pipeline scripts
 
-- canonical_count: 9
+- canonical_count: 10
 - duplicate_count: 0
 - archival_rule: Delete suffix copies from repo root; use docs/assets/distribution or /tmp for comparison outputs.
 - canonical: build_release_details_musicbrainz.py
@@ -28,16 +28,18 @@
 - canonical: build_release_rollup_from_history.py
 - canonical: build_tracking_watchlist.py
 - canonical: scan_upcoming_candidates.py
+- canonical: hydrate_release_windows.py
 - canonical: build_canonical_entity_metadata.py
 - canonical: build_release_artwork_catalog.py
 
 ### Repo root runtime-facing generated data
 
-- canonical_count: 9
+- canonical_count: 10
 - duplicate_count: 0
 - archival_rule: Keep one canonical file per artifact; archive dated evidence in docs/assets/distribution.
 - canonical: tracking_watchlist.json
 - canonical: upcoming_release_candidates.json
+- canonical: upcoming_release_candidates.csv
 - canonical: manual_review_queue.json
 - canonical: manual_review_queue.csv
 - canonical: canonical_entity_metadata.json
@@ -48,7 +50,7 @@
 
 ### Web runtime data exports
 
-- canonical_count: 8
+- canonical_count: 9
 - duplicate_count: 0
 - archival_rule: Suffix copies are forbidden in web/src/data because import/build paths must stay canonical.
 - canonical: web/src/data/artistProfiles.json
@@ -56,6 +58,7 @@
 - canonical: web/src/data/releaseDetails.json
 - canonical: web/src/data/releaseHistory.json
 - canonical: web/src/data/releases.json
+- canonical: web/src/data/unresolved.json
 - canonical: web/src/data/upcomingCandidates.json
 - canonical: web/src/data/watchlist.json
 - canonical: web/src/data/youtubeChannelAllowlists.json

--- a/backend/scripts/lib/runtimeArtifactRetention.mjs
+++ b/backend/scripts/lib/runtimeArtifactRetention.mjs
@@ -14,6 +14,7 @@ export const RUNTIME_ARTIFACT_RETENTION_GROUPS = [
       'build_release_rollup_from_history.py',
       'build_tracking_watchlist.py',
       'scan_upcoming_candidates.py',
+      'hydrate_release_windows.py',
       'build_canonical_entity_metadata.py',
       'build_release_artwork_catalog.py',
     ],
@@ -26,6 +27,7 @@ export const RUNTIME_ARTIFACT_RETENTION_GROUPS = [
     canonical_paths: [
       'tracking_watchlist.json',
       'upcoming_release_candidates.json',
+      'upcoming_release_candidates.csv',
       'manual_review_queue.json',
       'manual_review_queue.csv',
       'canonical_entity_metadata.json',
@@ -46,6 +48,7 @@ export const RUNTIME_ARTIFACT_RETENTION_GROUPS = [
       'web/src/data/releaseDetails.json',
       'web/src/data/releaseHistory.json',
       'web/src/data/releases.json',
+      'web/src/data/unresolved.json',
       'web/src/data/upcomingCandidates.json',
       'web/src/data/watchlist.json',
       'web/src/data/youtubeChannelAllowlists.json',
@@ -54,18 +57,16 @@ export const RUNTIME_ARTIFACT_RETENTION_GROUPS = [
   },
 ];
 
-function buildCanonicalIndex(repoDir) {
+function buildGroupCanonicalIndex(repoDir, group) {
   const index = new Map();
-  for (const group of RUNTIME_ARTIFACT_RETENTION_GROUPS) {
-    for (const relativePath of group.canonical_paths) {
-      const absolutePath = path.join(repoDir, relativePath);
-      index.set(absolutePath, {
-        group_key: group.key,
-        group_label: group.label,
-        canonical_path: relativePath,
-        archival_rule: group.archival_rule,
-      });
-    }
+  for (const relativePath of group.canonical_paths) {
+    const absolutePath = path.join(repoDir, relativePath);
+    index.set(absolutePath, {
+      group_key: group.key,
+      group_label: group.label,
+      canonical_path: relativePath,
+      archival_rule: group.archival_rule,
+    });
   }
   return index;
 }
@@ -84,11 +85,11 @@ function parseDuplicateName(entryName) {
 }
 
 export async function collectRuntimeArtifactDuplicates(repoDir) {
-  const canonicalIndex = buildCanonicalIndex(repoDir);
   const duplicates = [];
 
   for (const group of RUNTIME_ARTIFACT_RETENTION_GROUPS) {
     const directoryPath = path.join(repoDir, group.directory);
+    const canonicalIndex = buildGroupCanonicalIndex(repoDir, group);
     const entries = await readdir(directoryPath, { withFileTypes: true });
     for (const entry of entries) {
       if (!entry.isFile()) {
@@ -115,7 +116,15 @@ export async function collectRuntimeArtifactDuplicates(repoDir) {
     }
   }
 
-  return duplicates.sort((left, right) => left.duplicate_path.localeCompare(right.duplicate_path));
+  return duplicates
+    .filter(
+      (entry, index, array) =>
+        array.findIndex(
+          (candidate) =>
+            candidate.duplicate_path === entry.duplicate_path && candidate.canonical_path === entry.canonical_path,
+        ) === index,
+    )
+    .sort((left, right) => left.duplicate_path.localeCompare(right.duplicate_path));
 }
 
 export function buildRuntimeArtifactRetentionReport({ duplicates }) {

--- a/backend/scripts/lib/runtimeArtifactRetention.test.mjs
+++ b/backend/scripts/lib/runtimeArtifactRetention.test.mjs
@@ -1,8 +1,12 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import os from 'node:os';
+import path from 'node:path';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 
 import {
   buildRuntimeArtifactRetentionReport,
+  collectRuntimeArtifactDuplicates,
   renderRuntimeArtifactRetentionMarkdown,
 } from './runtimeArtifactRetention.mjs';
 
@@ -56,4 +60,47 @@ test('renderRuntimeArtifactRetentionMarkdown renders duplicate inventory and can
   assert.match(markdown, /# Runtime Artifact Retention Report/);
   assert.match(markdown, /\| web\/src\/data\/releaseArtwork 2\.json \| web\/src\/data\/releaseArtwork\.json \| Web runtime data exports \| delete_duplicate \|/);
   assert.match(markdown, /## Canonical Groups/);
+});
+
+test('collectRuntimeArtifactDuplicates scans each canonical group once and covers expanded runtime paths', async () => {
+  const repoDir = await mkdtemp(path.join(os.tmpdir(), 'idol-runtime-artifacts-'));
+  try {
+    await mkdir(path.join(repoDir, 'web', 'src', 'data'), { recursive: true });
+
+    const filesToCreate = [
+      'build_manual_review_queue.py',
+      'build_manual_review_queue 2.py',
+      'hydrate_release_windows.py',
+      'hydrate_release_windows 2.py',
+      'manual_review_queue.json',
+      'manual_review_queue 2.json',
+      'upcoming_release_candidates.csv',
+      'upcoming_release_candidates 2.csv',
+      'web/src/data/unresolved.json',
+      'web/src/data/unresolved 2.json',
+      'web/src/data/watchlist.json',
+      'web/src/data/watchlist 2.json',
+    ];
+
+    await Promise.all(
+      filesToCreate.map((relativePath) =>
+        writeFile(path.join(repoDir, relativePath), '{}\n', 'utf8'),
+      ),
+    );
+
+    const duplicates = await collectRuntimeArtifactDuplicates(repoDir);
+    assert.deepEqual(
+      duplicates.map((entry) => entry.duplicate_path),
+      [
+        'build_manual_review_queue 2.py',
+        'hydrate_release_windows 2.py',
+        'manual_review_queue 2.json',
+        'upcoming_release_candidates 2.csv',
+        'web/src/data/unresolved 2.json',
+        'web/src/data/watchlist 2.json',
+      ],
+    );
+  } finally {
+    await rm(repoDir, { recursive: true, force: true });
+  }
 });

--- a/docs/assets/distribution/backend_runtime_artifact_retention_local_2026-03-12.md
+++ b/docs/assets/distribution/backend_runtime_artifact_retention_local_2026-03-12.md
@@ -4,6 +4,7 @@
 
 - close `#540`
 - replace hard-coded duplicate artifact detection with a real scanner
+- remove scanner double-counting in repo-root groups and widen runtime-facing canonical scope
 - document canonical retention policy for runtime-facing JSON / pipeline scripts
 - remove in-scope suffix duplicates from canonical runtime-facing paths
 
@@ -32,5 +33,6 @@ git diff --check
 ## Notes
 
 - gap audit now reads the runtime artifact scanner instead of a hard-coded file list.
+- scanner now covers `hydrate_release_windows.py`, `upcoming_release_candidates.csv`, and `web/src/data/unresolved.json`.
 - canonical retention policy is documented in `docs/specs/backend/runtime-artifact-retention-policy.md`.
 - scope intentionally excludes mobile asset/doc duplicates and user scratch files outside runtime-facing import/build paths.

--- a/docs/specs/backend/runtime-artifact-retention-policy.md
+++ b/docs/specs/backend/runtime-artifact-retention-policy.md
@@ -26,6 +26,7 @@ mobile asset draft, docs scratch copy, 개인 메모는 이 정책의 직접 대
 - `build_release_rollup_from_history.py`
 - `build_tracking_watchlist.py`
 - `scan_upcoming_candidates.py`
+- `hydrate_release_windows.py`
 - `build_canonical_entity_metadata.py`
 - `build_release_artwork_catalog.py`
 
@@ -33,6 +34,7 @@ mobile asset draft, docs scratch copy, 개인 메모는 이 정책의 직접 대
 
 - `tracking_watchlist.json`
 - `upcoming_release_candidates.json`
+- `upcoming_release_candidates.csv`
 - `manual_review_queue.json`
 - `manual_review_queue.csv`
 - `canonical_entity_metadata.json`
@@ -48,6 +50,7 @@ mobile asset draft, docs scratch copy, 개인 메모는 이 정책의 직접 대
 - `web/src/data/releaseDetails.json`
 - `web/src/data/releaseHistory.json`
 - `web/src/data/releases.json`
+- `web/src/data/unresolved.json`
 - `web/src/data/upcomingCandidates.json`
 - `web/src/data/watchlist.json`
 - `web/src/data/youtubeChannelAllowlists.json`


### PR DESCRIPTION
## Summary\n- remove duplicate counting in the runtime artifact retention scanner\n- extend canonical runtime-facing coverage to hydrate/upcoming CSV/unresolved exports\n- refresh retention and gap audit artifacts with the corrected inventory\n\nRefs #540