### PR TITLE
Debounce mobile backend search requests during typing

### DIFF
--- a/docs/assets/distribution/mobile_search_debounce_local_2026-03-12.md
+++ b/docs/assets/distribution/mobile_search_debounce_local_2026-03-12.md
@@ -1,0 +1,26 @@
+# Mobile Search Debounce Local Verification
+
+- Date: 2026-03-12
+- Issue: #618
+
+## Summary
+
+- Added a reusable `useDebouncedValue` hook for backend-primary search reads.
+- Mobile search now debounces non-empty query changes for backend-primary mode only.
+- Empty query clears immediately, and bundled/local mode remains immediate.
+
+## Verification
+
+- `cd mobile && npm test -- --runInBand src/hooks/useDebouncedValue.test.tsx src/features/searchTab.test.tsx`
+- `cd mobile && npm run typecheck`
+- `cd mobile && npm run lint`
+- `git diff --check`
+
+## Notes
+
+- Search tab regression stayed green with the current non-backend test runtime.
+- The debounce hook regression covers:
+  - initial render immediate
+  - delayed non-empty updates when enabled
+  - immediate clear on empty query
+  - disabled mode immediate updates

--- a/mobile/app/(tabs)/search.tsx
+++ b/mobile/app/(tabs)/search.tsx
@@ -18,6 +18,7 @@ import {
   InlineFeedbackNotice,
   ScreenFeedbackState,
 } from '../../src/components/feedback/FeedbackState';
+import { getRuntimeConfigState } from '../../src/config/runtime';
 import { TeamIdentityRow } from '../../src/components/identity/TeamIdentityRow';
 import { AppBar } from '../../src/components/layout/AppBar';
 import { SourceLinkRow } from '../../src/components/meta/SourceLinkRow';
@@ -69,6 +70,7 @@ import {
   runWithPendingRouteResume,
   type RouteResumeTarget,
 } from '../../src/services/routeResume';
+import { useDebouncedValue } from '../../src/hooks/useDebouncedValue';
 import { useOptionalSafeAreaInsets } from '../../src/hooks/useOptionalSafeAreaInsets';
 import { MOBILE_TEXT_SCALE_LIMITS } from '../../src/tokens/accessibility';
 import { useAppTheme } from '../../src/tokens/theme';
