### PR TITLE
Add track-aware MV/title-track backfill improvements

### DIFF
--- a/backfill_release_detail_mvs.py
+++ b/backfill_release_detail_mvs.py
@@ -8,7 +8,7 @@ import re
 import time
 import urllib.parse
 import urllib.request
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -23,9 +23,11 @@ DETAILS_PATH = ROOT / "web/src/data/releaseDetails.json"
 OVERRIDES_PATH = ROOT / "release_detail_overrides.json"
 REPORT_PATH = ROOT / "mv_coverage_report.json"
 USER_AGENT = "Mozilla/5.0"
-REQUEST_DELAY_SECONDS = 0.35
+REQUEST_DELAY_SECONDS = 0.05
 MAX_RESULTS_PER_QUERY = 8
 MAX_QUERIES_PER_RELEASE = 8
+MAX_TRACK_CANDIDATES_PER_RELEASE = 3
+MAX_NAME_VARIANTS_PER_TRACK_SEARCH = 1
 QUERY_SUFFIXES = ("official mv", "mv")
 HANGUL_PATTERN = re.compile(r"[가-힣]")
 RELEASE_TITLE_FALLBACK_MIN_DATE = "2025-01-01"
@@ -36,6 +38,7 @@ CANDIDATE_TITLE_MARKER_PATTERN = re.compile(
     r"(?i)\b(official|music\s+video|m\/v|mv|performance\s+video|lyric\s+video|track\s+video|visualizer|teaser|shorts?)\b"
 )
 AUTO_ACCEPTED_YOUTUBE_PROVENANCE = "youtube search auto-accepted via allowlist/title/date/view scoring"
+VIDEO_CHANNEL_URL_CACHE: dict[str, str] = {}
 
 
 def load_json(path: Path) -> Any:
@@ -48,6 +51,20 @@ def write_json(path: Path, rows: Any) -> None:
 
 def now_utc() -> datetime:
     return datetime.now(timezone.utc)
+
+
+def infer_release_cohort(release_date_text: str, reference_date: date) -> str:
+    try:
+        release_date = date.fromisoformat(release_date_text)
+    except ValueError:
+        return "unknown"
+
+    age_days = (reference_date - release_date).days
+    if age_days <= 365:
+        return "latest"
+    if age_days <= 365 * 3:
+        return "recent"
+    return "historical"
 
 
 def extract_text(node: dict[str, Any] | None) -> str:
@@ -104,6 +121,7 @@ def build_candidate_channel_url(video: dict[str, Any]) -> str:
     run_sets = [
         video.get("ownerText", {}).get("runs", []),
         video.get("longBylineText", {}).get("runs", []),
+        video.get("shortBylineText", {}).get("runs", []),
     ]
     for runs in run_sets:
         for run in runs:
@@ -128,6 +146,26 @@ def candidate_channel_matches_url(candidate: dict[str, Any], channel_url: str) -
         if value
     }
     return bool(candidate_keys & channel_keys)
+
+
+def resolve_video_channel_url(video_id: str) -> str:
+    cached = VIDEO_CHANNEL_URL_CACHE.get(video_id)
+    if cached is not None:
+        return cached
+
+    watch_url = f"https://www.youtube.com/watch?v={video_id}"
+    request = urllib.request.Request(watch_url, headers={"User-Agent": USER_AGENT})
+    try:
+        with urllib.request.urlopen(request, timeout=20) as response:
+            html = response.read().decode("utf-8", "ignore")
+    except Exception:  # noqa: BLE001
+        VIDEO_CHANNEL_URL_CACHE[video_id] = ""
+        return ""
+
+    alias_urls = youtube_channel_allowlists.extract_youtube_channel_alias_urls(html)
+    resolved = alias_urls[0] if alias_urls else ""
+    VIDEO_CHANNEL_URL_CACHE[video_id] = resolved
+    return resolved
 
 
 def fetch_query_candidates(query: str, reference: datetime) -> list[dict[str, Any]]:
@@ -158,6 +196,8 @@ def fetch_query_candidates(query: str, reference: datetime) -> list[dict[str, An
                 "query": query,
             }
             if candidate["video_id"] and candidate["title"]:
+                if not candidate["channel_url"]:
+                    candidate["channel_url"] = resolve_video_channel_url(candidate["video_id"])
                 candidates.append(candidate)
             if len(candidates) >= MAX_RESULTS_PER_QUERY:
                 return candidates
@@ -263,6 +303,43 @@ def should_attempt_release_title_fallback(detail: dict[str, Any], title_tracks: 
     return detail.get("stream") == "song" or detail.get("release_kind") == "single"
 
 
+def pick_track_search_candidates(detail: dict[str, Any]) -> list[str]:
+    candidates: list[str] = []
+    seen: set[str] = set()
+    for track in detail.get("tracks", []):
+        title = " ".join(str(track.get("title") or "").split()).strip()
+        if not title or TITLE_TRACK_EXCLUSION_PATTERN.search(title):
+            continue
+
+        base_title = release_detail_builder.normalize_base_title(title)
+        if len(base_title) < 3:
+            continue
+
+        key = title.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        candidates.append(title)
+        if len(candidates) >= MAX_TRACK_CANDIDATES_PER_RELEASE:
+            break
+    return candidates
+
+
+def build_track_queries(detail: dict[str, Any], profile: dict[str, Any] | None, track_title: str) -> list[str]:
+    names = pick_name_variants(detail, profile)[:MAX_NAME_VARIANTS_PER_TRACK_SEARCH]
+    queries: list[str] = []
+    seen: set[str] = set()
+    for name in names:
+        for suffix in QUERY_SUFFIXES:
+            query = " ".join(part for part in [name, track_title, suffix] if part).strip()
+            key = query.casefold()
+            if key in seen:
+                continue
+            seen.add(key)
+            queries.append(query)
+    return queries
+
+
 def clean_candidate_title(candidate_title: str, group: str) -> str:
     cleaned = candidate_title
     cleaned = re.sub(r"\[[^\]]*\]", " ", cleaned)
@@ -308,6 +385,115 @@ def infer_title_tracks_from_candidate_title(detail: dict[str, Any], candidate_ti
     return matches if len(matches) == 1 else []
 
 
+def choose_track_search_resolution(
+    detail: dict[str, Any],
+    profile: dict[str, Any] | None,
+    allowlist: dict[str, Any],
+    reference: datetime,
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    track_outcomes: list[dict[str, Any]] = []
+    for track_title in pick_track_search_candidates(detail):
+        candidates_by_video_id: dict[str, dict[str, Any]] = {}
+        outcome: dict[str, Any] = {"status": "no_match", "accepted_video_id": None, "candidates": []}
+        for query in build_track_queries(detail, profile, track_title):
+            time.sleep(REQUEST_DELAY_SECONDS)
+            for candidate in fetch_query_candidates(query, reference):
+                existing = candidates_by_video_id.get(candidate["video_id"])
+                if existing is None or candidate["view_count"] > existing["view_count"]:
+                    candidates_by_video_id[candidate["video_id"]] = candidate
+            if not candidates_by_video_id:
+                continue
+
+            outcome = mv_scoring.score_candidates(
+                {
+                    "group": detail["group"],
+                    "release_title": detail["release_title"],
+                    "title_tracks": [track_title],
+                    "release_date": detail["release_date"],
+                    "mv_allowlist_match_keys": allowlist.get("mv_allowlist_match_keys", []),
+                },
+                list(candidates_by_video_id.values()),
+            )
+            if outcome["status"] == "accepted":
+                break
+
+        if not candidates_by_video_id:
+            continue
+
+        top_candidate = outcome["candidates"][0] if outcome["candidates"] else None
+        track_outcomes.append(
+            {
+                "track_title": track_title,
+                "outcome": outcome,
+                "top_candidate": top_candidate,
+            }
+        )
+
+    accepted_tracks = [row for row in track_outcomes if row["outcome"]["status"] == "accepted"]
+    if len(accepted_tracks) == 1:
+        accepted_track = accepted_tracks[0]
+        accepted_candidate = next(
+            candidate
+            for candidate in accepted_track["outcome"]["candidates"]
+            if candidate.get("video_id") == accepted_track["outcome"]["accepted_video_id"]
+        )
+        matched_channel = next(
+            (
+                channel
+                for channel in (allowlist.get("mv_source_channels") or allowlist.get("channels") or [])
+                if candidate_channel_matches_url(accepted_candidate, channel.get("channel_url", ""))
+            ),
+            None,
+        )
+        return (
+            {
+                "group": detail["group"],
+                "release_title": detail["release_title"],
+                "release_date": detail["release_date"],
+                "stream": detail["stream"],
+                "release_kind": detail["release_kind"],
+                "youtube_video_id": accepted_candidate["video_id"],
+                "youtube_video_url": release_detail_builder.build_youtube_video_url(accepted_candidate["video_id"]),
+                "youtube_video_provenance": AUTO_ACCEPTED_YOUTUBE_PROVENANCE,
+                "selected_query": accepted_candidate.get("query", ""),
+                "selected_title": accepted_candidate.get("title", ""),
+                "selected_channel_url": accepted_candidate.get("channel_url", ""),
+                "selected_channel_owner_type": matched_channel.get("owner_type", "unknown") if matched_channel else "unknown",
+                "selected_score": accepted_candidate.get("score", 0),
+                "title_track_basis": "track_search",
+                "inferred_title_tracks": [accepted_track["track_title"]],
+            },
+            None,
+        )
+
+    review_tracks = [row for row in track_outcomes if row["outcome"]["status"] == "needs_review" and row["top_candidate"]]
+    if review_tracks:
+        review_track = max(
+            review_tracks,
+            key=lambda row: row["top_candidate"].get("score", 0),
+        )
+        top_candidate = review_track["top_candidate"]
+        return (
+            None,
+            {
+                "group": detail["group"],
+                "release_title": detail["release_title"],
+                "release_date": detail["release_date"],
+                "stream": detail["stream"],
+                "top_candidate_title": top_candidate.get("title", ""),
+                "top_candidate_channel_url": top_candidate.get("channel_url", ""),
+                "top_candidate_score": top_candidate.get("score", 0),
+                "review_reason": (
+                    "Track-aware search found a likely official MV candidate, but the evidence still requires manual verification."
+                ),
+                "title_track_basis": "track_search",
+                "track_search_candidate": review_track["track_title"],
+            },
+        )
+
+    return None, None
+
+
 def choose_resolutions(details: list[dict[str, Any]], profiles_by_group: dict[str, dict[str, Any]], allowlists_by_group: dict[str, dict[str, Any]]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     reference = now_utc()
     resolutions: list[dict[str, Any]] = []
@@ -323,8 +509,9 @@ def choose_resolutions(details: list[dict[str, Any]], profiles_by_group: dict[st
             continue
 
         title_tracks = [track["title"] for track in detail.get("tracks", []) if track.get("is_title_track")]
-
-        if not should_attempt_release_title_fallback(detail, title_tracks):
+        release_title_search_enabled = should_attempt_release_title_fallback(detail, title_tracks)
+        track_search_enabled = not title_tracks and bool(pick_track_search_candidates(detail))
+        if not release_title_search_enabled and not track_search_enabled:
             continue
 
         allowlist = allowlists_by_group.get(detail["group"], {})
@@ -334,45 +521,30 @@ def choose_resolutions(details: list[dict[str, Any]], profiles_by_group: dict[st
 
         candidates_by_video_id: dict[str, dict[str, Any]] = {}
         outcome: dict[str, Any] = {"status": "no_match", "accepted_video_id": None, "candidates": []}
-        for query in build_queries(detail, profiles_by_group.get(detail["group"])):
-            time.sleep(REQUEST_DELAY_SECONDS)
-            for candidate in fetch_query_candidates(query, reference):
-                existing = candidates_by_video_id.get(candidate["video_id"])
-                if existing is None or candidate["view_count"] > existing["view_count"]:
-                    candidates_by_video_id[candidate["video_id"]] = candidate
-            if not candidates_by_video_id:
-                continue
+        if release_title_search_enabled:
+            for query in build_queries(detail, profiles_by_group.get(detail["group"])):
+                time.sleep(REQUEST_DELAY_SECONDS)
+                for candidate in fetch_query_candidates(query, reference):
+                    existing = candidates_by_video_id.get(candidate["video_id"])
+                    if existing is None or candidate["view_count"] > existing["view_count"]:
+                        candidates_by_video_id[candidate["video_id"]] = candidate
+                if not candidates_by_video_id:
+                    continue
 
-            outcome = mv_scoring.score_candidates(
-                {
-                    "group": detail["group"],
-                    "release_title": detail["release_title"],
-                    "title_tracks": title_tracks,
-                    "release_date": detail["release_date"],
-                    "mv_allowlist_match_keys": allowlist.get("mv_allowlist_match_keys", []),
-                },
-                list(candidates_by_video_id.values()),
-            )
-            if outcome["status"] == "accepted":
-                break
+                outcome = mv_scoring.score_candidates(
+                    {
+                        "group": detail["group"],
+                        "release_title": detail["release_title"],
+                        "title_tracks": title_tracks,
+                        "release_date": detail["release_date"],
+                        "mv_allowlist_match_keys": allowlist.get("mv_allowlist_match_keys", []),
+                    },
+                    list(candidates_by_video_id.values()),
+                )
+                if outcome["status"] == "accepted":
+                    break
 
-        if not candidates_by_video_id:
-            review_rows.append(
-                {
-                    "group": detail["group"],
-                    "release_title": detail["release_title"],
-                    "release_date": detail["release_date"],
-                    "stream": detail["stream"],
-                    "top_candidate_title": "",
-                    "top_candidate_channel_url": "",
-                    "top_candidate_score": 0,
-                    "review_reason": "No allowlisted official MV candidate was found from the generated historical search queries.",
-                    "title_track_basis": "release_title_fallback" if not title_tracks else "title_track",
-                }
-            )
-            continue
-
-        if outcome["status"] == "accepted" and outcome["accepted_video_id"]:
+        if candidates_by_video_id and outcome["status"] == "accepted" and outcome["accepted_video_id"]:
             accepted = next(
                 candidate for candidate in outcome["candidates"] if candidate.get("video_id") == outcome["accepted_video_id"]
             )
@@ -406,7 +578,21 @@ def choose_resolutions(details: list[dict[str, Any]], profiles_by_group: dict[st
             )
             continue
 
-        if outcome["status"] == "needs_review" and outcome["candidates"]:
+        if not title_tracks:
+            track_resolution, track_review_row = choose_track_search_resolution(
+                detail,
+                profiles_by_group.get(detail["group"]),
+                allowlist,
+                reference,
+            )
+            if track_resolution:
+                resolutions.append(track_resolution)
+                continue
+            if track_review_row:
+                review_rows.append(track_review_row)
+                continue
+
+        if candidates_by_video_id and outcome["status"] == "needs_review" and outcome["candidates"]:
             top = outcome["candidates"][0]
             review_rows.append(
                 {
@@ -421,6 +607,21 @@ def choose_resolutions(details: list[dict[str, Any]], profiles_by_group: dict[st
                     "title_track_basis": "release_title_fallback" if not title_tracks else "title_track",
                 }
             )
+            continue
+
+        review_rows.append(
+            {
+                "group": detail["group"],
+                "release_title": detail["release_title"],
+                "release_date": detail["release_date"],
+                "stream": detail["stream"],
+                "top_candidate_title": "",
+                "top_candidate_channel_url": "",
+                "top_candidate_score": 0,
+                "review_reason": "No allowlisted official MV candidate was found from the generated historical search queries.",
+                "title_track_basis": "release_title_fallback" if not title_tracks else "title_track",
+            }
+        )
 
     return resolutions, review_rows
 
@@ -558,6 +759,10 @@ def main() -> None:
         "--groups",
         help="Comma-separated list of groups to limit the current resolution pass.",
     )
+    parser.add_argument(
+        "--cohorts",
+        help="Comma-separated release cohorts to scope the pass (latest,recent,historical).",
+    )
     args = parser.parse_args()
 
     details = load_json(DETAILS_PATH)
@@ -570,6 +775,16 @@ def main() -> None:
     if args.groups:
         scoped_groups = {value.strip() for value in args.groups.split(",") if value.strip()}
         details = [detail for detail in details if detail["group"] in scoped_groups]
+
+    scoped_cohorts = None
+    if args.cohorts:
+        scoped_cohorts = {value.strip() for value in args.cohorts.split(",") if value.strip()}
+        reference_date = now_utc().date()
+        details = [
+            detail
+            for detail in details
+            if infer_release_cohort(detail.get("release_date", ""), reference_date) in scoped_cohorts
+        ]
 
     resolutions, review_rows = choose_resolutions(details, profiles_by_group, allowlists_by_group)
     reevaluated_keys = {
@@ -594,6 +809,10 @@ def main() -> None:
             "groups": sorted(scoped_groups),
             "scoped_rows": len(details),
         }
+    if scoped_cohorts is not None:
+        report.setdefault("execution_scope", {})
+        report["execution_scope"]["cohorts"] = sorted(scoped_cohorts)
+        report["execution_scope"]["scoped_rows"] = len(details)
 
     write_json(OVERRIDES_PATH, merged_overrides)
     write_json(DETAILS_PATH, updated_details)

--- a/test_backfill_release_detail_mvs.py
+++ b/test_backfill_release_detail_mvs.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import unittest
+from datetime import date
+from unittest.mock import patch
 
 import backfill_release_detail_mvs as backfill
 
@@ -123,6 +125,86 @@ class BackfillReleaseDetailMvQueryTests(unittest.TestCase):
         self.assertNotIn("youtube_video_id", merged[0])
         self.assertNotIn("youtube_video_url", merged[0])
         self.assertNotIn("youtube_video_provenance", merged[0])
+
+    def test_build_candidate_channel_url_uses_short_byline_text(self) -> None:
+        video = {
+            "shortBylineText": {
+                "runs": [
+                    {
+                        "text": "H1-KEY",
+                        "navigationEndpoint": {
+                            "browseEndpoint": {
+                                "canonicalBaseUrl": "/@H1KEY_official",
+                            }
+                        },
+                    }
+                ]
+            }
+        }
+
+        self.assertEqual(
+            backfill.build_candidate_channel_url(video),
+            "https://www.youtube.com/@H1KEY_official",
+        )
+
+    def test_infer_release_cohort_uses_one_year_and_three_year_windows(self) -> None:
+        reference_date = date(2026, 3, 12)
+
+        self.assertEqual(backfill.infer_release_cohort("2025-12-01", reference_date), "latest")
+        self.assertEqual(backfill.infer_release_cohort("2024-04-01", reference_date), "recent")
+        self.assertEqual(backfill.infer_release_cohort("2021-03-10", reference_date), "historical")
+
+    @patch.object(backfill, "REQUEST_DELAY_SECONDS", 0)
+    def test_choose_resolutions_uses_track_search_for_unresolved_album_rows(self) -> None:
+        details = [
+            {
+                "group": "YENA",
+                "release_title": "LOVE CATCHER",
+                "release_date": "2026-03-11",
+                "stream": "album",
+                "release_kind": "ep",
+                "youtube_video_status": "unresolved",
+                "tracks": [
+                    {"title": "캐치 캐치"},
+                    {"title": "봄이라서"},
+                ],
+            }
+        ]
+        profiles_by_group = {"YENA": {"display_name": "YENA", "aliases": [], "search_aliases": ["최예나"]}}
+        allowlists_by_group = {
+            "YENA": {
+                "mv_allowlist_match_keys": ["channel:uckrdegnm3mqzxhk2mfnojmw"],
+                "mv_source_channels": [
+                    {
+                        "channel_url": "https://www.youtube.com/channel/UCkrDEGNM3mqZXHk2MfnOjMw",
+                        "owner_type": "team",
+                    }
+                ],
+            }
+        }
+
+        def fake_fetch_query_candidates(query: str, reference: object) -> list[dict[str, object]]:
+            if "캐치 캐치" not in query:
+                return []
+            return [
+                {
+                    "video_id": "abc123",
+                    "title": "YENA(최예나) - '캐치 캐치' M/V",
+                    "channel_url": "https://www.youtube.com/channel/UCkrDEGNM3mqZXHk2MfnOjMw",
+                    "view_count": 1000,
+                    "published_at": "2026-03-11T09:00:00Z",
+                    "query": query,
+                }
+            ]
+
+        with patch.object(backfill, "fetch_query_candidates", side_effect=fake_fetch_query_candidates):
+            resolutions, review_rows = backfill.choose_resolutions(details, profiles_by_group, allowlists_by_group)
+
+        self.assertEqual(len(review_rows), 0)
+        self.assertEqual(len(resolutions), 1)
+        self.assertEqual(resolutions[0]["youtube_video_id"], "abc123")
+        self.assertEqual(resolutions[0]["inferred_title_tracks"], ["캐치 캐치"])
+        self.assertEqual(resolutions[0]["title_track_basis"], "track_search")
 
 
 if __name__ == "__main__":

--- a/test_youtube_channel_allowlists.py
+++ b/test_youtube_channel_allowlists.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import unittest
+
+import youtube_channel_allowlists as allowlists
+
+
+class YoutubeChannelAllowlistsTests(unittest.TestCase):
+    def test_extract_youtube_channel_alias_urls_returns_channel_and_canonical_handle(self) -> None:
+        html = """
+        <script>
+        var ytInitialData = {
+          "header": {"c4TabbedHeaderRenderer": {"channelId":"UC1234567890abcdefghijkl"}},
+          "metadata": {"channelMetadataRenderer": {"canonicalBaseUrl":"/@YENA_OFFICIAL"}}
+        };
+        </script>
+        """
+
+        self.assertEqual(
+            allowlists.extract_youtube_channel_alias_urls(html),
+            [
+                "https://www.youtube.com/channel/UC1234567890abcdefghijkl",
+                "https://www.youtube.com/@YENA_OFFICIAL",
+            ],
+        )
+
+    def test_build_source_adds_match_keys_for_resolved_channel_aliases(self) -> None:
+        source = allowlists.build_source(
+            "https://www.youtube.com/@YENA_OFFICIAL",
+            "YENA",
+            "team",
+            True,
+            "test",
+            fetcher=lambda _: """
+            <script>
+            {"channelId":"UC1234567890abcdefghijkl","canonicalBaseUrl":"/@YENA_OFFICIAL"}
+            </script>
+            """,
+        )
+
+        self.assertIn("https://www.youtube.com/channel/UC1234567890abcdefghijkl", source["resolved_alias_urls"])
+        self.assertIn("channel:uc1234567890abcdefghijkl", source["match_keys"])
+        self.assertIn("@yena_official", source["match_keys"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/src/data/youtubeChannelAllowlists.json
+++ b/web/src/data/youtubeChannelAllowlists.json
@@ -1,18 +1,24 @@
 [
   {
     "group": "&TEAM",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCHD1jo5RhijLfx5-0Ehe_cg",
+    "primary_team_channel_url": "https://www.youtube.com/@andteamofficial",
     "mv_source_channels": [
       {
-        "channel_url": "https://www.youtube.com/channel/UCHD1jo5RhijLfx5-0Ehe_cg",
+        "channel_url": "https://www.youtube.com/@andteamofficial",
         "channel_label": "&TEAM",
         "owner_type": "team",
         "allow_mv_uploads": true,
         "display_in_team_links": true,
         "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCHcOgAwmWOImnhBzNhRXgnA",
+          "https://www.youtube.com/@andteamofficial"
+        ],
         "match_keys": [
-          "channel:uchd1jo5rhijlfx5-0ehe_cg",
-          "https://www.youtube.com/channel/uchd1jo5rhijlfx5-0ehe_cg"
+          "@andteamofficial",
+          "https://www.youtube.com/@andteamofficial",
+          "channel:uchcogawmwoimnhbznhrxgna",
+          "https://www.youtube.com/channel/uchcogawmwoimnhbznhrxgna"
         ]
       },
       {
@@ -22,33 +28,49 @@
         "allow_mv_uploads": true,
         "display_in_team_links": false,
         "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UC3IZKseVpdzPSBaWxBxundA",
+          "https://www.youtube.com/@HYBELABELS"
+        ],
         "match_keys": [
           "@hybelabels",
-          "https://www.youtube.com/@hybelabels"
+          "https://www.youtube.com/@hybelabels",
+          "channel:uc3izksevpdzpsbawxbxunda",
+          "https://www.youtube.com/channel/uc3izksevpdzpsbawxbxunda"
         ]
       }
     ],
     "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCHD1jo5RhijLfx5-0Ehe_cg",
+      "https://www.youtube.com/@andteamofficial",
       "https://www.youtube.com/@HYBELABELS"
     ],
     "mv_allowlist_match_keys": [
-      "channel:uchd1jo5rhijlfx5-0ehe_cg",
-      "https://www.youtube.com/channel/uchd1jo5rhijlfx5-0ehe_cg",
+      "@andteamofficial",
+      "https://www.youtube.com/@andteamofficial",
+      "channel:uchcogawmwoimnhbznhrxgna",
+      "https://www.youtube.com/channel/uchcogawmwoimnhbznhrxgna",
       "@hybelabels",
-      "https://www.youtube.com/@hybelabels"
+      "https://www.youtube.com/@hybelabels",
+      "channel:uc3izksevpdzpsbawxbxunda",
+      "https://www.youtube.com/channel/uc3izksevpdzpsbawxbxunda"
     ],
     "channels": [
       {
-        "channel_url": "https://www.youtube.com/channel/UCHD1jo5RhijLfx5-0Ehe_cg",
+        "channel_url": "https://www.youtube.com/@andteamofficial",
         "channel_label": "&TEAM",
         "owner_type": "team",
         "allow_mv_uploads": true,
         "display_in_team_links": true,
         "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCHcOgAwmWOImnhBzNhRXgnA",
+          "https://www.youtube.com/@andteamofficial"
+        ],
         "match_keys": [
-          "channel:uchd1jo5rhijlfx5-0ehe_cg",
-          "https://www.youtube.com/channel/uchd1jo5rhijlfx5-0ehe_cg"
+          "@andteamofficial",
+          "https://www.youtube.com/@andteamofficial",
+          "channel:uchcogawmwoimnhbznhrxgna",
+          "https://www.youtube.com/channel/uchcogawmwoimnhbznhrxgna"
         ]
       },
       {
@@ -58,46 +80,66 @@
         "allow_mv_uploads": true,
         "display_in_team_links": false,
         "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UC3IZKseVpdzPSBaWxBxundA",
+          "https://www.youtube.com/@HYBELABELS"
+        ],
         "match_keys": [
           "@hybelabels",
-          "https://www.youtube.com/@hybelabels"
+          "https://www.youtube.com/@hybelabels",
+          "channel:uc3izksevpdzpsbawxbxunda",
+          "https://www.youtube.com/channel/uc3izksevpdzpsbawxbxunda"
         ]
       }
     ]
   },
   {
     "group": "(G)I-DLE",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCritGVo7pLJLUS8wEu32vow",
+    "primary_team_channel_url": "https://www.youtube.com/@official_i_dle",
     "mv_source_channels": [
       {
-        "channel_url": "https://www.youtube.com/channel/UCritGVo7pLJLUS8wEu32vow",
+        "channel_url": "https://www.youtube.com/@official_i_dle",
         "channel_label": "(G)I-DLE",
         "owner_type": "team",
         "allow_mv_uploads": true,
         "display_in_team_links": true,
         "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCritGVo7pLJLUS8wEu32vow",
+          "https://www.youtube.com/@official_i_dle"
+        ],
         "match_keys": [
+          "@official_i_dle",
+          "https://www.youtube.com/@official_i_dle",
           "channel:ucritgvo7pljlus8weu32vow",
           "https://www.youtube.com/channel/ucritgvo7pljlus8weu32vow"
         ]
       }
     ],
     "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCritGVo7pLJLUS8wEu32vow"
+      "https://www.youtube.com/@official_i_dle"
     ],
     "mv_allowlist_match_keys": [
+      "@official_i_dle",
+      "https://www.youtube.com/@official_i_dle",
       "channel:ucritgvo7pljlus8weu32vow",
       "https://www.youtube.com/channel/ucritgvo7pljlus8weu32vow"
     ],
     "channels": [
       {
-        "channel_url": "https://www.youtube.com/channel/UCritGVo7pLJLUS8wEu32vow",
+        "channel_url": "https://www.youtube.com/@official_i_dle",
         "channel_label": "(G)I-DLE",
         "owner_type": "team",
         "allow_mv_uploads": true,
         "display_in_team_links": true,
         "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCritGVo7pLJLUS8wEu32vow",
+          "https://www.youtube.com/@official_i_dle"
+        ],
         "match_keys": [
+          "@official_i_dle",
+          "https://www.youtube.com/@official_i_dle",
           "channel:ucritgvo7pljlus8weu32vow",
           "https://www.youtube.com/channel/ucritgvo7pljlus8weu32vow"
         ]
@@ -106,37 +148,51 @@
   },
   {
     "group": "82MAJOR",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UC6H_3Rv-q8Z23jtMofgPGsw",
+    "primary_team_channel_url": "https://www.youtube.com/@82major_official",
     "mv_source_channels": [
       {
-        "channel_url": "https://www.youtube.com/channel/UC6H_3Rv-q8Z23jtMofgPGsw",
+        "channel_url": "https://www.youtube.com/@82major_official",
         "channel_label": "82MAJOR",
         "owner_type": "team",
         "allow_mv_uploads": true,
         "display_in_team_links": true,
         "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UC6H_3Rv-q8Z23jtMofgPGsw",
+          "https://www.youtube.com/@82major_official"
+        ],
         "match_keys": [
+          "@82major_official",
+          "https://www.youtube.com/@82major_official",
           "channel:uc6h_3rv-q8z23jtmofgpgsw",
           "https://www.youtube.com/channel/uc6h_3rv-q8z23jtmofgpgsw"
         ]
       }
     ],
     "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UC6H_3Rv-q8Z23jtMofgPGsw"
+      "https://www.youtube.com/@82major_official"
     ],
     "mv_allowlist_match_keys": [
+      "@82major_official",
+      "https://www.youtube.com/@82major_official",
       "channel:uc6h_3rv-q8z23jtmofgpgsw",
       "https://www.youtube.com/channel/uc6h_3rv-q8z23jtmofgpgsw"
     ],
     "channels": [
       {
-        "channel_url": "https://www.youtube.com/channel/UC6H_3Rv-q8Z23jtMofgPGsw",
+        "channel_url": "https://www.youtube.com/@82major_official",
         "channel_label": "82MAJOR",
         "owner_type": "team",
         "allow_mv_uploads": true,
         "display_in_team_links": true,
         "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UC6H_3Rv-q8Z23jtMofgPGsw",
+          "https://www.youtube.com/@82major_official"
+        ],
         "match_keys": [
+          "@82major_official",
+          "https://www.youtube.com/@82major_official",
           "channel:uc6h_3rv-q8z23jtmofgpgsw",
           "https://www.youtube.com/channel/uc6h_3rv-q8z23jtmofgpgsw"
         ]
@@ -145,37 +201,51 @@
   },
   {
     "group": "8TURN",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCZzpLKZPTSNNycp-qQc2kLw",
+    "primary_team_channel_url": "https://www.youtube.com/@8TURN.official",
     "mv_source_channels": [
       {
-        "channel_url": "https://www.youtube.com/channel/UCZzpLKZPTSNNycp-qQc2kLw",
+        "channel_url": "https://www.youtube.com/@8TURN.official",
         "channel_label": "8TURN",
         "owner_type": "team",
         "allow_mv_uploads": true,
         "display_in_team_links": true,
         "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCZzpLKZPTSNNycp-qQc2kLw",
+          "https://www.youtube.com/@8TURN.official"
+        ],
         "match_keys": [
+          "@8turn.official",
+          "https://www.youtube.com/@8turn.official",
           "channel:uczzplkzptsnnycp-qqc2klw",
           "https://www.youtube.com/channel/uczzplkzptsnnycp-qqc2klw"
         ]
       }
     ],
     "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCZzpLKZPTSNNycp-qQc2kLw"
+      "https://www.youtube.com/@8TURN.official"
     ],
     "mv_allowlist_match_keys": [
+      "@8turn.official",
+      "https://www.youtube.com/@8turn.official",
       "channel:uczzplkzptsnnycp-qqc2klw",
       "https://www.youtube.com/channel/uczzplkzptsnnycp-qqc2klw"
     ],
     "channels": [
       {
-        "channel_url": "https://www.youtube.com/channel/UCZzpLKZPTSNNycp-qQc2kLw",
+        "channel_url": "https://www.youtube.com/@8TURN.official",
         "channel_label": "8TURN",
         "owner_type": "team",
         "allow_mv_uploads": true,
         "display_in_team_links": true,
         "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCZzpLKZPTSNNycp-qQc2kLw",
+          "https://www.youtube.com/@8TURN.official"
+        ],
         "match_keys": [
+          "@8turn.official",
+          "https://www.youtube.com/@8turn.official",
           "channel:uczzplkzptsnnycp-qqc2klw",
           "https://www.youtube.com/channel/uczzplkzptsnnycp-qqc2klw"
         ]
@@ -184,37 +254,51 @@
   },
   {
     "group": "AB6IX",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCwytna6i1rFCt13a3Qvuk-A",
+    "primary_team_channel_url": "https://www.youtube.com/@AB6IX",
     "mv_source_channels": [
       {
-        "channel_url": "https://www.youtube.com/channel/UCwytna6i1rFCt13a3Qvuk-A",
+        "channel_url": "https://www.youtube.com/@AB6IX",
         "channel_label": "AB6IX",
         "owner_type": "team",
         "allow_mv_uploads": true,
         "display_in_team_links": true,
         "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCwytna6i1rFCt13a3Qvuk-A",
+          "https://www.youtube.com/@AB6IX"
+        ],
         "match_keys": [
+          "@ab6ix",
+          "https://www.youtube.com/@ab6ix",
           "channel:ucwytna6i1rfct13a3qvuk-a",
           "https://www.youtube.com/channel/ucwytna6i1rfct13a3qvuk-a"
         ]
       }
     ],
     "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCwytna6i1rFCt13a3Qvuk-A"
+      "https://www.youtube.com/@AB6IX"
     ],
     "mv_allowlist_match_keys": [
+      "@ab6ix",
+      "https://www.youtube.com/@ab6ix",
       "channel:ucwytna6i1rfct13a3qvuk-a",
       "https://www.youtube.com/channel/ucwytna6i1rfct13a3qvuk-a"
     ],
     "channels": [
       {
-        "channel_url": "https://www.youtube.com/channel/UCwytna6i1rFCt13a3Qvuk-A",
+        "channel_url": "https://www.youtube.com/@AB6IX",
         "channel_label": "AB6IX",
         "owner_type": "team",
         "allow_mv_uploads": true,
         "display_in_team_links": true,
         "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCwytna6i1rFCt13a3Qvuk-A",
+          "https://www.youtube.com/@AB6IX"
+        ],
         "match_keys": [
+          "@ab6ix",
+          "https://www.youtube.com/@ab6ix",
           "channel:ucwytna6i1rfct13a3qvuk-a",
           "https://www.youtube.com/channel/ucwytna6i1rfct13a3qvuk-a"
         ]
@@ -222,254 +306,204 @@
     ]
   },
   {
-    "group": "CHUNG HA",
-    "primary_team_channel_url": "https://www.youtube.com/@CHUNGHA_OFFICIAL",
+    "group": "aespa",
+    "primary_team_channel_url": "https://www.youtube.com/@aespa_official",
     "mv_source_channels": [
       {
-        "channel_url": "https://www.youtube.com/@CHUNGHA_OFFICIAL",
-        "channel_label": "CHUNG HA",
+        "channel_url": "https://www.youtube.com/@aespa_official",
+        "channel_label": "aespa",
         "owner_type": "team",
         "allow_mv_uploads": true,
         "display_in_team_links": true,
         "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCZpFge83uRp3plkS-D9pj1w",
+          "https://www.youtube.com/@aespa_official"
+        ],
         "match_keys": [
-          "@chungha_official",
-          "https://www.youtube.com/@chungha_official"
+          "@aespa_official",
+          "https://www.youtube.com/@aespa_official",
+          "channel:uczpfge83urp3plks-d9pj1w",
+          "https://www.youtube.com/channel/uczpfge83urp3plks-d9pj1w"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/@SMTOWN",
+        "channel_label": "SMTOWN",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCyDd_CdcEtQk-jbmrBhBl5w",
+          "https://www.youtube.com/@SMTOWN"
+        ],
+        "match_keys": [
+          "@smtown",
+          "https://www.youtube.com/@smtown",
+          "channel:ucydd_cdcetqk-jbmrbhbl5w",
+          "https://www.youtube.com/channel/ucydd_cdcetqk-jbmrbhbl5w"
         ]
       }
     ],
     "mv_allowlist_urls": [
-      "https://www.youtube.com/@CHUNGHA_OFFICIAL"
+      "https://www.youtube.com/@aespa_official",
+      "https://www.youtube.com/@SMTOWN"
     ],
     "mv_allowlist_match_keys": [
-      "@chungha_official",
-      "https://www.youtube.com/@chungha_official"
+      "@aespa_official",
+      "https://www.youtube.com/@aespa_official",
+      "channel:uczpfge83urp3plks-d9pj1w",
+      "https://www.youtube.com/channel/uczpfge83urp3plks-d9pj1w",
+      "@smtown",
+      "https://www.youtube.com/@smtown",
+      "channel:ucydd_cdcetqk-jbmrbhbl5w",
+      "https://www.youtube.com/channel/ucydd_cdcetqk-jbmrbhbl5w"
     ],
     "channels": [
       {
-        "channel_url": "https://www.youtube.com/@CHUNGHA_OFFICIAL",
-        "channel_label": "CHUNG HA",
+        "channel_url": "https://www.youtube.com/@aespa_official",
+        "channel_label": "aespa",
         "owner_type": "team",
         "allow_mv_uploads": true,
         "display_in_team_links": true,
         "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCZpFge83uRp3plkS-D9pj1w",
+          "https://www.youtube.com/@aespa_official"
+        ],
         "match_keys": [
-          "@chungha_official",
-          "https://www.youtube.com/@chungha_official"
+          "@aespa_official",
+          "https://www.youtube.com/@aespa_official",
+          "channel:uczpfge83urp3plks-d9pj1w",
+          "https://www.youtube.com/channel/uczpfge83urp3plks-d9pj1w"
         ]
-      }
-    ]
-  },
-  {
-    "group": "CHUU",
-    "primary_team_channel_url": "https://www.youtube.com/@CHUUOfficial",
-    "mv_source_channels": [
+      },
       {
-        "channel_url": "https://www.youtube.com/@CHUUOfficial",
-        "channel_label": "CHUU",
-        "owner_type": "team",
+        "channel_url": "https://www.youtube.com/@SMTOWN",
+        "channel_label": "SMTOWN",
+        "owner_type": "label",
         "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
+        "display_in_team_links": false,
+        "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCyDd_CdcEtQk-jbmrBhBl5w",
+          "https://www.youtube.com/@SMTOWN"
+        ],
         "match_keys": [
-          "@chuuofficial",
-          "https://www.youtube.com/@chuuofficial"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/@CHUUOfficial"
-    ],
-    "mv_allowlist_match_keys": [
-      "@chuuofficial",
-      "https://www.youtube.com/@chuuofficial"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/@CHUUOfficial",
-        "channel_label": "CHUU",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "@chuuofficial",
-          "https://www.youtube.com/@chuuofficial"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "JEON SOMI",
-    "primary_team_channel_url": "https://www.youtube.com/@JEONSOMIOFFICIAL",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/@JEONSOMIOFFICIAL",
-        "channel_label": "JEON SOMI",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "@jeonsomiofficial",
-          "https://www.youtube.com/@jeonsomiofficial"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/@JEONSOMIOFFICIAL"
-    ],
-    "mv_allowlist_match_keys": [
-      "@jeonsomiofficial",
-      "https://www.youtube.com/@jeonsomiofficial"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/@JEONSOMIOFFICIAL",
-        "channel_label": "JEON SOMI",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "@jeonsomiofficial",
-          "https://www.youtube.com/@jeonsomiofficial"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "KWON EUNBI",
-    "primary_team_channel_url": "https://www.youtube.com/@KWONEUNBI",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/@KWONEUNBI",
-        "channel_label": "KWON EUNBI",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "@kwoneunbi",
-          "https://www.youtube.com/@kwoneunbi"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/@KWONEUNBI"
-    ],
-    "mv_allowlist_match_keys": [
-      "@kwoneunbi",
-      "https://www.youtube.com/@kwoneunbi"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/@KWONEUNBI",
-        "channel_label": "KWON EUNBI",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "@kwoneunbi",
-          "https://www.youtube.com/@kwoneunbi"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "YUJU",
-    "primary_team_channel_url": "https://www.youtube.com/@YUJUofficial",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/@YUJUofficial",
-        "channel_label": "YUJU",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "@yujuofficial",
-          "https://www.youtube.com/@yujuofficial"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/@YUJUofficial"
-    ],
-    "mv_allowlist_match_keys": [
-      "@yujuofficial",
-      "https://www.youtube.com/@yujuofficial"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/@YUJUofficial",
-        "channel_label": "YUJU",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "@yujuofficial",
-          "https://www.youtube.com/@yujuofficial"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "Yves",
-    "primary_team_channel_url": "https://www.youtube.com/@YVES_OFFICIAL",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/@YVES_OFFICIAL",
-        "channel_label": "Yves",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "@yves_official",
-          "https://www.youtube.com/@yves_official"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/@YVES_OFFICIAL"
-    ],
-    "mv_allowlist_match_keys": [
-      "@yves_official",
-      "https://www.youtube.com/@yves_official"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/@YVES_OFFICIAL",
-        "channel_label": "Yves",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "@yves_official",
-          "https://www.youtube.com/@yves_official"
+          "@smtown",
+          "https://www.youtube.com/@smtown",
+          "channel:ucydd_cdcetqk-jbmrbhbl5w",
+          "https://www.youtube.com/channel/ucydd_cdcetqk-jbmrbhbl5w"
         ]
       }
     ]
   },
   {
     "group": "ALL(H)OURS",
-    "primary_team_channel_url": null,
-    "mv_source_channels": [],
-    "mv_allowlist_urls": [],
-    "mv_allowlist_match_keys": [],
-    "channels": []
+    "primary_team_channel_url": "https://www.youtube.com/@ALL_H_OURS",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@ALL_H_OURS",
+        "channel_label": "ALL(H)OURS",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UC1buRciG8QIL9kRtHxI_tpw",
+          "https://www.youtube.com/@ALL_H_OURS"
+        ],
+        "match_keys": [
+          "@all_h_ours",
+          "https://www.youtube.com/@all_h_ours",
+          "channel:uc1burcig8qil9krthxi_tpw",
+          "https://www.youtube.com/channel/uc1burcig8qil9krthxi_tpw"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@ALL_H_OURS"
+    ],
+    "mv_allowlist_match_keys": [
+      "@all_h_ours",
+      "https://www.youtube.com/@all_h_ours",
+      "channel:uc1burcig8qil9krthxi_tpw",
+      "https://www.youtube.com/channel/uc1burcig8qil9krthxi_tpw"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@ALL_H_OURS",
+        "channel_label": "ALL(H)OURS",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UC1buRciG8QIL9kRtHxI_tpw",
+          "https://www.youtube.com/@ALL_H_OURS"
+        ],
+        "match_keys": [
+          "@all_h_ours",
+          "https://www.youtube.com/@all_h_ours",
+          "channel:uc1burcig8qil9krthxi_tpw",
+          "https://www.youtube.com/channel/uc1burcig8qil9krthxi_tpw"
+        ]
+      }
+    ]
   },
   {
     "group": "ALLDAY PROJECT",
-    "primary_team_channel_url": null,
-    "mv_source_channels": [],
-    "mv_allowlist_urls": [],
-    "mv_allowlist_match_keys": [],
-    "channels": []
+    "primary_team_channel_url": "https://www.youtube.com/@ALLDAY_PROJECT",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@ALLDAY_PROJECT",
+        "channel_label": "ALLDAY PROJECT",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCg8ZzloDPTrOiGztK0C9txQ",
+          "https://www.youtube.com/@ALLDAY_PROJECT"
+        ],
+        "match_keys": [
+          "@allday_project",
+          "https://www.youtube.com/@allday_project",
+          "channel:ucg8zzlodptroigztk0c9txq",
+          "https://www.youtube.com/channel/ucg8zzlodptroigztk0c9txq"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@ALLDAY_PROJECT"
+    ],
+    "mv_allowlist_match_keys": [
+      "@allday_project",
+      "https://www.youtube.com/@allday_project",
+      "channel:ucg8zzlodptroigztk0c9txq",
+      "https://www.youtube.com/channel/ucg8zzlodptroigztk0c9txq"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@ALLDAY_PROJECT",
+        "channel_label": "ALLDAY PROJECT",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCg8ZzloDPTrOiGztK0C9txQ",
+          "https://www.youtube.com/@ALLDAY_PROJECT"
+        ],
+        "match_keys": [
+          "@allday_project",
+          "https://www.youtube.com/@allday_project",
+          "channel:ucg8zzlodptroigztk0c9txq",
+          "https://www.youtube.com/channel/ucg8zzlodptroigztk0c9txq"
+        ]
+      }
+    ]
   },
   {
     "group": "AMPERS&ONE",
@@ -482,6 +516,7 @@
         "allow_mv_uploads": true,
         "display_in_team_links": true,
         "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [],
         "match_keys": [
           "channel:uch9ib4td3u2tsjt3zlicxta",
           "https://www.youtube.com/channel/uch9ib4td3u2tsjt3zlicxta"
@@ -503,6 +538,7 @@
         "allow_mv_uploads": true,
         "display_in_team_links": true,
         "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [],
         "match_keys": [
           "channel:uch9ib4td3u2tsjt3zlicxta",
           "https://www.youtube.com/channel/uch9ib4td3u2tsjt3zlicxta"
@@ -512,45 +548,104 @@
   },
   {
     "group": "ARTMS",
-    "primary_team_channel_url": null,
-    "mv_source_channels": [],
-    "mv_allowlist_urls": [],
-    "mv_allowlist_match_keys": [],
-    "channels": []
+    "primary_team_channel_url": "https://www.youtube.com/@official_artms",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@official_artms",
+        "channel_label": "ARTMS",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UChXC6ok0LaZIpf-50SIFf0Q",
+          "https://www.youtube.com/@official_artms"
+        ],
+        "match_keys": [
+          "@official_artms",
+          "https://www.youtube.com/@official_artms",
+          "channel:uchxc6ok0lazipf-50siff0q",
+          "https://www.youtube.com/channel/uchxc6ok0lazipf-50siff0q"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@official_artms"
+    ],
+    "mv_allowlist_match_keys": [
+      "@official_artms",
+      "https://www.youtube.com/@official_artms",
+      "channel:uchxc6ok0lazipf-50siff0q",
+      "https://www.youtube.com/channel/uchxc6ok0lazipf-50siff0q"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@official_artms",
+        "channel_label": "ARTMS",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UChXC6ok0LaZIpf-50SIFf0Q",
+          "https://www.youtube.com/@official_artms"
+        ],
+        "match_keys": [
+          "@official_artms",
+          "https://www.youtube.com/@official_artms",
+          "channel:uchxc6ok0lazipf-50siff0q",
+          "https://www.youtube.com/channel/uchxc6ok0lazipf-50siff0q"
+        ]
+      }
+    ]
   },
   {
     "group": "ATBO",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCZeIyD0qf91yYwNiyIquSTg",
+    "primary_team_channel_url": "https://www.youtube.com/@ATBO_ground",
     "mv_source_channels": [
       {
-        "channel_url": "https://www.youtube.com/channel/UCZeIyD0qf91yYwNiyIquSTg",
+        "channel_url": "https://www.youtube.com/@ATBO_ground",
         "channel_label": "ATBO",
         "owner_type": "team",
         "allow_mv_uploads": true,
         "display_in_team_links": true,
         "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCZeIyD0qf91yYwNiyIquSTg",
+          "https://www.youtube.com/@ATBO_ground"
+        ],
         "match_keys": [
+          "@atbo_ground",
+          "https://www.youtube.com/@atbo_ground",
           "channel:uczeiyd0qf91yywniyiqustg",
           "https://www.youtube.com/channel/uczeiyd0qf91yywniyiqustg"
         ]
       }
     ],
     "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCZeIyD0qf91yYwNiyIquSTg"
+      "https://www.youtube.com/@ATBO_ground"
     ],
     "mv_allowlist_match_keys": [
+      "@atbo_ground",
+      "https://www.youtube.com/@atbo_ground",
       "channel:uczeiyd0qf91yywniyiqustg",
       "https://www.youtube.com/channel/uczeiyd0qf91yywniyiqustg"
     ],
     "channels": [
       {
-        "channel_url": "https://www.youtube.com/channel/UCZeIyD0qf91yYwNiyIquSTg",
+        "channel_url": "https://www.youtube.com/@ATBO_ground",
         "channel_label": "ATBO",
         "owner_type": "team",
         "allow_mv_uploads": true,
         "display_in_team_links": true,
         "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCZeIyD0qf91yYwNiyIquSTg",
+          "https://www.youtube.com/@ATBO_ground"
+        ],
         "match_keys": [
+          "@atbo_ground",
+          "https://www.youtube.com/@atbo_ground",
           "channel:uczeiyd0qf91yywniyiqustg",
           "https://www.youtube.com/channel/uczeiyd0qf91yywniyiqustg"
         ]
@@ -559,37 +654,51 @@
   },
   {
     "group": "ATEEZ",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UC2e4Ukj5Pfr7cb3KpJAFBdQ",
+    "primary_team_channel_url": "https://www.youtube.com/@ATEEZofficial",
     "mv_source_channels": [
       {
-        "channel_url": "https://www.youtube.com/channel/UC2e4Ukj5Pfr7cb3KpJAFBdQ",
+        "channel_url": "https://www.youtube.com/@ATEEZofficial",
         "channel_label": "ATEEZ",
         "owner_type": "team",
         "allow_mv_uploads": true,
         "display_in_team_links": true,
         "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UC2e4Ukj5Pfr7cb3KpJAFBdQ",
+          "https://www.youtube.com/@ATEEZofficial"
+        ],
         "match_keys": [
+          "@ateezofficial",
+          "https://www.youtube.com/@ateezofficial",
           "channel:uc2e4ukj5pfr7cb3kpjafbdq",
           "https://www.youtube.com/channel/uc2e4ukj5pfr7cb3kpjafbdq"
         ]
       }
     ],
     "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UC2e4Ukj5Pfr7cb3KpJAFBdQ"
+      "https://www.youtube.com/@ATEEZofficial"
     ],
     "mv_allowlist_match_keys": [
+      "@ateezofficial",
+      "https://www.youtube.com/@ateezofficial",
       "channel:uc2e4ukj5pfr7cb3kpjafbdq",
       "https://www.youtube.com/channel/uc2e4ukj5pfr7cb3kpjafbdq"
     ],
     "channels": [
       {
-        "channel_url": "https://www.youtube.com/channel/UC2e4Ukj5Pfr7cb3KpJAFBdQ",
+        "channel_url": "https://www.youtube.com/@ATEEZofficial",
         "channel_label": "ATEEZ",
         "owner_type": "team",
         "allow_mv_uploads": true,
         "display_in_team_links": true,
         "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UC2e4Ukj5Pfr7cb3KpJAFBdQ",
+          "https://www.youtube.com/@ATEEZofficial"
+        ],
         "match_keys": [
+          "@ateezofficial",
+          "https://www.youtube.com/@ateezofficial",
           "channel:uc2e4ukj5pfr7cb3kpjafbdq",
           "https://www.youtube.com/channel/uc2e4ukj5pfr7cb3kpjafbdq"
         ]
@@ -606,13 +715,28 @@
         "owner_type": "team",
         "allow_mv_uploads": true,
         "display_in_team_links": true,
-        "provenance": "manual_override_uploader"
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCgSDdHK0MNXOHv7oBC2dHXA",
+          "https://www.youtube.com/@AtHeart_TITAN"
+        ],
+        "match_keys": [
+          "@atheart_titan",
+          "https://www.youtube.com/@atheart_titan",
+          "channel:ucgsddhk0mnxohv7obc2dhxa",
+          "https://www.youtube.com/channel/ucgsddhk0mnxohv7obc2dhxa"
+        ]
       }
     ],
     "mv_allowlist_urls": [
       "https://www.youtube.com/@AtHeart_TITAN"
     ],
-    "mv_allowlist_match_keys": [],
+    "mv_allowlist_match_keys": [
+      "@atheart_titan",
+      "https://www.youtube.com/@atheart_titan",
+      "channel:ucgsddhk0mnxohv7obc2dhxa",
+      "https://www.youtube.com/channel/ucgsddhk0mnxohv7obc2dhxa"
+    ],
     "channels": [
       {
         "channel_url": "https://www.youtube.com/@AtHeart_TITAN",
@@ -620,24 +744,40 @@
         "owner_type": "team",
         "allow_mv_uploads": true,
         "display_in_team_links": true,
-        "provenance": "manual_override_uploader"
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCgSDdHK0MNXOHv7oBC2dHXA",
+          "https://www.youtube.com/@AtHeart_TITAN"
+        ],
+        "match_keys": [
+          "@atheart_titan",
+          "https://www.youtube.com/@atheart_titan",
+          "channel:ucgsddhk0mnxohv7obc2dhxa",
+          "https://www.youtube.com/channel/ucgsddhk0mnxohv7obc2dhxa"
+        ]
       }
     ]
   },
   {
     "group": "BABYMONSTER",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCqwUnggBBct-AY2lAdI88jQ",
+    "primary_team_channel_url": "https://www.youtube.com/@YGBABYMONSTER_",
     "mv_source_channels": [
       {
-        "channel_url": "https://www.youtube.com/channel/UCqwUnggBBct-AY2lAdI88jQ",
+        "channel_url": "https://www.youtube.com/@YGBABYMONSTER_",
         "channel_label": "BABYMONSTER",
         "owner_type": "team",
         "allow_mv_uploads": true,
         "display_in_team_links": true,
         "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UC-vcrD4bJu1bone79fXbwhg",
+          "https://www.youtube.com/@YGBABYMONSTER_"
+        ],
         "match_keys": [
-          "channel:ucqwunggbbct-ay2ladi88jq",
-          "https://www.youtube.com/channel/ucqwunggbbct-ay2ladi88jq"
+          "@ygbabymonster_",
+          "https://www.youtube.com/@ygbabymonster_",
+          "channel:uc-vcrd4bju1bone79fxbwhg",
+          "https://www.youtube.com/channel/uc-vcrd4bju1bone79fxbwhg"
         ]
       },
       {
@@ -647,33 +787,49 @@
         "allow_mv_uploads": true,
         "display_in_team_links": false,
         "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCnsQjCVzmEd-YvlQZbo6zCg",
+          "https://www.youtube.com/@YGEntertainment"
+        ],
         "match_keys": [
           "@ygentertainment",
-          "https://www.youtube.com/@ygentertainment"
+          "https://www.youtube.com/@ygentertainment",
+          "channel:ucnsqjcvzmed-yvlqzbo6zcg",
+          "https://www.youtube.com/channel/ucnsqjcvzmed-yvlqzbo6zcg"
         ]
       }
     ],
     "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCqwUnggBBct-AY2lAdI88jQ",
+      "https://www.youtube.com/@YGBABYMONSTER_",
       "https://www.youtube.com/@YGEntertainment"
     ],
     "mv_allowlist_match_keys": [
-      "channel:ucqwunggbbct-ay2ladi88jq",
-      "https://www.youtube.com/channel/ucqwunggbbct-ay2ladi88jq",
+      "@ygbabymonster_",
+      "https://www.youtube.com/@ygbabymonster_",
+      "channel:uc-vcrd4bju1bone79fxbwhg",
+      "https://www.youtube.com/channel/uc-vcrd4bju1bone79fxbwhg",
       "@ygentertainment",
-      "https://www.youtube.com/@ygentertainment"
+      "https://www.youtube.com/@ygentertainment",
+      "channel:ucnsqjcvzmed-yvlqzbo6zcg",
+      "https://www.youtube.com/channel/ucnsqjcvzmed-yvlqzbo6zcg"
     ],
     "channels": [
       {
-        "channel_url": "https://www.youtube.com/channel/UCqwUnggBBct-AY2lAdI88jQ",
+        "channel_url": "https://www.youtube.com/@YGBABYMONSTER_",
         "channel_label": "BABYMONSTER",
         "owner_type": "team",
         "allow_mv_uploads": true,
         "display_in_team_links": true,
         "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UC-vcrD4bJu1bone79fXbwhg",
+          "https://www.youtube.com/@YGBABYMONSTER_"
+        ],
         "match_keys": [
-          "channel:ucqwunggbbct-ay2ladi88jq",
-          "https://www.youtube.com/channel/ucqwunggbbct-ay2ladi88jq"
+          "@ygbabymonster_",
+          "https://www.youtube.com/@ygbabymonster_",
+          "channel:uc-vcrd4bju1bone79fxbwhg",
+          "https://www.youtube.com/channel/uc-vcrd4bju1bone79fxbwhg"
         ]
       },
       {
@@ -683,25 +839,37 @@
         "allow_mv_uploads": true,
         "display_in_team_links": false,
         "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCnsQjCVzmEd-YvlQZbo6zCg",
+          "https://www.youtube.com/@YGEntertainment"
+        ],
         "match_keys": [
           "@ygentertainment",
-          "https://www.youtube.com/@ygentertainment"
+          "https://www.youtube.com/@ygentertainment",
+          "channel:ucnsqjcvzmed-yvlqzbo6zcg",
+          "https://www.youtube.com/channel/ucnsqjcvzmed-yvlqzbo6zcg"
         ]
       }
     ]
   },
   {
     "group": "BADVILLAIN",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCh0KpQuSJ9m0DaENZmnYwzw",
+    "primary_team_channel_url": "https://www.youtube.com/@badvillain_bpm",
     "mv_source_channels": [
       {
-        "channel_url": "https://www.youtube.com/channel/UCh0KpQuSJ9m0DaENZmnYwzw",
+        "channel_url": "https://www.youtube.com/@badvillain_bpm",
         "channel_label": "BADVILLAIN",
         "owner_type": "team",
         "allow_mv_uploads": true,
         "display_in_team_links": true,
         "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCh0KpQuSJ9m0DaENZmnYwzw",
+          "https://www.youtube.com/@badvillain_bpm"
+        ],
         "match_keys": [
+          "@badvillain_bpm",
+          "https://www.youtube.com/@badvillain_bpm",
           "channel:uch0kpqusj9m0daenzmnywzw",
           "https://www.youtube.com/channel/uch0kpqusj9m0daenzmnywzw"
         ]
@@ -716,22 +884,30 @@
       }
     ],
     "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCh0KpQuSJ9m0DaENZmnYwzw",
+      "https://www.youtube.com/@badvillain_bpm",
       "https://www.youtube.com/@BPMEntertainment-official"
     ],
     "mv_allowlist_match_keys": [
+      "@badvillain_bpm",
+      "https://www.youtube.com/@badvillain_bpm",
       "channel:uch0kpqusj9m0daenzmnywzw",
       "https://www.youtube.com/channel/uch0kpqusj9m0daenzmnywzw"
     ],
     "channels": [
       {
-        "channel_url": "https://www.youtube.com/channel/UCh0KpQuSJ9m0DaENZmnYwzw",
+        "channel_url": "https://www.youtube.com/@badvillain_bpm",
         "channel_label": "BADVILLAIN",
         "owner_type": "team",
         "allow_mv_uploads": true,
         "display_in_team_links": true,
         "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCh0KpQuSJ9m0DaENZmnYwzw",
+          "https://www.youtube.com/@badvillain_bpm"
+        ],
         "match_keys": [
+          "@badvillain_bpm",
+          "https://www.youtube.com/@badvillain_bpm",
           "channel:uch0kpqusj9m0daenzmnywzw",
           "https://www.youtube.com/channel/uch0kpqusj9m0daenzmnywzw"
         ]
@@ -757,6 +933,7 @@
         "allow_mv_uploads": true,
         "display_in_team_links": true,
         "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [],
         "match_keys": [
           "channel:ucwrngyk9nk9yu9clmlz6hww",
           "https://www.youtube.com/channel/ucwrngyk9nk9yu9clmlz6hww"
@@ -778,6 +955,7 @@
         "allow_mv_uploads": true,
         "display_in_team_links": true,
         "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [],
         "match_keys": [
           "channel:ucwrngyk9nk9yu9clmlz6hww",
           "https://www.youtube.com/channel/ucwrngyk9nk9yu9clmlz6hww"
@@ -787,18 +965,24 @@
   },
   {
     "group": "BLACKPINK",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCOmHUn--16B90oW2L6FRR3A",
+    "primary_team_channel_url": "https://www.youtube.com/@BLACKPINK",
     "mv_source_channels": [
       {
-        "channel_url": "https://www.youtube.com/channel/UCOmHUn--16B90oW2L6FRR3A",
+        "channel_url": "https://www.youtube.com/@BLACKPINK",
         "channel_label": "BLACKPINK",
         "owner_type": "team",
         "allow_mv_uploads": true,
         "display_in_team_links": true,
         "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCQi67q4kGdmnJaRzX81uK5g",
+          "https://www.youtube.com/@BLACKPINK"
+        ],
         "match_keys": [
-          "channel:ucomhun--16b90ow2l6frr3a",
-          "https://www.youtube.com/channel/ucomhun--16b90ow2l6frr3a"
+          "@blackpink",
+          "https://www.youtube.com/@blackpink",
+          "channel:ucqi67q4kgdmnjarzx81uk5g",
+          "https://www.youtube.com/channel/ucqi67q4kgdmnjarzx81uk5g"
         ]
       },
       {
@@ -808,33 +992,49 @@
         "allow_mv_uploads": true,
         "display_in_team_links": false,
         "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCnsQjCVzmEd-YvlQZbo6zCg",
+          "https://www.youtube.com/@YGEntertainment"
+        ],
         "match_keys": [
           "@ygentertainment",
-          "https://www.youtube.com/@ygentertainment"
+          "https://www.youtube.com/@ygentertainment",
+          "channel:ucnsqjcvzmed-yvlqzbo6zcg",
+          "https://www.youtube.com/channel/ucnsqjcvzmed-yvlqzbo6zcg"
         ]
       }
     ],
     "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCOmHUn--16B90oW2L6FRR3A",
+      "https://www.youtube.com/@BLACKPINK",
       "https://www.youtube.com/@YGEntertainment"
     ],
     "mv_allowlist_match_keys": [
-      "channel:ucomhun--16b90ow2l6frr3a",
-      "https://www.youtube.com/channel/ucomhun--16b90ow2l6frr3a",
+      "@blackpink",
+      "https://www.youtube.com/@blackpink",
+      "channel:ucqi67q4kgdmnjarzx81uk5g",
+      "https://www.youtube.com/channel/ucqi67q4kgdmnjarzx81uk5g",
       "@ygentertainment",
-      "https://www.youtube.com/@ygentertainment"
+      "https://www.youtube.com/@ygentertainment",
+      "channel:ucnsqjcvzmed-yvlqzbo6zcg",
+      "https://www.youtube.com/channel/ucnsqjcvzmed-yvlqzbo6zcg"
     ],
     "channels": [
       {
-        "channel_url": "https://www.youtube.com/channel/UCOmHUn--16B90oW2L6FRR3A",
+        "channel_url": "https://www.youtube.com/@BLACKPINK",
         "channel_label": "BLACKPINK",
         "owner_type": "team",
         "allow_mv_uploads": true,
         "display_in_team_links": true,
         "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCQi67q4kGdmnJaRzX81uK5g",
+          "https://www.youtube.com/@BLACKPINK"
+        ],
         "match_keys": [
-          "channel:ucomhun--16b90ow2l6frr3a",
-          "https://www.youtube.com/channel/ucomhun--16b90ow2l6frr3a"
+          "@blackpink",
+          "https://www.youtube.com/@blackpink",
+          "channel:ucqi67q4kgdmnjarzx81uk5g",
+          "https://www.youtube.com/channel/ucqi67q4kgdmnjarzx81uk5g"
         ]
       },
       {
@@ -844,69 +1044,90 @@
         "allow_mv_uploads": true,
         "display_in_team_links": false,
         "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCnsQjCVzmEd-YvlQZbo6zCg",
+          "https://www.youtube.com/@YGEntertainment"
+        ],
         "match_keys": [
           "@ygentertainment",
-          "https://www.youtube.com/@ygentertainment"
+          "https://www.youtube.com/@ygentertainment",
+          "channel:ucnsqjcvzmed-yvlqzbo6zcg",
+          "https://www.youtube.com/channel/ucnsqjcvzmed-yvlqzbo6zcg"
         ]
       }
     ]
   },
   {
     "group": "BLITZERS",
-    "primary_team_channel_url": null,
-    "mv_source_channels": [],
-    "mv_allowlist_urls": [],
-    "mv_allowlist_match_keys": [],
-    "channels": []
-  },
-  {
-    "group": "BOYNEXTDOOR",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UChhKBlh_wvspTh5n4mL0b5g",
+    "primary_team_channel_url": "https://www.youtube.com/@Blitzers",
     "mv_source_channels": [
       {
-        "channel_url": "https://www.youtube.com/channel/UChhKBlh_wvspTh5n4mL0b5g",
-        "channel_label": "BOYNEXTDOOR",
+        "channel_url": "https://www.youtube.com/@Blitzers",
+        "channel_label": "BLITZERS",
         "owner_type": "team",
         "allow_mv_uploads": true,
         "display_in_team_links": true,
         "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCfwfC9QCYr_wxgib5dAB-mQ",
+          "https://www.youtube.com/@Blitzers"
+        ],
         "match_keys": [
-          "channel:uchhkblh_wvspth5n4ml0b5g",
-          "https://www.youtube.com/channel/uchhkblh_wvspth5n4ml0b5g"
-        ]
-      },
-      {
-        "channel_url": "https://www.youtube.com/@HYBELABELS",
-        "channel_label": "HYBE LABELS",
-        "owner_type": "label",
-        "allow_mv_uploads": true,
-        "display_in_team_links": false,
-        "provenance": "curated_agency_allowlist",
-        "match_keys": [
-          "@hybelabels",
-          "https://www.youtube.com/@hybelabels"
+          "@blitzers",
+          "https://www.youtube.com/@blitzers",
+          "channel:ucfwfc9qcyr_wxgib5dab-mq",
+          "https://www.youtube.com/channel/ucfwfc9qcyr_wxgib5dab-mq"
         ]
       }
     ],
     "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UChhKBlh_wvspTh5n4mL0b5g",
-      "https://www.youtube.com/@HYBELABELS"
+      "https://www.youtube.com/@Blitzers"
     ],
     "mv_allowlist_match_keys": [
-      "channel:uchhkblh_wvspth5n4ml0b5g",
-      "https://www.youtube.com/channel/uchhkblh_wvspth5n4ml0b5g",
-      "@hybelabels",
-      "https://www.youtube.com/@hybelabels"
+      "@blitzers",
+      "https://www.youtube.com/@blitzers",
+      "channel:ucfwfc9qcyr_wxgib5dab-mq",
+      "https://www.youtube.com/channel/ucfwfc9qcyr_wxgib5dab-mq"
     ],
     "channels": [
       {
-        "channel_url": "https://www.youtube.com/channel/UChhKBlh_wvspTh5n4mL0b5g",
+        "channel_url": "https://www.youtube.com/@Blitzers",
+        "channel_label": "BLITZERS",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCfwfC9QCYr_wxgib5dAB-mQ",
+          "https://www.youtube.com/@Blitzers"
+        ],
+        "match_keys": [
+          "@blitzers",
+          "https://www.youtube.com/@blitzers",
+          "channel:ucfwfc9qcyr_wxgib5dab-mq",
+          "https://www.youtube.com/channel/ucfwfc9qcyr_wxgib5dab-mq"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "BOYNEXTDOOR",
+    "primary_team_channel_url": "https://www.youtube.com/@boynextdoor_official",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@boynextdoor_official",
         "channel_label": "BOYNEXTDOOR",
         "owner_type": "team",
         "allow_mv_uploads": true,
         "display_in_team_links": true,
         "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UChhKBlh_wvspTh5n4mL0b5g",
+          "https://www.youtube.com/@boynextdoor_official"
+        ],
         "match_keys": [
+          "@boynextdoor_official",
+          "https://www.youtube.com/@boynextdoor_official",
           "channel:uchhkblh_wvspth5n4ml0b5g",
           "https://www.youtube.com/channel/uchhkblh_wvspth5n4ml0b5g"
         ]
@@ -918,46 +1139,118 @@
         "allow_mv_uploads": true,
         "display_in_team_links": false,
         "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UC3IZKseVpdzPSBaWxBxundA",
+          "https://www.youtube.com/@HYBELABELS"
+        ],
         "match_keys": [
           "@hybelabels",
-          "https://www.youtube.com/@hybelabels"
+          "https://www.youtube.com/@hybelabels",
+          "channel:uc3izksevpdzpsbawxbxunda",
+          "https://www.youtube.com/channel/uc3izksevpdzpsbawxbxunda"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@boynextdoor_official",
+      "https://www.youtube.com/@HYBELABELS"
+    ],
+    "mv_allowlist_match_keys": [
+      "@boynextdoor_official",
+      "https://www.youtube.com/@boynextdoor_official",
+      "channel:uchhkblh_wvspth5n4ml0b5g",
+      "https://www.youtube.com/channel/uchhkblh_wvspth5n4ml0b5g",
+      "@hybelabels",
+      "https://www.youtube.com/@hybelabels",
+      "channel:uc3izksevpdzpsbawxbxunda",
+      "https://www.youtube.com/channel/uc3izksevpdzpsbawxbxunda"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@boynextdoor_official",
+        "channel_label": "BOYNEXTDOOR",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UChhKBlh_wvspTh5n4mL0b5g",
+          "https://www.youtube.com/@boynextdoor_official"
+        ],
+        "match_keys": [
+          "@boynextdoor_official",
+          "https://www.youtube.com/@boynextdoor_official",
+          "channel:uchhkblh_wvspth5n4ml0b5g",
+          "https://www.youtube.com/channel/uchhkblh_wvspth5n4ml0b5g"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/@HYBELABELS",
+        "channel_label": "HYBE LABELS",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UC3IZKseVpdzPSBaWxBxundA",
+          "https://www.youtube.com/@HYBELABELS"
+        ],
+        "match_keys": [
+          "@hybelabels",
+          "https://www.youtube.com/@hybelabels",
+          "channel:uc3izksevpdzpsbawxbxunda",
+          "https://www.youtube.com/channel/uc3izksevpdzpsbawxbxunda"
         ]
       }
     ]
   },
   {
     "group": "BTOB",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCgB7A457ULlgm5c3948vr-w",
+    "primary_team_channel_url": "https://www.youtube.com/@officialbtob",
     "mv_source_channels": [
       {
-        "channel_url": "https://www.youtube.com/channel/UCgB7A457ULlgm5c3948vr-w",
+        "channel_url": "https://www.youtube.com/@officialbtob",
         "channel_label": "BTOB",
         "owner_type": "team",
         "allow_mv_uploads": true,
         "display_in_team_links": true,
         "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCgB7A457ULlgm5c3948vr-w",
+          "https://www.youtube.com/@officialbtob"
+        ],
         "match_keys": [
+          "@officialbtob",
+          "https://www.youtube.com/@officialbtob",
           "channel:ucgb7a457ullgm5c3948vr-w",
           "https://www.youtube.com/channel/ucgb7a457ullgm5c3948vr-w"
         ]
       }
     ],
     "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCgB7A457ULlgm5c3948vr-w"
+      "https://www.youtube.com/@officialbtob"
     ],
     "mv_allowlist_match_keys": [
+      "@officialbtob",
+      "https://www.youtube.com/@officialbtob",
       "channel:ucgb7a457ullgm5c3948vr-w",
       "https://www.youtube.com/channel/ucgb7a457ullgm5c3948vr-w"
     ],
     "channels": [
       {
-        "channel_url": "https://www.youtube.com/channel/UCgB7A457ULlgm5c3948vr-w",
+        "channel_url": "https://www.youtube.com/@officialbtob",
         "channel_label": "BTOB",
         "owner_type": "team",
         "allow_mv_uploads": true,
         "display_in_team_links": true,
         "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCgB7A457ULlgm5c3948vr-w",
+          "https://www.youtube.com/@officialbtob"
+        ],
         "match_keys": [
+          "@officialbtob",
+          "https://www.youtube.com/@officialbtob",
           "channel:ucgb7a457ullgm5c3948vr-w",
           "https://www.youtube.com/channel/ucgb7a457ullgm5c3948vr-w"
         ]
@@ -975,6 +1268,7 @@
         "allow_mv_uploads": true,
         "display_in_team_links": true,
         "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [],
         "match_keys": [
           "channel:uclkaepwjdylmxsltoffvsyq",
           "https://www.youtube.com/channel/uclkaepwjdylmxsltoffvsyq"
@@ -987,9 +1281,15 @@
         "allow_mv_uploads": true,
         "display_in_team_links": false,
         "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UC3IZKseVpdzPSBaWxBxundA",
+          "https://www.youtube.com/@HYBELABELS"
+        ],
         "match_keys": [
           "@hybelabels",
-          "https://www.youtube.com/@hybelabels"
+          "https://www.youtube.com/@hybelabels",
+          "channel:uc3izksevpdzpsbawxbxunda",
+          "https://www.youtube.com/channel/uc3izksevpdzpsbawxbxunda"
         ]
       }
     ],
@@ -1001,7 +1301,9 @@
       "channel:uclkaepwjdylmxsltoffvsyq",
       "https://www.youtube.com/channel/uclkaepwjdylmxsltoffvsyq",
       "@hybelabels",
-      "https://www.youtube.com/@hybelabels"
+      "https://www.youtube.com/@hybelabels",
+      "channel:uc3izksevpdzpsbawxbxunda",
+      "https://www.youtube.com/channel/uc3izksevpdzpsbawxbxunda"
     ],
     "channels": [
       {
@@ -1011,6 +1313,7 @@
         "allow_mv_uploads": true,
         "display_in_team_links": true,
         "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [],
         "match_keys": [
           "channel:uclkaepwjdylmxsltoffvsyq",
           "https://www.youtube.com/channel/uclkaepwjdylmxsltoffvsyq"
@@ -1023,3176 +1326,121 @@
         "allow_mv_uploads": true,
         "display_in_team_links": false,
         "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UC3IZKseVpdzPSBaWxBxundA",
+          "https://www.youtube.com/@HYBELABELS"
+        ],
         "match_keys": [
           "@hybelabels",
-          "https://www.youtube.com/@hybelabels"
+          "https://www.youtube.com/@hybelabels",
+          "channel:uc3izksevpdzpsbawxbxunda",
+          "https://www.youtube.com/channel/uc3izksevpdzpsbawxbxunda"
         ]
       }
     ]
   },
   {
-    "group": "CIX",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCuaslC77K-NmCy8Xwk7x0hA",
+    "group": "CHUNG HA",
+    "primary_team_channel_url": "https://www.youtube.com/@CHUNGHA_OFFICIAL",
     "mv_source_channels": [
       {
-        "channel_url": "https://www.youtube.com/channel/UCuaslC77K-NmCy8Xwk7x0hA",
-        "channel_label": "CIX",
+        "channel_url": "https://www.youtube.com/@CHUNGHA_OFFICIAL",
+        "channel_label": "CHUNG HA",
         "owner_type": "team",
         "allow_mv_uploads": true,
         "display_in_team_links": true,
         "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UC9Gxb0gMCh3EPIDLQXeQUog",
+          "https://www.youtube.com/@CHUNGHA_OFFICIAL"
+        ],
         "match_keys": [
-          "channel:ucuaslc77k-nmcy8xwk7x0ha",
-          "https://www.youtube.com/channel/ucuaslc77k-nmcy8xwk7x0ha"
+          "@chungha_official",
+          "https://www.youtube.com/@chungha_official",
+          "channel:uc9gxb0gmch3epidlqxequog",
+          "https://www.youtube.com/channel/uc9gxb0gmch3epidlqxequog"
         ]
       }
     ],
     "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCuaslC77K-NmCy8Xwk7x0hA"
+      "https://www.youtube.com/@CHUNGHA_OFFICIAL"
     ],
     "mv_allowlist_match_keys": [
-      "channel:ucuaslc77k-nmcy8xwk7x0ha",
-      "https://www.youtube.com/channel/ucuaslc77k-nmcy8xwk7x0ha"
+      "@chungha_official",
+      "https://www.youtube.com/@chungha_official",
+      "channel:uc9gxb0gmch3epidlqxequog",
+      "https://www.youtube.com/channel/uc9gxb0gmch3epidlqxequog"
     ],
     "channels": [
       {
-        "channel_url": "https://www.youtube.com/channel/UCuaslC77K-NmCy8Xwk7x0hA",
-        "channel_label": "CIX",
+        "channel_url": "https://www.youtube.com/@CHUNGHA_OFFICIAL",
+        "channel_label": "CHUNG HA",
         "owner_type": "team",
         "allow_mv_uploads": true,
         "display_in_team_links": true,
         "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UC9Gxb0gMCh3EPIDLQXeQUog",
+          "https://www.youtube.com/@CHUNGHA_OFFICIAL"
+        ],
         "match_keys": [
-          "channel:ucuaslc77k-nmcy8xwk7x0ha",
-          "https://www.youtube.com/channel/ucuaslc77k-nmcy8xwk7x0ha"
+          "@chungha_official",
+          "https://www.youtube.com/@chungha_official",
+          "channel:uc9gxb0gmch3epidlqxequog",
+          "https://www.youtube.com/channel/uc9gxb0gmch3epidlqxequog"
         ]
       }
     ]
   },
   {
-    "group": "CLOSE YOUR EYES",
-    "primary_team_channel_url": null,
-    "mv_source_channels": [],
-    "mv_allowlist_urls": [],
-    "mv_allowlist_match_keys": [],
-    "channels": []
-  },
-  {
-    "group": "CLASS:y",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCbCyYn2M_1ccicwj-KU7t0Q",
+    "group": "CHUU",
+    "primary_team_channel_url": "https://www.youtube.com/@CHUUOfficial",
     "mv_source_channels": [
       {
-        "channel_url": "https://www.youtube.com/channel/UCbCyYn2M_1ccicwj-KU7t0Q",
-        "channel_label": "CLASS:y",
+        "channel_url": "https://www.youtube.com/@CHUUOfficial",
+        "channel_label": "CHUU",
         "owner_type": "team",
         "allow_mv_uploads": true,
         "display_in_team_links": true,
         "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCa0ylH-c4-MHZ7ih_6AHtXg",
+          "https://www.youtube.com/@CHUUOfficial"
+        ],
         "match_keys": [
-          "channel:ucbcyyn2m_1ccicwj-ku7t0q",
-          "https://www.youtube.com/channel/ucbcyyn2m_1ccicwj-ku7t0q"
+          "@chuuofficial",
+          "https://www.youtube.com/@chuuofficial",
+          "channel:uca0ylh-c4-mhz7ih_6ahtxg",
+          "https://www.youtube.com/channel/uca0ylh-c4-mhz7ih_6ahtxg"
         ]
       }
     ],
     "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCbCyYn2M_1ccicwj-KU7t0Q"
+      "https://www.youtube.com/@CHUUOfficial"
     ],
     "mv_allowlist_match_keys": [
-      "channel:ucbcyyn2m_1ccicwj-ku7t0q",
-      "https://www.youtube.com/channel/ucbcyyn2m_1ccicwj-ku7t0q"
+      "@chuuofficial",
+      "https://www.youtube.com/@chuuofficial",
+      "channel:uca0ylh-c4-mhz7ih_6ahtxg",
+      "https://www.youtube.com/channel/uca0ylh-c4-mhz7ih_6ahtxg"
     ],
     "channels": [
       {
-        "channel_url": "https://www.youtube.com/channel/UCbCyYn2M_1ccicwj-KU7t0Q",
-        "channel_label": "CLASS:y",
+        "channel_url": "https://www.youtube.com/@CHUUOfficial",
+        "channel_label": "CHUU",
         "owner_type": "team",
         "allow_mv_uploads": true,
         "display_in_team_links": true,
         "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCa0ylH-c4-MHZ7ih_6AHtXg",
+          "https://www.youtube.com/@CHUUOfficial"
+        ],
         "match_keys": [
-          "channel:ucbcyyn2m_1ccicwj-ku7t0q",
-          "https://www.youtube.com/channel/ucbcyyn2m_1ccicwj-ku7t0q"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "CRAVITY",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCRm-0JVuUFh5HV7NGG7qXlQ",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCRm-0JVuUFh5HV7NGG7qXlQ",
-        "channel_label": "CRAVITY",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucrm-0jvuufh5hv7ngg7qxlq",
-          "https://www.youtube.com/channel/ucrm-0jvuufh5hv7ngg7qxlq"
-        ]
-      },
-      {
-        "channel_url": "https://www.youtube.com/@officialstarship",
-        "channel_label": "STARSHIP",
-        "owner_type": "label",
-        "allow_mv_uploads": true,
-        "display_in_team_links": false,
-        "provenance": "curated_agency_allowlist",
-        "match_keys": [
-          "@officialstarship",
-          "https://www.youtube.com/@officialstarship"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCRm-0JVuUFh5HV7NGG7qXlQ",
-      "https://www.youtube.com/@officialstarship"
-    ],
-    "mv_allowlist_match_keys": [
-      "channel:ucrm-0jvuufh5hv7ngg7qxlq",
-      "https://www.youtube.com/channel/ucrm-0jvuufh5hv7ngg7qxlq",
-      "@officialstarship",
-      "https://www.youtube.com/@officialstarship"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCRm-0JVuUFh5HV7NGG7qXlQ",
-        "channel_label": "CRAVITY",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucrm-0jvuufh5hv7ngg7qxlq",
-          "https://www.youtube.com/channel/ucrm-0jvuufh5hv7ngg7qxlq"
-        ]
-      },
-      {
-        "channel_url": "https://www.youtube.com/@officialstarship",
-        "channel_label": "STARSHIP",
-        "owner_type": "label",
-        "allow_mv_uploads": true,
-        "display_in_team_links": false,
-        "provenance": "curated_agency_allowlist",
-        "match_keys": [
-          "@officialstarship",
-          "https://www.youtube.com/@officialstarship"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "CSR",
-    "primary_team_channel_url": null,
-    "mv_source_channels": [],
-    "mv_allowlist_urls": [],
-    "mv_allowlist_match_keys": [],
-    "channels": []
-  },
-  {
-    "group": "DAY6",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCp-pqXsizklX3ZHvLxXyhxw",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCp-pqXsizklX3ZHvLxXyhxw",
-        "channel_label": "DAY6",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucp-pqxsizklx3zhvlxxyhxw",
-          "https://www.youtube.com/channel/ucp-pqxsizklx3zhvlxxyhxw"
-        ]
-      },
-      {
-        "channel_url": "https://www.youtube.com/@JYPEntertainment",
-        "channel_label": "JYP Entertainment",
-        "owner_type": "label",
-        "allow_mv_uploads": true,
-        "display_in_team_links": false,
-        "provenance": "curated_agency_allowlist",
-        "match_keys": [
-          "@jypentertainment",
-          "https://www.youtube.com/@jypentertainment"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCp-pqXsizklX3ZHvLxXyhxw",
-      "https://www.youtube.com/@JYPEntertainment"
-    ],
-    "mv_allowlist_match_keys": [
-      "channel:ucp-pqxsizklx3zhvlxxyhxw",
-      "https://www.youtube.com/channel/ucp-pqxsizklx3zhvlxxyhxw",
-      "@jypentertainment",
-      "https://www.youtube.com/@jypentertainment"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCp-pqXsizklX3ZHvLxXyhxw",
-        "channel_label": "DAY6",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucp-pqxsizklx3zhvlxxyhxw",
-          "https://www.youtube.com/channel/ucp-pqxsizklx3zhvlxxyhxw"
-        ]
-      },
-      {
-        "channel_url": "https://www.youtube.com/@JYPEntertainment",
-        "channel_label": "JYP Entertainment",
-        "owner_type": "label",
-        "allow_mv_uploads": true,
-        "display_in_team_links": false,
-        "provenance": "curated_agency_allowlist",
-        "match_keys": [
-          "@jypentertainment",
-          "https://www.youtube.com/@jypentertainment"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "DKB",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCCwfiPqSomsqZkkmbjPK5wg",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCCwfiPqSomsqZkkmbjPK5wg",
-        "channel_label": "DKB",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:uccwfipqsomsqzkkmbjpk5wg",
-          "https://www.youtube.com/channel/uccwfipqsomsqzkkmbjpk5wg"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCCwfiPqSomsqZkkmbjPK5wg"
-    ],
-    "mv_allowlist_match_keys": [
-      "channel:uccwfipqsomsqzkkmbjpk5wg",
-      "https://www.youtube.com/channel/uccwfipqsomsqzkkmbjpk5wg"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCCwfiPqSomsqZkkmbjPK5wg",
-        "channel_label": "DKB",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:uccwfipqsomsqzkkmbjpk5wg",
-          "https://www.youtube.com/channel/uccwfipqsomsqzkkmbjpk5wg"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "DRIPPIN",
-    "primary_team_channel_url": null,
-    "mv_source_channels": [],
-    "mv_allowlist_urls": [],
-    "mv_allowlist_match_keys": [],
-    "channels": []
-  },
-  {
-    "group": "DXMON",
-    "primary_team_channel_url": null,
-    "mv_source_channels": [],
-    "mv_allowlist_urls": [],
-    "mv_allowlist_match_keys": [],
-    "channels": []
-  },
-  {
-    "group": "Dreamcatcher",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCijULR2sXLutCRBtW3_WEfA",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCijULR2sXLutCRBtW3_WEfA",
-        "channel_label": "Dreamcatcher",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucijulr2sxlutcrbtw3_wefa",
-          "https://www.youtube.com/channel/ucijulr2sxlutcrbtw3_wefa"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCijULR2sXLutCRBtW3_WEfA"
-    ],
-    "mv_allowlist_match_keys": [
-      "channel:ucijulr2sxlutcrbtw3_wefa",
-      "https://www.youtube.com/channel/ucijulr2sxlutcrbtw3_wefa"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCijULR2sXLutCRBtW3_WEfA",
-        "channel_label": "Dreamcatcher",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucijulr2sxlutcrbtw3_wefa",
-          "https://www.youtube.com/channel/ucijulr2sxlutcrbtw3_wefa"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "ENHYPEN",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCArLZtok93cO5R9RI4_Y5Jw",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCArLZtok93cO5R9RI4_Y5Jw",
-        "channel_label": "ENHYPEN",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucarlztok93co5r9ri4_y5jw",
-          "https://www.youtube.com/channel/ucarlztok93co5r9ri4_y5jw"
-        ]
-      },
-      {
-        "channel_url": "https://www.youtube.com/@HYBELABELS",
-        "channel_label": "HYBE LABELS",
-        "owner_type": "label",
-        "allow_mv_uploads": true,
-        "display_in_team_links": false,
-        "provenance": "curated_agency_allowlist",
-        "match_keys": [
-          "@hybelabels",
-          "https://www.youtube.com/@hybelabels"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCArLZtok93cO5R9RI4_Y5Jw",
-      "https://www.youtube.com/@HYBELABELS"
-    ],
-    "mv_allowlist_match_keys": [
-      "channel:ucarlztok93co5r9ri4_y5jw",
-      "https://www.youtube.com/channel/ucarlztok93co5r9ri4_y5jw",
-      "@hybelabels",
-      "https://www.youtube.com/@hybelabels"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCArLZtok93cO5R9RI4_Y5Jw",
-        "channel_label": "ENHYPEN",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucarlztok93co5r9ri4_y5jw",
-          "https://www.youtube.com/channel/ucarlztok93co5r9ri4_y5jw"
-        ]
-      },
-      {
-        "channel_url": "https://www.youtube.com/@HYBELABELS",
-        "channel_label": "HYBE LABELS",
-        "owner_type": "label",
-        "allow_mv_uploads": true,
-        "display_in_team_links": false,
-        "provenance": "curated_agency_allowlist",
-        "match_keys": [
-          "@hybelabels",
-          "https://www.youtube.com/@hybelabels"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "EPEX",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCKHl-9B-aa4AK5ZR9XLOg8A",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCKHl-9B-aa4AK5ZR9XLOg8A",
-        "channel_label": "EPEX",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:uckhl-9b-aa4ak5zr9xlog8a",
-          "https://www.youtube.com/channel/uckhl-9b-aa4ak5zr9xlog8a"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCKHl-9B-aa4AK5ZR9XLOg8A"
-    ],
-    "mv_allowlist_match_keys": [
-      "channel:uckhl-9b-aa4ak5zr9xlog8a",
-      "https://www.youtube.com/channel/uckhl-9b-aa4ak5zr9xlog8a"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCKHl-9B-aa4AK5ZR9XLOg8A",
-        "channel_label": "EPEX",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:uckhl-9b-aa4ak5zr9xlog8a",
-          "https://www.youtube.com/channel/uckhl-9b-aa4ak5zr9xlog8a"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "EVNNE",
-    "primary_team_channel_url": null,
-    "mv_source_channels": [],
-    "mv_allowlist_urls": [],
-    "mv_allowlist_match_keys": [],
-    "channels": []
-  },
-  {
-    "group": "EXO",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCzCedBCSSltI1TFd3bKyN6g",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCzCedBCSSltI1TFd3bKyN6g",
-        "channel_label": "EXO",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:uczcedbcsslti1tfd3bkyn6g",
-          "https://www.youtube.com/channel/uczcedbcsslti1tfd3bkyn6g"
-        ]
-      },
-      {
-        "channel_url": "https://www.youtube.com/@SMTOWN",
-        "channel_label": "SMTOWN",
-        "owner_type": "label",
-        "allow_mv_uploads": true,
-        "display_in_team_links": false,
-        "provenance": "curated_agency_allowlist",
-        "match_keys": [
-          "@smtown",
-          "https://www.youtube.com/@smtown"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCzCedBCSSltI1TFd3bKyN6g",
-      "https://www.youtube.com/@SMTOWN"
-    ],
-    "mv_allowlist_match_keys": [
-      "channel:uczcedbcsslti1tfd3bkyn6g",
-      "https://www.youtube.com/channel/uczcedbcsslti1tfd3bkyn6g",
-      "@smtown",
-      "https://www.youtube.com/@smtown"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCzCedBCSSltI1TFd3bKyN6g",
-        "channel_label": "EXO",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:uczcedbcsslti1tfd3bkyn6g",
-          "https://www.youtube.com/channel/uczcedbcsslti1tfd3bkyn6g"
-        ]
-      },
-      {
-        "channel_url": "https://www.youtube.com/@SMTOWN",
-        "channel_label": "SMTOWN",
-        "owner_type": "label",
-        "allow_mv_uploads": true,
-        "display_in_team_links": false,
-        "provenance": "curated_agency_allowlist",
-        "match_keys": [
-          "@smtown",
-          "https://www.youtube.com/@smtown"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "FIFTY FIFTY",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCJEER74X9kBenMT_x9iK9Mw",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCJEER74X9kBenMT_x9iK9Mw",
-        "channel_label": "FIFTY FIFTY",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucjeer74x9kbenmt_x9ik9mw",
-          "https://www.youtube.com/channel/ucjeer74x9kbenmt_x9ik9mw"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCJEER74X9kBenMT_x9iK9Mw"
-    ],
-    "mv_allowlist_match_keys": [
-      "channel:ucjeer74x9kbenmt_x9ik9mw",
-      "https://www.youtube.com/channel/ucjeer74x9kbenmt_x9ik9mw"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCJEER74X9kBenMT_x9iK9Mw",
-        "channel_label": "FIFTY FIFTY",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucjeer74x9kbenmt_x9ik9mw",
-          "https://www.youtube.com/channel/ucjeer74x9kbenmt_x9ik9mw"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "GHOST9",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCwBsVtDcTVG4QCorkVNJ5Sg",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCwBsVtDcTVG4QCorkVNJ5Sg",
-        "channel_label": "GHOST9",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucwbsvtdctvg4qcorkvnj5sg",
-          "https://www.youtube.com/channel/ucwbsvtdctvg4qcorkvnj5sg"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCwBsVtDcTVG4QCorkVNJ5Sg"
-    ],
-    "mv_allowlist_match_keys": [
-      "channel:ucwbsvtdctvg4qcorkvnj5sg",
-      "https://www.youtube.com/channel/ucwbsvtdctvg4qcorkvnj5sg"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCwBsVtDcTVG4QCorkVNJ5Sg",
-        "channel_label": "GHOST9",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucwbsvtdctvg4qcorkvnj5sg",
-          "https://www.youtube.com/channel/ucwbsvtdctvg4qcorkvnj5sg"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "H1-KEY",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UC-6L6QIx3M6O_ROf7CP-pJg",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UC-6L6QIx3M6O_ROf7CP-pJg",
-        "channel_label": "H1-KEY",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:uc-6l6qix3m6o_rof7cp-pjg",
-          "https://www.youtube.com/channel/uc-6l6qix3m6o_rof7cp-pjg"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UC-6L6QIx3M6O_ROf7CP-pJg"
-    ],
-    "mv_allowlist_match_keys": [
-      "channel:uc-6l6qix3m6o_rof7cp-pjg",
-      "https://www.youtube.com/channel/uc-6l6qix3m6o_rof7cp-pjg"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UC-6L6QIx3M6O_ROf7CP-pJg",
-        "channel_label": "H1-KEY",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:uc-6l6qix3m6o_rof7cp-pjg",
-          "https://www.youtube.com/channel/uc-6l6qix3m6o_rof7cp-pjg"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "Hearts2Hearts",
-    "primary_team_channel_url": null,
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/@SMTOWN",
-        "channel_label": "SMTOWN",
-        "owner_type": "label",
-        "allow_mv_uploads": true,
-        "display_in_team_links": false,
-        "provenance": "curated_agency_allowlist",
-        "match_keys": [
-          "@smtown",
-          "https://www.youtube.com/@smtown"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/@SMTOWN"
-    ],
-    "mv_allowlist_match_keys": [
-      "@smtown",
-      "https://www.youtube.com/@smtown"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/@SMTOWN",
-        "channel_label": "SMTOWN",
-        "owner_type": "label",
-        "allow_mv_uploads": true,
-        "display_in_team_links": false,
-        "provenance": "curated_agency_allowlist",
-        "match_keys": [
-          "@smtown",
-          "https://www.youtube.com/@smtown"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "INFINITE",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCdzXSux7OnRD1Cml-DQ416Q",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCdzXSux7OnRD1Cml-DQ416Q",
-        "channel_label": "INFINITE",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucdzxsux7onrd1cml-dq416q",
-          "https://www.youtube.com/channel/ucdzxsux7onrd1cml-dq416q"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCdzXSux7OnRD1Cml-DQ416Q"
-    ],
-    "mv_allowlist_match_keys": [
-      "channel:ucdzxsux7onrd1cml-dq416q",
-      "https://www.youtube.com/channel/ucdzxsux7onrd1cml-dq416q"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCdzXSux7OnRD1Cml-DQ416Q",
-        "channel_label": "INFINITE",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucdzxsux7onrd1cml-dq416q",
-          "https://www.youtube.com/channel/ucdzxsux7onrd1cml-dq416q"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "ITZY",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCDhM2k2Cua-JdobAh5moMFg",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCDhM2k2Cua-JdobAh5moMFg",
-        "channel_label": "ITZY",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucdhm2k2cua-jdobah5momfg",
-          "https://www.youtube.com/channel/ucdhm2k2cua-jdobah5momfg"
-        ]
-      },
-      {
-        "channel_url": "https://www.youtube.com/@JYPEntertainment",
-        "channel_label": "JYP Entertainment",
-        "owner_type": "label",
-        "allow_mv_uploads": true,
-        "display_in_team_links": false,
-        "provenance": "curated_agency_allowlist",
-        "match_keys": [
-          "@jypentertainment",
-          "https://www.youtube.com/@jypentertainment"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCDhM2k2Cua-JdobAh5moMFg",
-      "https://www.youtube.com/@JYPEntertainment"
-    ],
-    "mv_allowlist_match_keys": [
-      "channel:ucdhm2k2cua-jdobah5momfg",
-      "https://www.youtube.com/channel/ucdhm2k2cua-jdobah5momfg",
-      "@jypentertainment",
-      "https://www.youtube.com/@jypentertainment"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCDhM2k2Cua-JdobAh5moMFg",
-        "channel_label": "ITZY",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucdhm2k2cua-jdobah5momfg",
-          "https://www.youtube.com/channel/ucdhm2k2cua-jdobah5momfg"
-        ]
-      },
-      {
-        "channel_url": "https://www.youtube.com/@JYPEntertainment",
-        "channel_label": "JYP Entertainment",
-        "owner_type": "label",
-        "allow_mv_uploads": true,
-        "display_in_team_links": false,
-        "provenance": "curated_agency_allowlist",
-        "match_keys": [
-          "@jypentertainment",
-          "https://www.youtube.com/@jypentertainment"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "IVE",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UC-Fnix71vRP64WXeo0ikd0Q",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UC-Fnix71vRP64WXeo0ikd0Q",
-        "channel_label": "IVE",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:uc-fnix71vrp64wxeo0ikd0q",
-          "https://www.youtube.com/channel/uc-fnix71vrp64wxeo0ikd0q"
-        ]
-      },
-      {
-        "channel_url": "https://www.youtube.com/@officialstarship",
-        "channel_label": "STARSHIP",
-        "owner_type": "label",
-        "allow_mv_uploads": true,
-        "display_in_team_links": false,
-        "provenance": "curated_agency_allowlist",
-        "match_keys": [
-          "@officialstarship",
-          "https://www.youtube.com/@officialstarship"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UC-Fnix71vRP64WXeo0ikd0Q",
-      "https://www.youtube.com/@officialstarship"
-    ],
-    "mv_allowlist_match_keys": [
-      "channel:uc-fnix71vrp64wxeo0ikd0q",
-      "https://www.youtube.com/channel/uc-fnix71vrp64wxeo0ikd0q",
-      "@officialstarship",
-      "https://www.youtube.com/@officialstarship"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UC-Fnix71vRP64WXeo0ikd0Q",
-        "channel_label": "IVE",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:uc-fnix71vrp64wxeo0ikd0q",
-          "https://www.youtube.com/channel/uc-fnix71vrp64wxeo0ikd0q"
-        ]
-      },
-      {
-        "channel_url": "https://www.youtube.com/@officialstarship",
-        "channel_label": "STARSHIP",
-        "owner_type": "label",
-        "allow_mv_uploads": true,
-        "display_in_team_links": false,
-        "provenance": "curated_agency_allowlist",
-        "match_keys": [
-          "@officialstarship",
-          "https://www.youtube.com/@officialstarship"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "JUST B",
-    "primary_team_channel_url": null,
-    "mv_source_channels": [],
-    "mv_allowlist_urls": [],
-    "mv_allowlist_match_keys": [],
-    "channels": []
-  },
-  {
-    "group": "KARD",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UC5OwlwvsVmf_lXHguB6OYFw",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UC5OwlwvsVmf_lXHguB6OYFw",
-        "channel_label": "KARD",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:uc5owlwvsvmf_lxhgub6oyfw",
-          "https://www.youtube.com/channel/uc5owlwvsvmf_lxhgub6oyfw"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UC5OwlwvsVmf_lXHguB6OYFw"
-    ],
-    "mv_allowlist_match_keys": [
-      "channel:uc5owlwvsvmf_lxhgub6oyfw",
-      "https://www.youtube.com/channel/uc5owlwvsvmf_lxhgub6oyfw"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UC5OwlwvsVmf_lXHguB6OYFw",
-        "channel_label": "KARD",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:uc5owlwvsvmf_lxhgub6oyfw",
-          "https://www.youtube.com/channel/uc5owlwvsvmf_lxhgub6oyfw"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "KISS OF LIFE",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCvEEeBssb4XxIfWWIB8IjMw",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCvEEeBssb4XxIfWWIB8IjMw",
-        "channel_label": "KISS OF LIFE",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucveeebssb4xxifwwib8ijmw",
-          "https://www.youtube.com/channel/ucveeebssb4xxifwwib8ijmw"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCvEEeBssb4XxIfWWIB8IjMw"
-    ],
-    "mv_allowlist_match_keys": [
-      "channel:ucveeebssb4xxifwwib8ijmw",
-      "https://www.youtube.com/channel/ucveeebssb4xxifwwib8ijmw"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCvEEeBssb4XxIfWWIB8IjMw",
-        "channel_label": "KISS OF LIFE",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucveeebssb4xxifwwib8ijmw",
-          "https://www.youtube.com/channel/ucveeebssb4xxifwwib8ijmw"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "Kep1er",
-    "primary_team_channel_url": null,
-    "mv_source_channels": [],
-    "mv_allowlist_urls": [],
-    "mv_allowlist_match_keys": [],
-    "channels": []
-  },
-  {
-    "group": "KickFlip",
-    "primary_team_channel_url": null,
-    "mv_source_channels": [],
-    "mv_allowlist_urls": [],
-    "mv_allowlist_match_keys": [],
-    "channels": []
-  },
-  {
-    "group": "KiiiKiii",
-    "primary_team_channel_url": null,
-    "mv_source_channels": [],
-    "mv_allowlist_urls": [],
-    "mv_allowlist_match_keys": [],
-    "channels": []
-  },
-  {
-    "group": "LE SSERAFIM",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCs-QBT4qkj_YiQw1ZntDO3g",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCs-QBT4qkj_YiQw1ZntDO3g",
-        "channel_label": "LE SSERAFIM",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucs-qbt4qkj_yiqw1zntdo3g",
-          "https://www.youtube.com/channel/ucs-qbt4qkj_yiqw1zntdo3g"
-        ]
-      },
-      {
-        "channel_url": "https://www.youtube.com/@HYBELABELS",
-        "channel_label": "HYBE LABELS",
-        "owner_type": "label",
-        "allow_mv_uploads": true,
-        "display_in_team_links": false,
-        "provenance": "curated_agency_allowlist",
-        "match_keys": [
-          "@hybelabels",
-          "https://www.youtube.com/@hybelabels"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCs-QBT4qkj_YiQw1ZntDO3g",
-      "https://www.youtube.com/@HYBELABELS"
-    ],
-    "mv_allowlist_match_keys": [
-      "channel:ucs-qbt4qkj_yiqw1zntdo3g",
-      "https://www.youtube.com/channel/ucs-qbt4qkj_yiqw1zntdo3g",
-      "@hybelabels",
-      "https://www.youtube.com/@hybelabels"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCs-QBT4qkj_YiQw1ZntDO3g",
-        "channel_label": "LE SSERAFIM",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucs-qbt4qkj_yiqw1zntdo3g",
-          "https://www.youtube.com/channel/ucs-qbt4qkj_yiqw1zntdo3g"
-        ]
-      },
-      {
-        "channel_url": "https://www.youtube.com/@HYBELABELS",
-        "channel_label": "HYBE LABELS",
-        "owner_type": "label",
-        "allow_mv_uploads": true,
-        "display_in_team_links": false,
-        "provenance": "curated_agency_allowlist",
-        "match_keys": [
-          "@hybelabels",
-          "https://www.youtube.com/@hybelabels"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "LIGHTSUM",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCeQlMQ-4cedE7SNmF5JsdsA",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCeQlMQ-4cedE7SNmF5JsdsA",
-        "channel_label": "LIGHTSUM",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:uceqlmq-4cede7snmf5jsdsa",
-          "https://www.youtube.com/channel/uceqlmq-4cede7snmf5jsdsa"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCeQlMQ-4cedE7SNmF5JsdsA"
-    ],
-    "mv_allowlist_match_keys": [
-      "channel:uceqlmq-4cede7snmf5jsdsa",
-      "https://www.youtube.com/channel/uceqlmq-4cede7snmf5jsdsa"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCeQlMQ-4cedE7SNmF5JsdsA",
-        "channel_label": "LIGHTSUM",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:uceqlmq-4cede7snmf5jsdsa",
-          "https://www.youtube.com/channel/uceqlmq-4cede7snmf5jsdsa"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "LUN8",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCHx0MD2c0DTNGAtc0Yq6YPQ",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCHx0MD2c0DTNGAtc0Yq6YPQ",
-        "channel_label": "LUN8",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:uchx0md2c0dtngatc0yq6ypq",
-          "https://www.youtube.com/channel/uchx0md2c0dtngatc0yq6ypq"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCHx0MD2c0DTNGAtc0Yq6YPQ"
-    ],
-    "mv_allowlist_match_keys": [
-      "channel:uchx0md2c0dtngatc0yq6ypq",
-      "https://www.youtube.com/channel/uchx0md2c0dtngatc0yq6ypq"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCHx0MD2c0DTNGAtc0Yq6YPQ",
-        "channel_label": "LUN8",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:uchx0md2c0dtngatc0yq6ypq",
-          "https://www.youtube.com/channel/uchx0md2c0dtngatc0yq6ypq"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "Loossemble",
-    "primary_team_channel_url": null,
-    "mv_source_channels": [],
-    "mv_allowlist_urls": [],
-    "mv_allowlist_match_keys": [],
-    "channels": []
-  },
-  {
-    "group": "MAMAMOO",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCuhAUMLzJxlP1W7mEk0_6lA",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCuhAUMLzJxlP1W7mEk0_6lA",
-        "channel_label": "MAMAMOO",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucuhaumlzjxlp1w7mek0_6la",
-          "https://www.youtube.com/channel/ucuhaumlzjxlp1w7mek0_6la"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCuhAUMLzJxlP1W7mEk0_6lA"
-    ],
-    "mv_allowlist_match_keys": [
-      "channel:ucuhaumlzjxlp1w7mek0_6la",
-      "https://www.youtube.com/channel/ucuhaumlzjxlp1w7mek0_6la"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCuhAUMLzJxlP1W7mEk0_6lA",
-        "channel_label": "MAMAMOO",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucuhaumlzjxlp1w7mek0_6la",
-          "https://www.youtube.com/channel/ucuhaumlzjxlp1w7mek0_6la"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "MCND",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCNC_wxtoMCuvRVQzpbHPaZw",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCNC_wxtoMCuvRVQzpbHPaZw",
-        "channel_label": "MCND",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucnc_wxtomcuvrvqzpbhpazw",
-          "https://www.youtube.com/channel/ucnc_wxtomcuvrvqzpbhpazw"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCNC_wxtoMCuvRVQzpbHPaZw"
-    ],
-    "mv_allowlist_match_keys": [
-      "channel:ucnc_wxtomcuvrvqzpbhpazw",
-      "https://www.youtube.com/channel/ucnc_wxtomcuvrvqzpbhpazw"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCNC_wxtoMCuvRVQzpbHPaZw",
-        "channel_label": "MCND",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucnc_wxtomcuvrvqzpbhpazw",
-          "https://www.youtube.com/channel/ucnc_wxtomcuvrvqzpbhpazw"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "MEOVV",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCowiwt93gqGlNG4k5VDxO-w",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCowiwt93gqGlNG4k5VDxO-w",
-        "channel_label": "MEOVV",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucowiwt93gqglng4k5vdxo-w",
-          "https://www.youtube.com/channel/ucowiwt93gqglng4k5vdxo-w"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCowiwt93gqGlNG4k5VDxO-w"
-    ],
-    "mv_allowlist_match_keys": [
-      "channel:ucowiwt93gqglng4k5vdxo-w",
-      "https://www.youtube.com/channel/ucowiwt93gqglng4k5vdxo-w"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCowiwt93gqGlNG4k5VDxO-w",
-        "channel_label": "MEOVV",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucowiwt93gqglng4k5vdxo-w",
-          "https://www.youtube.com/channel/ucowiwt93gqglng4k5vdxo-w"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "MONSTA X",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCZvCP6sWj75MwpUP4LVtpNw",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCZvCP6sWj75MwpUP4LVtpNw",
-        "channel_label": "MONSTA X",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:uczvcp6swj75mwpup4lvtpnw",
-          "https://www.youtube.com/channel/uczvcp6swj75mwpup4lvtpnw"
-        ]
-      },
-      {
-        "channel_url": "https://www.youtube.com/@officialstarship",
-        "channel_label": "STARSHIP",
-        "owner_type": "label",
-        "allow_mv_uploads": true,
-        "display_in_team_links": false,
-        "provenance": "curated_agency_allowlist",
-        "match_keys": [
-          "@officialstarship",
-          "https://www.youtube.com/@officialstarship"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCZvCP6sWj75MwpUP4LVtpNw",
-      "https://www.youtube.com/@officialstarship"
-    ],
-    "mv_allowlist_match_keys": [
-      "channel:uczvcp6swj75mwpup4lvtpnw",
-      "https://www.youtube.com/channel/uczvcp6swj75mwpup4lvtpnw",
-      "@officialstarship",
-      "https://www.youtube.com/@officialstarship"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCZvCP6sWj75MwpUP4LVtpNw",
-        "channel_label": "MONSTA X",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:uczvcp6swj75mwpup4lvtpnw",
-          "https://www.youtube.com/channel/uczvcp6swj75mwpup4lvtpnw"
-        ]
-      },
-      {
-        "channel_url": "https://www.youtube.com/@officialstarship",
-        "channel_label": "STARSHIP",
-        "owner_type": "label",
-        "allow_mv_uploads": true,
-        "display_in_team_links": false,
-        "provenance": "curated_agency_allowlist",
-        "match_keys": [
-          "@officialstarship",
-          "https://www.youtube.com/@officialstarship"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "NCT 127",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCk2E0dbAyEJWnrN2bbQOcbg",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCk2E0dbAyEJWnrN2bbQOcbg",
-        "channel_label": "NCT 127",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:uck2e0dbayejwnrn2bbqocbg",
-          "https://www.youtube.com/channel/uck2e0dbayejwnrn2bbqocbg"
-        ]
-      },
-      {
-        "channel_url": "https://www.youtube.com/@SMTOWN",
-        "channel_label": "SMTOWN",
-        "owner_type": "label",
-        "allow_mv_uploads": true,
-        "display_in_team_links": false,
-        "provenance": "curated_agency_allowlist",
-        "match_keys": [
-          "@smtown",
-          "https://www.youtube.com/@smtown"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCk2E0dbAyEJWnrN2bbQOcbg",
-      "https://www.youtube.com/@SMTOWN"
-    ],
-    "mv_allowlist_match_keys": [
-      "channel:uck2e0dbayejwnrn2bbqocbg",
-      "https://www.youtube.com/channel/uck2e0dbayejwnrn2bbqocbg",
-      "@smtown",
-      "https://www.youtube.com/@smtown"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCk2E0dbAyEJWnrN2bbQOcbg",
-        "channel_label": "NCT 127",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:uck2e0dbayejwnrn2bbqocbg",
-          "https://www.youtube.com/channel/uck2e0dbayejwnrn2bbqocbg"
-        ]
-      },
-      {
-        "channel_url": "https://www.youtube.com/@SMTOWN",
-        "channel_label": "SMTOWN",
-        "owner_type": "label",
-        "allow_mv_uploads": true,
-        "display_in_team_links": false,
-        "provenance": "curated_agency_allowlist",
-        "match_keys": [
-          "@smtown",
-          "https://www.youtube.com/@smtown"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "NCT DREAM",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCXURHJRGr4-EB3l87kcbElw",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCXURHJRGr4-EB3l87kcbElw",
-        "channel_label": "NCT DREAM",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucxurhjrgr4-eb3l87kcbelw",
-          "https://www.youtube.com/channel/ucxurhjrgr4-eb3l87kcbelw"
-        ]
-      },
-      {
-        "channel_url": "https://www.youtube.com/@SMTOWN",
-        "channel_label": "SMTOWN",
-        "owner_type": "label",
-        "allow_mv_uploads": true,
-        "display_in_team_links": false,
-        "provenance": "curated_agency_allowlist",
-        "match_keys": [
-          "@smtown",
-          "https://www.youtube.com/@smtown"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCXURHJRGr4-EB3l87kcbElw",
-      "https://www.youtube.com/@SMTOWN"
-    ],
-    "mv_allowlist_match_keys": [
-      "channel:ucxurhjrgr4-eb3l87kcbelw",
-      "https://www.youtube.com/channel/ucxurhjrgr4-eb3l87kcbelw",
-      "@smtown",
-      "https://www.youtube.com/@smtown"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCXURHJRGr4-EB3l87kcbElw",
-        "channel_label": "NCT DREAM",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucxurhjrgr4-eb3l87kcbelw",
-          "https://www.youtube.com/channel/ucxurhjrgr4-eb3l87kcbelw"
-        ]
-      },
-      {
-        "channel_url": "https://www.youtube.com/@SMTOWN",
-        "channel_label": "SMTOWN",
-        "owner_type": "label",
-        "allow_mv_uploads": true,
-        "display_in_team_links": false,
-        "provenance": "curated_agency_allowlist",
-        "match_keys": [
-          "@smtown",
-          "https://www.youtube.com/@smtown"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "NCT WISH",
-    "primary_team_channel_url": null,
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/@SMTOWN",
-        "channel_label": "SMTOWN",
-        "owner_type": "label",
-        "allow_mv_uploads": true,
-        "display_in_team_links": false,
-        "provenance": "curated_agency_allowlist",
-        "match_keys": [
-          "@smtown",
-          "https://www.youtube.com/@smtown"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/@SMTOWN"
-    ],
-    "mv_allowlist_match_keys": [
-      "@smtown",
-      "https://www.youtube.com/@smtown"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/@SMTOWN",
-        "channel_label": "SMTOWN",
-        "owner_type": "label",
-        "allow_mv_uploads": true,
-        "display_in_team_links": false,
-        "provenance": "curated_agency_allowlist",
-        "match_keys": [
-          "@smtown",
-          "https://www.youtube.com/@smtown"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "NEXZ",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UC-o9yrZxu5Ru-DVGhnmeTug",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UC-o9yrZxu5Ru-DVGhnmeTug",
-        "channel_label": "NEXZ",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:uc-o9yrzxu5ru-dvghnmetug",
-          "https://www.youtube.com/channel/uc-o9yrzxu5ru-dvghnmetug"
-        ]
-      },
-      {
-        "channel_url": "https://www.youtube.com/@JYPEntertainment",
-        "channel_label": "JYP Entertainment",
-        "owner_type": "label",
-        "allow_mv_uploads": true,
-        "display_in_team_links": false,
-        "provenance": "curated_agency_allowlist",
-        "match_keys": [
-          "@jypentertainment",
-          "https://www.youtube.com/@jypentertainment"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UC-o9yrZxu5Ru-DVGhnmeTug",
-      "https://www.youtube.com/@JYPEntertainment"
-    ],
-    "mv_allowlist_match_keys": [
-      "channel:uc-o9yrzxu5ru-dvghnmetug",
-      "https://www.youtube.com/channel/uc-o9yrzxu5ru-dvghnmetug",
-      "@jypentertainment",
-      "https://www.youtube.com/@jypentertainment"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UC-o9yrZxu5Ru-DVGhnmeTug",
-        "channel_label": "NEXZ",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:uc-o9yrzxu5ru-dvghnmetug",
-          "https://www.youtube.com/channel/uc-o9yrzxu5ru-dvghnmetug"
-        ]
-      },
-      {
-        "channel_url": "https://www.youtube.com/@JYPEntertainment",
-        "channel_label": "JYP Entertainment",
-        "owner_type": "label",
-        "allow_mv_uploads": true,
-        "display_in_team_links": false,
-        "provenance": "curated_agency_allowlist",
-        "match_keys": [
-          "@jypentertainment",
-          "https://www.youtube.com/@jypentertainment"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "NMIXX",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCnUAyD4t2LkvW68YrDh7fDg",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCnUAyD4t2LkvW68YrDh7fDg",
-        "channel_label": "NMIXX",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucnuayd4t2lkvw68yrdh7fdg",
-          "https://www.youtube.com/channel/ucnuayd4t2lkvw68yrdh7fdg"
-        ]
-      },
-      {
-        "channel_url": "https://www.youtube.com/@JYPEntertainment",
-        "channel_label": "JYP Entertainment",
-        "owner_type": "label",
-        "allow_mv_uploads": true,
-        "display_in_team_links": false,
-        "provenance": "curated_agency_allowlist",
-        "match_keys": [
-          "@jypentertainment",
-          "https://www.youtube.com/@jypentertainment"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCnUAyD4t2LkvW68YrDh7fDg",
-      "https://www.youtube.com/@JYPEntertainment"
-    ],
-    "mv_allowlist_match_keys": [
-      "channel:ucnuayd4t2lkvw68yrdh7fdg",
-      "https://www.youtube.com/channel/ucnuayd4t2lkvw68yrdh7fdg",
-      "@jypentertainment",
-      "https://www.youtube.com/@jypentertainment"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCnUAyD4t2LkvW68YrDh7fDg",
-        "channel_label": "NMIXX",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucnuayd4t2lkvw68yrdh7fdg",
-          "https://www.youtube.com/channel/ucnuayd4t2lkvw68yrdh7fdg"
-        ]
-      },
-      {
-        "channel_url": "https://www.youtube.com/@JYPEntertainment",
-        "channel_label": "JYP Entertainment",
-        "owner_type": "label",
-        "allow_mv_uploads": true,
-        "display_in_team_links": false,
-        "provenance": "curated_agency_allowlist",
-        "match_keys": [
-          "@jypentertainment",
-          "https://www.youtube.com/@jypentertainment"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "NOMAD",
-    "primary_team_channel_url": null,
-    "mv_source_channels": [],
-    "mv_allowlist_urls": [],
-    "mv_allowlist_match_keys": [],
-    "channels": []
-  },
-  {
-    "group": "NewJeans",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCMki_UkHb4qSc0qyEcOHHJw",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCMki_UkHb4qSc0qyEcOHHJw",
-        "channel_label": "NewJeans",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucmki_ukhb4qsc0qyecohhjw",
-          "https://www.youtube.com/channel/ucmki_ukhb4qsc0qyecohhjw"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCMki_UkHb4qSc0qyEcOHHJw"
-    ],
-    "mv_allowlist_match_keys": [
-      "channel:ucmki_ukhb4qsc0qyecohhjw",
-      "https://www.youtube.com/channel/ucmki_ukhb4qsc0qyecohhjw"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCMki_UkHb4qSc0qyEcOHHJw",
-        "channel_label": "NewJeans",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucmki_ukhb4qsc0qyecohhjw",
-          "https://www.youtube.com/channel/ucmki_ukhb4qsc0qyecohhjw"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "ONEUS",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCWTYf4xModfNsyq2NUYjF5g",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCWTYf4xModfNsyq2NUYjF5g",
-        "channel_label": "ONEUS",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucwtyf4xmodfnsyq2nuyjf5g",
-          "https://www.youtube.com/channel/ucwtyf4xmodfnsyq2nuyjf5g"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCWTYf4xModfNsyq2NUYjF5g"
-    ],
-    "mv_allowlist_match_keys": [
-      "channel:ucwtyf4xmodfnsyq2nuyjf5g",
-      "https://www.youtube.com/channel/ucwtyf4xmodfnsyq2nuyjf5g"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCWTYf4xModfNsyq2NUYjF5g",
-        "channel_label": "ONEUS",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucwtyf4xmodfnsyq2nuyjf5g",
-          "https://www.youtube.com/channel/ucwtyf4xmodfnsyq2nuyjf5g"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "ONEWE",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCj-dtq6jHfj4_fufifPzMEQ",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCj-dtq6jHfj4_fufifPzMEQ",
-        "channel_label": "ONEWE",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucj-dtq6jhfj4_fufifpzmeq",
-          "https://www.youtube.com/channel/ucj-dtq6jhfj4_fufifpzmeq"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCj-dtq6jHfj4_fufifPzMEQ"
-    ],
-    "mv_allowlist_match_keys": [
-      "channel:ucj-dtq6jhfj4_fufifpzmeq",
-      "https://www.youtube.com/channel/ucj-dtq6jhfj4_fufifpzmeq"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCj-dtq6jHfj4_fufifPzMEQ",
-        "channel_label": "ONEWE",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucj-dtq6jhfj4_fufifpzmeq",
-          "https://www.youtube.com/channel/ucj-dtq6jhfj4_fufifpzmeq"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "ONF",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCgdj5bL5_Il2tqsQ7J4k6zw",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCgdj5bL5_Il2tqsQ7J4k6zw",
-        "channel_label": "ONF",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucgdj5bl5_il2tqsq7j4k6zw",
-          "https://www.youtube.com/channel/ucgdj5bl5_il2tqsq7j4k6zw"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCgdj5bL5_Il2tqsQ7J4k6zw"
-    ],
-    "mv_allowlist_match_keys": [
-      "channel:ucgdj5bl5_il2tqsq7j4k6zw",
-      "https://www.youtube.com/channel/ucgdj5bl5_il2tqsq7j4k6zw"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCgdj5bL5_Il2tqsQ7J4k6zw",
-        "channel_label": "ONF",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucgdj5bl5_il2tqsq7j4k6zw",
-          "https://www.youtube.com/channel/ucgdj5bl5_il2tqsq7j4k6zw"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "P1Harmony",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCe-XzQhLaq4zS_mPXzuc_2Q",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCe-XzQhLaq4zS_mPXzuc_2Q",
-        "channel_label": "P1Harmony",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:uce-xzqhlaq4zs_mpxzuc_2q",
-          "https://www.youtube.com/channel/uce-xzqhlaq4zs_mpxzuc_2q"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCe-XzQhLaq4zS_mPXzuc_2Q"
-    ],
-    "mv_allowlist_match_keys": [
-      "channel:uce-xzqhlaq4zs_mpxzuc_2q",
-      "https://www.youtube.com/channel/uce-xzqhlaq4zs_mpxzuc_2q"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCe-XzQhLaq4zS_mPXzuc_2Q",
-        "channel_label": "P1Harmony",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:uce-xzqhlaq4zs_mpxzuc_2q",
-          "https://www.youtube.com/channel/uce-xzqhlaq4zs_mpxzuc_2q"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "PLAVE",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCPZIPuQPrfrUG9Xe_okEmQA",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCPZIPuQPrfrUG9Xe_okEmQA",
-        "channel_label": "PLAVE",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucpzipuqprfrug9xe_okemqa",
-          "https://www.youtube.com/channel/ucpzipuqprfrug9xe_okemqa"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCPZIPuQPrfrUG9Xe_okEmQA"
-    ],
-    "mv_allowlist_match_keys": [
-      "channel:ucpzipuqprfrug9xe_okemqa",
-      "https://www.youtube.com/channel/ucpzipuqprfrug9xe_okemqa"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCPZIPuQPrfrUG9Xe_okEmQA",
-        "channel_label": "PLAVE",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucpzipuqprfrug9xe_okemqa",
-          "https://www.youtube.com/channel/ucpzipuqprfrug9xe_okemqa"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "POW",
-    "primary_team_channel_url": null,
-    "mv_source_channels": [],
-    "mv_allowlist_urls": [],
-    "mv_allowlist_match_keys": [],
-    "channels": []
-  },
-  {
-    "group": "Purple Kiss",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCor8nQnEdMs4eBcU-uVBQ8g",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCor8nQnEdMs4eBcU-uVBQ8g",
-        "channel_label": "Purple Kiss",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucor8nqnedms4ebcu-uvbq8g",
-          "https://www.youtube.com/channel/ucor8nqnedms4ebcu-uvbq8g"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCor8nQnEdMs4eBcU-uVBQ8g"
-    ],
-    "mv_allowlist_match_keys": [
-      "channel:ucor8nqnedms4ebcu-uvbq8g",
-      "https://www.youtube.com/channel/ucor8nqnedms4ebcu-uvbq8g"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCor8nQnEdMs4eBcU-uVBQ8g",
-        "channel_label": "Purple Kiss",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucor8nqnedms4ebcu-uvbq8g",
-          "https://www.youtube.com/channel/ucor8nqnedms4ebcu-uvbq8g"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "QWER",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCgD0APk2x9uBlLM0UsmhQjw",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCgD0APk2x9uBlLM0UsmhQjw",
-        "channel_label": "QWER",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucgd0apk2x9ubllm0usmhqjw",
-          "https://www.youtube.com/channel/ucgd0apk2x9ubllm0usmhqjw"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCgD0APk2x9uBlLM0UsmhQjw"
-    ],
-    "mv_allowlist_match_keys": [
-      "channel:ucgd0apk2x9ubllm0usmhqjw",
-      "https://www.youtube.com/channel/ucgd0apk2x9ubllm0usmhqjw"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCgD0APk2x9uBlLM0UsmhQjw",
-        "channel_label": "QWER",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucgd0apk2x9ubllm0usmhqjw",
-          "https://www.youtube.com/channel/ucgd0apk2x9ubllm0usmhqjw"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "RESCENE",
-    "primary_team_channel_url": null,
-    "mv_source_channels": [],
-    "mv_allowlist_urls": [],
-    "mv_allowlist_match_keys": [],
-    "channels": []
-  },
-  {
-    "group": "RIIZE",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCdVD0MsYecQaIE5Ru-pOIQQ",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCdVD0MsYecQaIE5Ru-pOIQQ",
-        "channel_label": "RIIZE",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucdvd0msyecqaie5ru-poiqq",
-          "https://www.youtube.com/channel/ucdvd0msyecqaie5ru-poiqq"
-        ]
-      },
-      {
-        "channel_url": "https://www.youtube.com/@SMTOWN",
-        "channel_label": "SMTOWN",
-        "owner_type": "label",
-        "allow_mv_uploads": true,
-        "display_in_team_links": false,
-        "provenance": "curated_agency_allowlist",
-        "match_keys": [
-          "@smtown",
-          "https://www.youtube.com/@smtown"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCdVD0MsYecQaIE5Ru-pOIQQ",
-      "https://www.youtube.com/@SMTOWN"
-    ],
-    "mv_allowlist_match_keys": [
-      "channel:ucdvd0msyecqaie5ru-poiqq",
-      "https://www.youtube.com/channel/ucdvd0msyecqaie5ru-poiqq",
-      "@smtown",
-      "https://www.youtube.com/@smtown"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCdVD0MsYecQaIE5Ru-pOIQQ",
-        "channel_label": "RIIZE",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucdvd0msyecqaie5ru-poiqq",
-          "https://www.youtube.com/channel/ucdvd0msyecqaie5ru-poiqq"
-        ]
-      },
-      {
-        "channel_url": "https://www.youtube.com/@SMTOWN",
-        "channel_label": "SMTOWN",
-        "owner_type": "label",
-        "allow_mv_uploads": true,
-        "display_in_team_links": false,
-        "provenance": "curated_agency_allowlist",
-        "match_keys": [
-          "@smtown",
-          "https://www.youtube.com/@smtown"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "Red Velvet",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCk9GmdlDTBfgGRb7vXeRMoQ",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCk9GmdlDTBfgGRb7vXeRMoQ",
-        "channel_label": "Red Velvet",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:uck9gmdldtbfggrb7vxermoq",
-          "https://www.youtube.com/channel/uck9gmdldtbfggrb7vxermoq"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCk9GmdlDTBfgGRb7vXeRMoQ"
-    ],
-    "mv_allowlist_match_keys": [
-      "channel:uck9gmdldtbfggrb7vxermoq",
-      "https://www.youtube.com/channel/uck9gmdldtbfggrb7vxermoq"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCk9GmdlDTBfgGRb7vXeRMoQ",
-        "channel_label": "Red Velvet",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:uck9gmdldtbfggrb7vxermoq",
-          "https://www.youtube.com/channel/uck9gmdldtbfggrb7vxermoq"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "SAY MY NAME",
-    "primary_team_channel_url": null,
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/@inkodeofficial",
-        "channel_label": "iNKODE Official",
-        "owner_type": "label",
-        "allow_mv_uploads": true,
-        "display_in_team_links": false,
-        "provenance": "manual_override_uploader"
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/@inkodeofficial"
-    ],
-    "mv_allowlist_match_keys": [],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/@inkodeofficial",
-        "channel_label": "iNKODE Official",
-        "owner_type": "label",
-        "allow_mv_uploads": true,
-        "display_in_team_links": false,
-        "provenance": "manual_override_uploader"
-      }
-    ]
-  },
-  {
-    "group": "SEVENTEEN",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UC0gpUnoyhu44aS3-NxYs7rg",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UC0gpUnoyhu44aS3-NxYs7rg",
-        "channel_label": "SEVENTEEN",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:uc0gpunoyhu44as3-nxys7rg",
-          "https://www.youtube.com/channel/uc0gpunoyhu44as3-nxys7rg"
-        ]
-      },
-      {
-        "channel_url": "https://www.youtube.com/@HYBELABELS",
-        "channel_label": "HYBE LABELS",
-        "owner_type": "label",
-        "allow_mv_uploads": true,
-        "display_in_team_links": false,
-        "provenance": "curated_agency_allowlist",
-        "match_keys": [
-          "@hybelabels",
-          "https://www.youtube.com/@hybelabels"
-        ]
-      },
-      {
-        "channel_url": "https://www.youtube.com/channel/UCfkXDY7vwkcJ8ddFGz8KusA",
-        "channel_label": "PLEDIS",
-        "owner_type": "label",
-        "allow_mv_uploads": true,
-        "display_in_team_links": false,
-        "provenance": "manual_override_legacy_label_channel"
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UC0gpUnoyhu44aS3-NxYs7rg",
-      "https://www.youtube.com/@HYBELABELS",
-      "https://www.youtube.com/channel/UCfkXDY7vwkcJ8ddFGz8KusA"
-    ],
-    "mv_allowlist_match_keys": [
-      "channel:uc0gpunoyhu44as3-nxys7rg",
-      "https://www.youtube.com/channel/uc0gpunoyhu44as3-nxys7rg",
-      "@hybelabels",
-      "https://www.youtube.com/@hybelabels"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UC0gpUnoyhu44aS3-NxYs7rg",
-        "channel_label": "SEVENTEEN",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:uc0gpunoyhu44as3-nxys7rg",
-          "https://www.youtube.com/channel/uc0gpunoyhu44as3-nxys7rg"
-        ]
-      },
-      {
-        "channel_url": "https://www.youtube.com/@HYBELABELS",
-        "channel_label": "HYBE LABELS",
-        "owner_type": "label",
-        "allow_mv_uploads": true,
-        "display_in_team_links": false,
-        "provenance": "curated_agency_allowlist",
-        "match_keys": [
-          "@hybelabels",
-          "https://www.youtube.com/@hybelabels"
-        ]
-      },
-      {
-        "channel_url": "https://www.youtube.com/channel/UCfkXDY7vwkcJ8ddFGz8KusA",
-        "channel_label": "PLEDIS",
-        "owner_type": "label",
-        "allow_mv_uploads": true,
-        "display_in_team_links": false,
-        "provenance": "manual_override_legacy_label_channel"
-      }
-    ]
-  },
-  {
-    "group": "SHINee",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCyPwRgc3gQGqhk6RoGS50Ug",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCyPwRgc3gQGqhk6RoGS50Ug",
-        "channel_label": "SHINee",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucypwrgc3gqgqhk6rogs50ug",
-          "https://www.youtube.com/channel/ucypwrgc3gqgqhk6rogs50ug"
-        ]
-      },
-      {
-        "channel_url": "https://www.youtube.com/@SMTOWN",
-        "channel_label": "SMTOWN",
-        "owner_type": "label",
-        "allow_mv_uploads": true,
-        "display_in_team_links": false,
-        "provenance": "curated_agency_allowlist",
-        "match_keys": [
-          "@smtown",
-          "https://www.youtube.com/@smtown"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCyPwRgc3gQGqhk6RoGS50Ug",
-      "https://www.youtube.com/@SMTOWN"
-    ],
-    "mv_allowlist_match_keys": [
-      "channel:ucypwrgc3gqgqhk6rogs50ug",
-      "https://www.youtube.com/channel/ucypwrgc3gqgqhk6rogs50ug",
-      "@smtown",
-      "https://www.youtube.com/@smtown"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCyPwRgc3gQGqhk6RoGS50Ug",
-        "channel_label": "SHINee",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucypwrgc3gqgqhk6rogs50ug",
-          "https://www.youtube.com/channel/ucypwrgc3gqgqhk6rogs50ug"
-        ]
-      },
-      {
-        "channel_url": "https://www.youtube.com/@SMTOWN",
-        "channel_label": "SMTOWN",
-        "owner_type": "label",
-        "allow_mv_uploads": true,
-        "display_in_team_links": false,
-        "provenance": "curated_agency_allowlist",
-        "match_keys": [
-          "@smtown",
-          "https://www.youtube.com/@smtown"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "STAYC",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCod5V2dpnpJLklGvVOv5FcQ",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCod5V2dpnpJLklGvVOv5FcQ",
-        "channel_label": "STAYC",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucod5v2dpnpjlklgvvov5fcq",
-          "https://www.youtube.com/channel/ucod5v2dpnpjlklgvvov5fcq"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCod5V2dpnpJLklGvVOv5FcQ"
-    ],
-    "mv_allowlist_match_keys": [
-      "channel:ucod5v2dpnpjlklgvvov5fcq",
-      "https://www.youtube.com/channel/ucod5v2dpnpjlklgvvov5fcq"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCod5V2dpnpJLklGvVOv5FcQ",
-        "channel_label": "STAYC",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucod5v2dpnpjlklgvvov5fcq",
-          "https://www.youtube.com/channel/ucod5v2dpnpjlklgvvov5fcq"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "Stray Kids",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UC9rMiEjNaCSsebs31MRDCRA",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UC9rMiEjNaCSsebs31MRDCRA",
-        "channel_label": "Stray Kids",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:uc9rmiejnacssebs31mrdcra",
-          "https://www.youtube.com/channel/uc9rmiejnacssebs31mrdcra"
-        ]
-      },
-      {
-        "channel_url": "https://www.youtube.com/@JYPEntertainment",
-        "channel_label": "JYP Entertainment",
-        "owner_type": "label",
-        "allow_mv_uploads": true,
-        "display_in_team_links": false,
-        "provenance": "curated_agency_allowlist",
-        "match_keys": [
-          "@jypentertainment",
-          "https://www.youtube.com/@jypentertainment"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UC9rMiEjNaCSsebs31MRDCRA",
-      "https://www.youtube.com/@JYPEntertainment"
-    ],
-    "mv_allowlist_match_keys": [
-      "channel:uc9rmiejnacssebs31mrdcra",
-      "https://www.youtube.com/channel/uc9rmiejnacssebs31mrdcra",
-      "@jypentertainment",
-      "https://www.youtube.com/@jypentertainment"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UC9rMiEjNaCSsebs31MRDCRA",
-        "channel_label": "Stray Kids",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:uc9rmiejnacssebs31mrdcra",
-          "https://www.youtube.com/channel/uc9rmiejnacssebs31mrdcra"
-        ]
-      },
-      {
-        "channel_url": "https://www.youtube.com/@JYPEntertainment",
-        "channel_label": "JYP Entertainment",
-        "owner_type": "label",
-        "allow_mv_uploads": true,
-        "display_in_team_links": false,
-        "provenance": "curated_agency_allowlist",
-        "match_keys": [
-          "@jypentertainment",
-          "https://www.youtube.com/@jypentertainment"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "TEMPEST",
-    "primary_team_channel_url": null,
-    "mv_source_channels": [],
-    "mv_allowlist_urls": [],
-    "mv_allowlist_match_keys": [],
-    "channels": []
-  },
-  {
-    "group": "THE BOYZ",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCkJ1rbOrsyPfBuHNfnLPm-Q",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCkJ1rbOrsyPfBuHNfnLPm-Q",
-        "channel_label": "THE BOYZ",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:uckj1rborsypfbuhnfnlpm-q",
-          "https://www.youtube.com/channel/uckj1rborsypfbuhnfnlpm-q"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCkJ1rbOrsyPfBuHNfnLPm-Q"
-    ],
-    "mv_allowlist_match_keys": [
-      "channel:uckj1rborsypfbuhnfnlpm-q",
-      "https://www.youtube.com/channel/uckj1rborsypfbuhnfnlpm-q"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCkJ1rbOrsyPfBuHNfnLPm-Q",
-        "channel_label": "THE BOYZ",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:uckj1rborsypfbuhnfnlpm-q",
-          "https://www.youtube.com/channel/uckj1rborsypfbuhnfnlpm-q"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "TIOT",
-    "primary_team_channel_url": "https://www.youtube.com/@TIOT_NOW",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/@TIOT_NOW",
-        "channel_label": "TIOT",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "manual_override_uploader"
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/@TIOT_NOW"
-    ],
-    "mv_allowlist_match_keys": [],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/@TIOT_NOW",
-        "channel_label": "TIOT",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "manual_override_uploader"
-      }
-    ]
-  },
-  {
-    "group": "TNX",
-    "primary_team_channel_url": null,
-    "mv_source_channels": [],
-    "mv_allowlist_urls": [],
-    "mv_allowlist_match_keys": [],
-    "channels": []
-  },
-  {
-    "group": "TOMORROW X TOGETHER",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCtiObj3CsEAdNU6ZPWDsddQ",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCtiObj3CsEAdNU6ZPWDsddQ",
-        "channel_label": "TOMORROW X TOGETHER",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:uctiobj3cseadnu6zpwdsddq",
-          "https://www.youtube.com/channel/uctiobj3cseadnu6zpwdsddq"
-        ]
-      },
-      {
-        "channel_url": "https://www.youtube.com/@HYBELABELS",
-        "channel_label": "HYBE LABELS",
-        "owner_type": "label",
-        "allow_mv_uploads": true,
-        "display_in_team_links": false,
-        "provenance": "curated_agency_allowlist",
-        "match_keys": [
-          "@hybelabels",
-          "https://www.youtube.com/@hybelabels"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCtiObj3CsEAdNU6ZPWDsddQ",
-      "https://www.youtube.com/@HYBELABELS"
-    ],
-    "mv_allowlist_match_keys": [
-      "channel:uctiobj3cseadnu6zpwdsddq",
-      "https://www.youtube.com/channel/uctiobj3cseadnu6zpwdsddq",
-      "@hybelabels",
-      "https://www.youtube.com/@hybelabels"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCtiObj3CsEAdNU6ZPWDsddQ",
-        "channel_label": "TOMORROW X TOGETHER",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:uctiobj3cseadnu6zpwdsddq",
-          "https://www.youtube.com/channel/uctiobj3cseadnu6zpwdsddq"
-        ]
-      },
-      {
-        "channel_url": "https://www.youtube.com/@HYBELABELS",
-        "channel_label": "HYBE LABELS",
-        "owner_type": "label",
-        "allow_mv_uploads": true,
-        "display_in_team_links": false,
-        "provenance": "curated_agency_allowlist",
-        "match_keys": [
-          "@hybelabels",
-          "https://www.youtube.com/@hybelabels"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "TREASURE",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCx9hXYOCvUYwrprEqe4ZQHA",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCx9hXYOCvUYwrprEqe4ZQHA",
-        "channel_label": "TREASURE",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucx9hxyocvuywrpreqe4zqha",
-          "https://www.youtube.com/channel/ucx9hxyocvuywrpreqe4zqha"
-        ]
-      },
-      {
-        "channel_url": "https://www.youtube.com/@YGEntertainment",
-        "channel_label": "YG ENTERTAINMENT",
-        "owner_type": "label",
-        "allow_mv_uploads": true,
-        "display_in_team_links": false,
-        "provenance": "curated_agency_allowlist",
-        "match_keys": [
-          "@ygentertainment",
-          "https://www.youtube.com/@ygentertainment"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCx9hXYOCvUYwrprEqe4ZQHA",
-      "https://www.youtube.com/@YGEntertainment"
-    ],
-    "mv_allowlist_match_keys": [
-      "channel:ucx9hxyocvuywrpreqe4zqha",
-      "https://www.youtube.com/channel/ucx9hxyocvuywrpreqe4zqha",
-      "@ygentertainment",
-      "https://www.youtube.com/@ygentertainment"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCx9hXYOCvUYwrprEqe4ZQHA",
-        "channel_label": "TREASURE",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucx9hxyocvuywrpreqe4zqha",
-          "https://www.youtube.com/channel/ucx9hxyocvuywrpreqe4zqha"
-        ]
-      },
-      {
-        "channel_url": "https://www.youtube.com/@YGEntertainment",
-        "channel_label": "YG ENTERTAINMENT",
-        "owner_type": "label",
-        "allow_mv_uploads": true,
-        "display_in_team_links": false,
-        "provenance": "curated_agency_allowlist",
-        "match_keys": [
-          "@ygentertainment",
-          "https://www.youtube.com/@ygentertainment"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "TRENDZ",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCvc55IOOCI165H3raqcjjrg",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCvc55IOOCI165H3raqcjjrg",
-        "channel_label": "TRENDZ",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucvc55iooci165h3raqcjjrg",
-          "https://www.youtube.com/channel/ucvc55iooci165h3raqcjjrg"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCvc55IOOCI165H3raqcjjrg"
-    ],
-    "mv_allowlist_match_keys": [
-      "channel:ucvc55iooci165h3raqcjjrg",
-      "https://www.youtube.com/channel/ucvc55iooci165h3raqcjjrg"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCvc55IOOCI165H3raqcjjrg",
-        "channel_label": "TRENDZ",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucvc55iooci165h3raqcjjrg",
-          "https://www.youtube.com/channel/ucvc55iooci165h3raqcjjrg"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "TWICE",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCzgxx_DM2Dcb9Y1spb9mUJA",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCzgxx_DM2Dcb9Y1spb9mUJA",
-        "channel_label": "TWICE",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:uczgxx_dm2dcb9y1spb9muja",
-          "https://www.youtube.com/channel/uczgxx_dm2dcb9y1spb9muja"
-        ]
-      },
-      {
-        "channel_url": "https://www.youtube.com/@JYPEntertainment",
-        "channel_label": "JYP Entertainment",
-        "owner_type": "label",
-        "allow_mv_uploads": true,
-        "display_in_team_links": false,
-        "provenance": "curated_agency_allowlist",
-        "match_keys": [
-          "@jypentertainment",
-          "https://www.youtube.com/@jypentertainment"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCzgxx_DM2Dcb9Y1spb9mUJA",
-      "https://www.youtube.com/@JYPEntertainment"
-    ],
-    "mv_allowlist_match_keys": [
-      "channel:uczgxx_dm2dcb9y1spb9muja",
-      "https://www.youtube.com/channel/uczgxx_dm2dcb9y1spb9muja",
-      "@jypentertainment",
-      "https://www.youtube.com/@jypentertainment"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCzgxx_DM2Dcb9Y1spb9mUJA",
-        "channel_label": "TWICE",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:uczgxx_dm2dcb9y1spb9muja",
-          "https://www.youtube.com/channel/uczgxx_dm2dcb9y1spb9muja"
-        ]
-      },
-      {
-        "channel_url": "https://www.youtube.com/@JYPEntertainment",
-        "channel_label": "JYP Entertainment",
-        "owner_type": "label",
-        "allow_mv_uploads": true,
-        "display_in_team_links": false,
-        "provenance": "curated_agency_allowlist",
-        "match_keys": [
-          "@jypentertainment",
-          "https://www.youtube.com/@jypentertainment"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "TUNEXX",
-    "primary_team_channel_url": "https://www.youtube.com/@official_TUNEXX",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/@official_TUNEXX",
-        "channel_label": "TUNEXX",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "@official_tunexx",
-          "https://www.youtube.com/@official_tunexx"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/@official_TUNEXX"
-    ],
-    "mv_allowlist_match_keys": [
-      "@official_tunexx",
-      "https://www.youtube.com/@official_tunexx"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/@official_TUNEXX",
-        "channel_label": "TUNEXX",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "@official_tunexx",
-          "https://www.youtube.com/@official_tunexx"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "TWS",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UC8C6QOPDVYwmuaSBZksefdg",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UC8C6QOPDVYwmuaSBZksefdg",
-        "channel_label": "TWS",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:uc8c6qopdvywmuasbzksefdg",
-          "https://www.youtube.com/channel/uc8c6qopdvywmuasbzksefdg"
-        ]
-      },
-      {
-        "channel_url": "https://www.youtube.com/@HYBELABELS",
-        "channel_label": "HYBE LABELS",
-        "owner_type": "label",
-        "allow_mv_uploads": true,
-        "display_in_team_links": false,
-        "provenance": "curated_agency_allowlist",
-        "match_keys": [
-          "@hybelabels",
-          "https://www.youtube.com/@hybelabels"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UC8C6QOPDVYwmuaSBZksefdg",
-      "https://www.youtube.com/@HYBELABELS"
-    ],
-    "mv_allowlist_match_keys": [
-      "channel:uc8c6qopdvywmuasbzksefdg",
-      "https://www.youtube.com/channel/uc8c6qopdvywmuasbzksefdg",
-      "@hybelabels",
-      "https://www.youtube.com/@hybelabels"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UC8C6QOPDVYwmuaSBZksefdg",
-        "channel_label": "TWS",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:uc8c6qopdvywmuasbzksefdg",
-          "https://www.youtube.com/channel/uc8c6qopdvywmuasbzksefdg"
-        ]
-      },
-      {
-        "channel_url": "https://www.youtube.com/@HYBELABELS",
-        "channel_label": "HYBE LABELS",
-        "owner_type": "label",
-        "allow_mv_uploads": true,
-        "display_in_team_links": false,
-        "provenance": "curated_agency_allowlist",
-        "match_keys": [
-          "@hybelabels",
-          "https://www.youtube.com/@hybelabels"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "The KingDom",
-    "primary_team_channel_url": null,
-    "mv_source_channels": [],
-    "mv_allowlist_urls": [],
-    "mv_allowlist_match_keys": [],
-    "channels": []
-  },
-  {
-    "group": "UNIS",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCspnElmzSLPhrZJDG9v7JWw",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCspnElmzSLPhrZJDG9v7JWw",
-        "channel_label": "UNIS",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucspnelmzslphrzjdg9v7jww",
-          "https://www.youtube.com/channel/ucspnelmzslphrzjdg9v7jww"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCspnElmzSLPhrZJDG9v7JWw"
-    ],
-    "mv_allowlist_match_keys": [
-      "channel:ucspnelmzslphrzjdg9v7jww",
-      "https://www.youtube.com/channel/ucspnelmzslphrzjdg9v7jww"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCspnElmzSLPhrZJDG9v7JWw",
-        "channel_label": "UNIS",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucspnelmzslphrzjdg9v7jww",
-          "https://www.youtube.com/channel/ucspnelmzslphrzjdg9v7jww"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "VERIVERY",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UC4t_pYSKIhLWFgutdzIK66Q",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UC4t_pYSKIhLWFgutdzIK66Q",
-        "channel_label": "VERIVERY",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:uc4t_pyskihlwfgutdzik66q",
-          "https://www.youtube.com/channel/uc4t_pyskihlwfgutdzik66q"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UC4t_pYSKIhLWFgutdzIK66Q"
-    ],
-    "mv_allowlist_match_keys": [
-      "channel:uc4t_pyskihlwfgutdzik66q",
-      "https://www.youtube.com/channel/uc4t_pyskihlwfgutdzik66q"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UC4t_pYSKIhLWFgutdzIK66Q",
-        "channel_label": "VERIVERY",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:uc4t_pyskihlwfgutdzik66q",
-          "https://www.youtube.com/channel/uc4t_pyskihlwfgutdzik66q"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "VIVIZ",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCWFMjDuWKlct0jy89k2kkRA",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCWFMjDuWKlct0jy89k2kkRA",
-        "channel_label": "VIVIZ",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucwfmjduwklct0jy89k2kkra",
-          "https://www.youtube.com/channel/ucwfmjduwklct0jy89k2kkra"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCWFMjDuWKlct0jy89k2kkRA"
-    ],
-    "mv_allowlist_match_keys": [
-      "channel:ucwfmjduwklct0jy89k2kkra",
-      "https://www.youtube.com/channel/ucwfmjduwklct0jy89k2kkra"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCWFMjDuWKlct0jy89k2kkRA",
-        "channel_label": "VIVIZ",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucwfmjduwklct0jy89k2kkra",
-          "https://www.youtube.com/channel/ucwfmjduwklct0jy89k2kkra"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "WEi",
-    "primary_team_channel_url": null,
-    "mv_source_channels": [],
-    "mv_allowlist_urls": [],
-    "mv_allowlist_match_keys": [],
-    "channels": []
-  },
-  {
-    "group": "WHIB",
-    "primary_team_channel_url": null,
-    "mv_source_channels": [],
-    "mv_allowlist_urls": [],
-    "mv_allowlist_match_keys": [],
-    "channels": []
-  },
-  {
-    "group": "WJSN",
-    "primary_team_channel_url": null,
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/@officialstarship",
-        "channel_label": "STARSHIP",
-        "owner_type": "label",
-        "allow_mv_uploads": true,
-        "display_in_team_links": false,
-        "provenance": "curated_agency_allowlist",
-        "match_keys": [
-          "@officialstarship",
-          "https://www.youtube.com/@officialstarship"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/@officialstarship"
-    ],
-    "mv_allowlist_match_keys": [
-      "@officialstarship",
-      "https://www.youtube.com/@officialstarship"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/@officialstarship",
-        "channel_label": "STARSHIP",
-        "owner_type": "label",
-        "allow_mv_uploads": true,
-        "display_in_team_links": false,
-        "provenance": "curated_agency_allowlist",
-        "match_keys": [
-          "@officialstarship",
-          "https://www.youtube.com/@officialstarship"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "WayV",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UC-ZHt5Zgadfx-B1CM63Lqew",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UC-ZHt5Zgadfx-B1CM63Lqew",
-        "channel_label": "WayV",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:uc-zht5zgadfx-b1cm63lqew",
-          "https://www.youtube.com/channel/uc-zht5zgadfx-b1cm63lqew"
-        ]
-      },
-      {
-        "channel_url": "https://www.youtube.com/@SMTOWN",
-        "channel_label": "SMTOWN",
-        "owner_type": "label",
-        "allow_mv_uploads": true,
-        "display_in_team_links": false,
-        "provenance": "curated_agency_allowlist",
-        "match_keys": [
-          "@smtown",
-          "https://www.youtube.com/@smtown"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UC-ZHt5Zgadfx-B1CM63Lqew",
-      "https://www.youtube.com/@SMTOWN"
-    ],
-    "mv_allowlist_match_keys": [
-      "channel:uc-zht5zgadfx-b1cm63lqew",
-      "https://www.youtube.com/channel/uc-zht5zgadfx-b1cm63lqew",
-      "@smtown",
-      "https://www.youtube.com/@smtown"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UC-ZHt5Zgadfx-B1CM63Lqew",
-        "channel_label": "WayV",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:uc-zht5zgadfx-b1cm63lqew",
-          "https://www.youtube.com/channel/uc-zht5zgadfx-b1cm63lqew"
-        ]
-      },
-      {
-        "channel_url": "https://www.youtube.com/@SMTOWN",
-        "channel_label": "SMTOWN",
-        "owner_type": "label",
-        "allow_mv_uploads": true,
-        "display_in_team_links": false,
-        "provenance": "curated_agency_allowlist",
-        "match_keys": [
-          "@smtown",
-          "https://www.youtube.com/@smtown"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "Weeekly",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UC5rp2rDRSpyKNj-QLytC-tw",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UC5rp2rDRSpyKNj-QLytC-tw",
-        "channel_label": "Weeekly",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:uc5rp2rdrspyknj-qlytc-tw",
-          "https://www.youtube.com/channel/uc5rp2rdrspyknj-qlytc-tw"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UC5rp2rDRSpyKNj-QLytC-tw"
-    ],
-    "mv_allowlist_match_keys": [
-      "channel:uc5rp2rdrspyknj-qlytc-tw",
-      "https://www.youtube.com/channel/uc5rp2rdrspyknj-qlytc-tw"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UC5rp2rDRSpyKNj-QLytC-tw",
-        "channel_label": "Weeekly",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:uc5rp2rdrspyknj-qlytc-tw",
-          "https://www.youtube.com/channel/uc5rp2rdrspyknj-qlytc-tw"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "Xdinary Heroes",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCO9GhtdQcCRf67GIdSQ0HNQ",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCO9GhtdQcCRf67GIdSQ0HNQ",
-        "channel_label": "Xdinary Heroes",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:uco9ghtdqccrf67gidsq0hnq",
-          "https://www.youtube.com/channel/uco9ghtdqccrf67gidsq0hnq"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCO9GhtdQcCRf67GIdSQ0HNQ"
-    ],
-    "mv_allowlist_match_keys": [
-      "channel:uco9ghtdqccrf67gidsq0hnq",
-      "https://www.youtube.com/channel/uco9ghtdqccrf67gidsq0hnq"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCO9GhtdQcCRf67GIdSQ0HNQ",
-        "channel_label": "Xdinary Heroes",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:uco9ghtdqccrf67gidsq0hnq",
-          "https://www.youtube.com/channel/uco9ghtdqccrf67gidsq0hnq"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "YOUNG POSSE",
-    "primary_team_channel_url": null,
-    "mv_source_channels": [],
-    "mv_allowlist_urls": [],
-    "mv_allowlist_match_keys": [],
-    "channels": []
-  },
-  {
-    "group": "YOUNITE",
-    "primary_team_channel_url": null,
-    "mv_source_channels": [],
-    "mv_allowlist_urls": [],
-    "mv_allowlist_match_keys": [],
-    "channels": []
-  },
-  {
-    "group": "ZEROBASEONE",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCSAp0Yl9S0Zq5uDqE6im_XQ",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCSAp0Yl9S0Zq5uDqE6im_XQ",
-        "channel_label": "ZEROBASEONE",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucsap0yl9s0zq5udqe6im_xq",
-          "https://www.youtube.com/channel/ucsap0yl9s0zq5udqe6im_xq"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCSAp0Yl9S0Zq5uDqE6im_XQ"
-    ],
-    "mv_allowlist_match_keys": [
-      "channel:ucsap0yl9s0zq5udqe6im_xq",
-      "https://www.youtube.com/channel/ucsap0yl9s0zq5udqe6im_xq"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UCSAp0Yl9S0Zq5uDqE6im_XQ",
-        "channel_label": "ZEROBASEONE",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:ucsap0yl9s0zq5udqe6im_xq",
-          "https://www.youtube.com/channel/ucsap0yl9s0zq5udqe6im_xq"
-        ]
-      }
-    ]
-  },
-  {
-    "group": "aespa",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UC9GtSLeksfK4yuJ_g1lgQbg",
-    "mv_source_channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UC9GtSLeksfK4yuJ_g1lgQbg",
-        "channel_label": "aespa",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:uc9gtsleksfk4yuj_g1lgqbg",
-          "https://www.youtube.com/channel/uc9gtsleksfk4yuj_g1lgqbg"
-        ]
-      },
-      {
-        "channel_url": "https://www.youtube.com/@SMTOWN",
-        "channel_label": "SMTOWN",
-        "owner_type": "label",
-        "allow_mv_uploads": true,
-        "display_in_team_links": false,
-        "provenance": "curated_agency_allowlist",
-        "match_keys": [
-          "@smtown",
-          "https://www.youtube.com/@smtown"
-        ]
-      }
-    ],
-    "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UC9GtSLeksfK4yuJ_g1lgQbg",
-      "https://www.youtube.com/@SMTOWN"
-    ],
-    "mv_allowlist_match_keys": [
-      "channel:uc9gtsleksfk4yuj_g1lgqbg",
-      "https://www.youtube.com/channel/uc9gtsleksfk4yuj_g1lgqbg",
-      "@smtown",
-      "https://www.youtube.com/@smtown"
-    ],
-    "channels": [
-      {
-        "channel_url": "https://www.youtube.com/channel/UC9GtSLeksfK4yuJ_g1lgQbg",
-        "channel_label": "aespa",
-        "owner_type": "team",
-        "allow_mv_uploads": true,
-        "display_in_team_links": true,
-        "provenance": "artistProfiles.official_youtube_url",
-        "match_keys": [
-          "channel:uc9gtsleksfk4yuj_g1lgqbg",
-          "https://www.youtube.com/channel/uc9gtsleksfk4yuj_g1lgqbg"
-        ]
-      },
-      {
-        "channel_url": "https://www.youtube.com/@SMTOWN",
-        "channel_label": "SMTOWN",
-        "owner_type": "label",
-        "allow_mv_uploads": true,
-        "display_in_team_links": false,
-        "provenance": "curated_agency_allowlist",
-        "match_keys": [
-          "@smtown",
-          "https://www.youtube.com/@smtown"
+          "@chuuofficial",
+          "https://www.youtube.com/@chuuofficial",
+          "channel:uca0ylh-c4-mhz7ih_6ahtxg",
+          "https://www.youtube.com/channel/uca0ylh-c4-mhz7ih_6ahtxg"
         ]
       }
     ]
@@ -4208,6 +1456,7 @@
         "allow_mv_uploads": true,
         "display_in_team_links": true,
         "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [],
         "match_keys": [
           "channel:ucardmtjgo6w0esjpzuozxrw",
           "https://www.youtube.com/channel/ucardmtjgo6w0esjpzuozxrw"
@@ -4229,6 +1478,7 @@
         "allow_mv_uploads": true,
         "display_in_team_links": true,
         "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [],
         "match_keys": [
           "channel:ucardmtjgo6w0esjpzuozxrw",
           "https://www.youtube.com/channel/ucardmtjgo6w0esjpzuozxrw"
@@ -4237,46 +1487,236 @@
     ]
   },
   {
-    "group": "fromis_9",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UC8qO5racajmy4YgPgNJkVXg",
+    "group": "CIX",
+    "primary_team_channel_url": "https://www.youtube.com/@cix.official",
     "mv_source_channels": [
       {
-        "channel_url": "https://www.youtube.com/channel/UC8qO5racajmy4YgPgNJkVXg",
-        "channel_label": "fromis_9",
+        "channel_url": "https://www.youtube.com/@cix.official",
+        "channel_label": "CIX",
         "owner_type": "team",
         "allow_mv_uploads": true,
         "display_in_team_links": true,
         "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCdkLaQm7kpWIE0EcesqLwJA",
+          "https://www.youtube.com/@cix.official"
+        ],
         "match_keys": [
-          "channel:uc8qo5racajmy4ygpgnjkvxg",
-          "https://www.youtube.com/channel/uc8qo5racajmy4ygpgnjkvxg"
+          "@cix.official",
+          "https://www.youtube.com/@cix.official",
+          "channel:ucdklaqm7kpwie0ecesqlwja",
+          "https://www.youtube.com/channel/ucdklaqm7kpwie0ecesqlwja"
         ]
       }
     ],
     "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UC8qO5racajmy4YgPgNJkVXg"
+      "https://www.youtube.com/@cix.official"
     ],
     "mv_allowlist_match_keys": [
-      "channel:uc8qo5racajmy4ygpgnjkvxg",
-      "https://www.youtube.com/channel/uc8qo5racajmy4ygpgnjkvxg"
+      "@cix.official",
+      "https://www.youtube.com/@cix.official",
+      "channel:ucdklaqm7kpwie0ecesqlwja",
+      "https://www.youtube.com/channel/ucdklaqm7kpwie0ecesqlwja"
     ],
     "channels": [
       {
-        "channel_url": "https://www.youtube.com/channel/UC8qO5racajmy4YgPgNJkVXg",
-        "channel_label": "fromis_9",
+        "channel_url": "https://www.youtube.com/@cix.official",
+        "channel_label": "CIX",
         "owner_type": "team",
         "allow_mv_uploads": true,
         "display_in_team_links": true,
         "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCdkLaQm7kpWIE0EcesqLwJA",
+          "https://www.youtube.com/@cix.official"
+        ],
         "match_keys": [
-          "channel:uc8qo5racajmy4ygpgnjkvxg",
-          "https://www.youtube.com/channel/uc8qo5racajmy4ygpgnjkvxg"
+          "@cix.official",
+          "https://www.youtube.com/@cix.official",
+          "channel:ucdklaqm7kpwie0ecesqlwja",
+          "https://www.youtube.com/channel/ucdklaqm7kpwie0ecesqlwja"
         ]
       }
     ]
   },
   {
-    "group": "ifeye",
+    "group": "CLASS:y",
+    "primary_team_channel_url": "https://www.youtube.com/channel/UCbCyYn2M_1ccicwj-KU7t0Q",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/channel/UCbCyYn2M_1ccicwj-KU7t0Q",
+        "channel_label": "CLASS:y",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [],
+        "match_keys": [
+          "channel:ucbcyyn2m_1ccicwj-ku7t0q",
+          "https://www.youtube.com/channel/ucbcyyn2m_1ccicwj-ku7t0q"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/channel/UCbCyYn2M_1ccicwj-KU7t0Q"
+    ],
+    "mv_allowlist_match_keys": [
+      "channel:ucbcyyn2m_1ccicwj-ku7t0q",
+      "https://www.youtube.com/channel/ucbcyyn2m_1ccicwj-ku7t0q"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/channel/UCbCyYn2M_1ccicwj-KU7t0Q",
+        "channel_label": "CLASS:y",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [],
+        "match_keys": [
+          "channel:ucbcyyn2m_1ccicwj-ku7t0q",
+          "https://www.youtube.com/channel/ucbcyyn2m_1ccicwj-ku7t0q"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "CLOSE YOUR EYES",
+    "primary_team_channel_url": "https://www.youtube.com/@close.your.eyes.official",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@close.your.eyes.official",
+        "channel_label": "CLOSE YOUR EYES",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCPo532dDHpbKVhJyJseLVbw",
+          "https://www.youtube.com/@close.your.eyes.official"
+        ],
+        "match_keys": [
+          "@close.your.eyes.official",
+          "https://www.youtube.com/@close.your.eyes.official",
+          "channel:ucpo532ddhpbkvhjyjselvbw",
+          "https://www.youtube.com/channel/ucpo532ddhpbkvhjyjselvbw"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@close.your.eyes.official"
+    ],
+    "mv_allowlist_match_keys": [
+      "@close.your.eyes.official",
+      "https://www.youtube.com/@close.your.eyes.official",
+      "channel:ucpo532ddhpbkvhjyjselvbw",
+      "https://www.youtube.com/channel/ucpo532ddhpbkvhjyjselvbw"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@close.your.eyes.official",
+        "channel_label": "CLOSE YOUR EYES",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCPo532dDHpbKVhJyJseLVbw",
+          "https://www.youtube.com/@close.your.eyes.official"
+        ],
+        "match_keys": [
+          "@close.your.eyes.official",
+          "https://www.youtube.com/@close.your.eyes.official",
+          "channel:ucpo532ddhpbkvhjyjselvbw",
+          "https://www.youtube.com/channel/ucpo532ddhpbkvhjyjselvbw"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "CRAVITY",
+    "primary_team_channel_url": "https://www.youtube.com/channel/UCRm-0JVuUFh5HV7NGG7qXlQ",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/channel/UCRm-0JVuUFh5HV7NGG7qXlQ",
+        "channel_label": "CRAVITY",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [],
+        "match_keys": [
+          "channel:ucrm-0jvuufh5hv7ngg7qxlq",
+          "https://www.youtube.com/channel/ucrm-0jvuufh5hv7ngg7qxlq"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/@officialstarship",
+        "channel_label": "STARSHIP",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UC7FAMNhb-BNeNj_6DrtrHCQ",
+          "https://www.youtube.com/@officialstarship"
+        ],
+        "match_keys": [
+          "@officialstarship",
+          "https://www.youtube.com/@officialstarship",
+          "channel:uc7famnhb-bnenj_6drtrhcq",
+          "https://www.youtube.com/channel/uc7famnhb-bnenj_6drtrhcq"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/channel/UCRm-0JVuUFh5HV7NGG7qXlQ",
+      "https://www.youtube.com/@officialstarship"
+    ],
+    "mv_allowlist_match_keys": [
+      "channel:ucrm-0jvuufh5hv7ngg7qxlq",
+      "https://www.youtube.com/channel/ucrm-0jvuufh5hv7ngg7qxlq",
+      "@officialstarship",
+      "https://www.youtube.com/@officialstarship",
+      "channel:uc7famnhb-bnenj_6drtrhcq",
+      "https://www.youtube.com/channel/uc7famnhb-bnenj_6drtrhcq"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/channel/UCRm-0JVuUFh5HV7NGG7qXlQ",
+        "channel_label": "CRAVITY",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [],
+        "match_keys": [
+          "channel:ucrm-0jvuufh5hv7ngg7qxlq",
+          "https://www.youtube.com/channel/ucrm-0jvuufh5hv7ngg7qxlq"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/@officialstarship",
+        "channel_label": "STARSHIP",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UC7FAMNhb-BNeNj_6DrtrHCQ",
+          "https://www.youtube.com/@officialstarship"
+        ],
+        "match_keys": [
+          "@officialstarship",
+          "https://www.youtube.com/@officialstarship",
+          "channel:uc7famnhb-bnenj_6drtrhcq",
+          "https://www.youtube.com/channel/uc7famnhb-bnenj_6drtrhcq"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "CSR",
     "primary_team_channel_url": null,
     "mv_source_channels": [],
     "mv_allowlist_urls": [],
@@ -4284,155 +1724,5162 @@
     "channels": []
   },
   {
-    "group": "izna",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCfbYNlxgLuKJXQZEhkMmaCQ",
+    "group": "DAY6",
+    "primary_team_channel_url": "https://www.youtube.com/@DAY6Official",
     "mv_source_channels": [
       {
-        "channel_url": "https://www.youtube.com/channel/UCfbYNlxgLuKJXQZEhkMmaCQ",
+        "channel_url": "https://www.youtube.com/@DAY6Official",
+        "channel_label": "DAY6",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCaO6TYtlC8U5ttz62hTrZgg",
+          "https://www.youtube.com/@DAY6Official"
+        ],
+        "match_keys": [
+          "@day6official",
+          "https://www.youtube.com/@day6official",
+          "channel:ucao6tytlc8u5ttz62htrzgg",
+          "https://www.youtube.com/channel/ucao6tytlc8u5ttz62htrzgg"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/@JYPEntertainment",
+        "channel_label": "JYP Entertainment",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCaO6TYtlC8U5ttz62hTrZgg",
+          "https://www.youtube.com/@JYPEntertainment"
+        ],
+        "match_keys": [
+          "@jypentertainment",
+          "https://www.youtube.com/@jypentertainment",
+          "channel:ucao6tytlc8u5ttz62htrzgg",
+          "https://www.youtube.com/channel/ucao6tytlc8u5ttz62htrzgg"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@DAY6Official",
+      "https://www.youtube.com/@JYPEntertainment"
+    ],
+    "mv_allowlist_match_keys": [
+      "@day6official",
+      "https://www.youtube.com/@day6official",
+      "channel:ucao6tytlc8u5ttz62htrzgg",
+      "https://www.youtube.com/channel/ucao6tytlc8u5ttz62htrzgg",
+      "@jypentertainment",
+      "https://www.youtube.com/@jypentertainment"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@DAY6Official",
+        "channel_label": "DAY6",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCaO6TYtlC8U5ttz62hTrZgg",
+          "https://www.youtube.com/@DAY6Official"
+        ],
+        "match_keys": [
+          "@day6official",
+          "https://www.youtube.com/@day6official",
+          "channel:ucao6tytlc8u5ttz62htrzgg",
+          "https://www.youtube.com/channel/ucao6tytlc8u5ttz62htrzgg"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/@JYPEntertainment",
+        "channel_label": "JYP Entertainment",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCaO6TYtlC8U5ttz62hTrZgg",
+          "https://www.youtube.com/@JYPEntertainment"
+        ],
+        "match_keys": [
+          "@jypentertainment",
+          "https://www.youtube.com/@jypentertainment",
+          "channel:ucao6tytlc8u5ttz62htrzgg",
+          "https://www.youtube.com/channel/ucao6tytlc8u5ttz62htrzgg"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "DKB",
+    "primary_team_channel_url": "https://www.youtube.com/channel/UCCwfiPqSomsqZkkmbjPK5wg",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/channel/UCCwfiPqSomsqZkkmbjPK5wg",
+        "channel_label": "DKB",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [],
+        "match_keys": [
+          "channel:uccwfipqsomsqzkkmbjpk5wg",
+          "https://www.youtube.com/channel/uccwfipqsomsqzkkmbjpk5wg"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/channel/UCCwfiPqSomsqZkkmbjPK5wg"
+    ],
+    "mv_allowlist_match_keys": [
+      "channel:uccwfipqsomsqzkkmbjpk5wg",
+      "https://www.youtube.com/channel/uccwfipqsomsqzkkmbjpk5wg"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/channel/UCCwfiPqSomsqZkkmbjPK5wg",
+        "channel_label": "DKB",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [],
+        "match_keys": [
+          "channel:uccwfipqsomsqzkkmbjpk5wg",
+          "https://www.youtube.com/channel/uccwfipqsomsqzkkmbjpk5wg"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "Dreamcatcher",
+    "primary_team_channel_url": "https://www.youtube.com/@hf_dreamcatcher",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@hf_dreamcatcher",
+        "channel_label": "Dreamcatcher",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCA-Cx-vSiuYEuWLo6NGPWWw",
+          "https://www.youtube.com/@hf_dreamcatcher"
+        ],
+        "match_keys": [
+          "@hf_dreamcatcher",
+          "https://www.youtube.com/@hf_dreamcatcher",
+          "channel:uca-cx-vsiuyeuwlo6ngpwww",
+          "https://www.youtube.com/channel/uca-cx-vsiuyeuwlo6ngpwww"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@hf_dreamcatcher"
+    ],
+    "mv_allowlist_match_keys": [
+      "@hf_dreamcatcher",
+      "https://www.youtube.com/@hf_dreamcatcher",
+      "channel:uca-cx-vsiuyeuwlo6ngpwww",
+      "https://www.youtube.com/channel/uca-cx-vsiuyeuwlo6ngpwww"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@hf_dreamcatcher",
+        "channel_label": "Dreamcatcher",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCA-Cx-vSiuYEuWLo6NGPWWw",
+          "https://www.youtube.com/@hf_dreamcatcher"
+        ],
+        "match_keys": [
+          "@hf_dreamcatcher",
+          "https://www.youtube.com/@hf_dreamcatcher",
+          "channel:uca-cx-vsiuyeuwlo6ngpwww",
+          "https://www.youtube.com/channel/uca-cx-vsiuyeuwlo6ngpwww"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "DRIPPIN",
+    "primary_team_channel_url": "https://www.youtube.com/@DRIPPIN",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@DRIPPIN",
+        "channel_label": "DRIPPIN",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCNf1JFLCOec-SUhREgZaR6w",
+          "https://www.youtube.com/@DRIPPIN"
+        ],
+        "match_keys": [
+          "@drippin",
+          "https://www.youtube.com/@drippin",
+          "channel:ucnf1jflcoec-suhregzar6w",
+          "https://www.youtube.com/channel/ucnf1jflcoec-suhregzar6w"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@DRIPPIN"
+    ],
+    "mv_allowlist_match_keys": [
+      "@drippin",
+      "https://www.youtube.com/@drippin",
+      "channel:ucnf1jflcoec-suhregzar6w",
+      "https://www.youtube.com/channel/ucnf1jflcoec-suhregzar6w"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@DRIPPIN",
+        "channel_label": "DRIPPIN",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCNf1JFLCOec-SUhREgZaR6w",
+          "https://www.youtube.com/@DRIPPIN"
+        ],
+        "match_keys": [
+          "@drippin",
+          "https://www.youtube.com/@drippin",
+          "channel:ucnf1jflcoec-suhregzar6w",
+          "https://www.youtube.com/channel/ucnf1jflcoec-suhregzar6w"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "DXMON",
+    "primary_team_channel_url": "https://www.youtube.com/@DXMON_HM",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@DXMON_HM",
+        "channel_label": "DXMON",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCrhNp7bqMHOjVfMcyjk_J9Q",
+          "https://www.youtube.com/@DXMON_HM"
+        ],
+        "match_keys": [
+          "@dxmon_hm",
+          "https://www.youtube.com/@dxmon_hm",
+          "channel:ucrhnp7bqmhojvfmcyjk_j9q",
+          "https://www.youtube.com/channel/ucrhnp7bqmhojvfmcyjk_j9q"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@DXMON_HM"
+    ],
+    "mv_allowlist_match_keys": [
+      "@dxmon_hm",
+      "https://www.youtube.com/@dxmon_hm",
+      "channel:ucrhnp7bqmhojvfmcyjk_j9q",
+      "https://www.youtube.com/channel/ucrhnp7bqmhojvfmcyjk_j9q"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@DXMON_HM",
+        "channel_label": "DXMON",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCrhNp7bqMHOjVfMcyjk_J9Q",
+          "https://www.youtube.com/@DXMON_HM"
+        ],
+        "match_keys": [
+          "@dxmon_hm",
+          "https://www.youtube.com/@dxmon_hm",
+          "channel:ucrhnp7bqmhojvfmcyjk_j9q",
+          "https://www.youtube.com/channel/ucrhnp7bqmhojvfmcyjk_j9q"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "ENHYPEN",
+    "primary_team_channel_url": "https://www.youtube.com/channel/UCArLZtok93cO5R9RI4_Y5Jw",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/channel/UCArLZtok93cO5R9RI4_Y5Jw",
+        "channel_label": "ENHYPEN",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [],
+        "match_keys": [
+          "channel:ucarlztok93co5r9ri4_y5jw",
+          "https://www.youtube.com/channel/ucarlztok93co5r9ri4_y5jw"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/@HYBELABELS",
+        "channel_label": "HYBE LABELS",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UC3IZKseVpdzPSBaWxBxundA",
+          "https://www.youtube.com/@HYBELABELS"
+        ],
+        "match_keys": [
+          "@hybelabels",
+          "https://www.youtube.com/@hybelabels",
+          "channel:uc3izksevpdzpsbawxbxunda",
+          "https://www.youtube.com/channel/uc3izksevpdzpsbawxbxunda"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/channel/UCArLZtok93cO5R9RI4_Y5Jw",
+      "https://www.youtube.com/@HYBELABELS"
+    ],
+    "mv_allowlist_match_keys": [
+      "channel:ucarlztok93co5r9ri4_y5jw",
+      "https://www.youtube.com/channel/ucarlztok93co5r9ri4_y5jw",
+      "@hybelabels",
+      "https://www.youtube.com/@hybelabels",
+      "channel:uc3izksevpdzpsbawxbxunda",
+      "https://www.youtube.com/channel/uc3izksevpdzpsbawxbxunda"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/channel/UCArLZtok93cO5R9RI4_Y5Jw",
+        "channel_label": "ENHYPEN",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [],
+        "match_keys": [
+          "channel:ucarlztok93co5r9ri4_y5jw",
+          "https://www.youtube.com/channel/ucarlztok93co5r9ri4_y5jw"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/@HYBELABELS",
+        "channel_label": "HYBE LABELS",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UC3IZKseVpdzPSBaWxBxundA",
+          "https://www.youtube.com/@HYBELABELS"
+        ],
+        "match_keys": [
+          "@hybelabels",
+          "https://www.youtube.com/@hybelabels",
+          "channel:uc3izksevpdzpsbawxbxunda",
+          "https://www.youtube.com/channel/uc3izksevpdzpsbawxbxunda"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "EPEX",
+    "primary_team_channel_url": "https://www.youtube.com/channel/UCKHl-9B-aa4AK5ZR9XLOg8A",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/channel/UCKHl-9B-aa4AK5ZR9XLOg8A",
+        "channel_label": "EPEX",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [],
+        "match_keys": [
+          "channel:uckhl-9b-aa4ak5zr9xlog8a",
+          "https://www.youtube.com/channel/uckhl-9b-aa4ak5zr9xlog8a"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/channel/UCKHl-9B-aa4AK5ZR9XLOg8A"
+    ],
+    "mv_allowlist_match_keys": [
+      "channel:uckhl-9b-aa4ak5zr9xlog8a",
+      "https://www.youtube.com/channel/uckhl-9b-aa4ak5zr9xlog8a"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/channel/UCKHl-9B-aa4AK5ZR9XLOg8A",
+        "channel_label": "EPEX",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [],
+        "match_keys": [
+          "channel:uckhl-9b-aa4ak5zr9xlog8a",
+          "https://www.youtube.com/channel/uckhl-9b-aa4ak5zr9xlog8a"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "EVNNE",
+    "primary_team_channel_url": "https://www.youtube.com/@EVNNE_Official",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@EVNNE_Official",
+        "channel_label": "EVNNE",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCAWT2IC2TrPFNPCvkKZUFjg",
+          "https://www.youtube.com/@EVNNE_Official"
+        ],
+        "match_keys": [
+          "@evnne_official",
+          "https://www.youtube.com/@evnne_official",
+          "channel:ucawt2ic2trpfnpcvkkzufjg",
+          "https://www.youtube.com/channel/ucawt2ic2trpfnpcvkkzufjg"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@EVNNE_Official"
+    ],
+    "mv_allowlist_match_keys": [
+      "@evnne_official",
+      "https://www.youtube.com/@evnne_official",
+      "channel:ucawt2ic2trpfnpcvkkzufjg",
+      "https://www.youtube.com/channel/ucawt2ic2trpfnpcvkkzufjg"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@EVNNE_Official",
+        "channel_label": "EVNNE",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCAWT2IC2TrPFNPCvkKZUFjg",
+          "https://www.youtube.com/@EVNNE_Official"
+        ],
+        "match_keys": [
+          "@evnne_official",
+          "https://www.youtube.com/@evnne_official",
+          "channel:ucawt2ic2trpfnpcvkkzufjg",
+          "https://www.youtube.com/channel/ucawt2ic2trpfnpcvkkzufjg"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "EXO",
+    "primary_team_channel_url": "https://www.youtube.com/@weareoneEXO",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@weareoneEXO",
+        "channel_label": "EXO",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCzCedBCSSltI1TFd3bKyN6g",
+          "https://www.youtube.com/@weareoneEXO"
+        ],
+        "match_keys": [
+          "@weareoneexo",
+          "https://www.youtube.com/@weareoneexo",
+          "channel:uczcedbcsslti1tfd3bkyn6g",
+          "https://www.youtube.com/channel/uczcedbcsslti1tfd3bkyn6g"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/@SMTOWN",
+        "channel_label": "SMTOWN",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCyDd_CdcEtQk-jbmrBhBl5w",
+          "https://www.youtube.com/@SMTOWN"
+        ],
+        "match_keys": [
+          "@smtown",
+          "https://www.youtube.com/@smtown",
+          "channel:ucydd_cdcetqk-jbmrbhbl5w",
+          "https://www.youtube.com/channel/ucydd_cdcetqk-jbmrbhbl5w"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@weareoneEXO",
+      "https://www.youtube.com/@SMTOWN"
+    ],
+    "mv_allowlist_match_keys": [
+      "@weareoneexo",
+      "https://www.youtube.com/@weareoneexo",
+      "channel:uczcedbcsslti1tfd3bkyn6g",
+      "https://www.youtube.com/channel/uczcedbcsslti1tfd3bkyn6g",
+      "@smtown",
+      "https://www.youtube.com/@smtown",
+      "channel:ucydd_cdcetqk-jbmrbhbl5w",
+      "https://www.youtube.com/channel/ucydd_cdcetqk-jbmrbhbl5w"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@weareoneEXO",
+        "channel_label": "EXO",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCzCedBCSSltI1TFd3bKyN6g",
+          "https://www.youtube.com/@weareoneEXO"
+        ],
+        "match_keys": [
+          "@weareoneexo",
+          "https://www.youtube.com/@weareoneexo",
+          "channel:uczcedbcsslti1tfd3bkyn6g",
+          "https://www.youtube.com/channel/uczcedbcsslti1tfd3bkyn6g"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/@SMTOWN",
+        "channel_label": "SMTOWN",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCyDd_CdcEtQk-jbmrBhBl5w",
+          "https://www.youtube.com/@SMTOWN"
+        ],
+        "match_keys": [
+          "@smtown",
+          "https://www.youtube.com/@smtown",
+          "channel:ucydd_cdcetqk-jbmrbhbl5w",
+          "https://www.youtube.com/channel/ucydd_cdcetqk-jbmrbhbl5w"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "FIFTY FIFTY",
+    "primary_team_channel_url": "https://www.youtube.com/@WE_FIFTYFIFTY",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@WE_FIFTYFIFTY",
+        "channel_label": "FIFTY FIFTY",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCJEER74X9kBenMT_x9iK9Mw",
+          "https://www.youtube.com/@WE_FIFTYFIFTY"
+        ],
+        "match_keys": [
+          "@we_fiftyfifty",
+          "https://www.youtube.com/@we_fiftyfifty",
+          "channel:ucjeer74x9kbenmt_x9ik9mw",
+          "https://www.youtube.com/channel/ucjeer74x9kbenmt_x9ik9mw"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@WE_FIFTYFIFTY"
+    ],
+    "mv_allowlist_match_keys": [
+      "@we_fiftyfifty",
+      "https://www.youtube.com/@we_fiftyfifty",
+      "channel:ucjeer74x9kbenmt_x9ik9mw",
+      "https://www.youtube.com/channel/ucjeer74x9kbenmt_x9ik9mw"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@WE_FIFTYFIFTY",
+        "channel_label": "FIFTY FIFTY",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCJEER74X9kBenMT_x9iK9Mw",
+          "https://www.youtube.com/@WE_FIFTYFIFTY"
+        ],
+        "match_keys": [
+          "@we_fiftyfifty",
+          "https://www.youtube.com/@we_fiftyfifty",
+          "channel:ucjeer74x9kbenmt_x9ik9mw",
+          "https://www.youtube.com/channel/ucjeer74x9kbenmt_x9ik9mw"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "fromis_9",
+    "primary_team_channel_url": "https://www.youtube.com/@realfromis_9",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@realfromis_9",
+        "channel_label": "fromis_9",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCv5DulWwp71Q2g-YU6ic2aQ",
+          "https://www.youtube.com/@realfromis_9"
+        ],
+        "match_keys": [
+          "@realfromis_9",
+          "https://www.youtube.com/@realfromis_9",
+          "channel:ucv5dulwwp71q2g-yu6ic2aq",
+          "https://www.youtube.com/channel/ucv5dulwwp71q2g-yu6ic2aq"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@realfromis_9"
+    ],
+    "mv_allowlist_match_keys": [
+      "@realfromis_9",
+      "https://www.youtube.com/@realfromis_9",
+      "channel:ucv5dulwwp71q2g-yu6ic2aq",
+      "https://www.youtube.com/channel/ucv5dulwwp71q2g-yu6ic2aq"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@realfromis_9",
+        "channel_label": "fromis_9",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCv5DulWwp71Q2g-YU6ic2aQ",
+          "https://www.youtube.com/@realfromis_9"
+        ],
+        "match_keys": [
+          "@realfromis_9",
+          "https://www.youtube.com/@realfromis_9",
+          "channel:ucv5dulwwp71q2g-yu6ic2aq",
+          "https://www.youtube.com/channel/ucv5dulwwp71q2g-yu6ic2aq"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "GHOST9",
+    "primary_team_channel_url": "https://www.youtube.com/@GHOST9Official",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@GHOST9Official",
+        "channel_label": "GHOST9",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCwBsVtDcTVG4QCorkVNJ5Sg",
+          "https://www.youtube.com/@GHOST9Official"
+        ],
+        "match_keys": [
+          "@ghost9official",
+          "https://www.youtube.com/@ghost9official",
+          "channel:ucwbsvtdctvg4qcorkvnj5sg",
+          "https://www.youtube.com/channel/ucwbsvtdctvg4qcorkvnj5sg"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@GHOST9Official"
+    ],
+    "mv_allowlist_match_keys": [
+      "@ghost9official",
+      "https://www.youtube.com/@ghost9official",
+      "channel:ucwbsvtdctvg4qcorkvnj5sg",
+      "https://www.youtube.com/channel/ucwbsvtdctvg4qcorkvnj5sg"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@GHOST9Official",
+        "channel_label": "GHOST9",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCwBsVtDcTVG4QCorkVNJ5Sg",
+          "https://www.youtube.com/@GHOST9Official"
+        ],
+        "match_keys": [
+          "@ghost9official",
+          "https://www.youtube.com/@ghost9official",
+          "channel:ucwbsvtdctvg4qcorkvnj5sg",
+          "https://www.youtube.com/channel/ucwbsvtdctvg4qcorkvnj5sg"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "H1-KEY",
+    "primary_team_channel_url": "https://www.youtube.com/@H1KEY_official",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@H1KEY_official",
+        "channel_label": "H1-KEY",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UC0novDS2VRX59Trmbf83I3g",
+          "https://www.youtube.com/@H1KEY_official"
+        ],
+        "match_keys": [
+          "@h1key_official",
+          "https://www.youtube.com/@h1key_official",
+          "channel:uc0novds2vrx59trmbf83i3g",
+          "https://www.youtube.com/channel/uc0novds2vrx59trmbf83i3g"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@H1KEY_official"
+    ],
+    "mv_allowlist_match_keys": [
+      "@h1key_official",
+      "https://www.youtube.com/@h1key_official",
+      "channel:uc0novds2vrx59trmbf83i3g",
+      "https://www.youtube.com/channel/uc0novds2vrx59trmbf83i3g"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@H1KEY_official",
+        "channel_label": "H1-KEY",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UC0novDS2VRX59Trmbf83I3g",
+          "https://www.youtube.com/@H1KEY_official"
+        ],
+        "match_keys": [
+          "@h1key_official",
+          "https://www.youtube.com/@h1key_official",
+          "channel:uc0novds2vrx59trmbf83i3g",
+          "https://www.youtube.com/channel/uc0novds2vrx59trmbf83i3g"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "Hearts2Hearts",
+    "primary_team_channel_url": "https://www.youtube.com/@SMTOWN",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@SMTOWN",
+        "channel_label": "Hearts2Hearts",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCyDd_CdcEtQk-jbmrBhBl5w",
+          "https://www.youtube.com/@SMTOWN"
+        ],
+        "match_keys": [
+          "@smtown",
+          "https://www.youtube.com/@smtown",
+          "channel:ucydd_cdcetqk-jbmrbhbl5w",
+          "https://www.youtube.com/channel/ucydd_cdcetqk-jbmrbhbl5w"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@SMTOWN"
+    ],
+    "mv_allowlist_match_keys": [
+      "@smtown",
+      "https://www.youtube.com/@smtown",
+      "channel:ucydd_cdcetqk-jbmrbhbl5w",
+      "https://www.youtube.com/channel/ucydd_cdcetqk-jbmrbhbl5w"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@SMTOWN",
+        "channel_label": "Hearts2Hearts",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCyDd_CdcEtQk-jbmrBhBl5w",
+          "https://www.youtube.com/@SMTOWN"
+        ],
+        "match_keys": [
+          "@smtown",
+          "https://www.youtube.com/@smtown",
+          "channel:ucydd_cdcetqk-jbmrbhbl5w",
+          "https://www.youtube.com/channel/ucydd_cdcetqk-jbmrbhbl5w"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "ifeye",
+    "primary_team_channel_url": "https://www.youtube.com/@ifeye_official",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@ifeye_official",
+        "channel_label": "ifeye",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCQ5K9InArSCtJoiUOlqu27g",
+          "https://www.youtube.com/@ifeye_official"
+        ],
+        "match_keys": [
+          "@ifeye_official",
+          "https://www.youtube.com/@ifeye_official",
+          "channel:ucq5k9inarsctjoiuolqu27g",
+          "https://www.youtube.com/channel/ucq5k9inarsctjoiuolqu27g"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@ifeye_official"
+    ],
+    "mv_allowlist_match_keys": [
+      "@ifeye_official",
+      "https://www.youtube.com/@ifeye_official",
+      "channel:ucq5k9inarsctjoiuolqu27g",
+      "https://www.youtube.com/channel/ucq5k9inarsctjoiuolqu27g"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@ifeye_official",
+        "channel_label": "ifeye",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCQ5K9InArSCtJoiUOlqu27g",
+          "https://www.youtube.com/@ifeye_official"
+        ],
+        "match_keys": [
+          "@ifeye_official",
+          "https://www.youtube.com/@ifeye_official",
+          "channel:ucq5k9inarsctjoiuolqu27g",
+          "https://www.youtube.com/channel/ucq5k9inarsctjoiuolqu27g"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "INFINITE",
+    "primary_team_channel_url": "https://www.youtube.com/channel/UCdzXSux7OnRD1Cml-DQ416Q",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/channel/UCdzXSux7OnRD1Cml-DQ416Q",
+        "channel_label": "INFINITE",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [],
+        "match_keys": [
+          "channel:ucdzxsux7onrd1cml-dq416q",
+          "https://www.youtube.com/channel/ucdzxsux7onrd1cml-dq416q"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/channel/UCdzXSux7OnRD1Cml-DQ416Q"
+    ],
+    "mv_allowlist_match_keys": [
+      "channel:ucdzxsux7onrd1cml-dq416q",
+      "https://www.youtube.com/channel/ucdzxsux7onrd1cml-dq416q"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/channel/UCdzXSux7OnRD1Cml-DQ416Q",
+        "channel_label": "INFINITE",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [],
+        "match_keys": [
+          "channel:ucdzxsux7onrd1cml-dq416q",
+          "https://www.youtube.com/channel/ucdzxsux7onrd1cml-dq416q"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "ITZY",
+    "primary_team_channel_url": "https://www.youtube.com/@ItzyOfficial",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@ItzyOfficial",
+        "channel_label": "ITZY",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCCB73cTL3awOpsMYcFHzVXg",
+          "https://www.youtube.com/@ItzyOfficial"
+        ],
+        "match_keys": [
+          "@itzyofficial",
+          "https://www.youtube.com/@itzyofficial",
+          "channel:uccb73ctl3awopsmycfhzvxg",
+          "https://www.youtube.com/channel/uccb73ctl3awopsmycfhzvxg"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/@JYPEntertainment",
+        "channel_label": "JYP Entertainment",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCaO6TYtlC8U5ttz62hTrZgg",
+          "https://www.youtube.com/@JYPEntertainment"
+        ],
+        "match_keys": [
+          "@jypentertainment",
+          "https://www.youtube.com/@jypentertainment",
+          "channel:ucao6tytlc8u5ttz62htrzgg",
+          "https://www.youtube.com/channel/ucao6tytlc8u5ttz62htrzgg"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@ItzyOfficial",
+      "https://www.youtube.com/@JYPEntertainment"
+    ],
+    "mv_allowlist_match_keys": [
+      "@itzyofficial",
+      "https://www.youtube.com/@itzyofficial",
+      "channel:uccb73ctl3awopsmycfhzvxg",
+      "https://www.youtube.com/channel/uccb73ctl3awopsmycfhzvxg",
+      "@jypentertainment",
+      "https://www.youtube.com/@jypentertainment",
+      "channel:ucao6tytlc8u5ttz62htrzgg",
+      "https://www.youtube.com/channel/ucao6tytlc8u5ttz62htrzgg"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@ItzyOfficial",
+        "channel_label": "ITZY",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCCB73cTL3awOpsMYcFHzVXg",
+          "https://www.youtube.com/@ItzyOfficial"
+        ],
+        "match_keys": [
+          "@itzyofficial",
+          "https://www.youtube.com/@itzyofficial",
+          "channel:uccb73ctl3awopsmycfhzvxg",
+          "https://www.youtube.com/channel/uccb73ctl3awopsmycfhzvxg"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/@JYPEntertainment",
+        "channel_label": "JYP Entertainment",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCaO6TYtlC8U5ttz62hTrZgg",
+          "https://www.youtube.com/@JYPEntertainment"
+        ],
+        "match_keys": [
+          "@jypentertainment",
+          "https://www.youtube.com/@jypentertainment",
+          "channel:ucao6tytlc8u5ttz62htrzgg",
+          "https://www.youtube.com/channel/ucao6tytlc8u5ttz62htrzgg"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "IVE",
+    "primary_team_channel_url": "https://www.youtube.com/@IVEstarship",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@IVEstarship",
+        "channel_label": "IVE",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UC-Fnix71vRP64WXeo0ikd0Q",
+          "https://www.youtube.com/@IVEstarship"
+        ],
+        "match_keys": [
+          "@ivestarship",
+          "https://www.youtube.com/@ivestarship",
+          "channel:uc-fnix71vrp64wxeo0ikd0q",
+          "https://www.youtube.com/channel/uc-fnix71vrp64wxeo0ikd0q"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/@officialstarship",
+        "channel_label": "STARSHIP",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UC7FAMNhb-BNeNj_6DrtrHCQ",
+          "https://www.youtube.com/@officialstarship"
+        ],
+        "match_keys": [
+          "@officialstarship",
+          "https://www.youtube.com/@officialstarship",
+          "channel:uc7famnhb-bnenj_6drtrhcq",
+          "https://www.youtube.com/channel/uc7famnhb-bnenj_6drtrhcq"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@IVEstarship",
+      "https://www.youtube.com/@officialstarship"
+    ],
+    "mv_allowlist_match_keys": [
+      "@ivestarship",
+      "https://www.youtube.com/@ivestarship",
+      "channel:uc-fnix71vrp64wxeo0ikd0q",
+      "https://www.youtube.com/channel/uc-fnix71vrp64wxeo0ikd0q",
+      "@officialstarship",
+      "https://www.youtube.com/@officialstarship",
+      "channel:uc7famnhb-bnenj_6drtrhcq",
+      "https://www.youtube.com/channel/uc7famnhb-bnenj_6drtrhcq"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@IVEstarship",
+        "channel_label": "IVE",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UC-Fnix71vRP64WXeo0ikd0Q",
+          "https://www.youtube.com/@IVEstarship"
+        ],
+        "match_keys": [
+          "@ivestarship",
+          "https://www.youtube.com/@ivestarship",
+          "channel:uc-fnix71vrp64wxeo0ikd0q",
+          "https://www.youtube.com/channel/uc-fnix71vrp64wxeo0ikd0q"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/@officialstarship",
+        "channel_label": "STARSHIP",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UC7FAMNhb-BNeNj_6DrtrHCQ",
+          "https://www.youtube.com/@officialstarship"
+        ],
+        "match_keys": [
+          "@officialstarship",
+          "https://www.youtube.com/@officialstarship",
+          "channel:uc7famnhb-bnenj_6drtrhcq",
+          "https://www.youtube.com/channel/uc7famnhb-bnenj_6drtrhcq"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "izna",
+    "primary_team_channel_url": "https://www.youtube.com/@izna_offcl",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@izna_offcl",
         "channel_label": "izna",
         "owner_type": "team",
         "allow_mv_uploads": true,
         "display_in_team_links": true,
         "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCfbYNlxgLuKJXQZEhkMmaCQ",
+          "https://www.youtube.com/@izna_offcl"
+        ],
         "match_keys": [
+          "@izna_offcl",
+          "https://www.youtube.com/@izna_offcl",
           "channel:ucfbynlxglukjxqzehkmmacq",
           "https://www.youtube.com/channel/ucfbynlxglukjxqzehkmmacq"
         ]
       }
     ],
     "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCfbYNlxgLuKJXQZEhkMmaCQ"
+      "https://www.youtube.com/@izna_offcl"
     ],
     "mv_allowlist_match_keys": [
+      "@izna_offcl",
+      "https://www.youtube.com/@izna_offcl",
       "channel:ucfbynlxglukjxqzehkmmacq",
       "https://www.youtube.com/channel/ucfbynlxglukjxqzehkmmacq"
     ],
     "channels": [
       {
-        "channel_url": "https://www.youtube.com/channel/UCfbYNlxgLuKJXQZEhkMmaCQ",
+        "channel_url": "https://www.youtube.com/@izna_offcl",
         "channel_label": "izna",
         "owner_type": "team",
         "allow_mv_uploads": true,
         "display_in_team_links": true,
         "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCfbYNlxgLuKJXQZEhkMmaCQ",
+          "https://www.youtube.com/@izna_offcl"
+        ],
         "match_keys": [
+          "@izna_offcl",
+          "https://www.youtube.com/@izna_offcl",
           "channel:ucfbynlxglukjxqzehkmmacq",
           "https://www.youtube.com/channel/ucfbynlxglukjxqzehkmmacq"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "JEON SOMI",
+    "primary_team_channel_url": "https://www.youtube.com/@jeonsomiofficial",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@jeonsomiofficial",
+        "channel_label": "JEON SOMI",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCjDH1Pld9zc8pTYjbv5eM-Q",
+          "https://www.youtube.com/@jeonsomiofficial"
+        ],
+        "match_keys": [
+          "@jeonsomiofficial",
+          "https://www.youtube.com/@jeonsomiofficial",
+          "channel:ucjdh1pld9zc8ptyjbv5em-q",
+          "https://www.youtube.com/channel/ucjdh1pld9zc8ptyjbv5em-q"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@jeonsomiofficial"
+    ],
+    "mv_allowlist_match_keys": [
+      "@jeonsomiofficial",
+      "https://www.youtube.com/@jeonsomiofficial",
+      "channel:ucjdh1pld9zc8ptyjbv5em-q",
+      "https://www.youtube.com/channel/ucjdh1pld9zc8ptyjbv5em-q"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@jeonsomiofficial",
+        "channel_label": "JEON SOMI",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCjDH1Pld9zc8pTYjbv5eM-Q",
+          "https://www.youtube.com/@jeonsomiofficial"
+        ],
+        "match_keys": [
+          "@jeonsomiofficial",
+          "https://www.youtube.com/@jeonsomiofficial",
+          "channel:ucjdh1pld9zc8ptyjbv5em-q",
+          "https://www.youtube.com/channel/ucjdh1pld9zc8ptyjbv5em-q"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "JUST B",
+    "primary_team_channel_url": "https://www.youtube.com/@JUSTB_Official",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@JUSTB_Official",
+        "channel_label": "JUST B",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCcpodGf_wkyawcTc-fXa82g",
+          "https://www.youtube.com/@JUSTB_Official"
+        ],
+        "match_keys": [
+          "@justb_official",
+          "https://www.youtube.com/@justb_official",
+          "channel:uccpodgf_wkyawctc-fxa82g",
+          "https://www.youtube.com/channel/uccpodgf_wkyawctc-fxa82g"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@JUSTB_Official"
+    ],
+    "mv_allowlist_match_keys": [
+      "@justb_official",
+      "https://www.youtube.com/@justb_official",
+      "channel:uccpodgf_wkyawctc-fxa82g",
+      "https://www.youtube.com/channel/uccpodgf_wkyawctc-fxa82g"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@JUSTB_Official",
+        "channel_label": "JUST B",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCcpodGf_wkyawcTc-fXa82g",
+          "https://www.youtube.com/@JUSTB_Official"
+        ],
+        "match_keys": [
+          "@justb_official",
+          "https://www.youtube.com/@justb_official",
+          "channel:uccpodgf_wkyawctc-fxa82g",
+          "https://www.youtube.com/channel/uccpodgf_wkyawctc-fxa82g"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "KARD",
+    "primary_team_channel_url": "https://www.youtube.com/@Kard_official",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@Kard_official",
+        "channel_label": "KARD",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UC4_WggmbQgCFqXGhCFpDAhg",
+          "https://www.youtube.com/@Kard_official"
+        ],
+        "match_keys": [
+          "@kard_official",
+          "https://www.youtube.com/@kard_official",
+          "channel:uc4_wggmbqgcfqxghcfpdahg",
+          "https://www.youtube.com/channel/uc4_wggmbqgcfqxghcfpdahg"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@Kard_official"
+    ],
+    "mv_allowlist_match_keys": [
+      "@kard_official",
+      "https://www.youtube.com/@kard_official",
+      "channel:uc4_wggmbqgcfqxghcfpdahg",
+      "https://www.youtube.com/channel/uc4_wggmbqgcfqxghcfpdahg"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@Kard_official",
+        "channel_label": "KARD",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UC4_WggmbQgCFqXGhCFpDAhg",
+          "https://www.youtube.com/@Kard_official"
+        ],
+        "match_keys": [
+          "@kard_official",
+          "https://www.youtube.com/@kard_official",
+          "channel:uc4_wggmbqgcfqxghcfpdahg",
+          "https://www.youtube.com/channel/uc4_wggmbqgcfqxghcfpdahg"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "Kep1er",
+    "primary_team_channel_url": "https://www.youtube.com/@official_kep1er",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@official_kep1er",
+        "channel_label": "Kep1er",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCoQwdDRNobhnp6_wIvsE4aw",
+          "https://www.youtube.com/@official_kep1er"
+        ],
+        "match_keys": [
+          "@official_kep1er",
+          "https://www.youtube.com/@official_kep1er",
+          "channel:ucoqwddrnobhnp6_wivse4aw",
+          "https://www.youtube.com/channel/ucoqwddrnobhnp6_wivse4aw"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@official_kep1er"
+    ],
+    "mv_allowlist_match_keys": [
+      "@official_kep1er",
+      "https://www.youtube.com/@official_kep1er",
+      "channel:ucoqwddrnobhnp6_wivse4aw",
+      "https://www.youtube.com/channel/ucoqwddrnobhnp6_wivse4aw"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@official_kep1er",
+        "channel_label": "Kep1er",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCoQwdDRNobhnp6_wIvsE4aw",
+          "https://www.youtube.com/@official_kep1er"
+        ],
+        "match_keys": [
+          "@official_kep1er",
+          "https://www.youtube.com/@official_kep1er",
+          "channel:ucoqwddrnobhnp6_wivse4aw",
+          "https://www.youtube.com/channel/ucoqwddrnobhnp6_wivse4aw"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "KickFlip",
+    "primary_team_channel_url": "https://www.youtube.com/@kickflip_jype",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@kickflip_jype",
+        "channel_label": "KickFlip",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCmq9jjpHA69PwAwlA0DwOsg",
+          "https://www.youtube.com/@kickflip_jype"
+        ],
+        "match_keys": [
+          "@kickflip_jype",
+          "https://www.youtube.com/@kickflip_jype",
+          "channel:ucmq9jjpha69pwawla0dwosg",
+          "https://www.youtube.com/channel/ucmq9jjpha69pwawla0dwosg"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/@JYPEntertainment",
+        "channel_label": "JYP Entertainment",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCaO6TYtlC8U5ttz62hTrZgg",
+          "https://www.youtube.com/@JYPEntertainment"
+        ],
+        "match_keys": [
+          "@jypentertainment",
+          "https://www.youtube.com/@jypentertainment",
+          "channel:ucao6tytlc8u5ttz62htrzgg",
+          "https://www.youtube.com/channel/ucao6tytlc8u5ttz62htrzgg"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@kickflip_jype",
+      "https://www.youtube.com/@JYPEntertainment"
+    ],
+    "mv_allowlist_match_keys": [
+      "@kickflip_jype",
+      "https://www.youtube.com/@kickflip_jype",
+      "channel:ucmq9jjpha69pwawla0dwosg",
+      "https://www.youtube.com/channel/ucmq9jjpha69pwawla0dwosg",
+      "@jypentertainment",
+      "https://www.youtube.com/@jypentertainment",
+      "channel:ucao6tytlc8u5ttz62htrzgg",
+      "https://www.youtube.com/channel/ucao6tytlc8u5ttz62htrzgg"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@kickflip_jype",
+        "channel_label": "KickFlip",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCmq9jjpHA69PwAwlA0DwOsg",
+          "https://www.youtube.com/@kickflip_jype"
+        ],
+        "match_keys": [
+          "@kickflip_jype",
+          "https://www.youtube.com/@kickflip_jype",
+          "channel:ucmq9jjpha69pwawla0dwosg",
+          "https://www.youtube.com/channel/ucmq9jjpha69pwawla0dwosg"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/@JYPEntertainment",
+        "channel_label": "JYP Entertainment",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCaO6TYtlC8U5ttz62hTrZgg",
+          "https://www.youtube.com/@JYPEntertainment"
+        ],
+        "match_keys": [
+          "@jypentertainment",
+          "https://www.youtube.com/@jypentertainment",
+          "channel:ucao6tytlc8u5ttz62htrzgg",
+          "https://www.youtube.com/channel/ucao6tytlc8u5ttz62htrzgg"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "KiiiKiii",
+    "primary_team_channel_url": "https://www.youtube.com/@We_KiiiKiii",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@We_KiiiKiii",
+        "channel_label": "KiiiKiii",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCcoT6JMccOgbh0Qtw_Kb3XA",
+          "https://www.youtube.com/@We_KiiiKiii"
+        ],
+        "match_keys": [
+          "@we_kiiikiii",
+          "https://www.youtube.com/@we_kiiikiii",
+          "channel:uccot6jmccogbh0qtw_kb3xa",
+          "https://www.youtube.com/channel/uccot6jmccogbh0qtw_kb3xa"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@We_KiiiKiii"
+    ],
+    "mv_allowlist_match_keys": [
+      "@we_kiiikiii",
+      "https://www.youtube.com/@we_kiiikiii",
+      "channel:uccot6jmccogbh0qtw_kb3xa",
+      "https://www.youtube.com/channel/uccot6jmccogbh0qtw_kb3xa"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@We_KiiiKiii",
+        "channel_label": "KiiiKiii",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCcoT6JMccOgbh0Qtw_Kb3XA",
+          "https://www.youtube.com/@We_KiiiKiii"
+        ],
+        "match_keys": [
+          "@we_kiiikiii",
+          "https://www.youtube.com/@we_kiiikiii",
+          "channel:uccot6jmccogbh0qtw_kb3xa",
+          "https://www.youtube.com/channel/uccot6jmccogbh0qtw_kb3xa"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "KISS OF LIFE",
+    "primary_team_channel_url": "https://www.youtube.com/@KISSOFLIFE_S2",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@KISSOFLIFE_S2",
+        "channel_label": "KISS OF LIFE",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCBS1RBddoi2e_ZcCCtbTpkQ",
+          "https://www.youtube.com/@KISSOFLIFE_S2"
+        ],
+        "match_keys": [
+          "@kissoflife_s2",
+          "https://www.youtube.com/@kissoflife_s2",
+          "channel:ucbs1rbddoi2e_zccctbtpkq",
+          "https://www.youtube.com/channel/ucbs1rbddoi2e_zccctbtpkq"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@KISSOFLIFE_S2"
+    ],
+    "mv_allowlist_match_keys": [
+      "@kissoflife_s2",
+      "https://www.youtube.com/@kissoflife_s2",
+      "channel:ucbs1rbddoi2e_zccctbtpkq",
+      "https://www.youtube.com/channel/ucbs1rbddoi2e_zccctbtpkq"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@KISSOFLIFE_S2",
+        "channel_label": "KISS OF LIFE",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCBS1RBddoi2e_ZcCCtbTpkQ",
+          "https://www.youtube.com/@KISSOFLIFE_S2"
+        ],
+        "match_keys": [
+          "@kissoflife_s2",
+          "https://www.youtube.com/@kissoflife_s2",
+          "channel:ucbs1rbddoi2e_zccctbtpkq",
+          "https://www.youtube.com/channel/ucbs1rbddoi2e_zccctbtpkq"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "KWON EUNBI",
+    "primary_team_channel_url": "https://www.youtube.com/@KWONEUNBI",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@KWONEUNBI",
+        "channel_label": "KWON EUNBI",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCoCvj_VhZPOtttlJK7RCh2A",
+          "https://www.youtube.com/@KWONEUNBI"
+        ],
+        "match_keys": [
+          "@kwoneunbi",
+          "https://www.youtube.com/@kwoneunbi",
+          "channel:ucocvj_vhzpotttljk7rch2a",
+          "https://www.youtube.com/channel/ucocvj_vhzpotttljk7rch2a"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@KWONEUNBI"
+    ],
+    "mv_allowlist_match_keys": [
+      "@kwoneunbi",
+      "https://www.youtube.com/@kwoneunbi",
+      "channel:ucocvj_vhzpotttljk7rch2a",
+      "https://www.youtube.com/channel/ucocvj_vhzpotttljk7rch2a"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@KWONEUNBI",
+        "channel_label": "KWON EUNBI",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCoCvj_VhZPOtttlJK7RCh2A",
+          "https://www.youtube.com/@KWONEUNBI"
+        ],
+        "match_keys": [
+          "@kwoneunbi",
+          "https://www.youtube.com/@kwoneunbi",
+          "channel:ucocvj_vhzpotttljk7rch2a",
+          "https://www.youtube.com/channel/ucocvj_vhzpotttljk7rch2a"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "LE SSERAFIM",
+    "primary_team_channel_url": "https://www.youtube.com/@LE_SSERAFIM",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@LE_SSERAFIM",
+        "channel_label": "LE SSERAFIM",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCs-QBT4qkj_YiQw1ZntDO3g",
+          "https://www.youtube.com/@LE_SSERAFIM"
+        ],
+        "match_keys": [
+          "@le_sserafim",
+          "https://www.youtube.com/@le_sserafim",
+          "channel:ucs-qbt4qkj_yiqw1zntdo3g",
+          "https://www.youtube.com/channel/ucs-qbt4qkj_yiqw1zntdo3g"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/@HYBELABELS",
+        "channel_label": "HYBE LABELS",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UC3IZKseVpdzPSBaWxBxundA",
+          "https://www.youtube.com/@HYBELABELS"
+        ],
+        "match_keys": [
+          "@hybelabels",
+          "https://www.youtube.com/@hybelabels",
+          "channel:uc3izksevpdzpsbawxbxunda",
+          "https://www.youtube.com/channel/uc3izksevpdzpsbawxbxunda"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@LE_SSERAFIM",
+      "https://www.youtube.com/@HYBELABELS"
+    ],
+    "mv_allowlist_match_keys": [
+      "@le_sserafim",
+      "https://www.youtube.com/@le_sserafim",
+      "channel:ucs-qbt4qkj_yiqw1zntdo3g",
+      "https://www.youtube.com/channel/ucs-qbt4qkj_yiqw1zntdo3g",
+      "@hybelabels",
+      "https://www.youtube.com/@hybelabels",
+      "channel:uc3izksevpdzpsbawxbxunda",
+      "https://www.youtube.com/channel/uc3izksevpdzpsbawxbxunda"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@LE_SSERAFIM",
+        "channel_label": "LE SSERAFIM",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCs-QBT4qkj_YiQw1ZntDO3g",
+          "https://www.youtube.com/@LE_SSERAFIM"
+        ],
+        "match_keys": [
+          "@le_sserafim",
+          "https://www.youtube.com/@le_sserafim",
+          "channel:ucs-qbt4qkj_yiqw1zntdo3g",
+          "https://www.youtube.com/channel/ucs-qbt4qkj_yiqw1zntdo3g"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/@HYBELABELS",
+        "channel_label": "HYBE LABELS",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UC3IZKseVpdzPSBaWxBxundA",
+          "https://www.youtube.com/@HYBELABELS"
+        ],
+        "match_keys": [
+          "@hybelabels",
+          "https://www.youtube.com/@hybelabels",
+          "channel:uc3izksevpdzpsbawxbxunda",
+          "https://www.youtube.com/channel/uc3izksevpdzpsbawxbxunda"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "LIGHTSUM",
+    "primary_team_channel_url": "https://www.youtube.com/channel/UCeQlMQ-4cedE7SNmF5JsdsA",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/channel/UCeQlMQ-4cedE7SNmF5JsdsA",
+        "channel_label": "LIGHTSUM",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [],
+        "match_keys": [
+          "channel:uceqlmq-4cede7snmf5jsdsa",
+          "https://www.youtube.com/channel/uceqlmq-4cede7snmf5jsdsa"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/channel/UCeQlMQ-4cedE7SNmF5JsdsA"
+    ],
+    "mv_allowlist_match_keys": [
+      "channel:uceqlmq-4cede7snmf5jsdsa",
+      "https://www.youtube.com/channel/uceqlmq-4cede7snmf5jsdsa"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/channel/UCeQlMQ-4cedE7SNmF5JsdsA",
+        "channel_label": "LIGHTSUM",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [],
+        "match_keys": [
+          "channel:uceqlmq-4cede7snmf5jsdsa",
+          "https://www.youtube.com/channel/uceqlmq-4cede7snmf5jsdsa"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "Loossemble",
+    "primary_team_channel_url": "https://www.youtube.com/@Loossemble_official",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@Loossemble_official",
+        "channel_label": "Loossemble",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCbTzy8kj_6Kik_LFD1XyN5g",
+          "https://www.youtube.com/@Loossemble_official"
+        ],
+        "match_keys": [
+          "@loossemble_official",
+          "https://www.youtube.com/@loossemble_official",
+          "channel:ucbtzy8kj_6kik_lfd1xyn5g",
+          "https://www.youtube.com/channel/ucbtzy8kj_6kik_lfd1xyn5g"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@Loossemble_official"
+    ],
+    "mv_allowlist_match_keys": [
+      "@loossemble_official",
+      "https://www.youtube.com/@loossemble_official",
+      "channel:ucbtzy8kj_6kik_lfd1xyn5g",
+      "https://www.youtube.com/channel/ucbtzy8kj_6kik_lfd1xyn5g"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@Loossemble_official",
+        "channel_label": "Loossemble",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCbTzy8kj_6Kik_LFD1XyN5g",
+          "https://www.youtube.com/@Loossemble_official"
+        ],
+        "match_keys": [
+          "@loossemble_official",
+          "https://www.youtube.com/@loossemble_official",
+          "channel:ucbtzy8kj_6kik_lfd1xyn5g",
+          "https://www.youtube.com/channel/ucbtzy8kj_6kik_lfd1xyn5g"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "LUN8",
+    "primary_team_channel_url": "https://www.youtube.com/@LUN8_Official",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@LUN8_Official",
+        "channel_label": "LUN8",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCHx0MD2c0DTNGAtc0Yq6YPQ",
+          "https://www.youtube.com/@LUN8_Official"
+        ],
+        "match_keys": [
+          "@lun8_official",
+          "https://www.youtube.com/@lun8_official",
+          "channel:uchx0md2c0dtngatc0yq6ypq",
+          "https://www.youtube.com/channel/uchx0md2c0dtngatc0yq6ypq"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@LUN8_Official"
+    ],
+    "mv_allowlist_match_keys": [
+      "@lun8_official",
+      "https://www.youtube.com/@lun8_official",
+      "channel:uchx0md2c0dtngatc0yq6ypq",
+      "https://www.youtube.com/channel/uchx0md2c0dtngatc0yq6ypq"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@LUN8_Official",
+        "channel_label": "LUN8",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCHx0MD2c0DTNGAtc0Yq6YPQ",
+          "https://www.youtube.com/@LUN8_Official"
+        ],
+        "match_keys": [
+          "@lun8_official",
+          "https://www.youtube.com/@lun8_official",
+          "channel:uchx0md2c0dtngatc0yq6ypq",
+          "https://www.youtube.com/channel/uchx0md2c0dtngatc0yq6ypq"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "MAMAMOO",
+    "primary_team_channel_url": "https://www.youtube.com/@MAMAMOO_OFFICIAL",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@MAMAMOO_OFFICIAL",
+        "channel_label": "MAMAMOO",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCNx0TXIuGVEA_TWB5H2I6Lg",
+          "https://www.youtube.com/@MAMAMOO_OFFICIAL"
+        ],
+        "match_keys": [
+          "@mamamoo_official",
+          "https://www.youtube.com/@mamamoo_official",
+          "channel:ucnx0txiugvea_twb5h2i6lg",
+          "https://www.youtube.com/channel/ucnx0txiugvea_twb5h2i6lg"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@MAMAMOO_OFFICIAL"
+    ],
+    "mv_allowlist_match_keys": [
+      "@mamamoo_official",
+      "https://www.youtube.com/@mamamoo_official",
+      "channel:ucnx0txiugvea_twb5h2i6lg",
+      "https://www.youtube.com/channel/ucnx0txiugvea_twb5h2i6lg"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@MAMAMOO_OFFICIAL",
+        "channel_label": "MAMAMOO",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCNx0TXIuGVEA_TWB5H2I6Lg",
+          "https://www.youtube.com/@MAMAMOO_OFFICIAL"
+        ],
+        "match_keys": [
+          "@mamamoo_official",
+          "https://www.youtube.com/@mamamoo_official",
+          "channel:ucnx0txiugvea_twb5h2i6lg",
+          "https://www.youtube.com/channel/ucnx0txiugvea_twb5h2i6lg"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "MCND",
+    "primary_team_channel_url": "https://www.youtube.com/@MCND_OFFICIAL",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@MCND_OFFICIAL",
+        "channel_label": "MCND",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCgfqWWcc9WA9sJ00Xeh_eyQ",
+          "https://www.youtube.com/@MCND_OFFICIAL"
+        ],
+        "match_keys": [
+          "@mcnd_official",
+          "https://www.youtube.com/@mcnd_official",
+          "channel:ucgfqwwcc9wa9sj00xeh_eyq",
+          "https://www.youtube.com/channel/ucgfqwwcc9wa9sj00xeh_eyq"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@MCND_OFFICIAL"
+    ],
+    "mv_allowlist_match_keys": [
+      "@mcnd_official",
+      "https://www.youtube.com/@mcnd_official",
+      "channel:ucgfqwwcc9wa9sj00xeh_eyq",
+      "https://www.youtube.com/channel/ucgfqwwcc9wa9sj00xeh_eyq"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@MCND_OFFICIAL",
+        "channel_label": "MCND",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCgfqWWcc9WA9sJ00Xeh_eyQ",
+          "https://www.youtube.com/@MCND_OFFICIAL"
+        ],
+        "match_keys": [
+          "@mcnd_official",
+          "https://www.youtube.com/@mcnd_official",
+          "channel:ucgfqwwcc9wa9sj00xeh_eyq",
+          "https://www.youtube.com/channel/ucgfqwwcc9wa9sj00xeh_eyq"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "MEOVV",
+    "primary_team_channel_url": "https://www.youtube.com/@official_meovv",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@official_meovv",
+        "channel_label": "MEOVV",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCseKeEeVELkVkzyzJgHnEUg",
+          "https://www.youtube.com/@official_meovv"
+        ],
+        "match_keys": [
+          "@official_meovv",
+          "https://www.youtube.com/@official_meovv",
+          "channel:ucsekeeevelkvkzyzjghneug",
+          "https://www.youtube.com/channel/ucsekeeevelkvkzyzjghneug"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@official_meovv"
+    ],
+    "mv_allowlist_match_keys": [
+      "@official_meovv",
+      "https://www.youtube.com/@official_meovv",
+      "channel:ucsekeeevelkvkzyzjghneug",
+      "https://www.youtube.com/channel/ucsekeeevelkvkzyzjghneug"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@official_meovv",
+        "channel_label": "MEOVV",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCseKeEeVELkVkzyzJgHnEUg",
+          "https://www.youtube.com/@official_meovv"
+        ],
+        "match_keys": [
+          "@official_meovv",
+          "https://www.youtube.com/@official_meovv",
+          "channel:ucsekeeevelkvkzyzjghneug",
+          "https://www.youtube.com/channel/ucsekeeevelkvkzyzjghneug"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "MONSTA X",
+    "primary_team_channel_url": "https://www.youtube.com/@officialmonstax",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@officialmonstax",
+        "channel_label": "MONSTA X",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCQoHX5jMpQ-jS1VC0LL10yw",
+          "https://www.youtube.com/@officialmonstax"
+        ],
+        "match_keys": [
+          "@officialmonstax",
+          "https://www.youtube.com/@officialmonstax",
+          "channel:ucqohx5jmpq-js1vc0ll10yw",
+          "https://www.youtube.com/channel/ucqohx5jmpq-js1vc0ll10yw"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/@officialstarship",
+        "channel_label": "STARSHIP",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UC7FAMNhb-BNeNj_6DrtrHCQ",
+          "https://www.youtube.com/@officialstarship"
+        ],
+        "match_keys": [
+          "@officialstarship",
+          "https://www.youtube.com/@officialstarship",
+          "channel:uc7famnhb-bnenj_6drtrhcq",
+          "https://www.youtube.com/channel/uc7famnhb-bnenj_6drtrhcq"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@officialmonstax",
+      "https://www.youtube.com/@officialstarship"
+    ],
+    "mv_allowlist_match_keys": [
+      "@officialmonstax",
+      "https://www.youtube.com/@officialmonstax",
+      "channel:ucqohx5jmpq-js1vc0ll10yw",
+      "https://www.youtube.com/channel/ucqohx5jmpq-js1vc0ll10yw",
+      "@officialstarship",
+      "https://www.youtube.com/@officialstarship",
+      "channel:uc7famnhb-bnenj_6drtrhcq",
+      "https://www.youtube.com/channel/uc7famnhb-bnenj_6drtrhcq"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@officialmonstax",
+        "channel_label": "MONSTA X",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCQoHX5jMpQ-jS1VC0LL10yw",
+          "https://www.youtube.com/@officialmonstax"
+        ],
+        "match_keys": [
+          "@officialmonstax",
+          "https://www.youtube.com/@officialmonstax",
+          "channel:ucqohx5jmpq-js1vc0ll10yw",
+          "https://www.youtube.com/channel/ucqohx5jmpq-js1vc0ll10yw"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/@officialstarship",
+        "channel_label": "STARSHIP",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UC7FAMNhb-BNeNj_6DrtrHCQ",
+          "https://www.youtube.com/@officialstarship"
+        ],
+        "match_keys": [
+          "@officialstarship",
+          "https://www.youtube.com/@officialstarship",
+          "channel:uc7famnhb-bnenj_6drtrhcq",
+          "https://www.youtube.com/channel/uc7famnhb-bnenj_6drtrhcq"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "NCT 127",
+    "primary_team_channel_url": "https://www.youtube.com/@NCT127",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@NCT127",
+        "channel_label": "NCT 127",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCk2E0dbAyEJWnrN2bbQOcbg",
+          "https://www.youtube.com/@NCT127"
+        ],
+        "match_keys": [
+          "@nct127",
+          "https://www.youtube.com/@nct127",
+          "channel:uck2e0dbayejwnrn2bbqocbg",
+          "https://www.youtube.com/channel/uck2e0dbayejwnrn2bbqocbg"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/@SMTOWN",
+        "channel_label": "SMTOWN",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCyDd_CdcEtQk-jbmrBhBl5w",
+          "https://www.youtube.com/@SMTOWN"
+        ],
+        "match_keys": [
+          "@smtown",
+          "https://www.youtube.com/@smtown",
+          "channel:ucydd_cdcetqk-jbmrbhbl5w",
+          "https://www.youtube.com/channel/ucydd_cdcetqk-jbmrbhbl5w"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@NCT127",
+      "https://www.youtube.com/@SMTOWN"
+    ],
+    "mv_allowlist_match_keys": [
+      "@nct127",
+      "https://www.youtube.com/@nct127",
+      "channel:uck2e0dbayejwnrn2bbqocbg",
+      "https://www.youtube.com/channel/uck2e0dbayejwnrn2bbqocbg",
+      "@smtown",
+      "https://www.youtube.com/@smtown",
+      "channel:ucydd_cdcetqk-jbmrbhbl5w",
+      "https://www.youtube.com/channel/ucydd_cdcetqk-jbmrbhbl5w"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@NCT127",
+        "channel_label": "NCT 127",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCk2E0dbAyEJWnrN2bbQOcbg",
+          "https://www.youtube.com/@NCT127"
+        ],
+        "match_keys": [
+          "@nct127",
+          "https://www.youtube.com/@nct127",
+          "channel:uck2e0dbayejwnrn2bbqocbg",
+          "https://www.youtube.com/channel/uck2e0dbayejwnrn2bbqocbg"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/@SMTOWN",
+        "channel_label": "SMTOWN",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCyDd_CdcEtQk-jbmrBhBl5w",
+          "https://www.youtube.com/@SMTOWN"
+        ],
+        "match_keys": [
+          "@smtown",
+          "https://www.youtube.com/@smtown",
+          "channel:ucydd_cdcetqk-jbmrbhbl5w",
+          "https://www.youtube.com/channel/ucydd_cdcetqk-jbmrbhbl5w"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "NCT DREAM",
+    "primary_team_channel_url": "https://www.youtube.com/@NCTsmtown_DREAM",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@NCTsmtown_DREAM",
+        "channel_label": "NCT DREAM",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCJmkphXcmB4jJJdaSxSTUNQ",
+          "https://www.youtube.com/@NCTsmtown_DREAM"
+        ],
+        "match_keys": [
+          "@nctsmtown_dream",
+          "https://www.youtube.com/@nctsmtown_dream",
+          "channel:ucjmkphxcmb4jjjdasxstunq",
+          "https://www.youtube.com/channel/ucjmkphxcmb4jjjdasxstunq"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/@SMTOWN",
+        "channel_label": "SMTOWN",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCyDd_CdcEtQk-jbmrBhBl5w",
+          "https://www.youtube.com/@SMTOWN"
+        ],
+        "match_keys": [
+          "@smtown",
+          "https://www.youtube.com/@smtown",
+          "channel:ucydd_cdcetqk-jbmrbhbl5w",
+          "https://www.youtube.com/channel/ucydd_cdcetqk-jbmrbhbl5w"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@NCTsmtown_DREAM",
+      "https://www.youtube.com/@SMTOWN"
+    ],
+    "mv_allowlist_match_keys": [
+      "@nctsmtown_dream",
+      "https://www.youtube.com/@nctsmtown_dream",
+      "channel:ucjmkphxcmb4jjjdasxstunq",
+      "https://www.youtube.com/channel/ucjmkphxcmb4jjjdasxstunq",
+      "@smtown",
+      "https://www.youtube.com/@smtown",
+      "channel:ucydd_cdcetqk-jbmrbhbl5w",
+      "https://www.youtube.com/channel/ucydd_cdcetqk-jbmrbhbl5w"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@NCTsmtown_DREAM",
+        "channel_label": "NCT DREAM",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCJmkphXcmB4jJJdaSxSTUNQ",
+          "https://www.youtube.com/@NCTsmtown_DREAM"
+        ],
+        "match_keys": [
+          "@nctsmtown_dream",
+          "https://www.youtube.com/@nctsmtown_dream",
+          "channel:ucjmkphxcmb4jjjdasxstunq",
+          "https://www.youtube.com/channel/ucjmkphxcmb4jjjdasxstunq"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/@SMTOWN",
+        "channel_label": "SMTOWN",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCyDd_CdcEtQk-jbmrBhBl5w",
+          "https://www.youtube.com/@SMTOWN"
+        ],
+        "match_keys": [
+          "@smtown",
+          "https://www.youtube.com/@smtown",
+          "channel:ucydd_cdcetqk-jbmrbhbl5w",
+          "https://www.youtube.com/channel/ucydd_cdcetqk-jbmrbhbl5w"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "NCT WISH",
+    "primary_team_channel_url": "https://www.youtube.com/@NCTWISH",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@NCTWISH",
+        "channel_label": "NCT WISH",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCiZqWVAeChfqlom5ZPR3ZJA",
+          "https://www.youtube.com/@NCTWISH"
+        ],
+        "match_keys": [
+          "@nctwish",
+          "https://www.youtube.com/@nctwish",
+          "channel:ucizqwvaechfqlom5zpr3zja",
+          "https://www.youtube.com/channel/ucizqwvaechfqlom5zpr3zja"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/@SMTOWN",
+        "channel_label": "SMTOWN",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCyDd_CdcEtQk-jbmrBhBl5w",
+          "https://www.youtube.com/@SMTOWN"
+        ],
+        "match_keys": [
+          "@smtown",
+          "https://www.youtube.com/@smtown",
+          "channel:ucydd_cdcetqk-jbmrbhbl5w",
+          "https://www.youtube.com/channel/ucydd_cdcetqk-jbmrbhbl5w"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@NCTWISH",
+      "https://www.youtube.com/@SMTOWN"
+    ],
+    "mv_allowlist_match_keys": [
+      "@nctwish",
+      "https://www.youtube.com/@nctwish",
+      "channel:ucizqwvaechfqlom5zpr3zja",
+      "https://www.youtube.com/channel/ucizqwvaechfqlom5zpr3zja",
+      "@smtown",
+      "https://www.youtube.com/@smtown",
+      "channel:ucydd_cdcetqk-jbmrbhbl5w",
+      "https://www.youtube.com/channel/ucydd_cdcetqk-jbmrbhbl5w"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@NCTWISH",
+        "channel_label": "NCT WISH",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCiZqWVAeChfqlom5ZPR3ZJA",
+          "https://www.youtube.com/@NCTWISH"
+        ],
+        "match_keys": [
+          "@nctwish",
+          "https://www.youtube.com/@nctwish",
+          "channel:ucizqwvaechfqlom5zpr3zja",
+          "https://www.youtube.com/channel/ucizqwvaechfqlom5zpr3zja"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/@SMTOWN",
+        "channel_label": "SMTOWN",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCyDd_CdcEtQk-jbmrBhBl5w",
+          "https://www.youtube.com/@SMTOWN"
+        ],
+        "match_keys": [
+          "@smtown",
+          "https://www.youtube.com/@smtown",
+          "channel:ucydd_cdcetqk-jbmrbhbl5w",
+          "https://www.youtube.com/channel/ucydd_cdcetqk-jbmrbhbl5w"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "NewJeans",
+    "primary_team_channel_url": "https://www.youtube.com/@NewJeans_official",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@NewJeans_official",
+        "channel_label": "NewJeans",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCMki_UkHb4qSc0qyEcOHHJw",
+          "https://www.youtube.com/@NewJeans_official"
+        ],
+        "match_keys": [
+          "@newjeans_official",
+          "https://www.youtube.com/@newjeans_official",
+          "channel:ucmki_ukhb4qsc0qyecohhjw",
+          "https://www.youtube.com/channel/ucmki_ukhb4qsc0qyecohhjw"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@NewJeans_official"
+    ],
+    "mv_allowlist_match_keys": [
+      "@newjeans_official",
+      "https://www.youtube.com/@newjeans_official",
+      "channel:ucmki_ukhb4qsc0qyecohhjw",
+      "https://www.youtube.com/channel/ucmki_ukhb4qsc0qyecohhjw"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@NewJeans_official",
+        "channel_label": "NewJeans",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCMki_UkHb4qSc0qyEcOHHJw",
+          "https://www.youtube.com/@NewJeans_official"
+        ],
+        "match_keys": [
+          "@newjeans_official",
+          "https://www.youtube.com/@newjeans_official",
+          "channel:ucmki_ukhb4qsc0qyecohhjw",
+          "https://www.youtube.com/channel/ucmki_ukhb4qsc0qyecohhjw"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "NEXZ",
+    "primary_team_channel_url": "https://www.youtube.com/@NEXZ_official",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@NEXZ_official",
+        "channel_label": "NEXZ",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UC-o9yrZxu5Ru-DVGhnmeTug",
+          "https://www.youtube.com/@NEXZ_official"
+        ],
+        "match_keys": [
+          "@nexz_official",
+          "https://www.youtube.com/@nexz_official",
+          "channel:uc-o9yrzxu5ru-dvghnmetug",
+          "https://www.youtube.com/channel/uc-o9yrzxu5ru-dvghnmetug"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/@JYPEntertainment",
+        "channel_label": "JYP Entertainment",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCaO6TYtlC8U5ttz62hTrZgg",
+          "https://www.youtube.com/@JYPEntertainment"
+        ],
+        "match_keys": [
+          "@jypentertainment",
+          "https://www.youtube.com/@jypentertainment",
+          "channel:ucao6tytlc8u5ttz62htrzgg",
+          "https://www.youtube.com/channel/ucao6tytlc8u5ttz62htrzgg"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@NEXZ_official",
+      "https://www.youtube.com/@JYPEntertainment"
+    ],
+    "mv_allowlist_match_keys": [
+      "@nexz_official",
+      "https://www.youtube.com/@nexz_official",
+      "channel:uc-o9yrzxu5ru-dvghnmetug",
+      "https://www.youtube.com/channel/uc-o9yrzxu5ru-dvghnmetug",
+      "@jypentertainment",
+      "https://www.youtube.com/@jypentertainment",
+      "channel:ucao6tytlc8u5ttz62htrzgg",
+      "https://www.youtube.com/channel/ucao6tytlc8u5ttz62htrzgg"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@NEXZ_official",
+        "channel_label": "NEXZ",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UC-o9yrZxu5Ru-DVGhnmeTug",
+          "https://www.youtube.com/@NEXZ_official"
+        ],
+        "match_keys": [
+          "@nexz_official",
+          "https://www.youtube.com/@nexz_official",
+          "channel:uc-o9yrzxu5ru-dvghnmetug",
+          "https://www.youtube.com/channel/uc-o9yrzxu5ru-dvghnmetug"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/@JYPEntertainment",
+        "channel_label": "JYP Entertainment",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCaO6TYtlC8U5ttz62hTrZgg",
+          "https://www.youtube.com/@JYPEntertainment"
+        ],
+        "match_keys": [
+          "@jypentertainment",
+          "https://www.youtube.com/@jypentertainment",
+          "channel:ucao6tytlc8u5ttz62htrzgg",
+          "https://www.youtube.com/channel/ucao6tytlc8u5ttz62htrzgg"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "NMIXX",
+    "primary_team_channel_url": "https://www.youtube.com/channel/UCnUAyD4t2LkvW68YrDh7fDg",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/channel/UCnUAyD4t2LkvW68YrDh7fDg",
+        "channel_label": "NMIXX",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [],
+        "match_keys": [
+          "channel:ucnuayd4t2lkvw68yrdh7fdg",
+          "https://www.youtube.com/channel/ucnuayd4t2lkvw68yrdh7fdg"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/@JYPEntertainment",
+        "channel_label": "JYP Entertainment",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCaO6TYtlC8U5ttz62hTrZgg",
+          "https://www.youtube.com/@JYPEntertainment"
+        ],
+        "match_keys": [
+          "@jypentertainment",
+          "https://www.youtube.com/@jypentertainment",
+          "channel:ucao6tytlc8u5ttz62htrzgg",
+          "https://www.youtube.com/channel/ucao6tytlc8u5ttz62htrzgg"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/channel/UCnUAyD4t2LkvW68YrDh7fDg",
+      "https://www.youtube.com/@JYPEntertainment"
+    ],
+    "mv_allowlist_match_keys": [
+      "channel:ucnuayd4t2lkvw68yrdh7fdg",
+      "https://www.youtube.com/channel/ucnuayd4t2lkvw68yrdh7fdg",
+      "@jypentertainment",
+      "https://www.youtube.com/@jypentertainment",
+      "channel:ucao6tytlc8u5ttz62htrzgg",
+      "https://www.youtube.com/channel/ucao6tytlc8u5ttz62htrzgg"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/channel/UCnUAyD4t2LkvW68YrDh7fDg",
+        "channel_label": "NMIXX",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [],
+        "match_keys": [
+          "channel:ucnuayd4t2lkvw68yrdh7fdg",
+          "https://www.youtube.com/channel/ucnuayd4t2lkvw68yrdh7fdg"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/@JYPEntertainment",
+        "channel_label": "JYP Entertainment",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCaO6TYtlC8U5ttz62hTrZgg",
+          "https://www.youtube.com/@JYPEntertainment"
+        ],
+        "match_keys": [
+          "@jypentertainment",
+          "https://www.youtube.com/@jypentertainment",
+          "channel:ucao6tytlc8u5ttz62htrzgg",
+          "https://www.youtube.com/channel/ucao6tytlc8u5ttz62htrzgg"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "NOMAD",
+    "primary_team_channel_url": "https://www.youtube.com/@nomad_is_here",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@nomad_is_here",
+        "channel_label": "NOMAD",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCtCFxLt-bMmSnxGEbjsyg6Q",
+          "https://www.youtube.com/@nomad_is_here"
+        ],
+        "match_keys": [
+          "@nomad_is_here",
+          "https://www.youtube.com/@nomad_is_here",
+          "channel:uctcfxlt-bmmsnxgebjsyg6q",
+          "https://www.youtube.com/channel/uctcfxlt-bmmsnxgebjsyg6q"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@nomad_is_here"
+    ],
+    "mv_allowlist_match_keys": [
+      "@nomad_is_here",
+      "https://www.youtube.com/@nomad_is_here",
+      "channel:uctcfxlt-bmmsnxgebjsyg6q",
+      "https://www.youtube.com/channel/uctcfxlt-bmmsnxgebjsyg6q"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@nomad_is_here",
+        "channel_label": "NOMAD",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCtCFxLt-bMmSnxGEbjsyg6Q",
+          "https://www.youtube.com/@nomad_is_here"
+        ],
+        "match_keys": [
+          "@nomad_is_here",
+          "https://www.youtube.com/@nomad_is_here",
+          "channel:uctcfxlt-bmmsnxgebjsyg6q",
+          "https://www.youtube.com/channel/uctcfxlt-bmmsnxgebjsyg6q"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "ONEUS",
+    "primary_team_channel_url": "https://www.youtube.com/channel/UCWTYf4xModfNsyq2NUYjF5g",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/channel/UCWTYf4xModfNsyq2NUYjF5g",
+        "channel_label": "ONEUS",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [],
+        "match_keys": [
+          "channel:ucwtyf4xmodfnsyq2nuyjf5g",
+          "https://www.youtube.com/channel/ucwtyf4xmodfnsyq2nuyjf5g"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/channel/UCWTYf4xModfNsyq2NUYjF5g"
+    ],
+    "mv_allowlist_match_keys": [
+      "channel:ucwtyf4xmodfnsyq2nuyjf5g",
+      "https://www.youtube.com/channel/ucwtyf4xmodfnsyq2nuyjf5g"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/channel/UCWTYf4xModfNsyq2NUYjF5g",
+        "channel_label": "ONEUS",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [],
+        "match_keys": [
+          "channel:ucwtyf4xmodfnsyq2nuyjf5g",
+          "https://www.youtube.com/channel/ucwtyf4xmodfnsyq2nuyjf5g"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "ONEWE",
+    "primary_team_channel_url": "https://www.youtube.com/channel/UCj-dtq6jHfj4_fufifPzMEQ",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/channel/UCj-dtq6jHfj4_fufifPzMEQ",
+        "channel_label": "ONEWE",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [],
+        "match_keys": [
+          "channel:ucj-dtq6jhfj4_fufifpzmeq",
+          "https://www.youtube.com/channel/ucj-dtq6jhfj4_fufifpzmeq"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/channel/UCj-dtq6jHfj4_fufifPzMEQ"
+    ],
+    "mv_allowlist_match_keys": [
+      "channel:ucj-dtq6jhfj4_fufifpzmeq",
+      "https://www.youtube.com/channel/ucj-dtq6jhfj4_fufifpzmeq"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/channel/UCj-dtq6jHfj4_fufifPzMEQ",
+        "channel_label": "ONEWE",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [],
+        "match_keys": [
+          "channel:ucj-dtq6jhfj4_fufifpzmeq",
+          "https://www.youtube.com/channel/ucj-dtq6jhfj4_fufifpzmeq"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "ONF",
+    "primary_team_channel_url": "https://www.youtube.com/channel/UCgdj5bL5_Il2tqsQ7J4k6zw",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/channel/UCgdj5bL5_Il2tqsQ7J4k6zw",
+        "channel_label": "ONF",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [],
+        "match_keys": [
+          "channel:ucgdj5bl5_il2tqsq7j4k6zw",
+          "https://www.youtube.com/channel/ucgdj5bl5_il2tqsq7j4k6zw"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/channel/UCgdj5bL5_Il2tqsQ7J4k6zw"
+    ],
+    "mv_allowlist_match_keys": [
+      "channel:ucgdj5bl5_il2tqsq7j4k6zw",
+      "https://www.youtube.com/channel/ucgdj5bl5_il2tqsq7j4k6zw"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/channel/UCgdj5bL5_Il2tqsQ7J4k6zw",
+        "channel_label": "ONF",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [],
+        "match_keys": [
+          "channel:ucgdj5bl5_il2tqsq7j4k6zw",
+          "https://www.youtube.com/channel/ucgdj5bl5_il2tqsq7j4k6zw"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "P1Harmony",
+    "primary_team_channel_url": "https://www.youtube.com/@P1H_official",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@P1H_official",
+        "channel_label": "P1Harmony",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCusCD4I-_-AAWpAnm0xgkCw",
+          "https://www.youtube.com/@P1H_official"
+        ],
+        "match_keys": [
+          "@p1h_official",
+          "https://www.youtube.com/@p1h_official",
+          "channel:ucuscd4i-_-aawpanm0xgkcw",
+          "https://www.youtube.com/channel/ucuscd4i-_-aawpanm0xgkcw"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@P1H_official"
+    ],
+    "mv_allowlist_match_keys": [
+      "@p1h_official",
+      "https://www.youtube.com/@p1h_official",
+      "channel:ucuscd4i-_-aawpanm0xgkcw",
+      "https://www.youtube.com/channel/ucuscd4i-_-aawpanm0xgkcw"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@P1H_official",
+        "channel_label": "P1Harmony",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCusCD4I-_-AAWpAnm0xgkCw",
+          "https://www.youtube.com/@P1H_official"
+        ],
+        "match_keys": [
+          "@p1h_official",
+          "https://www.youtube.com/@p1h_official",
+          "channel:ucuscd4i-_-aawpanm0xgkcw",
+          "https://www.youtube.com/channel/ucuscd4i-_-aawpanm0xgkcw"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "PLAVE",
+    "primary_team_channel_url": "https://www.youtube.com/@plave_official",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@plave_official",
+        "channel_label": "PLAVE",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCPZIPuQPrfrUG9Xe_okEmQA",
+          "https://www.youtube.com/@plave_official"
+        ],
+        "match_keys": [
+          "@plave_official",
+          "https://www.youtube.com/@plave_official",
+          "channel:ucpzipuqprfrug9xe_okemqa",
+          "https://www.youtube.com/channel/ucpzipuqprfrug9xe_okemqa"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@plave_official"
+    ],
+    "mv_allowlist_match_keys": [
+      "@plave_official",
+      "https://www.youtube.com/@plave_official",
+      "channel:ucpzipuqprfrug9xe_okemqa",
+      "https://www.youtube.com/channel/ucpzipuqprfrug9xe_okemqa"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@plave_official",
+        "channel_label": "PLAVE",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCPZIPuQPrfrUG9Xe_okEmQA",
+          "https://www.youtube.com/@plave_official"
+        ],
+        "match_keys": [
+          "@plave_official",
+          "https://www.youtube.com/@plave_official",
+          "channel:ucpzipuqprfrug9xe_okemqa",
+          "https://www.youtube.com/channel/ucpzipuqprfrug9xe_okemqa"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "POW",
+    "primary_team_channel_url": "https://www.youtube.com/@POW_Official",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@POW_Official",
+        "channel_label": "POW",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCc8hWuK9dgKvB04rzZL23sQ",
+          "https://www.youtube.com/@POW_Official"
+        ],
+        "match_keys": [
+          "@pow_official",
+          "https://www.youtube.com/@pow_official",
+          "channel:ucc8hwuk9dgkvb04rzzl23sq",
+          "https://www.youtube.com/channel/ucc8hwuk9dgkvb04rzzl23sq"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@POW_Official"
+    ],
+    "mv_allowlist_match_keys": [
+      "@pow_official",
+      "https://www.youtube.com/@pow_official",
+      "channel:ucc8hwuk9dgkvb04rzzl23sq",
+      "https://www.youtube.com/channel/ucc8hwuk9dgkvb04rzzl23sq"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@POW_Official",
+        "channel_label": "POW",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCc8hWuK9dgKvB04rzZL23sQ",
+          "https://www.youtube.com/@POW_Official"
+        ],
+        "match_keys": [
+          "@pow_official",
+          "https://www.youtube.com/@pow_official",
+          "channel:ucc8hwuk9dgkvb04rzzl23sq",
+          "https://www.youtube.com/channel/ucc8hwuk9dgkvb04rzzl23sq"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "Purple Kiss",
+    "primary_team_channel_url": "https://www.youtube.com/@PURPLEKISS_Official",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@PURPLEKISS_Official",
+        "channel_label": "Purple Kiss",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCYthb3GTHmOaIwUUQJWgGiQ",
+          "https://www.youtube.com/@PURPLEKISS_Official"
+        ],
+        "match_keys": [
+          "@purplekiss_official",
+          "https://www.youtube.com/@purplekiss_official",
+          "channel:ucythb3gthmoaiwuuqjwggiq",
+          "https://www.youtube.com/channel/ucythb3gthmoaiwuuqjwggiq"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@PURPLEKISS_Official"
+    ],
+    "mv_allowlist_match_keys": [
+      "@purplekiss_official",
+      "https://www.youtube.com/@purplekiss_official",
+      "channel:ucythb3gthmoaiwuuqjwggiq",
+      "https://www.youtube.com/channel/ucythb3gthmoaiwuuqjwggiq"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@PURPLEKISS_Official",
+        "channel_label": "Purple Kiss",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCYthb3GTHmOaIwUUQJWgGiQ",
+          "https://www.youtube.com/@PURPLEKISS_Official"
+        ],
+        "match_keys": [
+          "@purplekiss_official",
+          "https://www.youtube.com/@purplekiss_official",
+          "channel:ucythb3gthmoaiwuuqjwggiq",
+          "https://www.youtube.com/channel/ucythb3gthmoaiwuuqjwggiq"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "QWER",
+    "primary_team_channel_url": "https://www.youtube.com/@qwerband_official",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@qwerband_official",
+        "channel_label": "QWER",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCzDIlhmQTqHnadV28WRVdYw",
+          "https://www.youtube.com/@qwerband_official"
+        ],
+        "match_keys": [
+          "@qwerband_official",
+          "https://www.youtube.com/@qwerband_official",
+          "channel:uczdilhmqtqhnadv28wrvdyw",
+          "https://www.youtube.com/channel/uczdilhmqtqhnadv28wrvdyw"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@qwerband_official"
+    ],
+    "mv_allowlist_match_keys": [
+      "@qwerband_official",
+      "https://www.youtube.com/@qwerband_official",
+      "channel:uczdilhmqtqhnadv28wrvdyw",
+      "https://www.youtube.com/channel/uczdilhmqtqhnadv28wrvdyw"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@qwerband_official",
+        "channel_label": "QWER",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCzDIlhmQTqHnadV28WRVdYw",
+          "https://www.youtube.com/@qwerband_official"
+        ],
+        "match_keys": [
+          "@qwerband_official",
+          "https://www.youtube.com/@qwerband_official",
+          "channel:uczdilhmqtqhnadv28wrvdyw",
+          "https://www.youtube.com/channel/uczdilhmqtqhnadv28wrvdyw"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "Red Velvet",
+    "primary_team_channel_url": "https://www.youtube.com/@redvelvet.smtown",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@redvelvet.smtown",
+        "channel_label": "Red Velvet",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCzCPlvzBhDCz4Z3fWatCUUA",
+          "https://www.youtube.com/@redvelvet.smtown"
+        ],
+        "match_keys": [
+          "@redvelvet.smtown",
+          "https://www.youtube.com/@redvelvet.smtown",
+          "channel:uczcplvzbhdcz4z3fwatcuua",
+          "https://www.youtube.com/channel/uczcplvzbhdcz4z3fwatcuua"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/@SMTOWN",
+        "channel_label": "SMTOWN",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCyDd_CdcEtQk-jbmrBhBl5w",
+          "https://www.youtube.com/@SMTOWN"
+        ],
+        "match_keys": [
+          "@smtown",
+          "https://www.youtube.com/@smtown",
+          "channel:ucydd_cdcetqk-jbmrbhbl5w",
+          "https://www.youtube.com/channel/ucydd_cdcetqk-jbmrbhbl5w"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@redvelvet.smtown",
+      "https://www.youtube.com/@SMTOWN"
+    ],
+    "mv_allowlist_match_keys": [
+      "@redvelvet.smtown",
+      "https://www.youtube.com/@redvelvet.smtown",
+      "channel:uczcplvzbhdcz4z3fwatcuua",
+      "https://www.youtube.com/channel/uczcplvzbhdcz4z3fwatcuua",
+      "@smtown",
+      "https://www.youtube.com/@smtown",
+      "channel:ucydd_cdcetqk-jbmrbhbl5w",
+      "https://www.youtube.com/channel/ucydd_cdcetqk-jbmrbhbl5w"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@redvelvet.smtown",
+        "channel_label": "Red Velvet",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCzCPlvzBhDCz4Z3fWatCUUA",
+          "https://www.youtube.com/@redvelvet.smtown"
+        ],
+        "match_keys": [
+          "@redvelvet.smtown",
+          "https://www.youtube.com/@redvelvet.smtown",
+          "channel:uczcplvzbhdcz4z3fwatcuua",
+          "https://www.youtube.com/channel/uczcplvzbhdcz4z3fwatcuua"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/@SMTOWN",
+        "channel_label": "SMTOWN",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCyDd_CdcEtQk-jbmrBhBl5w",
+          "https://www.youtube.com/@SMTOWN"
+        ],
+        "match_keys": [
+          "@smtown",
+          "https://www.youtube.com/@smtown",
+          "channel:ucydd_cdcetqk-jbmrbhbl5w",
+          "https://www.youtube.com/channel/ucydd_cdcetqk-jbmrbhbl5w"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "RESCENE",
+    "primary_team_channel_url": "https://www.youtube.com/@RESCENEofficial",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@RESCENEofficial",
+        "channel_label": "RESCENE",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UC4jgjZ6BDua0IjI4JT7h0-A",
+          "https://www.youtube.com/@RESCENEofficial"
+        ],
+        "match_keys": [
+          "@resceneofficial",
+          "https://www.youtube.com/@resceneofficial",
+          "channel:uc4jgjz6bdua0iji4jt7h0-a",
+          "https://www.youtube.com/channel/uc4jgjz6bdua0iji4jt7h0-a"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@RESCENEofficial"
+    ],
+    "mv_allowlist_match_keys": [
+      "@resceneofficial",
+      "https://www.youtube.com/@resceneofficial",
+      "channel:uc4jgjz6bdua0iji4jt7h0-a",
+      "https://www.youtube.com/channel/uc4jgjz6bdua0iji4jt7h0-a"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@RESCENEofficial",
+        "channel_label": "RESCENE",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UC4jgjZ6BDua0IjI4JT7h0-A",
+          "https://www.youtube.com/@RESCENEofficial"
+        ],
+        "match_keys": [
+          "@resceneofficial",
+          "https://www.youtube.com/@resceneofficial",
+          "channel:uc4jgjz6bdua0iji4jt7h0-a",
+          "https://www.youtube.com/channel/uc4jgjz6bdua0iji4jt7h0-a"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "RIIZE",
+    "primary_team_channel_url": "https://www.youtube.com/@RIIZE_official",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@RIIZE_official",
+        "channel_label": "RIIZE",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCdVD0MsYecQaIE5Ru-pOIQQ",
+          "https://www.youtube.com/@RIIZE_official"
+        ],
+        "match_keys": [
+          "@riize_official",
+          "https://www.youtube.com/@riize_official",
+          "channel:ucdvd0msyecqaie5ru-poiqq",
+          "https://www.youtube.com/channel/ucdvd0msyecqaie5ru-poiqq"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/@SMTOWN",
+        "channel_label": "SMTOWN",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCyDd_CdcEtQk-jbmrBhBl5w",
+          "https://www.youtube.com/@SMTOWN"
+        ],
+        "match_keys": [
+          "@smtown",
+          "https://www.youtube.com/@smtown",
+          "channel:ucydd_cdcetqk-jbmrbhbl5w",
+          "https://www.youtube.com/channel/ucydd_cdcetqk-jbmrbhbl5w"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@RIIZE_official",
+      "https://www.youtube.com/@SMTOWN"
+    ],
+    "mv_allowlist_match_keys": [
+      "@riize_official",
+      "https://www.youtube.com/@riize_official",
+      "channel:ucdvd0msyecqaie5ru-poiqq",
+      "https://www.youtube.com/channel/ucdvd0msyecqaie5ru-poiqq",
+      "@smtown",
+      "https://www.youtube.com/@smtown",
+      "channel:ucydd_cdcetqk-jbmrbhbl5w",
+      "https://www.youtube.com/channel/ucydd_cdcetqk-jbmrbhbl5w"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@RIIZE_official",
+        "channel_label": "RIIZE",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCdVD0MsYecQaIE5Ru-pOIQQ",
+          "https://www.youtube.com/@RIIZE_official"
+        ],
+        "match_keys": [
+          "@riize_official",
+          "https://www.youtube.com/@riize_official",
+          "channel:ucdvd0msyecqaie5ru-poiqq",
+          "https://www.youtube.com/channel/ucdvd0msyecqaie5ru-poiqq"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/@SMTOWN",
+        "channel_label": "SMTOWN",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCyDd_CdcEtQk-jbmrBhBl5w",
+          "https://www.youtube.com/@SMTOWN"
+        ],
+        "match_keys": [
+          "@smtown",
+          "https://www.youtube.com/@smtown",
+          "channel:ucydd_cdcetqk-jbmrbhbl5w",
+          "https://www.youtube.com/channel/ucydd_cdcetqk-jbmrbhbl5w"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "SAY MY NAME",
+    "primary_team_channel_url": "https://www.youtube.com/@sa2m2nam3",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@sa2m2nam3",
+        "channel_label": "SAY MY NAME",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCTItOHr70Tq_GAOACSGawPw",
+          "https://www.youtube.com/@sa2m2nam3"
+        ],
+        "match_keys": [
+          "@sa2m2nam3",
+          "https://www.youtube.com/@sa2m2nam3",
+          "channel:uctitohr70tq_gaoacsgawpw",
+          "https://www.youtube.com/channel/uctitohr70tq_gaoacsgawpw"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/@inkodeofficial",
+        "channel_label": "iNKODE Official",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "manual_override_uploader"
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@sa2m2nam3",
+      "https://www.youtube.com/@inkodeofficial"
+    ],
+    "mv_allowlist_match_keys": [
+      "@sa2m2nam3",
+      "https://www.youtube.com/@sa2m2nam3",
+      "channel:uctitohr70tq_gaoacsgawpw",
+      "https://www.youtube.com/channel/uctitohr70tq_gaoacsgawpw"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@sa2m2nam3",
+        "channel_label": "SAY MY NAME",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCTItOHr70Tq_GAOACSGawPw",
+          "https://www.youtube.com/@sa2m2nam3"
+        ],
+        "match_keys": [
+          "@sa2m2nam3",
+          "https://www.youtube.com/@sa2m2nam3",
+          "channel:uctitohr70tq_gaoacsgawpw",
+          "https://www.youtube.com/channel/uctitohr70tq_gaoacsgawpw"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/@inkodeofficial",
+        "channel_label": "iNKODE Official",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "manual_override_uploader"
+      }
+    ]
+  },
+  {
+    "group": "SEVENTEEN",
+    "primary_team_channel_url": "https://www.youtube.com/@pledis_17",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@pledis_17",
+        "channel_label": "SEVENTEEN",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCus0FFI3ZSFv4e2Yw6nn3aw",
+          "https://www.youtube.com/@pledis_17"
+        ],
+        "match_keys": [
+          "@pledis_17",
+          "https://www.youtube.com/@pledis_17",
+          "channel:ucus0ffi3zsfv4e2yw6nn3aw",
+          "https://www.youtube.com/channel/ucus0ffi3zsfv4e2yw6nn3aw"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/@HYBELABELS",
+        "channel_label": "HYBE LABELS",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UC3IZKseVpdzPSBaWxBxundA",
+          "https://www.youtube.com/@HYBELABELS"
+        ],
+        "match_keys": [
+          "@hybelabels",
+          "https://www.youtube.com/@hybelabels",
+          "channel:uc3izksevpdzpsbawxbxunda",
+          "https://www.youtube.com/channel/uc3izksevpdzpsbawxbxunda"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/channel/UCfkXDY7vwkcJ8ddFGz8KusA",
+        "channel_label": "PLEDIS",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "manual_override_legacy_label_channel"
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@pledis_17",
+      "https://www.youtube.com/@HYBELABELS",
+      "https://www.youtube.com/channel/UCfkXDY7vwkcJ8ddFGz8KusA"
+    ],
+    "mv_allowlist_match_keys": [
+      "@pledis_17",
+      "https://www.youtube.com/@pledis_17",
+      "channel:ucus0ffi3zsfv4e2yw6nn3aw",
+      "https://www.youtube.com/channel/ucus0ffi3zsfv4e2yw6nn3aw",
+      "@hybelabels",
+      "https://www.youtube.com/@hybelabels",
+      "channel:uc3izksevpdzpsbawxbxunda",
+      "https://www.youtube.com/channel/uc3izksevpdzpsbawxbxunda"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@pledis_17",
+        "channel_label": "SEVENTEEN",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCus0FFI3ZSFv4e2Yw6nn3aw",
+          "https://www.youtube.com/@pledis_17"
+        ],
+        "match_keys": [
+          "@pledis_17",
+          "https://www.youtube.com/@pledis_17",
+          "channel:ucus0ffi3zsfv4e2yw6nn3aw",
+          "https://www.youtube.com/channel/ucus0ffi3zsfv4e2yw6nn3aw"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/@HYBELABELS",
+        "channel_label": "HYBE LABELS",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UC3IZKseVpdzPSBaWxBxundA",
+          "https://www.youtube.com/@HYBELABELS"
+        ],
+        "match_keys": [
+          "@hybelabels",
+          "https://www.youtube.com/@hybelabels",
+          "channel:uc3izksevpdzpsbawxbxunda",
+          "https://www.youtube.com/channel/uc3izksevpdzpsbawxbxunda"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/channel/UCfkXDY7vwkcJ8ddFGz8KusA",
+        "channel_label": "PLEDIS",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "manual_override_legacy_label_channel"
+      }
+    ]
+  },
+  {
+    "group": "SHINee",
+    "primary_team_channel_url": "https://www.youtube.com/@SHINee",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@SHINee",
+        "channel_label": "SHINee",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCyPwRgc3gQGqhk6RoGS50Ug",
+          "https://www.youtube.com/@SHINee"
+        ],
+        "match_keys": [
+          "@shinee",
+          "https://www.youtube.com/@shinee",
+          "channel:ucypwrgc3gqgqhk6rogs50ug",
+          "https://www.youtube.com/channel/ucypwrgc3gqgqhk6rogs50ug"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/@SMTOWN",
+        "channel_label": "SMTOWN",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCyDd_CdcEtQk-jbmrBhBl5w",
+          "https://www.youtube.com/@SMTOWN"
+        ],
+        "match_keys": [
+          "@smtown",
+          "https://www.youtube.com/@smtown",
+          "channel:ucydd_cdcetqk-jbmrbhbl5w",
+          "https://www.youtube.com/channel/ucydd_cdcetqk-jbmrbhbl5w"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@SHINee",
+      "https://www.youtube.com/@SMTOWN"
+    ],
+    "mv_allowlist_match_keys": [
+      "@shinee",
+      "https://www.youtube.com/@shinee",
+      "channel:ucypwrgc3gqgqhk6rogs50ug",
+      "https://www.youtube.com/channel/ucypwrgc3gqgqhk6rogs50ug",
+      "@smtown",
+      "https://www.youtube.com/@smtown",
+      "channel:ucydd_cdcetqk-jbmrbhbl5w",
+      "https://www.youtube.com/channel/ucydd_cdcetqk-jbmrbhbl5w"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@SHINee",
+        "channel_label": "SHINee",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCyPwRgc3gQGqhk6RoGS50Ug",
+          "https://www.youtube.com/@SHINee"
+        ],
+        "match_keys": [
+          "@shinee",
+          "https://www.youtube.com/@shinee",
+          "channel:ucypwrgc3gqgqhk6rogs50ug",
+          "https://www.youtube.com/channel/ucypwrgc3gqgqhk6rogs50ug"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/@SMTOWN",
+        "channel_label": "SMTOWN",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCyDd_CdcEtQk-jbmrBhBl5w",
+          "https://www.youtube.com/@SMTOWN"
+        ],
+        "match_keys": [
+          "@smtown",
+          "https://www.youtube.com/@smtown",
+          "channel:ucydd_cdcetqk-jbmrbhbl5w",
+          "https://www.youtube.com/channel/ucydd_cdcetqk-jbmrbhbl5w"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "STAYC",
+    "primary_team_channel_url": "https://www.youtube.com/@stayc_official",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@stayc_official",
+        "channel_label": "STAYC",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCatNHrB0kCG8Cq8j6l7qivg",
+          "https://www.youtube.com/@stayc_official"
+        ],
+        "match_keys": [
+          "@stayc_official",
+          "https://www.youtube.com/@stayc_official",
+          "channel:ucatnhrb0kcg8cq8j6l7qivg",
+          "https://www.youtube.com/channel/ucatnhrb0kcg8cq8j6l7qivg"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@stayc_official"
+    ],
+    "mv_allowlist_match_keys": [
+      "@stayc_official",
+      "https://www.youtube.com/@stayc_official",
+      "channel:ucatnhrb0kcg8cq8j6l7qivg",
+      "https://www.youtube.com/channel/ucatnhrb0kcg8cq8j6l7qivg"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@stayc_official",
+        "channel_label": "STAYC",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCatNHrB0kCG8Cq8j6l7qivg",
+          "https://www.youtube.com/@stayc_official"
+        ],
+        "match_keys": [
+          "@stayc_official",
+          "https://www.youtube.com/@stayc_official",
+          "channel:ucatnhrb0kcg8cq8j6l7qivg",
+          "https://www.youtube.com/channel/ucatnhrb0kcg8cq8j6l7qivg"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "Stray Kids",
+    "primary_team_channel_url": "https://www.youtube.com/@stray_kids",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@stray_kids",
+        "channel_label": "Stray Kids",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCw65oxhmqIxjE_ijNkBb4xg",
+          "https://www.youtube.com/@stray_kids"
+        ],
+        "match_keys": [
+          "@stray_kids",
+          "https://www.youtube.com/@stray_kids",
+          "channel:ucw65oxhmqixje_ijnkbb4xg",
+          "https://www.youtube.com/channel/ucw65oxhmqixje_ijnkbb4xg"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/@JYPEntertainment",
+        "channel_label": "JYP Entertainment",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCaO6TYtlC8U5ttz62hTrZgg",
+          "https://www.youtube.com/@JYPEntertainment"
+        ],
+        "match_keys": [
+          "@jypentertainment",
+          "https://www.youtube.com/@jypentertainment",
+          "channel:ucao6tytlc8u5ttz62htrzgg",
+          "https://www.youtube.com/channel/ucao6tytlc8u5ttz62htrzgg"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@stray_kids",
+      "https://www.youtube.com/@JYPEntertainment"
+    ],
+    "mv_allowlist_match_keys": [
+      "@stray_kids",
+      "https://www.youtube.com/@stray_kids",
+      "channel:ucw65oxhmqixje_ijnkbb4xg",
+      "https://www.youtube.com/channel/ucw65oxhmqixje_ijnkbb4xg",
+      "@jypentertainment",
+      "https://www.youtube.com/@jypentertainment",
+      "channel:ucao6tytlc8u5ttz62htrzgg",
+      "https://www.youtube.com/channel/ucao6tytlc8u5ttz62htrzgg"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@stray_kids",
+        "channel_label": "Stray Kids",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCw65oxhmqIxjE_ijNkBb4xg",
+          "https://www.youtube.com/@stray_kids"
+        ],
+        "match_keys": [
+          "@stray_kids",
+          "https://www.youtube.com/@stray_kids",
+          "channel:ucw65oxhmqixje_ijnkbb4xg",
+          "https://www.youtube.com/channel/ucw65oxhmqixje_ijnkbb4xg"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/@JYPEntertainment",
+        "channel_label": "JYP Entertainment",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCaO6TYtlC8U5ttz62hTrZgg",
+          "https://www.youtube.com/@JYPEntertainment"
+        ],
+        "match_keys": [
+          "@jypentertainment",
+          "https://www.youtube.com/@jypentertainment",
+          "channel:ucao6tytlc8u5ttz62htrzgg",
+          "https://www.youtube.com/channel/ucao6tytlc8u5ttz62htrzgg"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "TEMPEST",
+    "primary_team_channel_url": "https://www.youtube.com/@TPSTOFFICIAL",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@TPSTOFFICIAL",
+        "channel_label": "TEMPEST",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCCViKQ1A1tXhIVKAVEazcaA",
+          "https://www.youtube.com/@TPSTOFFICIAL"
+        ],
+        "match_keys": [
+          "@tpstofficial",
+          "https://www.youtube.com/@tpstofficial",
+          "channel:uccvikq1a1txhivkaveazcaa",
+          "https://www.youtube.com/channel/uccvikq1a1txhivkaveazcaa"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@TPSTOFFICIAL"
+    ],
+    "mv_allowlist_match_keys": [
+      "@tpstofficial",
+      "https://www.youtube.com/@tpstofficial",
+      "channel:uccvikq1a1txhivkaveazcaa",
+      "https://www.youtube.com/channel/uccvikq1a1txhivkaveazcaa"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@TPSTOFFICIAL",
+        "channel_label": "TEMPEST",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCCViKQ1A1tXhIVKAVEazcaA",
+          "https://www.youtube.com/@TPSTOFFICIAL"
+        ],
+        "match_keys": [
+          "@tpstofficial",
+          "https://www.youtube.com/@tpstofficial",
+          "channel:uccvikq1a1txhivkaveazcaa",
+          "https://www.youtube.com/channel/uccvikq1a1txhivkaveazcaa"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "THE BOYZ",
+    "primary_team_channel_url": "https://www.youtube.com/channel/UCkJ1rbOrsyPfBuHNfnLPm-Q",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/channel/UCkJ1rbOrsyPfBuHNfnLPm-Q",
+        "channel_label": "THE BOYZ",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [],
+        "match_keys": [
+          "channel:uckj1rborsypfbuhnfnlpm-q",
+          "https://www.youtube.com/channel/uckj1rborsypfbuhnfnlpm-q"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/channel/UCkJ1rbOrsyPfBuHNfnLPm-Q"
+    ],
+    "mv_allowlist_match_keys": [
+      "channel:uckj1rborsypfbuhnfnlpm-q",
+      "https://www.youtube.com/channel/uckj1rborsypfbuhnfnlpm-q"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/channel/UCkJ1rbOrsyPfBuHNfnLPm-Q",
+        "channel_label": "THE BOYZ",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [],
+        "match_keys": [
+          "channel:uckj1rborsypfbuhnfnlpm-q",
+          "https://www.youtube.com/channel/uckj1rborsypfbuhnfnlpm-q"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "The KingDom",
+    "primary_team_channel_url": "https://www.youtube.com/@gf_entertainment",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@gf_entertainment",
+        "channel_label": "The KingDom",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCYp2CgC9Hxj_YnliiVKlOsQ",
+          "https://www.youtube.com/@gf_entertainment"
+        ],
+        "match_keys": [
+          "@gf_entertainment",
+          "https://www.youtube.com/@gf_entertainment",
+          "channel:ucyp2cgc9hxj_ynliivklosq",
+          "https://www.youtube.com/channel/ucyp2cgc9hxj_ynliivklosq"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@gf_entertainment"
+    ],
+    "mv_allowlist_match_keys": [
+      "@gf_entertainment",
+      "https://www.youtube.com/@gf_entertainment",
+      "channel:ucyp2cgc9hxj_ynliivklosq",
+      "https://www.youtube.com/channel/ucyp2cgc9hxj_ynliivklosq"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@gf_entertainment",
+        "channel_label": "The KingDom",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCYp2CgC9Hxj_YnliiVKlOsQ",
+          "https://www.youtube.com/@gf_entertainment"
+        ],
+        "match_keys": [
+          "@gf_entertainment",
+          "https://www.youtube.com/@gf_entertainment",
+          "channel:ucyp2cgc9hxj_ynliivklosq",
+          "https://www.youtube.com/channel/ucyp2cgc9hxj_ynliivklosq"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "TIOT",
+    "primary_team_channel_url": "https://www.youtube.com/@TIOT_NOW",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@TIOT_NOW",
+        "channel_label": "TIOT",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UC4AVxeN8iY5j8kzg2WE0Vng",
+          "https://www.youtube.com/@TIOT_NOW"
+        ],
+        "match_keys": [
+          "@tiot_now",
+          "https://www.youtube.com/@tiot_now",
+          "channel:uc4avxen8iy5j8kzg2we0vng",
+          "https://www.youtube.com/channel/uc4avxen8iy5j8kzg2we0vng"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@TIOT_NOW"
+    ],
+    "mv_allowlist_match_keys": [
+      "@tiot_now",
+      "https://www.youtube.com/@tiot_now",
+      "channel:uc4avxen8iy5j8kzg2we0vng",
+      "https://www.youtube.com/channel/uc4avxen8iy5j8kzg2we0vng"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@TIOT_NOW",
+        "channel_label": "TIOT",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UC4AVxeN8iY5j8kzg2WE0Vng",
+          "https://www.youtube.com/@TIOT_NOW"
+        ],
+        "match_keys": [
+          "@tiot_now",
+          "https://www.youtube.com/@tiot_now",
+          "channel:uc4avxen8iy5j8kzg2we0vng",
+          "https://www.youtube.com/channel/uc4avxen8iy5j8kzg2we0vng"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "TNX",
+    "primary_team_channel_url": "https://www.youtube.com/@PNATIONOfficial",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@PNATIONOfficial",
+        "channel_label": "TNX",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCZOA7I_vjrxLuLGatPekGoA",
+          "https://www.youtube.com/@PNATIONOfficial"
+        ],
+        "match_keys": [
+          "@pnationofficial",
+          "https://www.youtube.com/@pnationofficial",
+          "channel:uczoa7i_vjrxlulgatpekgoa",
+          "https://www.youtube.com/channel/uczoa7i_vjrxlulgatpekgoa"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@PNATIONOfficial"
+    ],
+    "mv_allowlist_match_keys": [
+      "@pnationofficial",
+      "https://www.youtube.com/@pnationofficial",
+      "channel:uczoa7i_vjrxlulgatpekgoa",
+      "https://www.youtube.com/channel/uczoa7i_vjrxlulgatpekgoa"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@PNATIONOfficial",
+        "channel_label": "TNX",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCZOA7I_vjrxLuLGatPekGoA",
+          "https://www.youtube.com/@PNATIONOfficial"
+        ],
+        "match_keys": [
+          "@pnationofficial",
+          "https://www.youtube.com/@pnationofficial",
+          "channel:uczoa7i_vjrxlulgatpekgoa",
+          "https://www.youtube.com/channel/uczoa7i_vjrxlulgatpekgoa"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "TOMORROW X TOGETHER",
+    "primary_team_channel_url": "https://www.youtube.com/@txt_members",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@txt_members",
+        "channel_label": "TOMORROW X TOGETHER",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCYvcKgQ91-CU-bbDM4svhKw",
+          "https://www.youtube.com/@txt_members"
+        ],
+        "match_keys": [
+          "@txt_members",
+          "https://www.youtube.com/@txt_members",
+          "channel:ucyvckgq91-cu-bbdm4svhkw",
+          "https://www.youtube.com/channel/ucyvckgq91-cu-bbdm4svhkw"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/@HYBELABELS",
+        "channel_label": "HYBE LABELS",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UC3IZKseVpdzPSBaWxBxundA",
+          "https://www.youtube.com/@HYBELABELS"
+        ],
+        "match_keys": [
+          "@hybelabels",
+          "https://www.youtube.com/@hybelabels",
+          "channel:uc3izksevpdzpsbawxbxunda",
+          "https://www.youtube.com/channel/uc3izksevpdzpsbawxbxunda"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@txt_members",
+      "https://www.youtube.com/@HYBELABELS"
+    ],
+    "mv_allowlist_match_keys": [
+      "@txt_members",
+      "https://www.youtube.com/@txt_members",
+      "channel:ucyvckgq91-cu-bbdm4svhkw",
+      "https://www.youtube.com/channel/ucyvckgq91-cu-bbdm4svhkw",
+      "@hybelabels",
+      "https://www.youtube.com/@hybelabels",
+      "channel:uc3izksevpdzpsbawxbxunda",
+      "https://www.youtube.com/channel/uc3izksevpdzpsbawxbxunda"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@txt_members",
+        "channel_label": "TOMORROW X TOGETHER",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCYvcKgQ91-CU-bbDM4svhKw",
+          "https://www.youtube.com/@txt_members"
+        ],
+        "match_keys": [
+          "@txt_members",
+          "https://www.youtube.com/@txt_members",
+          "channel:ucyvckgq91-cu-bbdm4svhkw",
+          "https://www.youtube.com/channel/ucyvckgq91-cu-bbdm4svhkw"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/@HYBELABELS",
+        "channel_label": "HYBE LABELS",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UC3IZKseVpdzPSBaWxBxundA",
+          "https://www.youtube.com/@HYBELABELS"
+        ],
+        "match_keys": [
+          "@hybelabels",
+          "https://www.youtube.com/@hybelabels",
+          "channel:uc3izksevpdzpsbawxbxunda",
+          "https://www.youtube.com/channel/uc3izksevpdzpsbawxbxunda"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "TREASURE",
+    "primary_team_channel_url": "https://www.youtube.com/@ygtreasuremaker",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@ygtreasuremaker",
+        "channel_label": "TREASURE",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCw8lWZs8AB_1PwODKAYAKBw",
+          "https://www.youtube.com/@ygtreasuremaker"
+        ],
+        "match_keys": [
+          "@ygtreasuremaker",
+          "https://www.youtube.com/@ygtreasuremaker",
+          "channel:ucw8lwzs8ab_1pwodkayakbw",
+          "https://www.youtube.com/channel/ucw8lwzs8ab_1pwodkayakbw"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/@YGEntertainment",
+        "channel_label": "YG ENTERTAINMENT",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCnsQjCVzmEd-YvlQZbo6zCg",
+          "https://www.youtube.com/@YGEntertainment"
+        ],
+        "match_keys": [
+          "@ygentertainment",
+          "https://www.youtube.com/@ygentertainment",
+          "channel:ucnsqjcvzmed-yvlqzbo6zcg",
+          "https://www.youtube.com/channel/ucnsqjcvzmed-yvlqzbo6zcg"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@ygtreasuremaker",
+      "https://www.youtube.com/@YGEntertainment"
+    ],
+    "mv_allowlist_match_keys": [
+      "@ygtreasuremaker",
+      "https://www.youtube.com/@ygtreasuremaker",
+      "channel:ucw8lwzs8ab_1pwodkayakbw",
+      "https://www.youtube.com/channel/ucw8lwzs8ab_1pwodkayakbw",
+      "@ygentertainment",
+      "https://www.youtube.com/@ygentertainment",
+      "channel:ucnsqjcvzmed-yvlqzbo6zcg",
+      "https://www.youtube.com/channel/ucnsqjcvzmed-yvlqzbo6zcg"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@ygtreasuremaker",
+        "channel_label": "TREASURE",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCw8lWZs8AB_1PwODKAYAKBw",
+          "https://www.youtube.com/@ygtreasuremaker"
+        ],
+        "match_keys": [
+          "@ygtreasuremaker",
+          "https://www.youtube.com/@ygtreasuremaker",
+          "channel:ucw8lwzs8ab_1pwodkayakbw",
+          "https://www.youtube.com/channel/ucw8lwzs8ab_1pwodkayakbw"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/@YGEntertainment",
+        "channel_label": "YG ENTERTAINMENT",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCnsQjCVzmEd-YvlQZbo6zCg",
+          "https://www.youtube.com/@YGEntertainment"
+        ],
+        "match_keys": [
+          "@ygentertainment",
+          "https://www.youtube.com/@ygentertainment",
+          "channel:ucnsqjcvzmed-yvlqzbo6zcg",
+          "https://www.youtube.com/channel/ucnsqjcvzmed-yvlqzbo6zcg"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "TRENDZ",
+    "primary_team_channel_url": "https://www.youtube.com/@TRENDZ_OFFCL",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@TRENDZ_OFFCL",
+        "channel_label": "TRENDZ",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCvc55IOOCI165H3raqcjjrg",
+          "https://www.youtube.com/@TRENDZ_OFFCL"
+        ],
+        "match_keys": [
+          "@trendz_offcl",
+          "https://www.youtube.com/@trendz_offcl",
+          "channel:ucvc55iooci165h3raqcjjrg",
+          "https://www.youtube.com/channel/ucvc55iooci165h3raqcjjrg"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@TRENDZ_OFFCL"
+    ],
+    "mv_allowlist_match_keys": [
+      "@trendz_offcl",
+      "https://www.youtube.com/@trendz_offcl",
+      "channel:ucvc55iooci165h3raqcjjrg",
+      "https://www.youtube.com/channel/ucvc55iooci165h3raqcjjrg"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@TRENDZ_OFFCL",
+        "channel_label": "TRENDZ",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCvc55IOOCI165H3raqcjjrg",
+          "https://www.youtube.com/@TRENDZ_OFFCL"
+        ],
+        "match_keys": [
+          "@trendz_offcl",
+          "https://www.youtube.com/@trendz_offcl",
+          "channel:ucvc55iooci165h3raqcjjrg",
+          "https://www.youtube.com/channel/ucvc55iooci165h3raqcjjrg"
         ]
       }
     ]
   },
   {
     "group": "tripleS",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCJnL-TBcsYrF2SLs7tmiC8Q",
+    "primary_team_channel_url": "https://www.youtube.com/@triplescosmos",
     "mv_source_channels": [
       {
-        "channel_url": "https://www.youtube.com/channel/UCJnL-TBcsYrF2SLs7tmiC8Q",
+        "channel_url": "https://www.youtube.com/@triplescosmos",
         "channel_label": "tripleS",
         "owner_type": "team",
         "allow_mv_uploads": true,
         "display_in_team_links": true,
         "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCJnL-TBcsYrF2SLs7tmiC8Q",
+          "https://www.youtube.com/@triplescosmos"
+        ],
         "match_keys": [
+          "@triplescosmos",
+          "https://www.youtube.com/@triplescosmos",
           "channel:ucjnl-tbcsyrf2sls7tmic8q",
           "https://www.youtube.com/channel/ucjnl-tbcsyrf2sls7tmic8q"
         ]
       }
     ],
     "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCJnL-TBcsYrF2SLs7tmiC8Q"
+      "https://www.youtube.com/@triplescosmos"
     ],
     "mv_allowlist_match_keys": [
+      "@triplescosmos",
+      "https://www.youtube.com/@triplescosmos",
       "channel:ucjnl-tbcsyrf2sls7tmic8q",
       "https://www.youtube.com/channel/ucjnl-tbcsyrf2sls7tmic8q"
     ],
     "channels": [
       {
-        "channel_url": "https://www.youtube.com/channel/UCJnL-TBcsYrF2SLs7tmiC8Q",
+        "channel_url": "https://www.youtube.com/@triplescosmos",
         "channel_label": "tripleS",
         "owner_type": "team",
         "allow_mv_uploads": true,
         "display_in_team_links": true,
         "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCJnL-TBcsYrF2SLs7tmiC8Q",
+          "https://www.youtube.com/@triplescosmos"
+        ],
         "match_keys": [
+          "@triplescosmos",
+          "https://www.youtube.com/@triplescosmos",
           "channel:ucjnl-tbcsyrf2sls7tmic8q",
           "https://www.youtube.com/channel/ucjnl-tbcsyrf2sls7tmic8q"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "TUNEXX",
+    "primary_team_channel_url": "https://www.youtube.com/@official_TUNEXX",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@official_TUNEXX",
+        "channel_label": "TUNEXX",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCjyoasKZmVv1uHDIID04ivw",
+          "https://www.youtube.com/@official_TUNEXX"
+        ],
+        "match_keys": [
+          "@official_tunexx",
+          "https://www.youtube.com/@official_tunexx",
+          "channel:ucjyoaskzmvv1uhdiid04ivw",
+          "https://www.youtube.com/channel/ucjyoaskzmvv1uhdiid04ivw"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@official_TUNEXX"
+    ],
+    "mv_allowlist_match_keys": [
+      "@official_tunexx",
+      "https://www.youtube.com/@official_tunexx",
+      "channel:ucjyoaskzmvv1uhdiid04ivw",
+      "https://www.youtube.com/channel/ucjyoaskzmvv1uhdiid04ivw"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@official_TUNEXX",
+        "channel_label": "TUNEXX",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCjyoasKZmVv1uHDIID04ivw",
+          "https://www.youtube.com/@official_TUNEXX"
+        ],
+        "match_keys": [
+          "@official_tunexx",
+          "https://www.youtube.com/@official_tunexx",
+          "channel:ucjyoaskzmvv1uhdiid04ivw",
+          "https://www.youtube.com/channel/ucjyoaskzmvv1uhdiid04ivw"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "TWICE",
+    "primary_team_channel_url": "https://www.youtube.com/@JYPETWICE",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@JYPETWICE",
+        "channel_label": "TWICE",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCUfYUFGlR9PkQfJ4YHKEcyQ",
+          "https://www.youtube.com/@JYPETWICE"
+        ],
+        "match_keys": [
+          "@jypetwice",
+          "https://www.youtube.com/@jypetwice",
+          "channel:ucufyufglr9pkqfj4yhkecyq",
+          "https://www.youtube.com/channel/ucufyufglr9pkqfj4yhkecyq"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/@JYPEntertainment",
+        "channel_label": "JYP Entertainment",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCaO6TYtlC8U5ttz62hTrZgg",
+          "https://www.youtube.com/@JYPEntertainment"
+        ],
+        "match_keys": [
+          "@jypentertainment",
+          "https://www.youtube.com/@jypentertainment",
+          "channel:ucao6tytlc8u5ttz62htrzgg",
+          "https://www.youtube.com/channel/ucao6tytlc8u5ttz62htrzgg"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@JYPETWICE",
+      "https://www.youtube.com/@JYPEntertainment"
+    ],
+    "mv_allowlist_match_keys": [
+      "@jypetwice",
+      "https://www.youtube.com/@jypetwice",
+      "channel:ucufyufglr9pkqfj4yhkecyq",
+      "https://www.youtube.com/channel/ucufyufglr9pkqfj4yhkecyq",
+      "@jypentertainment",
+      "https://www.youtube.com/@jypentertainment",
+      "channel:ucao6tytlc8u5ttz62htrzgg",
+      "https://www.youtube.com/channel/ucao6tytlc8u5ttz62htrzgg"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@JYPETWICE",
+        "channel_label": "TWICE",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCUfYUFGlR9PkQfJ4YHKEcyQ",
+          "https://www.youtube.com/@JYPETWICE"
+        ],
+        "match_keys": [
+          "@jypetwice",
+          "https://www.youtube.com/@jypetwice",
+          "channel:ucufyufglr9pkqfj4yhkecyq",
+          "https://www.youtube.com/channel/ucufyufglr9pkqfj4yhkecyq"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/@JYPEntertainment",
+        "channel_label": "JYP Entertainment",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCaO6TYtlC8U5ttz62hTrZgg",
+          "https://www.youtube.com/@JYPEntertainment"
+        ],
+        "match_keys": [
+          "@jypentertainment",
+          "https://www.youtube.com/@jypentertainment",
+          "channel:ucao6tytlc8u5ttz62htrzgg",
+          "https://www.youtube.com/channel/ucao6tytlc8u5ttz62htrzgg"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "TWS",
+    "primary_team_channel_url": "https://www.youtube.com/@TWS_PLEDIS",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@TWS_PLEDIS",
+        "channel_label": "TWS",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UC8C6QOPDVYwmuaSBZksefdg",
+          "https://www.youtube.com/@TWS_PLEDIS"
+        ],
+        "match_keys": [
+          "@tws_pledis",
+          "https://www.youtube.com/@tws_pledis",
+          "channel:uc8c6qopdvywmuasbzksefdg",
+          "https://www.youtube.com/channel/uc8c6qopdvywmuasbzksefdg"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/@HYBELABELS",
+        "channel_label": "HYBE LABELS",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UC3IZKseVpdzPSBaWxBxundA",
+          "https://www.youtube.com/@HYBELABELS"
+        ],
+        "match_keys": [
+          "@hybelabels",
+          "https://www.youtube.com/@hybelabels",
+          "channel:uc3izksevpdzpsbawxbxunda",
+          "https://www.youtube.com/channel/uc3izksevpdzpsbawxbxunda"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@TWS_PLEDIS",
+      "https://www.youtube.com/@HYBELABELS"
+    ],
+    "mv_allowlist_match_keys": [
+      "@tws_pledis",
+      "https://www.youtube.com/@tws_pledis",
+      "channel:uc8c6qopdvywmuasbzksefdg",
+      "https://www.youtube.com/channel/uc8c6qopdvywmuasbzksefdg",
+      "@hybelabels",
+      "https://www.youtube.com/@hybelabels",
+      "channel:uc3izksevpdzpsbawxbxunda",
+      "https://www.youtube.com/channel/uc3izksevpdzpsbawxbxunda"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@TWS_PLEDIS",
+        "channel_label": "TWS",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UC8C6QOPDVYwmuaSBZksefdg",
+          "https://www.youtube.com/@TWS_PLEDIS"
+        ],
+        "match_keys": [
+          "@tws_pledis",
+          "https://www.youtube.com/@tws_pledis",
+          "channel:uc8c6qopdvywmuasbzksefdg",
+          "https://www.youtube.com/channel/uc8c6qopdvywmuasbzksefdg"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/@HYBELABELS",
+        "channel_label": "HYBE LABELS",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UC3IZKseVpdzPSBaWxBxundA",
+          "https://www.youtube.com/@HYBELABELS"
+        ],
+        "match_keys": [
+          "@hybelabels",
+          "https://www.youtube.com/@hybelabels",
+          "channel:uc3izksevpdzpsbawxbxunda",
+          "https://www.youtube.com/channel/uc3izksevpdzpsbawxbxunda"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "UNIS",
+    "primary_team_channel_url": "https://www.youtube.com/@UNIS_Offcl",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@UNIS_Offcl",
+        "channel_label": "UNIS",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCspnElmzSLPhrZJDG9v7JWw"
+        ],
+        "match_keys": [
+          "@unis_offcl",
+          "https://www.youtube.com/@unis_offcl",
+          "channel:ucspnelmzslphrzjdg9v7jww",
+          "https://www.youtube.com/channel/ucspnelmzslphrzjdg9v7jww"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@UNIS_Offcl"
+    ],
+    "mv_allowlist_match_keys": [
+      "@unis_offcl",
+      "https://www.youtube.com/@unis_offcl",
+      "channel:ucspnelmzslphrzjdg9v7jww",
+      "https://www.youtube.com/channel/ucspnelmzslphrzjdg9v7jww"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@UNIS_Offcl",
+        "channel_label": "UNIS",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCspnElmzSLPhrZJDG9v7JWw"
+        ],
+        "match_keys": [
+          "@unis_offcl",
+          "https://www.youtube.com/@unis_offcl",
+          "channel:ucspnelmzslphrzjdg9v7jww",
+          "https://www.youtube.com/channel/ucspnelmzslphrzjdg9v7jww"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "VERIVERY",
+    "primary_team_channel_url": "https://www.youtube.com/channel/UC4t_pYSKIhLWFgutdzIK66Q",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/channel/UC4t_pYSKIhLWFgutdzIK66Q",
+        "channel_label": "VERIVERY",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [],
+        "match_keys": [
+          "channel:uc4t_pyskihlwfgutdzik66q",
+          "https://www.youtube.com/channel/uc4t_pyskihlwfgutdzik66q"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/channel/UC4t_pYSKIhLWFgutdzIK66Q"
+    ],
+    "mv_allowlist_match_keys": [
+      "channel:uc4t_pyskihlwfgutdzik66q",
+      "https://www.youtube.com/channel/uc4t_pyskihlwfgutdzik66q"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/channel/UC4t_pYSKIhLWFgutdzIK66Q",
+        "channel_label": "VERIVERY",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [],
+        "match_keys": [
+          "channel:uc4t_pyskihlwfgutdzik66q",
+          "https://www.youtube.com/channel/uc4t_pyskihlwfgutdzik66q"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "VIVIZ",
+    "primary_team_channel_url": "https://www.youtube.com/@viviz_official",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@viviz_official",
+        "channel_label": "VIVIZ",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCL8T_1DD84e1A62UUrtFQ6Q",
+          "https://www.youtube.com/@viviz_official"
+        ],
+        "match_keys": [
+          "@viviz_official",
+          "https://www.youtube.com/@viviz_official",
+          "channel:ucl8t_1dd84e1a62uurtfq6q",
+          "https://www.youtube.com/channel/ucl8t_1dd84e1a62uurtfq6q"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@viviz_official"
+    ],
+    "mv_allowlist_match_keys": [
+      "@viviz_official",
+      "https://www.youtube.com/@viviz_official",
+      "channel:ucl8t_1dd84e1a62uurtfq6q",
+      "https://www.youtube.com/channel/ucl8t_1dd84e1a62uurtfq6q"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@viviz_official",
+        "channel_label": "VIVIZ",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCL8T_1DD84e1A62UUrtFQ6Q",
+          "https://www.youtube.com/@viviz_official"
+        ],
+        "match_keys": [
+          "@viviz_official",
+          "https://www.youtube.com/@viviz_official",
+          "channel:ucl8t_1dd84e1a62uurtfq6q",
+          "https://www.youtube.com/channel/ucl8t_1dd84e1a62uurtfq6q"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "WayV",
+    "primary_team_channel_url": "https://www.youtube.com/@WayV_official",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@WayV_official",
+        "channel_label": "WayV",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCB7Uy-F5AKKIjy89Qfwq02g",
+          "https://www.youtube.com/@WayV_official"
+        ],
+        "match_keys": [
+          "@wayv_official",
+          "https://www.youtube.com/@wayv_official",
+          "channel:ucb7uy-f5akkijy89qfwq02g",
+          "https://www.youtube.com/channel/ucb7uy-f5akkijy89qfwq02g"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/@SMTOWN",
+        "channel_label": "SMTOWN",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCyDd_CdcEtQk-jbmrBhBl5w",
+          "https://www.youtube.com/@SMTOWN"
+        ],
+        "match_keys": [
+          "@smtown",
+          "https://www.youtube.com/@smtown",
+          "channel:ucydd_cdcetqk-jbmrbhbl5w",
+          "https://www.youtube.com/channel/ucydd_cdcetqk-jbmrbhbl5w"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@WayV_official",
+      "https://www.youtube.com/@SMTOWN"
+    ],
+    "mv_allowlist_match_keys": [
+      "@wayv_official",
+      "https://www.youtube.com/@wayv_official",
+      "channel:ucb7uy-f5akkijy89qfwq02g",
+      "https://www.youtube.com/channel/ucb7uy-f5akkijy89qfwq02g",
+      "@smtown",
+      "https://www.youtube.com/@smtown",
+      "channel:ucydd_cdcetqk-jbmrbhbl5w",
+      "https://www.youtube.com/channel/ucydd_cdcetqk-jbmrbhbl5w"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@WayV_official",
+        "channel_label": "WayV",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCB7Uy-F5AKKIjy89Qfwq02g",
+          "https://www.youtube.com/@WayV_official"
+        ],
+        "match_keys": [
+          "@wayv_official",
+          "https://www.youtube.com/@wayv_official",
+          "channel:ucb7uy-f5akkijy89qfwq02g",
+          "https://www.youtube.com/channel/ucb7uy-f5akkijy89qfwq02g"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/@SMTOWN",
+        "channel_label": "SMTOWN",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCyDd_CdcEtQk-jbmrBhBl5w",
+          "https://www.youtube.com/@SMTOWN"
+        ],
+        "match_keys": [
+          "@smtown",
+          "https://www.youtube.com/@smtown",
+          "channel:ucydd_cdcetqk-jbmrbhbl5w",
+          "https://www.youtube.com/channel/ucydd_cdcetqk-jbmrbhbl5w"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "Weeekly",
+    "primary_team_channel_url": "https://www.youtube.com/channel/UC5rp2rDRSpyKNj-QLytC-tw",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/channel/UC5rp2rDRSpyKNj-QLytC-tw",
+        "channel_label": "Weeekly",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [],
+        "match_keys": [
+          "channel:uc5rp2rdrspyknj-qlytc-tw",
+          "https://www.youtube.com/channel/uc5rp2rdrspyknj-qlytc-tw"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/channel/UC5rp2rDRSpyKNj-QLytC-tw"
+    ],
+    "mv_allowlist_match_keys": [
+      "channel:uc5rp2rdrspyknj-qlytc-tw",
+      "https://www.youtube.com/channel/uc5rp2rdrspyknj-qlytc-tw"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/channel/UC5rp2rDRSpyKNj-QLytC-tw",
+        "channel_label": "Weeekly",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [],
+        "match_keys": [
+          "channel:uc5rp2rdrspyknj-qlytc-tw",
+          "https://www.youtube.com/channel/uc5rp2rdrspyknj-qlytc-tw"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "WEi",
+    "primary_team_channel_url": "https://www.youtube.com/@wei_Official",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@wei_Official",
+        "channel_label": "WEi",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCbTXWjND2y7zLlSKtHqiwGA",
+          "https://www.youtube.com/@wei_Official"
+        ],
+        "match_keys": [
+          "@wei_official",
+          "https://www.youtube.com/@wei_official",
+          "channel:ucbtxwjnd2y7zllskthqiwga",
+          "https://www.youtube.com/channel/ucbtxwjnd2y7zllskthqiwga"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@wei_Official"
+    ],
+    "mv_allowlist_match_keys": [
+      "@wei_official",
+      "https://www.youtube.com/@wei_official",
+      "channel:ucbtxwjnd2y7zllskthqiwga",
+      "https://www.youtube.com/channel/ucbtxwjnd2y7zllskthqiwga"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@wei_Official",
+        "channel_label": "WEi",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCbTXWjND2y7zLlSKtHqiwGA",
+          "https://www.youtube.com/@wei_Official"
+        ],
+        "match_keys": [
+          "@wei_official",
+          "https://www.youtube.com/@wei_official",
+          "channel:ucbtxwjnd2y7zllskthqiwga",
+          "https://www.youtube.com/channel/ucbtxwjnd2y7zllskthqiwga"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "WHIB",
+    "primary_team_channel_url": "https://www.youtube.com/@WHIB_OFFICIAL",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@WHIB_OFFICIAL",
+        "channel_label": "WHIB",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UC_isDbPZQyyQqXX-POFFPIw",
+          "https://www.youtube.com/@WHIB_OFFICIAL"
+        ],
+        "match_keys": [
+          "@whib_official",
+          "https://www.youtube.com/@whib_official",
+          "channel:uc_isdbpzqyyqqxx-poffpiw",
+          "https://www.youtube.com/channel/uc_isdbpzqyyqqxx-poffpiw"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@WHIB_OFFICIAL"
+    ],
+    "mv_allowlist_match_keys": [
+      "@whib_official",
+      "https://www.youtube.com/@whib_official",
+      "channel:uc_isdbpzqyyqqxx-poffpiw",
+      "https://www.youtube.com/channel/uc_isdbpzqyyqqxx-poffpiw"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@WHIB_OFFICIAL",
+        "channel_label": "WHIB",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UC_isDbPZQyyQqXX-POFFPIw",
+          "https://www.youtube.com/@WHIB_OFFICIAL"
+        ],
+        "match_keys": [
+          "@whib_official",
+          "https://www.youtube.com/@whib_official",
+          "channel:uc_isdbpzqyyqqxx-poffpiw",
+          "https://www.youtube.com/channel/uc_isdbpzqyyqqxx-poffpiw"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "WJSN",
+    "primary_team_channel_url": "https://www.youtube.com/@officialstarship",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@officialstarship",
+        "channel_label": "WJSN",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UC7FAMNhb-BNeNj_6DrtrHCQ",
+          "https://www.youtube.com/@officialstarship"
+        ],
+        "match_keys": [
+          "@officialstarship",
+          "https://www.youtube.com/@officialstarship",
+          "channel:uc7famnhb-bnenj_6drtrhcq",
+          "https://www.youtube.com/channel/uc7famnhb-bnenj_6drtrhcq"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@officialstarship"
+    ],
+    "mv_allowlist_match_keys": [
+      "@officialstarship",
+      "https://www.youtube.com/@officialstarship",
+      "channel:uc7famnhb-bnenj_6drtrhcq",
+      "https://www.youtube.com/channel/uc7famnhb-bnenj_6drtrhcq"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@officialstarship",
+        "channel_label": "WJSN",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UC7FAMNhb-BNeNj_6DrtrHCQ",
+          "https://www.youtube.com/@officialstarship"
+        ],
+        "match_keys": [
+          "@officialstarship",
+          "https://www.youtube.com/@officialstarship",
+          "channel:uc7famnhb-bnenj_6drtrhcq",
+          "https://www.youtube.com/channel/uc7famnhb-bnenj_6drtrhcq"
         ]
       }
     ]
   },
   {
     "group": "woo!ah!",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCNeLbWtlJzTsavMC70zY0dQ",
+    "primary_team_channel_url": "https://www.youtube.com/@wooah_nv",
     "mv_source_channels": [
       {
-        "channel_url": "https://www.youtube.com/channel/UCNeLbWtlJzTsavMC70zY0dQ",
+        "channel_url": "https://www.youtube.com/@wooah_nv",
         "channel_label": "woo!ah!",
         "owner_type": "team",
         "allow_mv_uploads": true,
         "display_in_team_links": true,
         "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCvXlDEplM4rTX01ySkXWcEg",
+          "https://www.youtube.com/@wooah_nv"
+        ],
         "match_keys": [
-          "channel:ucnelbwtljztsavmc70zy0dq",
-          "https://www.youtube.com/channel/ucnelbwtljztsavmc70zy0dq"
+          "@wooah_nv",
+          "https://www.youtube.com/@wooah_nv",
+          "channel:ucvxldeplm4rtx01yskxwceg",
+          "https://www.youtube.com/channel/ucvxldeplm4rtx01yskxwceg"
         ]
       }
     ],
     "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCNeLbWtlJzTsavMC70zY0dQ"
+      "https://www.youtube.com/@wooah_nv"
     ],
     "mv_allowlist_match_keys": [
-      "channel:ucnelbwtljztsavmc70zy0dq",
-      "https://www.youtube.com/channel/ucnelbwtljztsavmc70zy0dq"
+      "@wooah_nv",
+      "https://www.youtube.com/@wooah_nv",
+      "channel:ucvxldeplm4rtx01yskxwceg",
+      "https://www.youtube.com/channel/ucvxldeplm4rtx01yskxwceg"
     ],
     "channels": [
       {
-        "channel_url": "https://www.youtube.com/channel/UCNeLbWtlJzTsavMC70zY0dQ",
+        "channel_url": "https://www.youtube.com/@wooah_nv",
         "channel_label": "woo!ah!",
         "owner_type": "team",
         "allow_mv_uploads": true,
         "display_in_team_links": true,
         "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCvXlDEplM4rTX01ySkXWcEg",
+          "https://www.youtube.com/@wooah_nv"
+        ],
         "match_keys": [
-          "channel:ucnelbwtljztsavmc70zy0dq",
-          "https://www.youtube.com/channel/ucnelbwtljztsavmc70zy0dq"
+          "@wooah_nv",
+          "https://www.youtube.com/@wooah_nv",
+          "channel:ucvxldeplm4rtx01yskxwceg",
+          "https://www.youtube.com/channel/ucvxldeplm4rtx01yskxwceg"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "Xdinary Heroes",
+    "primary_team_channel_url": "https://www.youtube.com/@XH_official",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@XH_official",
+        "channel_label": "Xdinary Heroes",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCQtcaqbl8UpyehCMHaXy-5g",
+          "https://www.youtube.com/@XH_official"
+        ],
+        "match_keys": [
+          "@xh_official",
+          "https://www.youtube.com/@xh_official",
+          "channel:ucqtcaqbl8upyehcmhaxy-5g",
+          "https://www.youtube.com/channel/ucqtcaqbl8upyehcmhaxy-5g"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/@JYPEntertainment",
+        "channel_label": "JYP Entertainment",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCaO6TYtlC8U5ttz62hTrZgg",
+          "https://www.youtube.com/@JYPEntertainment"
+        ],
+        "match_keys": [
+          "@jypentertainment",
+          "https://www.youtube.com/@jypentertainment",
+          "channel:ucao6tytlc8u5ttz62htrzgg",
+          "https://www.youtube.com/channel/ucao6tytlc8u5ttz62htrzgg"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@XH_official",
+      "https://www.youtube.com/@JYPEntertainment"
+    ],
+    "mv_allowlist_match_keys": [
+      "@xh_official",
+      "https://www.youtube.com/@xh_official",
+      "channel:ucqtcaqbl8upyehcmhaxy-5g",
+      "https://www.youtube.com/channel/ucqtcaqbl8upyehcmhaxy-5g",
+      "@jypentertainment",
+      "https://www.youtube.com/@jypentertainment",
+      "channel:ucao6tytlc8u5ttz62htrzgg",
+      "https://www.youtube.com/channel/ucao6tytlc8u5ttz62htrzgg"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@XH_official",
+        "channel_label": "Xdinary Heroes",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCQtcaqbl8UpyehCMHaXy-5g",
+          "https://www.youtube.com/@XH_official"
+        ],
+        "match_keys": [
+          "@xh_official",
+          "https://www.youtube.com/@xh_official",
+          "channel:ucqtcaqbl8upyehcmhaxy-5g",
+          "https://www.youtube.com/channel/ucqtcaqbl8upyehcmhaxy-5g"
+        ]
+      },
+      {
+        "channel_url": "https://www.youtube.com/@JYPEntertainment",
+        "channel_label": "JYP Entertainment",
+        "owner_type": "label",
+        "allow_mv_uploads": true,
+        "display_in_team_links": false,
+        "provenance": "curated_agency_allowlist",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCaO6TYtlC8U5ttz62hTrZgg",
+          "https://www.youtube.com/@JYPEntertainment"
+        ],
+        "match_keys": [
+          "@jypentertainment",
+          "https://www.youtube.com/@jypentertainment",
+          "channel:ucao6tytlc8u5ttz62htrzgg",
+          "https://www.youtube.com/channel/ucao6tytlc8u5ttz62htrzgg"
         ]
       }
     ]
   },
   {
     "group": "xikers",
-    "primary_team_channel_url": "https://www.youtube.com/channel/UCPtC0MXSW40Qq7RkhsCXjUQ",
+    "primary_team_channel_url": "https://www.youtube.com/@xikers_official",
     "mv_source_channels": [
       {
-        "channel_url": "https://www.youtube.com/channel/UCPtC0MXSW40Qq7RkhsCXjUQ",
+        "channel_url": "https://www.youtube.com/@xikers_official",
         "channel_label": "xikers",
         "owner_type": "team",
         "allow_mv_uploads": true,
         "display_in_team_links": true,
         "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCPtC0MXSW40Qq7RkhsCXjUQ",
+          "https://www.youtube.com/@xikers_official"
+        ],
         "match_keys": [
+          "@xikers_official",
+          "https://www.youtube.com/@xikers_official",
           "channel:ucptc0mxsw40qq7rkhscxjuq",
           "https://www.youtube.com/channel/ucptc0mxsw40qq7rkhscxjuq"
         ]
       }
     ],
     "mv_allowlist_urls": [
-      "https://www.youtube.com/channel/UCPtC0MXSW40Qq7RkhsCXjUQ"
+      "https://www.youtube.com/@xikers_official"
     ],
     "mv_allowlist_match_keys": [
+      "@xikers_official",
+      "https://www.youtube.com/@xikers_official",
       "channel:ucptc0mxsw40qq7rkhscxjuq",
       "https://www.youtube.com/channel/ucptc0mxsw40qq7rkhscxjuq"
     ],
     "channels": [
       {
-        "channel_url": "https://www.youtube.com/channel/UCPtC0MXSW40Qq7RkhsCXjUQ",
+        "channel_url": "https://www.youtube.com/@xikers_official",
         "channel_label": "xikers",
         "owner_type": "team",
         "allow_mv_uploads": true,
         "display_in_team_links": true,
         "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCPtC0MXSW40Qq7RkhsCXjUQ",
+          "https://www.youtube.com/@xikers_official"
+        ],
         "match_keys": [
+          "@xikers_official",
+          "https://www.youtube.com/@xikers_official",
           "channel:ucptc0mxsw40qq7rkhscxjuq",
           "https://www.youtube.com/channel/ucptc0mxsw40qq7rkhscxjuq"
         ]
@@ -4450,9 +6897,15 @@
         "allow_mv_uploads": true,
         "display_in_team_links": true,
         "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCHWhn9xw7x8NPPnV6eWQDQA",
+          "https://www.youtube.com/@XLOV_official"
+        ],
         "match_keys": [
           "@xlov_official",
-          "https://www.youtube.com/@xlov_official"
+          "https://www.youtube.com/@xlov_official",
+          "channel:uchwhn9xw7x8nppnv6ewqdqa",
+          "https://www.youtube.com/channel/uchwhn9xw7x8nppnv6ewqdqa"
         ]
       }
     ],
@@ -4461,7 +6914,9 @@
     ],
     "mv_allowlist_match_keys": [
       "@xlov_official",
-      "https://www.youtube.com/@xlov_official"
+      "https://www.youtube.com/@xlov_official",
+      "channel:uchwhn9xw7x8nppnv6ewqdqa",
+      "https://www.youtube.com/channel/uchwhn9xw7x8nppnv6ewqdqa"
     ],
     "channels": [
       {
@@ -4471,48 +6926,333 @@
         "allow_mv_uploads": true,
         "display_in_team_links": true,
         "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCHWhn9xw7x8NPPnV6eWQDQA",
+          "https://www.youtube.com/@XLOV_official"
+        ],
         "match_keys": [
           "@xlov_official",
-          "https://www.youtube.com/@xlov_official"
+          "https://www.youtube.com/@xlov_official",
+          "channel:uchwhn9xw7x8nppnv6ewqdqa",
+          "https://www.youtube.com/channel/uchwhn9xw7x8nppnv6ewqdqa"
         ]
       }
     ]
   },
   {
     "group": "YENA",
-    "primary_team_channel_url": "https://www.youtube.com/@yena_official",
+    "primary_team_channel_url": "https://www.youtube.com/@YENA_OFFICIAL",
     "mv_source_channels": [
       {
-        "channel_url": "https://www.youtube.com/@yena_official",
+        "channel_url": "https://www.youtube.com/@YENA_OFFICIAL",
         "channel_label": "YENA",
         "owner_type": "team",
         "allow_mv_uploads": true,
         "display_in_team_links": true,
         "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCkrDEGNM3mqZXHk2MfnOjMw",
+          "https://www.youtube.com/@YENA_OFFICIAL"
+        ],
         "match_keys": [
           "@yena_official",
-          "https://www.youtube.com/@yena_official"
+          "https://www.youtube.com/@yena_official",
+          "channel:uckrdegnm3mqzxhk2mfnojmw",
+          "https://www.youtube.com/channel/uckrdegnm3mqzxhk2mfnojmw"
         ]
       }
     ],
     "mv_allowlist_urls": [
-      "https://www.youtube.com/@yena_official"
+      "https://www.youtube.com/@YENA_OFFICIAL"
     ],
     "mv_allowlist_match_keys": [
       "@yena_official",
-      "https://www.youtube.com/@yena_official"
+      "https://www.youtube.com/@yena_official",
+      "channel:uckrdegnm3mqzxhk2mfnojmw",
+      "https://www.youtube.com/channel/uckrdegnm3mqzxhk2mfnojmw"
     ],
     "channels": [
       {
-        "channel_url": "https://www.youtube.com/@yena_official",
+        "channel_url": "https://www.youtube.com/@YENA_OFFICIAL",
         "channel_label": "YENA",
         "owner_type": "team",
         "allow_mv_uploads": true,
         "display_in_team_links": true,
         "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCkrDEGNM3mqZXHk2MfnOjMw",
+          "https://www.youtube.com/@YENA_OFFICIAL"
+        ],
         "match_keys": [
           "@yena_official",
-          "https://www.youtube.com/@yena_official"
+          "https://www.youtube.com/@yena_official",
+          "channel:uckrdegnm3mqzxhk2mfnojmw",
+          "https://www.youtube.com/channel/uckrdegnm3mqzxhk2mfnojmw"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "YOUNG POSSE",
+    "primary_team_channel_url": "https://www.youtube.com/@YOUNGPOSSEUP",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@YOUNGPOSSEUP",
+        "channel_label": "YOUNG POSSE",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCYvGSZPvQj09LgpcziCszyA",
+          "https://www.youtube.com/@YOUNGPOSSEUP"
+        ],
+        "match_keys": [
+          "@youngposseup",
+          "https://www.youtube.com/@youngposseup",
+          "channel:ucyvgszpvqj09lgpczicszya",
+          "https://www.youtube.com/channel/ucyvgszpvqj09lgpczicszya"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@YOUNGPOSSEUP"
+    ],
+    "mv_allowlist_match_keys": [
+      "@youngposseup",
+      "https://www.youtube.com/@youngposseup",
+      "channel:ucyvgszpvqj09lgpczicszya",
+      "https://www.youtube.com/channel/ucyvgszpvqj09lgpczicszya"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@YOUNGPOSSEUP",
+        "channel_label": "YOUNG POSSE",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCYvGSZPvQj09LgpcziCszyA",
+          "https://www.youtube.com/@YOUNGPOSSEUP"
+        ],
+        "match_keys": [
+          "@youngposseup",
+          "https://www.youtube.com/@youngposseup",
+          "channel:ucyvgszpvqj09lgpczicszya",
+          "https://www.youtube.com/channel/ucyvgszpvqj09lgpczicszya"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "YOUNITE",
+    "primary_team_channel_url": "https://www.youtube.com/@Younite",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@Younite",
+        "channel_label": "YOUNITE",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCtBLjxlnFpzt7Jvl_0aA7lw",
+          "https://www.youtube.com/@Younite"
+        ],
+        "match_keys": [
+          "@younite",
+          "https://www.youtube.com/@younite",
+          "channel:uctbljxlnfpzt7jvl_0aa7lw",
+          "https://www.youtube.com/channel/uctbljxlnfpzt7jvl_0aa7lw"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@Younite"
+    ],
+    "mv_allowlist_match_keys": [
+      "@younite",
+      "https://www.youtube.com/@younite",
+      "channel:uctbljxlnfpzt7jvl_0aa7lw",
+      "https://www.youtube.com/channel/uctbljxlnfpzt7jvl_0aa7lw"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@Younite",
+        "channel_label": "YOUNITE",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCtBLjxlnFpzt7Jvl_0aA7lw",
+          "https://www.youtube.com/@Younite"
+        ],
+        "match_keys": [
+          "@younite",
+          "https://www.youtube.com/@younite",
+          "channel:uctbljxlnfpzt7jvl_0aa7lw",
+          "https://www.youtube.com/channel/uctbljxlnfpzt7jvl_0aa7lw"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "YUJU",
+    "primary_team_channel_url": "https://www.youtube.com/@Yujuofficial",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@Yujuofficial",
+        "channel_label": "YUJU",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCt7Nlt3vXkz-NTyou5Kqp6w",
+          "https://www.youtube.com/@Yujuofficial"
+        ],
+        "match_keys": [
+          "@yujuofficial",
+          "https://www.youtube.com/@yujuofficial",
+          "channel:uct7nlt3vxkz-ntyou5kqp6w",
+          "https://www.youtube.com/channel/uct7nlt3vxkz-ntyou5kqp6w"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@Yujuofficial"
+    ],
+    "mv_allowlist_match_keys": [
+      "@yujuofficial",
+      "https://www.youtube.com/@yujuofficial",
+      "channel:uct7nlt3vxkz-ntyou5kqp6w",
+      "https://www.youtube.com/channel/uct7nlt3vxkz-ntyou5kqp6w"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@Yujuofficial",
+        "channel_label": "YUJU",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCt7Nlt3vXkz-NTyou5Kqp6w",
+          "https://www.youtube.com/@Yujuofficial"
+        ],
+        "match_keys": [
+          "@yujuofficial",
+          "https://www.youtube.com/@yujuofficial",
+          "channel:uct7nlt3vxkz-ntyou5kqp6w",
+          "https://www.youtube.com/channel/uct7nlt3vxkz-ntyou5kqp6w"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "Yves",
+    "primary_team_channel_url": "https://www.youtube.com/@YVES_OFFICIAL",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@YVES_OFFICIAL",
+        "channel_label": "Yves",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCMuK2QPg9oFJ1-veMCw3Irg",
+          "https://www.youtube.com/@YVES_OFFICIAL"
+        ],
+        "match_keys": [
+          "@yves_official",
+          "https://www.youtube.com/@yves_official",
+          "channel:ucmuk2qpg9ofj1-vemcw3irg",
+          "https://www.youtube.com/channel/ucmuk2qpg9ofj1-vemcw3irg"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@YVES_OFFICIAL"
+    ],
+    "mv_allowlist_match_keys": [
+      "@yves_official",
+      "https://www.youtube.com/@yves_official",
+      "channel:ucmuk2qpg9ofj1-vemcw3irg",
+      "https://www.youtube.com/channel/ucmuk2qpg9ofj1-vemcw3irg"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@YVES_OFFICIAL",
+        "channel_label": "Yves",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCMuK2QPg9oFJ1-veMCw3Irg",
+          "https://www.youtube.com/@YVES_OFFICIAL"
+        ],
+        "match_keys": [
+          "@yves_official",
+          "https://www.youtube.com/@yves_official",
+          "channel:ucmuk2qpg9ofj1-vemcw3irg",
+          "https://www.youtube.com/channel/ucmuk2qpg9ofj1-vemcw3irg"
+        ]
+      }
+    ]
+  },
+  {
+    "group": "ZEROBASEONE",
+    "primary_team_channel_url": "https://www.youtube.com/@ZB1_official",
+    "mv_source_channels": [
+      {
+        "channel_url": "https://www.youtube.com/@ZB1_official",
+        "channel_label": "ZEROBASEONE",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCSAp0Yl9S0Zq5uDqE6im_XQ",
+          "https://www.youtube.com/@ZB1_official"
+        ],
+        "match_keys": [
+          "@zb1_official",
+          "https://www.youtube.com/@zb1_official",
+          "channel:ucsap0yl9s0zq5udqe6im_xq",
+          "https://www.youtube.com/channel/ucsap0yl9s0zq5udqe6im_xq"
+        ]
+      }
+    ],
+    "mv_allowlist_urls": [
+      "https://www.youtube.com/@ZB1_official"
+    ],
+    "mv_allowlist_match_keys": [
+      "@zb1_official",
+      "https://www.youtube.com/@zb1_official",
+      "channel:ucsap0yl9s0zq5udqe6im_xq",
+      "https://www.youtube.com/channel/ucsap0yl9s0zq5udqe6im_xq"
+    ],
+    "channels": [
+      {
+        "channel_url": "https://www.youtube.com/@ZB1_official",
+        "channel_label": "ZEROBASEONE",
+        "owner_type": "team",
+        "allow_mv_uploads": true,
+        "display_in_team_links": true,
+        "provenance": "artistProfiles.official_youtube_url",
+        "resolved_alias_urls": [
+          "https://www.youtube.com/channel/UCSAp0Yl9S0Zq5uDqE6im_XQ",
+          "https://www.youtube.com/@ZB1_official"
+        ],
+        "match_keys": [
+          "@zb1_official",
+          "https://www.youtube.com/@zb1_official",
+          "channel:ucsap0yl9s0zq5udqe6im_xq",
+          "https://www.youtube.com/channel/ucsap0yl9s0zq5udqe6im_xq"
         ]
       }
     ]

--- a/youtube_channel_allowlists.py
+++ b/youtube_channel_allowlists.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import re
+import urllib.request
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
@@ -11,6 +13,14 @@ from urllib.parse import urlparse
 ROOT = Path(__file__).resolve().parent
 PROFILES_PATH = ROOT / "web/src/data/artistProfiles.json"
 OUTPUT_PATH = ROOT / "web/src/data/youtubeChannelAllowlists.json"
+USER_AGENT = "Mozilla/5.0"
+REQUEST_TIMEOUT_SECONDS = 15
+YOUTUBE_CHANNEL_ID_PATTERNS = (
+    re.compile(r'"channelId":"(UC[\w-]{20,})"'),
+    re.compile(r'"externalId":"(UC[\w-]{20,})"'),
+    re.compile(r'"browseId":"(UC[\w-]{20,})"'),
+)
+YOUTUBE_CANONICAL_BASE_PATTERN = re.compile(r'"canonicalBaseUrl":"([^"]+)"')
 
 AGENCY_MV_CHANNELS: dict[str, dict[str, str]] = {
     "HYBE Labels": {
@@ -133,13 +143,74 @@ def extract_youtube_channel_match_keys(channel_url: str) -> list[str]:
     return deduped
 
 
+def fetch_text(url: str) -> str:
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    with urllib.request.urlopen(request, timeout=REQUEST_TIMEOUT_SECONDS) as response:
+        return response.read().decode("utf-8", "ignore")
+
+
+def extract_youtube_channel_alias_urls(html: str) -> list[str]:
+    aliases: list[str] = []
+
+    for pattern in YOUTUBE_CHANNEL_ID_PATTERNS:
+        channel_id_match = pattern.search(html)
+        if channel_id_match:
+            aliases.append(f"https://www.youtube.com/channel/{channel_id_match.group(1)}")
+            break
+
+    canonical_match = YOUTUBE_CANONICAL_BASE_PATTERN.search(html)
+    if canonical_match:
+        canonical_path = canonical_match.group(1)
+        if canonical_path.startswith(("/@", "/channel/")):
+            aliases.append(f"https://www.youtube.com{canonical_path}")
+
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for alias in aliases:
+        normalized = alias.rstrip("/")
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        deduped.append(normalized)
+    return deduped
+
+
+def resolve_youtube_channel_alias_urls(
+    channel_url: str,
+    fetcher: Any = fetch_text,
+) -> list[str]:
+    parsed = urlparse(channel_url)
+    if "youtube.com" not in parsed.netloc.lower():
+        return []
+
+    path = parsed.path.strip("/")
+    if not path or path.startswith("channel/"):
+        return []
+
+    try:
+        html = fetcher(channel_url)
+    except Exception:  # noqa: BLE001
+        return []
+    return extract_youtube_channel_alias_urls(html)
+
+
 def build_source(
     channel_url: str,
     channel_label: str,
     owner_type: str,
     display_in_team_links: bool,
     provenance: str,
+    fetcher: Any = fetch_text,
 ) -> dict[str, Any]:
+    alias_urls = resolve_youtube_channel_alias_urls(channel_url, fetcher=fetcher)
+    match_keys = dedupe_strings(
+        extract_youtube_channel_match_keys(channel_url)
+        + [
+            match_key
+            for alias_url in alias_urls
+            for match_key in extract_youtube_channel_match_keys(alias_url)
+        ]
+    )
     return {
         "channel_url": channel_url,
         "channel_label": channel_label,
@@ -147,7 +218,8 @@ def build_source(
         "allow_mv_uploads": True,
         "display_in_team_links": display_in_team_links,
         "provenance": provenance,
-        "match_keys": extract_youtube_channel_match_keys(channel_url),
+        "resolved_alias_urls": alias_urls,
+        "match_keys": match_keys,
     }
 
 


### PR DESCRIPTION
## Summary
- resolve extra YouTube allowlist match keys from official handle pages and watch-page fallback
- add track-aware MV/title-track search for unresolved album/EP rows with dependable tracklists
- add scoped cohort filtering and regression tests for the new backfill paths

Closes #646