### PR TITLE
Keep mobile search chrome visible during in-flight query refresh

### DIFF
--- a/docs/assets/distribution/mobile_search_loading_chrome_local_2026-03-12.md
+++ b/docs/assets/distribution/mobile_search_loading_chrome_local_2026-03-12.md
@@ -1,0 +1,23 @@
+# Mobile Search Loading Chrome Local Verification
+
+- Date: 2026-03-12
+- Issue: #622
+
+## Summary
+
+- Initial empty search load still uses the existing full-screen loading state.
+- Non-empty in-flight query refresh now keeps the search chrome visible and shows a compact loading notice instead of replacing the entire screen.
+
+## Verification
+
+- `cd mobile && npm test -- --runInBand src/features/searchTabLoading.test.tsx src/features/searchTab.test.tsx`
+- `cd mobile && npm run typecheck`
+- `cd mobile && npm run lint`
+- `git diff --check`
+
+## Notes
+
+- Loading-specific regression covers:
+  - query-present loading keeps search input visible
+  - compact loading notice renders in the results section
+  - empty initial load still renders the full-screen loading state

--- a/mobile/app/(tabs)/search.tsx
+++ b/mobile/app/(tabs)/search.tsx
@@ -694,67 +694,14 @@ export default function SearchTabScreen() {
     });
   }, [activeSegment]);
 
-  if (datasetState.kind === 'loading') {
-    return (
-      <ScreenFeedbackState
-        body="검색 대상 팀, 발매, 예정 데이터를 불러오는 중입니다."
-        eyebrow="데이터 로딩"
-        loadingLayout="search"
-        title={MOBILE_COPY.surface.searchTitle}
-        variant="loading"
-      />
-    );
-  }
-
-  if (datasetState.kind === 'error') {
-    return (
-      <ScreenFeedbackState
-        action={{
-          label: MOBILE_COPY.action.retry,
-          onPress: () => setReloadCount((count) => count + 1),
-        }}
-        body={datasetState.message}
-        eyebrow="로드 오류"
-        title={MOBILE_COPY.surface.searchTitle}
-        variant="error"
-      />
-    );
-  }
-
-  if (!results) {
-    return null;
-  }
-
   const segmentCounts: Record<SearchSegment, number> = {
-    entities: results.entities.length,
-    releases: results.releases.length,
-    upcoming: results.upcoming.length,
+    entities: results?.entities.length ?? 0,
+    releases: results?.releases.length ?? 0,
+    upcoming: results?.upcoming.length ?? 0,
   };
-
-  const activeRows =
-    activeSegment === 'entities'
-      ? results.entities
-      : activeSegment === 'releases'
-        ? results.releases
-        : results.upcoming;
-  const totalResults = segmentCounts.entities + segmentCounts.releases + segmentCounts.upcoming;
-  const availableSegments = (['entities', 'releases', 'upcoming'] as SearchSegment[]).filter(
-    (segment) => segmentCounts[segment] > 0,
-  );
-  const hasPartialResults = totalResults > 0 && availableSegments.length < 3;
-  const firstAvailableSegment = availableSegments[0] ?? null;
-  const showActiveSegmentEmpty = query.trim().length > 0 && activeRows.length === 0 && totalResults > 0;
-  const showSegmentSummaryNotice =
-    query.trim().length > 0 && activeRows.length > 0 && hasPartialResults;
   const showCancelAction = isInputFocused || query.trim().length > 0;