@@ -231,12 +233,24 @@ export default function SearchTabScreen() {
   const [handoffFeedback, setHandoffFeedback] = useState<string | null>(null);
   const [recentQueries, setRecentQueries] = useState<string[]>([]);
   const deferredQuery = useDeferredValue(query);
+  const runtimeConfigState = useMemo(() => getRuntimeConfigState(), []);
+  const shouldDebounceSearchQuery = useMemo(
+    () =>
+      runtimeConfigState.mode === 'normal' &&
+      runtimeConfigState.config.dataSource.mode === 'backend-api' &&
+      Boolean(runtimeConfigState.config.services.apiBaseUrl),
+    [runtimeConfigState],
+  );
+  const searchQuery = useDebouncedValue(deferredQuery, 250, {
+    enabled: shouldDebounceSearchQuery,
+    shouldFlush: (nextValue) => nextValue.trim().length === 0,
+  });
   const bundledSelectorContext = useMemo(
     () => createSelectorContext(cloneBundledDatasetFixture()),
     [],
   );
   const loadBundledResults = useCallback(async () => {
-    const normalizedQuery = deferredQuery.trim();
+    const normalizedQuery = searchQuery.trim();
     if (!normalizedQuery) {
       return {
         query: '',
@@ -248,10 +262,10 @@ export default function SearchTabScreen() {
 
     const activeDataset = await loadActiveMobileDataset();
     return selectSearchResults(createSelectorContext(activeDataset.dataset), normalizedQuery);
-  }, [deferredQuery]);
+  }, [searchQuery]);
   const loadBackendResults = useCallback(
     async (client: BackendReadClient) => {
-      const normalizedQuery = deferredQuery.trim();
+      const normalizedQuery = searchQuery.trim();
       if (!normalizedQuery) {
         return {
           data: {
@@ -270,12 +284,12 @@ export default function SearchTabScreen() {
         generatedAt: response.meta?.generatedAt ?? null,
       };
     },
-    [deferredQuery],
+    [searchQuery],
   );
   const datasetState = useActiveDatasetScreen({
     surface: 'search',
     reloadKey: reloadCount,
-    cacheKey: `search:${deferredQuery.trim().toLowerCase() || 'empty'}`,
+    cacheKey: `search:${searchQuery.trim().toLowerCase() || 'empty'}`,
     fallbackErrorMessage: '검색 데이터를 지금 불러오지 못했습니다.',
     loadBundled: loadBundledResults,
     loadBackend: loadBackendResults,

--- a/mobile/src/hooks/useDebouncedValue.test.tsx
+++ b/mobile/src/hooks/useDebouncedValue.test.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import { Text } from 'react-native';
+
+import { useDebouncedValue } from './useDebouncedValue';
+
+type ProbeProps = {
+  delayMs?: number;
+  enabled?: boolean;
+  value: string;
+};
+
+function DebounceProbe({ delayMs = 250, enabled = true, value }: ProbeProps) {
+  const debouncedValue = useDebouncedValue(value, delayMs, {
+    enabled,
+    shouldFlush: (nextValue) => nextValue.trim().length === 0,
+  });
+
+  return <Text testID="debounced-value">{debouncedValue}</Text>;
+}
+
+function readValue(tree: renderer.ReactTestRenderer): string {
+  return tree.root.findByProps({ testID: 'debounced-value' }).props.children;
+}
+
+async function renderProbe(props: ProbeProps) {
+  let tree: renderer.ReactTestRenderer;
+
+  await act(async () => {
+    tree = renderer.create(<DebounceProbe {...props} />);
+  });
+
+  return tree!;
+}
+
+describe('useDebouncedValue', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  test('returns the initial value immediately', async () => {
+    const tree = await renderProbe({ value: '최예나' });
+
+    expect(readValue(tree)).toBe('최예나');
+  });
+
+  test('delays non-empty updates while enabled', async () => {
+    const tree = await renderProbe({ value: '최예나' });
+
+    await act(async () => {
+      tree.update(<DebounceProbe value="YENA" />);
+    });
+
+    expect(readValue(tree)).toBe('최예나');
+
+    await act(async () => {
+      jest.advanceTimersByTime(250);
+    });
+
+    expect(readValue(tree)).toBe('YENA');
+  });
+
+  test('flushes empty updates immediately', async () => {
+    const tree = await renderProbe({ value: '최예나' });
+
+    await act(async () => {
+      tree.update(<DebounceProbe value="" />);
+    });
+
+    expect(readValue(tree)).toBe('');
+  });
+
+  test('updates immediately when disabled', async () => {
+    const tree = await renderProbe({ value: '최예나', enabled: false });
+
+    await act(async () => {
+      tree.update(<DebounceProbe value="YENA" enabled={false} />);
+    });
+
+    expect(readValue(tree)).toBe('YENA');
+  });
+});

--- a/mobile/src/hooks/useDebouncedValue.ts
+++ b/mobile/src/hooks/useDebouncedValue.ts
@@ -1,0 +1,39 @@
+import React from 'react';
+
+type UseDebouncedValueOptions<T> = {
+  enabled?: boolean;
+  shouldFlush?: (value: T) => boolean;
+};
+
+export function useDebouncedValue<T>(
+  value: T,
+  delayMs: number,
+  options: UseDebouncedValueOptions<T> = {},
+): T {
+  const { enabled = true, shouldFlush } = options;
+  const [debouncedValue, setDebouncedValue] = React.useState(value);
+  const isFirstRenderRef = React.useRef(true);
+
+  React.useEffect(() => {
+    if (isFirstRenderRef.current) {
+      isFirstRenderRef.current = false;
+      setDebouncedValue(value);
+      return undefined;
+    }
+
+    if (!enabled || shouldFlush?.(value)) {
+      setDebouncedValue(value);
+      return undefined;
+    }
+
+    const timeoutId = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delayMs);
+
+    return () => {
+      clearTimeout(timeoutId);
+    };
+  }, [delayMs, enabled, shouldFlush, value]);
+
+  return debouncedValue;
+}


### PR DESCRIPTION
## Summary
- add a reusable debounced-value hook for mobile runtime reads
- debounce non-empty search queries only in backend-primary mode
- keep initial render and empty-query clearing immediate, and add regression evidence

## Verification
- cd mobile && npm test -- --runInBand src/hooks/useDebouncedValue.test.tsx src/features/searchTab.test.tsx
- cd mobile && npm run typecheck
- cd mobile && npm run lint
- git diff --check

Closes #618