-
-  return (
-    <ScrollView
-      contentContainerStyle={scrollContentStyle}
-      keyboardDismissMode={Platform.OS === 'android' ? 'on-drag' : 'interactive'}
-      keyboardShouldPersistTaps="handled"
-      style={styles.screen}
-    >
+  const searchChrome = (
+    <>
       <AppBar
         subtitle={MOBILE_COPY.surface.searchSubtitle}
         testID="search-app-bar"
@@ -851,6 +798,93 @@ export default function SearchTabScreen() {
         selectedKey={activeSegment}
         testID="search-segment"
       />
+    </>
+  );
+
+  if (datasetState.kind === 'loading' && !query.trim()) {
+    return (
+      <ScreenFeedbackState
+        body="검색 대상 팀, 발매, 예정 데이터를 불러오는 중입니다."
+        eyebrow="데이터 로딩"
+        loadingLayout="search"
+        title={MOBILE_COPY.surface.searchTitle}
+        variant="loading"
+      />
+    );
+  }
+
+  if (datasetState.kind === 'loading') {
+    return (
+      <ScrollView
+        contentContainerStyle={scrollContentStyle}
+        keyboardDismissMode={Platform.OS === 'android' ? 'on-drag' : 'interactive'}
+        keyboardShouldPersistTaps="handled"
+        style={styles.screen}
+      >
+        {searchChrome}
+        <InsetSection
+          accessory={
+            <Text allowFontScaling maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.body} style={styles.sectionMeta}>
+              업데이트 중
+            </Text>
+          }
+          description={`현재 세그먼트: ${resolveSearchSegmentLabel(activeSegment)}`}
+          testID="search-results-section"
+          title="검색 결과"
+        >
+          <InlineFeedbackNotice
+            body="입력한 키워드로 결과를 다시 찾고 있습니다."
+            testID="search-loading-notice"
+            title="검색 업데이트 중"
+          />
+        </InsetSection>
+      </ScrollView>
+    );
+  }
+
+  if (datasetState.kind === 'error') {
+    return (
+      <ScreenFeedbackState
+        action={{
+          label: MOBILE_COPY.action.retry,
+          onPress: () => setReloadCount((count) => count + 1),
+        }}
+        body={datasetState.message}
+        eyebrow="로드 오류"
+        title={MOBILE_COPY.surface.searchTitle}
+        variant="error"
+      />
+    );
+  }
+
+  if (!results) {
+    return null;
+  }
+
+  const activeRows =
+    activeSegment === 'entities'
+      ? results.entities
+      : activeSegment === 'releases'
+        ? results.releases
+        : results.upcoming;
+  const totalResults = segmentCounts.entities + segmentCounts.releases + segmentCounts.upcoming;
+  const availableSegments = (['entities', 'releases', 'upcoming'] as SearchSegment[]).filter(
+    (segment) => segmentCounts[segment] > 0,
+  );
+  const hasPartialResults = totalResults > 0 && availableSegments.length < 3;
+  const firstAvailableSegment = availableSegments[0] ?? null;
+  const showActiveSegmentEmpty = query.trim().length > 0 && activeRows.length === 0 && totalResults > 0;
+  const showSegmentSummaryNotice =
+    query.trim().length > 0 && activeRows.length > 0 && hasPartialResults;
+
+  return (
+    <ScrollView
+      contentContainerStyle={scrollContentStyle}
+      keyboardDismissMode={Platform.OS === 'android' ? 'on-drag' : 'interactive'}
+      keyboardShouldPersistTaps="handled"
+      style={styles.screen}
+    >
+      {searchChrome}
 
       {!query.trim() ? (
         <>

--- a/mobile/src/features/searchTabLoading.test.tsx
+++ b/mobile/src/features/searchTabLoading.test.tsx
@@ -1,0 +1,113 @@
+import renderer, { act } from 'react-test-renderer';
+import { Text } from 'react-native';
+
+import SearchTabScreen from '../../app/(tabs)/search';
+import { resetStorageAdapter, setStorageAdapter, type KeyValueStorageAdapter } from '../services/storage';
+
+let mockRouteParams: Record<string, string> = {};
+const mockUseActiveDatasetScreen = jest.fn();
+
+function createMemoryStorage(): KeyValueStorageAdapter {
+  const values = new Map<string, string>();
+
+  return {
+    async getItem(key) {
+      return values.has(key) ? values.get(key) ?? null : null;
+    },
+    async setItem(key, value) {
+      values.set(key, value);
+    },
+    async removeItem(key) {
+      values.delete(key);
+    },
+  };
+}
+
+jest.mock('expo-router', () => {
+  const push = jest.fn();
+  const setParams = jest.fn((nextParams: Record<string, string | undefined>) => {
+    mockRouteParams = Object.fromEntries(
+      Object.entries(nextParams).filter(([, value]) => typeof value === 'string' && value.length > 0),
+    ) as Record<string, string>;
+  });
+  const useLocalSearchParams = jest.fn(() => mockRouteParams);
+  const setLocalSearchParams = (nextParams: Record<string, string>) => {
+    mockRouteParams = { ...nextParams };
+  };
+
+  return {
+    useRouter: () => ({ push, setParams }),
+    useLocalSearchParams,
+    __mock: { push, setParams, useLocalSearchParams, setLocalSearchParams },
+  };
+});
+
+jest.mock('../features/useActiveDatasetScreen', () => ({
+  useActiveDatasetScreen: (...args: unknown[]) => mockUseActiveDatasetScreen(...args),
+}));
+
+const { __mock } = jest.requireMock('expo-router') as {
+  __mock: {
+    setLocalSearchParams: (nextParams: Record<string, string>) => void;
+  };
+};
+
+async function renderSearchScreen() {
+  let tree: renderer.ReactTestRenderer;
+
+  await act(async () => {
+    tree = renderer.create(<SearchTabScreen />);
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+
+  return tree!;
+}
+
+function hasText(tree: renderer.ReactTestRenderer, value: string): boolean {
+  return tree.root.findAllByType(Text).some((node) => node.props.children === value);
+}
+
+describe('mobile search loading presentation', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    setStorageAdapter(createMemoryStorage());
+    __mock.setLocalSearchParams({});
+    mockUseActiveDatasetScreen.mockReset();
+    mockUseActiveDatasetScreen.mockReturnValue({ kind: 'loading' });
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+    resetStorageAdapter();
+  });
+
+  test('keeps search chrome visible during in-flight query refresh', async () => {
+    __mock.setLocalSearchParams({
+      q: '최예나',
+      segment: 'entities',
+    });
+
+    const tree = await renderSearchScreen();
+
+    expect(tree.root.findByProps({ testID: 'search-input' })).toBeDefined();
+    expect(tree.root.findByProps({ testID: 'search-loading-notice' })).toBeDefined();
+    expect(hasText(tree, '검색 업데이트 중')).toBe(true);
+
+    await act(async () => {
+      tree.unmount();
+    });
+  });
+
+  test('uses full-screen loading for the initial empty load', async () => {
+    const tree = await renderSearchScreen();
+
+    expect(tree.root.findAllByProps({ testID: 'search-input' })).toHaveLength(0);
+    expect(hasText(tree, '검색 대상 팀, 발매, 예정 데이터를 불러오는 중입니다.')).toBe(true);
+
+    await act(async () => {
+      tree.unmount();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- keep mobile search app chrome visible during in-flight query refresh
- show a compact loading notice for non-empty query refreshes while preserving initial full-screen loading
- add loading presentation regression coverage and local verification note

## Verification
- cd mobile && /usr/local/bin/node ./node_modules/jest/bin/jest.js --runInBand src/features/searchTabLoading.test.tsx src/features/searchTab.test.tsx
- cd mobile && /usr/local/bin/node ./node_modules/typescript/bin/tsc --noEmit
- cd mobile && /usr/local/bin/node ./node_modules/eslint/bin/eslint.js .
- git diff --check

Closes #622
