### PR TITLE
feat: make web calendar and radar api-native

### DIFF
--- a/backend/sql/migrations/0011_calendar_radar_api_native_payloads.sql
+++ b/backend/sql/migrations/0011_calendar_radar_api_native_payloads.sql
@@ -1,0 +1,756 @@
+drop materialized view if exists radar_projection;
+drop materialized view if exists calendar_month_projection;
+
+create materialized view calendar_month_projection as
+with current_clock as (
+  select
+    timezone('Asia/Seoul', now())::date as current_date_kst,
+    date_trunc('month', timezone('Asia/Seoul', now()))::date as current_month_kst
+),
+all_months as (
+  select date_trunc('month', r.release_date::timestamp)::date as month_start
+  from releases r
+  union
+  select date_trunc('month', u.scheduled_date::timestamp)::date
+  from upcoming_signals u
+  where u.is_active = true and u.date_precision = 'exact' and u.scheduled_date is not null
+  union
+  select u.scheduled_month
+  from upcoming_signals u
+  where u.is_active = true and u.date_precision = 'month_only' and u.scheduled_month is not null
+),
+month_bounds as (
+  select
+    coalesce(min(all_months.month_start), min(current_clock.current_month_kst)) as min_month,
+    coalesce(max(all_months.month_start), min(current_clock.current_month_kst)) as max_month
+  from all_months
+  cross join current_clock
+),
+month_keys as (
+  select generate_series(month_bounds.min_month, month_bounds.max_month, interval '1 month')::date as month_start
+  from month_bounds
+),
+upcoming_source_choice as (
+  select distinct on (uss.upcoming_signal_id)
+    uss.upcoming_signal_id,
+    uss.source_type,
+    uss.source_url,
+    uss.source_domain,
+    uss.evidence_summary,
+    count(*) over (partition by uss.upcoming_signal_id) as source_count
+  from upcoming_signal_sources uss
+  order by
+    uss.upcoming_signal_id,
+    case uss.source_type
+      when 'agency_notice' then 0
+      when 'weverse_notice' then 1
+      when 'official_social' then 2
+      when 'news_rss' then 3
+      else 4
+    end,
+    uss.published_at desc nulls last,
+    uss.source_url asc
+),
+nearest_upcoming as (
+  select
+    u.id as upcoming_signal_id,
+    e.slug as entity_slug,
+    e.display_name,
+    e.entity_type,
+    e.agency_name,
+    coalesce(u.tracking_status, ets.tracking_status) as tracking_status,
+    u.scheduled_date,
+    to_char(date_trunc('month', u.scheduled_date::timestamp)::date, 'YYYY-MM') as scheduled_month,
+    u.date_precision,
+    u.date_status,
+    u.headline,
+    u.confidence_score,
+    u.release_format,
+    usc.source_url,
+    usc.source_type,
+    usc.source_domain,
+    usc.evidence_summary,
+    usc.source_count
+  from upcoming_signals u
+  join entities e on e.id = u.entity_id
+  left join entity_tracking_state ets on ets.entity_id = u.entity_id
+  left join upcoming_source_choice usc on usc.upcoming_signal_id = u.id
+  cross join current_clock
+  where
+    u.is_active = true
+    and u.date_precision = 'exact'
+    and u.scheduled_date >= current_clock.current_date_kst
+  order by
+    u.scheduled_date asc,
+    case u.date_status when 'confirmed' then 0 when 'scheduled' then 1 else 2 end,
+    u.confidence_score desc nulls last,
+    e.display_name asc,
+    u.id
+  limit 1
+)
+select
+  month_keys.month_start,
+  to_char(month_keys.month_start, 'YYYY-MM') as month_key,
+  jsonb_build_object(
+    'summary', jsonb_build_object(
+      'verified_count', (
+        select count(*)
+        from releases r
+        where date_trunc('month', r.release_date::timestamp)::date = month_keys.month_start
+      ),
+      'exact_upcoming_count', (
+        select count(*)
+        from upcoming_signals u
+        where
+          u.is_active = true
+          and u.date_precision = 'exact'
+          and date_trunc('month', u.scheduled_date::timestamp)::date = month_keys.month_start
+      ),
+      'month_only_upcoming_count', (
+        select count(*)
+        from upcoming_signals u
+        where
+          u.is_active = true
+          and u.date_precision = 'month_only'
+          and u.scheduled_month = month_keys.month_start
+      )
+    ),
+    'nearest_upcoming', (
+      select case
+        when nearest_upcoming.upcoming_signal_id is null then null
+        else jsonb_build_object(
+          'upcoming_signal_id', nearest_upcoming.upcoming_signal_id::text,
+          'entity_slug', nearest_upcoming.entity_slug,
+          'display_name', nearest_upcoming.display_name,
+          'entity_type', nearest_upcoming.entity_type,
+          'agency_name', nearest_upcoming.agency_name,
+          'tracking_status', nearest_upcoming.tracking_status,
+          'headline', nearest_upcoming.headline,
+          'scheduled_date', nearest_upcoming.scheduled_date::text,
+          'scheduled_month', nearest_upcoming.scheduled_month,
+          'date_precision', nearest_upcoming.date_precision,
+          'date_status', nearest_upcoming.date_status,
+          'confidence_score', nearest_upcoming.confidence_score,
+          'release_format', nearest_upcoming.release_format,
+          'source_url', nearest_upcoming.source_url,
+          'source_type', nearest_upcoming.source_type,
+          'source_domain', nearest_upcoming.source_domain,
+          'evidence_summary', nearest_upcoming.evidence_summary,
+          'source_count', nearest_upcoming.source_count
+        )
+      end
+      from nearest_upcoming
+    ),
+    'days', (
+      select coalesce(
+        jsonb_agg(
+          jsonb_build_object(
+            'date', day_bucket.day_date::text,
+            'verified_releases', day_bucket.verified_releases,
+            'exact_upcoming', day_bucket.exact_upcoming
+          )
+          order by day_bucket.day_date
+        ),
+        '[]'::jsonb
+      )
+      from (
+        select
+          day_keys.day_date,
+          (
+            select coalesce(
+              jsonb_agg(
+                jsonb_build_object(
+                  'release_id', r.id::text,
+                  'entity_slug', e.slug,
+                  'display_name', e.display_name,
+                  'entity_type', e.entity_type,
+                  'agency_name', e.agency_name,
+                  'release_title', r.release_title,
+                  'release_date', r.release_date::text,
+                  'stream', r.stream,
+                  'release_kind', r.release_kind,
+                  'release_format', r.release_format,
+                  'source_url', r.source_url,
+                  'artist_source_url', r.artist_source_url
+                )
+                order by e.display_name asc, r.release_title asc
+              ),
+              '[]'::jsonb
+            )
+            from releases r
+            join entities e on e.id = r.entity_id
+            where r.release_date = day_keys.day_date
+          ) as verified_releases,
+          (
+            select coalesce(
+              jsonb_agg(
+                jsonb_build_object(
+                  'upcoming_signal_id', u.id::text,
+                  'entity_slug', e.slug,
+                  'display_name', e.display_name,
+                  'entity_type', e.entity_type,
+                  'agency_name', e.agency_name,
+                  'tracking_status', coalesce(u.tracking_status, ets.tracking_status),
+                  'headline', u.headline,
+                  'scheduled_date', u.scheduled_date::text,
+                  'scheduled_month', to_char(date_trunc('month', u.scheduled_date::timestamp)::date, 'YYYY-MM'),
+                  'date_precision', u.date_precision,
+                  'date_status', u.date_status,
+                  'confidence_score', u.confidence_score,
+                  'release_format', u.release_format,
+                  'source_url', usc.source_url,
+                  'source_type', usc.source_type,
+                  'source_domain', usc.source_domain,
+                  'evidence_summary', usc.evidence_summary,
+                  'source_count', usc.source_count
+                )
+                order by
+                  u.scheduled_date asc,
+                  case u.date_status when 'confirmed' then 0 when 'scheduled' then 1 else 2 end,
+                  u.confidence_score desc nulls last,
+                  e.display_name asc,
+                  u.headline asc
+              ),
+              '[]'::jsonb
+            )
+            from upcoming_signals u
+            join entities e on e.id = u.entity_id
+            left join entity_tracking_state ets on ets.entity_id = u.entity_id
+            left join upcoming_source_choice usc on usc.upcoming_signal_id = u.id
+            where
+              u.is_active = true
+              and u.date_precision = 'exact'
+              and u.scheduled_date = day_keys.day_date
+          ) as exact_upcoming
+        from (
+          select distinct day_date
+          from (
+            select r.release_date as day_date
+            from releases r
+            where date_trunc('month', r.release_date::timestamp)::date = month_keys.month_start
+            union
+            select u.scheduled_date as day_date
+            from upcoming_signals u
+            where
+              u.is_active = true
+              and u.date_precision = 'exact'
+              and date_trunc('month', u.scheduled_date::timestamp)::date = month_keys.month_start
+          ) raw_days
+        ) day_keys
+      ) day_bucket
+    ),
+    'month_only_upcoming', (
+      select coalesce(
+        jsonb_agg(
+          jsonb_build_object(
+            'upcoming_signal_id', u.id::text,
+            'entity_slug', e.slug,
+            'display_name', e.display_name,
+            'entity_type', e.entity_type,
+            'agency_name', e.agency_name,
+            'tracking_status', coalesce(u.tracking_status, ets.tracking_status),
+            'headline', u.headline,
+            'scheduled_date', null,
+            'scheduled_month', to_char(u.scheduled_month, 'YYYY-MM'),
+            'date_precision', u.date_precision,
+            'date_status', u.date_status,
+            'confidence_score', u.confidence_score,
+            'release_format', u.release_format,
+            'source_url', usc.source_url,
+            'source_type', usc.source_type,
+            'source_domain', usc.source_domain,
+            'evidence_summary', usc.evidence_summary,
+            'source_count', usc.source_count
+          )
+          order by
+            case u.date_status when 'confirmed' then 0 when 'scheduled' then 1 else 2 end,
+            u.confidence_score desc nulls last,
+            e.display_name asc,
+            u.headline asc
+        ),
+        '[]'::jsonb
+      )
+      from upcoming_signals u
+      join entities e on e.id = u.entity_id
+      left join entity_tracking_state ets on ets.entity_id = u.entity_id
+      left join upcoming_source_choice usc on usc.upcoming_signal_id = u.id
+      where
+        u.is_active = true
+        and u.date_precision = 'month_only'
+        and u.scheduled_month = month_keys.month_start
+    ),
+    'verified_list', (
+      select coalesce(
+        jsonb_agg(
+          jsonb_build_object(
+            'release_id', r.id::text,
+            'entity_slug', e.slug,
+            'display_name', e.display_name,
+            'entity_type', e.entity_type,
+            'agency_name', e.agency_name,
+            'release_title', r.release_title,
+            'release_date', r.release_date::text,
+            'stream', r.stream,
+            'release_kind', r.release_kind,
+            'release_format', r.release_format,
+            'source_url', r.source_url,
+            'artist_source_url', r.artist_source_url
+          )
+          order by r.release_date asc, e.display_name asc, r.release_title asc
+        ),
+        '[]'::jsonb
+      )
+      from releases r
+      join entities e on e.id = r.entity_id
+      where date_trunc('month', r.release_date::timestamp)::date = month_keys.month_start
+    ),
+    'scheduled_list', (
+      select coalesce(
+        jsonb_agg(
+          jsonb_build_object(
+            'upcoming_signal_id', u.id::text,
+            'entity_slug', e.slug,
+            'display_name', e.display_name,
+            'entity_type', e.entity_type,
+            'agency_name', e.agency_name,
+            'tracking_status', coalesce(u.tracking_status, ets.tracking_status),
+            'headline', u.headline,
+            'scheduled_date', u.scheduled_date::text,
+            'scheduled_month', to_char(coalesce(date_trunc('month', u.scheduled_date::timestamp)::date, u.scheduled_month), 'YYYY-MM'),
+            'date_precision', u.date_precision,
+            'date_status', u.date_status,
+            'confidence_score', u.confidence_score,
+            'release_format', u.release_format,
+            'source_url', usc.source_url,
+            'source_type', usc.source_type,
+            'source_domain', usc.source_domain,
+            'evidence_summary', usc.evidence_summary,
+            'source_count', usc.source_count
+          )
+          order by
+            case when u.date_precision = 'exact' then 0 when u.date_precision = 'month_only' then 1 else 2 end,
+            coalesce(u.scheduled_date, u.scheduled_month) asc,
+            case u.date_status when 'confirmed' then 0 when 'scheduled' then 1 else 2 end,
+            u.confidence_score desc nulls last,
+            e.display_name asc,
+            u.headline asc
+        ),
+        '[]'::jsonb
+      )
+      from upcoming_signals u
+      join entities e on e.id = u.entity_id
+      left join entity_tracking_state ets on ets.entity_id = u.entity_id
+      left join upcoming_source_choice usc on usc.upcoming_signal_id = u.id
+      where
+        u.is_active = true
+        and (
+          (u.date_precision = 'exact' and date_trunc('month', u.scheduled_date::timestamp)::date = month_keys.month_start)
+          or (u.date_precision = 'month_only' and u.scheduled_month = month_keys.month_start)
+        )
+    )
+  ) as payload,
+  now() as generated_at
+from month_keys
+with no data;
+
+create unique index if not exists idx_calendar_month_projection_month_start
+  on calendar_month_projection (month_start);
+
+create unique index if not exists idx_calendar_month_projection_month_key
+  on calendar_month_projection (month_key);
+
+create materialized view radar_projection as
+with current_clock as (
+  select
+    timezone('Asia/Seoul', now())::date as current_date_kst,
+    extract(year from timezone('Asia/Seoul', now()))::integer as current_year_kst
+),
+upcoming_source_choice as (
+  select distinct on (uss.upcoming_signal_id)
+    uss.upcoming_signal_id,
+    uss.source_type,
+    uss.source_url,
+    uss.source_domain,
+    uss.evidence_summary,
+    count(*) over (partition by uss.upcoming_signal_id) as source_count
+  from upcoming_signal_sources uss
+  order by
+    uss.upcoming_signal_id,
+    case uss.source_type
+      when 'agency_notice' then 0
+      when 'weverse_notice' then 1
+      when 'official_social' then 2
+      when 'news_rss' then 3
+      else 4
+    end,
+    uss.published_at desc nulls last,
+    uss.source_url asc
+),
+latest_release as (
+  select distinct on (r.entity_id)
+    r.entity_id,
+    r.id as release_id,
+    r.release_title,
+    r.release_date,
+    r.stream,
+    r.release_kind,
+    r.release_format,
+    r.source_url,
+    r.artist_source_url
+  from releases r
+  order by
+    r.entity_id,
+    r.release_date desc,
+    case when r.stream = 'album' then 0 else 1 end,
+    r.release_title asc
+),
+latest_signal as (
+  select distinct on (u.entity_id)
+    u.entity_id,
+    u.id as upcoming_signal_id,
+    u.headline,
+    u.scheduled_date,
+    u.scheduled_month,
+    u.date_precision,
+    u.date_status,
+    u.release_format,
+    u.confidence_score,
+    coalesce(u.tracking_status, ets.tracking_status) as tracking_status,
+    u.latest_seen_at,
+    u.first_seen_at,
+    usc.source_url,
+    usc.source_type,
+    usc.source_domain,
+    usc.evidence_summary,
+    usc.source_count
+  from upcoming_signals u
+  left join entity_tracking_state ets on ets.entity_id = u.entity_id
+  left join upcoming_source_choice usc on usc.upcoming_signal_id = u.id
+  where u.is_active = true
+  order by
+    u.entity_id,
+    coalesce(u.latest_seen_at, u.first_seen_at) desc nulls last,
+    u.confidence_score desc nulls last,
+    u.headline asc
+),
+featured_upcoming as (
+  select
+    u.id as upcoming_signal_id,
+    e.slug as entity_slug,
+    e.display_name,
+    e.entity_type,
+    e.agency_name,
+    coalesce(u.tracking_status, ets.tracking_status) as tracking_status,
+    u.headline,
+    u.scheduled_date,
+    to_char(date_trunc('month', u.scheduled_date::timestamp)::date, 'YYYY-MM') as scheduled_month,
+    u.date_precision,
+    u.date_status,
+    u.confidence_score,
+    u.release_format,
+    usc.source_url,
+    usc.source_type,
+    usc.source_domain,
+    usc.evidence_summary,
+    usc.source_count
+  from upcoming_signals u
+  join entities e on e.id = u.entity_id
+  left join entity_tracking_state ets on ets.entity_id = u.entity_id
+  left join upcoming_source_choice usc on usc.upcoming_signal_id = u.id
+  cross join current_clock
+  where
+    u.is_active = true
+    and u.date_precision = 'exact'
+    and u.scheduled_date >= current_clock.current_date_kst
+  order by
+    u.scheduled_date asc,
+    case u.date_status when 'confirmed' then 0 when 'scheduled' then 1 else 2 end,
+    u.confidence_score desc nulls last,
+    e.display_name asc,
+    u.headline asc
+  limit 1
+),
+weekly_upcoming as (
+  select coalesce(
+    jsonb_agg(
+      jsonb_build_object(
+        'upcoming_signal_id', u.id::text,
+        'entity_slug', e.slug,
+        'display_name', e.display_name,
+        'entity_type', e.entity_type,
+        'agency_name', e.agency_name,
+        'tracking_status', coalesce(u.tracking_status, ets.tracking_status),
+        'headline', u.headline,
+        'scheduled_date', u.scheduled_date::text,
+        'scheduled_month', to_char(date_trunc('month', u.scheduled_date::timestamp)::date, 'YYYY-MM'),
+        'date_precision', u.date_precision,
+        'date_status', u.date_status,
+        'confidence_score', u.confidence_score,
+        'release_format', u.release_format,
+        'source_url', usc.source_url,
+        'source_type', usc.source_type,
+        'source_domain', usc.source_domain,
+        'evidence_summary', usc.evidence_summary,
+        'source_count', usc.source_count
+      )
+      order by
+        u.scheduled_date asc,
+        case u.date_status when 'confirmed' then 0 when 'scheduled' then 1 else 2 end,
+        u.confidence_score desc nulls last,
+        e.display_name asc,
+        u.headline asc
+    ),
+    '[]'::jsonb
+  ) as payload
+  from upcoming_signals u
+  join entities e on e.id = u.entity_id
+  left join entity_tracking_state ets on ets.entity_id = u.entity_id
+  left join upcoming_source_choice usc on usc.upcoming_signal_id = u.id
+  cross join current_clock
+  where
+    u.is_active = true
+    and u.date_precision = 'exact'
+    and u.scheduled_date >= current_clock.current_date_kst
+    and u.scheduled_date <= current_clock.current_date_kst + 7
+),
+change_feed as (
+  select coalesce(
+    jsonb_agg(feed.payload order by feed.sort_at desc, feed.display_name asc) filter (where feed.feed_rank <= 20),
+    '[]'::jsonb
+  ) as payload
+  from (
+    select
+      feed_rows.*,
+      row_number() over (order by feed_rows.sort_at desc, feed_rows.display_name asc) as feed_rank
+    from (
+      select
+        r.updated_at as sort_at,
+        e.display_name,
+        jsonb_build_object(
+          'kind', 'verified_release',
+          'entity_slug', e.slug,
+          'display_name', e.display_name,
+          'release_id', r.id::text,
+          'release_title', r.release_title,
+          'release_date', r.release_date::text,
+          'stream', r.stream,
+          'release_kind', r.release_kind,
+          'occurred_at', r.updated_at
+        ) as payload
+      from releases r
+      join entities e on e.id = r.entity_id
+      cross join current_clock
+      where r.release_date >= current_clock.current_date_kst - 30
+
+      union all
+
+      select
+        coalesce(u.latest_seen_at, u.first_seen_at, now()) as sort_at,
+        e.display_name,
+        jsonb_build_object(
+          'kind', 'upcoming_signal',
+          'entity_slug', e.slug,
+          'display_name', e.display_name,
+          'upcoming_signal_id', u.id::text,
+          'headline', u.headline,
+          'scheduled_date', u.scheduled_date::text,
+          'scheduled_month', u.scheduled_month::text,
+          'date_precision', u.date_precision,
+          'date_status', u.date_status,
+          'confidence_score', u.confidence_score,
+          'occurred_at', coalesce(u.latest_seen_at, u.first_seen_at)
+        ) as payload
+      from upcoming_signals u
+      join entities e on e.id = u.entity_id
+      cross join current_clock
+      where coalesce(u.latest_seen_at, u.first_seen_at, now()) >= now() - interval '30 days'
+    ) feed_rows
+  ) feed
+),
+long_gap as (
+  select coalesce(
+    jsonb_agg(
+      jsonb_build_object(
+        'entity_slug', ranked.entity_slug,
+        'display_name', ranked.display_name,
+        'entity_type', ranked.entity_type,
+        'agency_name', ranked.agency_name,
+        'tracking_status', ranked.tracking_status,
+        'watch_reason', ranked.watch_reason,
+        'latest_release', jsonb_build_object(
+          'release_id', ranked.release_id::text,
+          'release_title', ranked.release_title,
+          'release_date', ranked.release_date::text,
+          'stream', ranked.stream,
+          'release_kind', ranked.release_kind,
+          'release_format', ranked.release_format,
+          'source_url', ranked.release_source_url,
+          'artist_source_url', ranked.artist_source_url
+        ),
+        'gap_days', ranked.gap_days,
+        'has_upcoming_signal', ranked.has_upcoming_signal,
+        'latest_signal', ranked.latest_signal
+      )
+      order by ranked.sort_has_signal asc, ranked.sort_confidence desc, ranked.sort_signal_at desc, ranked.gap_days desc, ranked.display_name asc
+    ),
+    '[]'::jsonb
+  ) as payload
+  from (
+    select
+      e.slug as entity_slug,
+      e.display_name,
+      e.entity_type,
+      e.agency_name,
+      ets.tracking_status,
+      ets.watch_reason,
+      lr.release_id,
+      lr.release_title,
+      lr.release_date,
+      lr.stream,
+      lr.release_kind,
+      lr.release_format,
+      lr.source_url as release_source_url,
+      lr.artist_source_url,
+      (timezone('Asia/Seoul', now())::date - lr.release_date) as gap_days,
+      (ls.upcoming_signal_id is not null) as has_upcoming_signal,
+      case
+        when ls.upcoming_signal_id is null then null
+        else jsonb_build_object(
+          'upcoming_signal_id', ls.upcoming_signal_id::text,
+          'headline', ls.headline,
+          'scheduled_date', ls.scheduled_date::text,
+          'scheduled_month', to_char(ls.scheduled_month, 'YYYY-MM'),
+          'date_precision', ls.date_precision,
+          'date_status', ls.date_status,
+          'release_format', ls.release_format,
+          'confidence_score', ls.confidence_score,
+          'latest_seen_at', ls.latest_seen_at,
+          'source_url', ls.source_url,
+          'source_type', ls.source_type,
+          'source_domain', ls.source_domain,
+          'evidence_summary', ls.evidence_summary,
+          'source_count', ls.source_count
+        )
+      end as latest_signal,
+      case when ls.upcoming_signal_id is not null then 0 else 1 end as sort_has_signal,
+      coalesce(ls.confidence_score, -1) as sort_confidence,
+      extract(epoch from coalesce(ls.latest_seen_at, ls.first_seen_at, to_timestamp(0))) as sort_signal_at
+    from entity_tracking_state ets
+    join entities e on e.id = ets.entity_id
+    join latest_release lr on lr.entity_id = ets.entity_id
+    left join latest_signal ls on ls.entity_id = ets.entity_id
+    where
+      ets.watch_reason = 'long_gap'
+      and lr.release_date <= timezone('Asia/Seoul', now())::date - 365
+  ) ranked
+),
+rookie as (
+  select coalesce(
+    jsonb_agg(
+      jsonb_build_object(
+        'entity_slug', ranked.entity_slug,
+        'display_name', ranked.display_name,
+        'entity_type', ranked.entity_type,
+        'agency_name', ranked.agency_name,
+        'tracking_status', ranked.tracking_status,
+        'debut_year', ranked.debut_year,
+        'latest_release', ranked.latest_release,
+        'has_upcoming_signal', ranked.has_upcoming_signal,
+        'latest_signal', ranked.latest_signal
+      )
+      order by ranked.sort_has_signal asc, ranked.sort_release_date desc, ranked.debut_year desc nulls last, ranked.display_name asc
+    ),
+    '[]'::jsonb
+  ) as payload
+  from (
+    select
+      e.slug as entity_slug,
+      e.display_name,
+      e.entity_type,
+      e.agency_name,
+      coalesce(ets.tracking_status, 'watch_only') as tracking_status,
+      e.debut_year,
+      case
+        when lr.release_id is null then null
+        else jsonb_build_object(
+          'release_id', lr.release_id::text,
+          'release_title', lr.release_title,
+          'release_date', lr.release_date::text,
+          'stream', lr.stream,
+          'release_kind', lr.release_kind,
+          'release_format', lr.release_format,
+          'source_url', lr.source_url,
+          'artist_source_url', lr.artist_source_url
+        )
+      end as latest_release,
+      (ls.upcoming_signal_id is not null) as has_upcoming_signal,
+      case
+        when ls.upcoming_signal_id is null then null
+        else jsonb_build_object(
+          'upcoming_signal_id', ls.upcoming_signal_id::text,
+          'headline', ls.headline,
+          'scheduled_date', ls.scheduled_date::text,
+          'scheduled_month', to_char(ls.scheduled_month, 'YYYY-MM'),
+          'date_precision', ls.date_precision,
+          'date_status', ls.date_status,
+          'release_format', ls.release_format,
+          'confidence_score', ls.confidence_score,
+          'latest_seen_at', ls.latest_seen_at,
+          'source_url', ls.source_url,
+          'source_type', ls.source_type,
+          'source_domain', ls.source_domain,
+          'evidence_summary', ls.evidence_summary,
+          'source_count', ls.source_count
+        )
+      end as latest_signal,
+      case when ls.upcoming_signal_id is not null then 0 else 1 end as sort_has_signal,
+      coalesce(extract(epoch from lr.release_date::timestamp), 0) as sort_release_date
+    from entities e
+    cross join current_clock
+    left join entity_tracking_state ets on ets.entity_id = e.id
+    left join latest_release lr on lr.entity_id = e.id
+    left join latest_signal ls on ls.entity_id = e.id
+    where
+      e.debut_year is not null
+      and e.debut_year between current_clock.current_year_kst - 1 and current_clock.current_year_kst
+  ) ranked
+)
+select
+  'default'::text as projection_key,
+  jsonb_build_object(
+    'featured_upcoming', (
+      select case
+        when featured_upcoming.upcoming_signal_id is null then null
+        else jsonb_build_object(
+          'upcoming_signal_id', featured_upcoming.upcoming_signal_id::text,
+          'entity_slug', featured_upcoming.entity_slug,
+          'display_name', featured_upcoming.display_name,
+          'entity_type', featured_upcoming.entity_type,
+          'agency_name', featured_upcoming.agency_name,
+          'tracking_status', featured_upcoming.tracking_status,
+          'headline', featured_upcoming.headline,
+          'scheduled_date', featured_upcoming.scheduled_date::text,
+          'scheduled_month', featured_upcoming.scheduled_month,
+          'date_precision', featured_upcoming.date_precision,
+          'date_status', featured_upcoming.date_status,
+          'confidence_score', featured_upcoming.confidence_score,
+          'release_format', featured_upcoming.release_format,
+          'source_url', featured_upcoming.source_url,
+          'source_type', featured_upcoming.source_type,
+          'source_domain', featured_upcoming.source_domain,
+          'evidence_summary', featured_upcoming.evidence_summary,
+          'source_count', featured_upcoming.source_count
+        )
+      end
+      from featured_upcoming
+    ),
+    'weekly_upcoming', (select weekly_upcoming.payload from weekly_upcoming),
+    'change_feed', (select change_feed.payload from change_feed),
+    'long_gap', (select long_gap.payload from long_gap),
+    'rookie', (select rookie.payload from rookie)
+  ) as payload,
+  now() as generated_at
+with no data;
+
+create unique index if not exists idx_radar_projection_key
+  on radar_projection (projection_key);

--- a/backend/src/route-contract.test.ts
+++ b/backend/src/route-contract.test.ts
@@ -369,6 +369,9 @@ function buildCalendarMonthPayload() {
       upcoming_signal_id: UPCOMING_SIGNAL_ID,
       entity_slug: 'yena',
       display_name: 'YENA',
+      entity_type: 'solo',
+      agency_name: 'YUE HUA Entertainment',
+      tracking_status: 'watch_only',
       headline: '최예나, 3월 11일 컴백 확정',
       scheduled_date: '2026-03-11',
       scheduled_month: '2026-03',
@@ -390,9 +393,14 @@ function buildCalendarMonthPayload() {
             release_id: YENA_RELEASE_ID,
             entity_slug: 'yena',
             display_name: 'YENA',
+            entity_type: 'solo',
+            agency_name: 'YUE HUA Entertainment',
             release_title: 'LOVE CATCHER',
             stream: 'album',
             release_kind: 'ep',
+            release_format: 'ep',
+            source_url: 'https://musicbrainz.example/yena-love-catcher',
+            artist_source_url: 'https://www.youtube.com/@YENA_OFFICIAL',
             release_date: '2026-03-11',
           },
         ],
@@ -401,6 +409,9 @@ function buildCalendarMonthPayload() {
             upcoming_signal_id: UPCOMING_SIGNAL_ID,
             entity_slug: 'yena',
             display_name: 'YENA',
+            entity_type: 'solo',
+            agency_name: 'YUE HUA Entertainment',
+            tracking_status: 'watch_only',
             headline: '최예나, 3월 11일 컴백 확정',
             scheduled_date: '2026-03-11',
             scheduled_month: '2026-03',
@@ -422,6 +433,9 @@ function buildCalendarMonthPayload() {
         upcoming_signal_id: 'month-only-signal',
         entity_slug: 'kickflip',
         display_name: 'KickFlip',
+        entity_type: 'group',
+        agency_name: 'JYP Entertainment',
+        tracking_status: 'watch_only',
         headline: 'KickFlip announces April comeback',
         scheduled_date: null,
         scheduled_month: '2026-04',
@@ -441,9 +455,14 @@ function buildCalendarMonthPayload() {
         release_id: YENA_RELEASE_ID,
         entity_slug: 'yena',
         display_name: 'YENA',
+        entity_type: 'solo',
+        agency_name: 'YUE HUA Entertainment',
         release_title: 'LOVE CATCHER',
         stream: 'album',
         release_kind: 'ep',
+        release_format: 'ep',
+        source_url: 'https://musicbrainz.example/yena-love-catcher',
+        artist_source_url: 'https://www.youtube.com/@YENA_OFFICIAL',
         release_date: '2026-03-11',
       },
     ],
@@ -452,6 +471,9 @@ function buildCalendarMonthPayload() {
         upcoming_signal_id: UPCOMING_SIGNAL_ID,
         entity_slug: 'yena',
         display_name: 'YENA',
+        entity_type: 'solo',
+        agency_name: 'YUE HUA Entertainment',
+        tracking_status: 'watch_only',
         headline: '최예나, 3월 11일 컴백 확정',
         scheduled_date: '2026-03-11',
         scheduled_month: '2026-03',
@@ -475,24 +497,42 @@ function buildRadarPayload() {
       upcoming_signal_id: 'upcoming-yena',
       entity_slug: 'yena',
       display_name: 'YENA',
+      entity_type: 'solo',
+      agency_name: 'YUE HUA Entertainment',
+      tracking_status: 'watch_only',
       headline: 'YENA confirms March comeback',
       scheduled_date: '2026-03-11',
+      scheduled_month: '2026-03',
       date_precision: 'exact',
       date_status: 'confirmed',
       confidence_score: 0.84,
       release_format: 'ep',
+      source_url: 'https://starnews.example/yena-love-catcher',
+      source_type: 'news_rss',
+      source_domain: 'starnews.example',
+      evidence_summary: 'Korean article confirmed the release date.',
+      source_count: 1,
     },
     weekly_upcoming: [
       {
         upcoming_signal_id: 'upcoming-yena',
         entity_slug: 'yena',
         display_name: 'YENA',
+        entity_type: 'solo',
+        agency_name: 'YUE HUA Entertainment',
+        tracking_status: 'watch_only',
         headline: 'YENA confirms March comeback',
         scheduled_date: '2026-03-11',
+        scheduled_month: '2026-03',
         date_precision: 'exact',
         date_status: 'confirmed',
         confidence_score: 0.84,
         release_format: 'ep',
+        source_url: 'https://starnews.example/yena-love-catcher',
+        source_type: 'news_rss',
+        source_domain: 'starnews.example',
+        evidence_summary: 'Korean article confirmed the release date.',
+        source_count: 1,
       },
     ],
     change_feed: [
@@ -514,6 +554,9 @@ function buildRadarPayload() {
       {
         entity_slug: 'woo-ah',
         display_name: 'woo!ah!',
+        entity_type: 'group',
+        agency_name: 'NV Entertainment',
+        tracking_status: 'watch_only',
         watch_reason: 'long_gap',
         latest_release: {
           release_id: 'release-wooah',
@@ -521,6 +564,9 @@ function buildRadarPayload() {
           release_date: '2024-07-16',
           stream: 'album',
           release_kind: 'ep',
+          release_format: 'ep',
+          source_url: 'https://musicbrainz.example/wooah-shining-on-you',
+          artist_source_url: 'https://www.youtube.com/@wooah',
         },
         gap_days: 600,
         has_upcoming_signal: false,
@@ -531,6 +577,9 @@ function buildRadarPayload() {
       {
         entity_slug: 'atheart',
         display_name: 'AtHeart',
+        entity_type: 'group',
+        agency_name: 'Titan Content',
+        tracking_status: 'watch_only',
         debut_year: 2025,
         latest_release: {
           release_id: 'release-atheart',
@@ -538,6 +587,9 @@ function buildRadarPayload() {
           release_date: '2026-02-26',
           stream: 'song',
           release_kind: 'single',
+          release_format: 'single',
+          source_url: 'https://musicbrainz.example/atheart-shut-up',
+          artist_source_url: 'https://www.youtube.com/@AtHeart',
         },
         has_upcoming_signal: true,
         latest_signal: {
@@ -550,6 +602,11 @@ function buildRadarPayload() {
           release_format: '',
           confidence_score: 0.76,
           latest_seen_at: NOW,
+          source_url: 'https://example.com/atheart-april',
+          source_type: 'news_rss',
+          source_domain: 'example.com',
+          evidence_summary: 'Month-only teaser coverage.',
+          source_count: 1,
         },
       },
     ],
@@ -1382,7 +1439,12 @@ test('GET /v1/calendar/month returns calendar projection contract', async (t) =>
   assert.equal(body.data.scheduled_list.length, 0);
   assert.equal(body.data.nearest_upcoming, null);
   assert.equal(body.data.verified_list[0].release_id, YENA_RELEASE_ID);
+  assert.equal(body.data.verified_list[0].entity_type, 'solo');
+  assert.equal(body.data.verified_list[0].agency_name, 'YUE HUA Entertainment');
+  assert.equal(body.data.verified_list[0].artist_source_url, 'https://www.youtube.com/@YENA_OFFICIAL');
   assert.equal(body.data.month_only_upcoming[0].date_precision, 'month_only');
+  assert.equal(body.data.month_only_upcoming[0].tracking_status, 'watch_only');
+  assert.equal(body.data.month_only_upcoming[0].agency_name, 'JYP Entertainment');
 });
 
 test('GET /v1/radar returns projection-backed radar payload', async (t) => {
@@ -1398,9 +1460,13 @@ test('GET /v1/radar returns projection-backed radar payload', async (t) => {
   assert.equal(body.data.featured_upcoming, null);
   assert.equal(body.data.weekly_upcoming.length, 0);
   assert.equal(body.data.rookie.length, 1);
+  assert.equal(body.data.long_gap[0].agency_name, 'NV Entertainment');
+  assert.equal(body.data.long_gap[0].latest_release.artist_source_url, 'https://www.youtube.com/@wooah');
   assert.equal(body.data.long_gap[0].latest_release.stream, 'album');
+  assert.equal(body.data.rookie[0].tracking_status, 'watch_only');
   assert.equal(body.data.rookie[0].latest_signal.scheduled_month, '2026-04');
   assert.equal(body.data.rookie[0].latest_signal.release_format, null);
+  assert.equal(body.data.rookie[0].latest_signal.source_domain, 'example.com');
   assert.equal(typeof body.data.change_feed[0].occurred_at, 'string');
 });
 

--- a/backend/src/routes/calendar.ts
+++ b/backend/src/routes/calendar.ts
@@ -29,6 +29,9 @@ type CalendarNearestUpcoming = {
   upcoming_signal_id: string;
   entity_slug: string;
   display_name: string;
+  entity_type: string | null;
+  agency_name: string | null;
+  tracking_status: string | null;
   headline: string;
   scheduled_date: string;
   scheduled_month: string;
@@ -47,9 +50,14 @@ type CalendarVerifiedRelease = {
   release_id: string;
   entity_slug: string;
   display_name: string;
+  entity_type: string | null;
+  agency_name: string | null;
   release_title: string;
   stream: string;
   release_kind: string | null;
+  release_format: string | null;
+  source_url: string | null;
+  artist_source_url: string | null;
   release_date?: string;
 };
 
@@ -57,6 +65,9 @@ type CalendarUpcomingItem = {
   upcoming_signal_id: string;
   entity_slug: string;
   display_name: string;
+  entity_type: string | null;
+  agency_name: string | null;
+  tracking_status: string | null;
   headline: string;
   scheduled_date: string | null;
   scheduled_month: string;
@@ -162,9 +173,14 @@ function normalizeVerifiedRelease(value: unknown): CalendarVerifiedRelease | nul
     release_id: releaseId,
     entity_slug: entitySlug,
     display_name: displayName,
+    entity_type: asNullableString(value.entity_type),
+    agency_name: asNullableString(value.agency_name),
     release_title: releaseTitle,
     stream,
     release_kind: asNullableString(value.release_kind),
+    release_format: asNullableString(value.release_format),
+    source_url: asNullableString(value.source_url),
+    artist_source_url: asNullableString(value.artist_source_url),
     release_date: asNullableString(value.release_date) ?? undefined,
   };
 }
@@ -199,6 +215,9 @@ function normalizeUpcomingItem(value: unknown): CalendarUpcomingItem | null {
     upcoming_signal_id: upcomingSignalId,
     entity_slug: entitySlug,
     display_name: displayName,
+    entity_type: asNullableString(value.entity_type),
+    agency_name: asNullableString(value.agency_name),
+    tracking_status: asNullableString(value.tracking_status),
     headline,
     scheduled_date: scheduledDate,
     scheduled_month: scheduledMonth,
@@ -297,6 +316,9 @@ function normalizeCalendarMonthPayload(payload: unknown): CalendarMonthData | nu
             upcoming_signal_id: nearestUpcoming.upcoming_signal_id,
             entity_slug: nearestUpcoming.entity_slug,
             display_name: nearestUpcoming.display_name,
+            entity_type: nearestUpcoming.entity_type,
+            agency_name: nearestUpcoming.agency_name,
+            tracking_status: nearestUpcoming.tracking_status,
             headline: nearestUpcoming.headline,
             scheduled_date: nearestUpcoming.scheduled_date,
             scheduled_month: nearestUpcoming.scheduled_month,

--- a/backend/src/routes/radar.ts
+++ b/backend/src/routes/radar.ts
@@ -82,6 +82,10 @@ function normalizeRadarLatestSignal(value: unknown): Record<string, unknown> | n
     scheduled_date: normalizeOptionalString(value.scheduled_date),
     scheduled_month: normalizeScheduledMonth(value.scheduled_month),
     release_format: normalizeOptionalString(value.release_format),
+    source_url: normalizeOptionalString(value.source_url),
+    source_type: normalizeOptionalString(value.source_type),
+    source_domain: normalizeOptionalString(value.source_domain),
+    evidence_summary: normalizeOptionalString(value.evidence_summary),
     latest_seen_at: normalizeIsoLikeString(value.latest_seen_at),
   };
 }
@@ -95,6 +99,9 @@ function normalizeRadarReleaseSummary(value: unknown): Record<string, unknown> |
     ...value,
     release_date: normalizeOptionalString(value.release_date),
     release_kind: normalizeOptionalString(value.release_kind),
+    release_format: normalizeOptionalString(value.release_format),
+    source_url: normalizeOptionalString(value.source_url),
+    artist_source_url: normalizeOptionalString(value.artist_source_url),
   };
 }
 
@@ -147,7 +154,13 @@ function normalizeRadarUpcomingItem(value: unknown): Record<string, unknown> | n
   return {
     ...value,
     scheduled_date: normalizeOptionalString(value.scheduled_date),
+    scheduled_month: normalizeScheduledMonth(value.scheduled_month),
     release_format: normalizeOptionalString(value.release_format),
+    source_url: normalizeOptionalString(value.source_url),
+    source_type: normalizeOptionalString(value.source_type),
+    source_domain: normalizeOptionalString(value.source_domain),
+    evidence_summary: normalizeOptionalString(value.evidence_summary),
+    latest_seen_at: normalizeIsoLikeString(value.latest_seen_at),
   };
 }
 

--- a/docs/specs/backend/shared-read-api-contracts.md
+++ b/docs/specs/backend/shared-read-api-contracts.md
@@ -97,7 +97,9 @@
 - monthly verified list
 - monthly scheduled list
 - nearest upcoming calculated from exact future date only
+- direct-render identity/meta for verified and upcoming rows (`entity_type`, `agency_name`, `tracking_status`)
 - scheduled row action-ready source summary (`source_url`, `source_type`, `source_domain`, `evidence_summary`, `source_count`)
+- verified row action-ready source summary (`release_format`, `source_url`, `artist_source_url`)
 - stable `scheduled_month` in `YYYY-MM` format for both `exact` and `month_only` rows
 
 ### 5.4 Response Shape
@@ -119,6 +121,9 @@
       "upcoming_signal_id": "upc_yena_2026_03_11",
       "entity_slug": "yena",
       "display_name": "YENA",
+      "entity_type": "solo",
+      "agency_name": "YUE HUA Entertainment",
+      "tracking_status": "watch_only",
       "headline": "YENA 4th Mini Album",
       "scheduled_date": "2026-03-11",
       "scheduled_month": "2026-03",
@@ -140,10 +145,15 @@
             "release_id": "rel_tunexx_set_by_us_only_2026_03_03_album",
             "entity_slug": "tunexx",
             "display_name": "TUNEXX",
+            "entity_type": "group",
+            "agency_name": "IST Entertainment",
             "release_title": "SET BY US ONLY",
             "release_date": "2026-03-03",
             "stream": "album",
-            "release_kind": "ep"
+            "release_kind": "ep",
+            "release_format": "ep",
+            "source_url": "https://musicbrainz.org/release-group/...",
+            "artist_source_url": "https://www.youtube.com/@official_TUNEXX"
           }
         ],
         "exact_upcoming": []
@@ -153,6 +163,9 @@
       {
         "entity_slug": "tomorrow-x-together",
         "display_name": "TOMORROW X TOGETHER",
+        "entity_type": "group",
+        "agency_name": "BIGHIT MUSIC",
+        "tracking_status": "watch_only",
         "headline": "March comeback",
         "scheduled_date": null,
         "scheduled_month": "2026-03",
@@ -181,6 +194,7 @@
 - `scheduled_month`는 항상 `YYYY-MM` 형식이다
 - `scheduled_month`는 `exact` row에서도 month context를 유지하기 위해 채워진다
 - source summary는 `agency_notice -> weverse_notice -> official_social -> news_rss -> manual` 우선순위의 대표 source를 사용한다
+- web calendar는 `verified_list`, `scheduled_list`, `month_only_upcoming`만으로 CTA/agency/entity routing을 그릴 수 있어야 한다
 
 ## 6. `GET /v1/search`
 
@@ -580,6 +594,7 @@ lookup helper response:
 - change feed
 - long-gap
 - rookie
+- long-gap / rookie direct-render meta (`entity_type`, `agency_name`, `tracking_status`, nested release/signal source pointers)
 
 ### 9.3 Response Shape
 
@@ -616,12 +631,21 @@ lookup helper response:
   "upcoming_signal_id": "uuid",
   "entity_slug": "yena",
   "display_name": "YENA",
+  "entity_type": "solo",
+  "agency_name": "YUE HUA Entertainment",
+  "tracking_status": "watch_only",
   "headline": "YENA confirms March comeback",
   "scheduled_date": "2026-03-11",
+  "scheduled_month": "2026-03",
   "date_precision": "exact",
   "date_status": "confirmed",
   "confidence_score": 0.84,
-  "release_format": "ep"
+  "release_format": "ep",
+  "source_url": "https://starnewskorea.com/...",
+  "source_type": "news_rss",
+  "source_domain": "starnewskorea.com",
+  "evidence_summary": "YENA will release a new mini album on March 11.",
+  "source_count": 2
 }
 ```
 
@@ -632,12 +656,21 @@ lookup helper response:
   "upcoming_signal_id": "uuid",
   "entity_slug": "p1harmony",
   "display_name": "P1Harmony",
+  "entity_type": "group",
+  "agency_name": "FNC Entertainment",
+  "tracking_status": "watch_only",
   "headline": "P1Harmony's Hero's Return: 9th Mini-Album Drops March 12",
   "scheduled_date": "2026-03-12",
+  "scheduled_month": "2026-03",
   "date_precision": "exact",
   "date_status": "confirmed",
   "confidence_score": 0.82,
-  "release_format": "ep"
+  "release_format": "ep",
+  "source_url": "https://fncent.com/...",
+  "source_type": "agency_notice",
+  "source_domain": "fncent.com",
+  "evidence_summary": "FNC confirmed the March 12 mini-album release.",
+  "source_count": 2
 }
 ```
 
@@ -683,13 +716,19 @@ upcoming signal item:
 {
   "entity_slug": "weeekly",
   "display_name": "Weeekly",
+  "entity_type": "group",
+  "agency_name": "IST Entertainment",
+  "tracking_status": "watch_only",
   "watch_reason": "long_gap",
   "latest_release": {
     "release_id": "uuid",
     "release_title": "Bliss",
     "release_date": "2024-07-09",
     "stream": "album",
-    "release_kind": "ep"
+    "release_kind": "ep",
+    "release_format": "ep",
+    "source_url": "https://musicbrainz.org/release-group/...",
+    "artist_source_url": "https://www.youtube.com/@Weeekly"
   },
   "gap_days": 608,
   "has_upcoming_signal": false,
@@ -703,25 +742,36 @@ upcoming signal item:
 {
   "entity_slug": "atheart",
   "display_name": "AtHeart",
+  "entity_type": "group",
+  "agency_name": "Titan Content",
+  "tracking_status": "watch_only",
   "debut_year": 2025,
   "latest_release": {
     "release_id": "uuid",
     "release_title": "Shut Up",
     "release_date": "2026-02-26",
     "stream": "song",
-    "release_kind": "single"
+    "release_kind": "single",
+    "release_format": "single",
+    "source_url": "https://musicbrainz.org/release-group/...",
+    "artist_source_url": "https://www.youtube.com/@AtHeart"
   },
   "has_upcoming_signal": true,
   "latest_signal": {
     "upcoming_signal_id": "uuid",
     "headline": "Rookie group AtHeart drops bold new teaser photos...",
     "scheduled_date": null,
-    "scheduled_month": null,
-    "date_precision": "unknown",
-    "date_status": "rumor",
+    "scheduled_month": "2026-04",
+    "date_precision": "month_only",
+    "date_status": "scheduled",
     "release_format": null,
     "confidence_score": 0.68,
-    "latest_seen_at": "2026-01-31T08:00:00+00:00"
+    "latest_seen_at": "2026-01-31T08:00:00+00:00",
+    "source_url": "https://example.com/atheart-april",
+    "source_type": "news_rss",
+    "source_domain": "example.com",
+    "evidence_summary": "Month-only teaser coverage.",
+    "source_count": 1
   }
 }
 ```

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -511,16 +511,24 @@ type CalendarMonthApiVerifiedRelease = {
   release_id?: string
   entity_slug?: string
   display_name?: string
+  entity_type?: string | null
+  agency_name?: string | null
   release_title?: string
+  release_format?: string | null
   stream?: string
   release_kind?: string | null
   release_date?: string
+  source_url?: string | null
+  artist_source_url?: string | null
 }
 
 type CalendarMonthApiUpcomingItem = {
   upcoming_signal_id?: string
   entity_slug?: string
   display_name?: string
+  entity_type?: string | null
+  agency_name?: string | null
+  tracking_status?: string | null
   headline?: string
   scheduled_date?: string | null
   scheduled_month?: string | null
@@ -528,6 +536,11 @@ type CalendarMonthApiUpcomingItem = {
   date_status?: string
   confidence_score?: number | null
   release_format?: string | null
+  source_url?: string | null
+  source_type?: string | null
+  source_domain?: string | null
+  evidence_summary?: string | null
+  source_count?: number | null
 }
 
 type CalendarMonthApiResponse = {
@@ -567,10 +580,14 @@ type CalendarMonthSurfaceResource = {
 }
 
 type RadarApiReleaseSummary = {
+  release_id?: string | null
   release_title?: string
   release_date?: string | null
   stream?: string | null
   release_kind?: string | null
+  release_format?: string | null
+  source_url?: string | null
+  artist_source_url?: string | null
 }
 
 type RadarApiUpcomingSummary = {
@@ -584,11 +601,20 @@ type RadarApiUpcomingSummary = {
   date_status?: string
   confidence_score?: number | null
   release_format?: string | null
+  source_url?: string | null
+  source_type?: string | null
+  source_domain?: string | null
+  evidence_summary?: string | null
+  source_count?: number | null
+  latest_seen_at?: string | null
 }
 
 type RadarApiLongGapItem = {
   entity_slug?: string
   display_name?: string
+  entity_type?: string | null
+  agency_name?: string | null
+  tracking_status?: string | null
   watch_reason?: string | null
   latest_release?: RadarApiReleaseSummary | null
   gap_days?: number | null
@@ -599,6 +625,9 @@ type RadarApiLongGapItem = {
 type RadarApiRookieItem = {
   entity_slug?: string
   display_name?: string
+  entity_type?: string | null
+  agency_name?: string | null
+  tracking_status?: string | null
   debut_year?: number | null
   latest_release?: RadarApiReleaseSummary | null
   has_upcoming_signal?: boolean
@@ -633,6 +662,9 @@ type UpcomingDatePrecision = 'exact' | 'month_only' | 'unknown'
 
 type VerifiedRelease = ReleaseFact & {
   group: string
+  entitySlug?: string
+  displayName?: string
+  agencyName?: string | null
   artist_name_mb: string
   artist_mbid: string
   artist_source: string
@@ -653,6 +685,10 @@ type UnresolvedRow = {
 
 type UpcomingSignalBase = {
   group: string
+  entitySlug?: string
+  displayName?: string
+  agencyName?: string | null
+  actType?: ActType
   scheduled_date: string
   scheduled_month: string
   date_precision: UpcomingDatePrecision
@@ -892,6 +928,8 @@ type ScheduledDashboardSortKey = 'date' | 'team' | 'status' | 'confidence'
 
 type LongGapRadarEntry = {
   group: string
+  entitySlug?: string
+  agencyName?: string | null
   watchReason: WatchReason
   latestRelease: TeamLatestRelease
   gapDays: number
@@ -901,6 +939,8 @@ type LongGapRadarEntry = {
 
 type RookieRadarEntry = {
   group: string
+  entitySlug?: string
+  agencyName?: string | null
   debutYear: number | null
   latestRelease: TeamLatestRelease | null
   hasUpcomingSignal: boolean
@@ -2563,8 +2603,8 @@ function App() {
     }
   }, [selectedGroup])
 
-  function openTeamPage(group: string) {
-    setSelectedEntitySlug(artistProfileByGroup.get(group)?.slug ?? slugifyGroup(group))
+  function openTeamPage(group: string, entitySlug?: string | null) {
+    setSelectedEntitySlug(entitySlug ?? artistProfileByGroup.get(group)?.slug ?? slugifyGroup(group))
     setSelectedGroup(group)
     setSelectedCompareGroup(null)
     setSelectedAlbumKey(null)
@@ -2580,7 +2620,7 @@ function App() {
   }
 
   function openReleaseDetail(release: VerifiedRelease) {
-    const entitySlug = artistProfileByGroup.get(release.group)?.slug ?? slugifyGroup(release.group)
+    const entitySlug = release.entitySlug ?? artistProfileByGroup.get(release.group)?.slug ?? slugifyGroup(release.group)
     setSelectedEntitySlug(entitySlug)
     setSelectedGroup(release.group)
     setSelectedCompareGroup(null)
@@ -3923,7 +3963,7 @@ function ReleaseDetailPage({
   language: Language
   displayDateFormatter: Intl.DateTimeFormat
   onBack: () => void
-  onOpenTeamPage: (group: string) => void
+  onOpenTeamPage: (group: string, entitySlug?: string | null) => void
 }) {
   const copy = TRANSLATIONS[language]
   const teamCopy = TEAM_COPY[language]
@@ -4549,7 +4589,7 @@ function LongGapRadarList({
   entries: LongGapRadarEntry[]
   language: Language
   displayDateFormatter: Intl.DateTimeFormat
-  onOpenTeamPage: (group: string) => void
+  onOpenTeamPage: (group: string, entitySlug?: string | null) => void
 }) {
   const copy = TRANSLATIONS[language]
   const teamCopy = TEAM_COPY[language]
@@ -4624,7 +4664,7 @@ function LongGapRadarList({
             <p className="empty-copy">{copy.longGapLatestSignalEmpty}</p>
           )}
           <div className="detail-links">
-            <button type="button" className="inline-button" onClick={() => onOpenTeamPage(entry.group)}>
+            <button type="button" className="inline-button" onClick={() => onOpenTeamPage(entry.group, entry.entitySlug)}>
               {teamCopy.action}
             </button>
           </div>
@@ -4643,7 +4683,7 @@ function RookieRadarList({
   entries: RookieRadarEntry[]
   language: Language
   displayDateFormatter: Intl.DateTimeFormat
-  onOpenTeamPage: (group: string) => void
+  onOpenTeamPage: (group: string, entitySlug?: string | null) => void
 }) {
   const copy = TRANSLATIONS[language]
   const teamCopy = TEAM_COPY[language]
@@ -4739,7 +4779,7 @@ function RookieRadarList({
           )}
 
           <div className="detail-links">
-            <button type="button" className="inline-button" onClick={() => onOpenTeamPage(entry.group)}>
+            <button type="button" className="inline-button" onClick={() => onOpenTeamPage(entry.group, entry.entitySlug)}>
               {teamCopy.action}
             </button>
           </div>
@@ -4968,7 +5008,7 @@ function CompareTeamView({
   language: Language
   displayDateFormatter: Intl.DateTimeFormat
   onSelectCompareGroup: (group: string | null) => void
-  onOpenTeamPage: (group: string) => void
+  onOpenTeamPage: (group: string, entitySlug?: string | null) => void
   onOpenReleaseDetail: (release: VerifiedRelease) => void
   onClearCompare: () => void
 }) {
@@ -5240,7 +5280,7 @@ function DashboardScheduledBucket({
   rows: UpcomingCandidateRow[]
   language: Language
   displayDateFormatter: Intl.DateTimeFormat
-  onOpenTeamPage: (group: string) => void
+  onOpenTeamPage: (group: string, entitySlug?: string | null) => void
 }) {
   const copy = TRANSLATIONS[language]
 
@@ -5299,7 +5339,7 @@ function DashboardScheduledBucket({
                 </td>
                 <td>
                   <div className="dashboard-table-actions">
-                    <ActionButton variant="primary" onClick={() => onOpenTeamPage(item.group)}>
+                    <ActionButton variant="primary" onClick={() => onOpenTeamPage(item.group, item.entitySlug)}>
                       {TEAM_COPY[language].action}
                     </ActionButton>
                   </div>
@@ -5339,7 +5379,7 @@ function DashboardScheduledBucket({
             ) : null}
             <div className="action-stack">
               <div className="action-row">
-                <ActionButton variant="primary" onClick={() => onOpenTeamPage(item.group)}>
+                <ActionButton variant="primary" onClick={() => onOpenTeamPage(item.group, item.entitySlug)}>
                   {TEAM_COPY[language].action}
                 </ActionButton>
               </div>
@@ -5380,7 +5420,7 @@ function MonthlyReleaseDashboard({
   activeFilters: string[]
   language: Language
   displayDateFormatter: Intl.DateTimeFormat
-  onOpenTeamPage: (group: string) => void
+  onOpenTeamPage: (group: string, entitySlug?: string | null) => void
   onOpenReleaseDetail: (release: VerifiedRelease) => void
 }) {
   const copy = TRANSLATIONS[language]
@@ -5515,7 +5555,7 @@ function MonthlyReleaseDashboard({
                         </td>
                         <td>
                           <div className="dashboard-table-actions">
-                            <ActionButton variant="primary" onClick={() => onOpenTeamPage(item.group)}>
+                            <ActionButton variant="primary" onClick={() => onOpenTeamPage(item.group, item.entitySlug)}>
                               {TEAM_COPY[language].action}
                             </ActionButton>
                             <ActionButton variant="secondary" onClick={() => onOpenReleaseDetail(item)}>
@@ -5546,7 +5586,7 @@ function MonthlyReleaseDashboard({
                     </p>
                     <div className="action-stack">
                       <div className="action-row">
-                        <ActionButton variant="primary" onClick={() => onOpenTeamPage(item.group)}>
+                        <ActionButton variant="primary" onClick={() => onOpenTeamPage(item.group, item.entitySlug)}>
                           {TEAM_COPY[language].action}
                         </ActionButton>
                         <ActionButton variant="secondary" onClick={() => onOpenReleaseDetail(item)}>
@@ -5643,7 +5683,7 @@ function AgencyCalendarView({
   sections: AgencyMonthSection[]
   language: Language
   displayDateFormatter: Intl.DateTimeFormat
-  onOpenTeamPage: (group: string) => void
+  onOpenTeamPage: (group: string, entitySlug?: string | null) => void
   onOpenReleaseDetail: (release: VerifiedRelease) => void
 }) {
   const copy = TRANSLATIONS[language]
@@ -5693,7 +5733,7 @@ function AgencyCalendarView({
                             {formatOptionalDate(item.date, displayDateFormatter, copy.none)}
                           </p>
                           <div className="action-row">
-                            <ActionButton variant="primary" onClick={() => onOpenTeamPage(item.group)}>
+                            <ActionButton variant="primary" onClick={() => onOpenTeamPage(item.group, item.entitySlug)}>
                               {TEAM_COPY[language].action}
                             </ActionButton>
                             <ActionButton variant="secondary" onClick={() => onOpenReleaseDetail(item)}>
@@ -5728,7 +5768,7 @@ function AgencyCalendarView({
                             {formatUpcomingTimingLabel(item, language, displayDateFormatter, copy.none)}
                           </p>
                           <div className="action-row">
-                            <ActionButton variant="primary" onClick={() => onOpenTeamPage(item.group)}>
+                            <ActionButton variant="primary" onClick={() => onOpenTeamPage(item.group, item.entitySlug)}>
                               {TEAM_COPY[language].action}
                             </ActionButton>
                           </div>
@@ -5993,7 +6033,7 @@ function SelectedDayPanel({
   upcomingSignals: DatedUpcomingSignal[]
   language: Language
   shortDateFormatter: Intl.DateTimeFormat
-  onOpenTeamPage: (group: string) => void
+  onOpenTeamPage: (group: string, entitySlug?: string | null) => void
   onOpenReleaseDetail: (release: VerifiedRelease) => void
 }) {
   const copy = TRANSLATIONS[language]
@@ -6028,7 +6068,7 @@ function SelectedDayPanel({
                     </div>
                     <div className="action-stack">
                       <div className="action-row">
-                        <ActionButton variant="primary" onClick={() => onOpenTeamPage(item.group)}>
+                        <ActionButton variant="primary" onClick={() => onOpenTeamPage(item.group, item.entitySlug)}>
                           {teamCopy.action}
                         </ActionButton>
                         <ActionButton variant="secondary" onClick={() => onOpenReleaseDetail(item)}>
@@ -6105,7 +6145,7 @@ function SelectedDayPanel({
                   </div>
                   <div className="action-stack">
                     <div className="action-row">
-                      <ActionButton variant="primary" onClick={() => onOpenTeamPage(item.group)}>
+                      <ActionButton variant="primary" onClick={() => onOpenTeamPage(item.group, item.entitySlug)}>
                         {teamCopy.action}
                       </ActionButton>
                     </div>
@@ -7603,6 +7643,24 @@ function normalizeApiReleaseKind(
   return fallbackReleaseKind === 'album' || fallbackReleaseKind === 'ep' ? fallbackReleaseKind : 'single'
 }
 
+function normalizeApiActType(entityType: string | null | undefined): ActType {
+  if (entityType === 'solo' || entityType === 'unit') {
+    return entityType
+  }
+
+  return 'group'
+}
+
+function resolveApiDisplayGroup(entitySlug: string | null | undefined, displayName: string | null | undefined) {
+  const normalizedDisplayName = readNonEmptyString(displayName)
+  if (normalizedDisplayName) {
+    return normalizedDisplayName
+  }
+
+  const normalizedEntitySlug = readNonEmptyString(entitySlug)
+  return normalizedEntitySlug ? humanizeRouteSlug(normalizedEntitySlug) : null
+}
+
 function buildLocalReleaseDetailSnapshot(album: ReleaseDetailApiRequest, group: string): ReleaseDetailApiSnapshot {
   return {
     detail: buildFallbackReleaseDetail(group, album.title, album.date, album.stream, album.release_kind),
@@ -8346,77 +8404,49 @@ function useSearchSurfaceResource({
   }
 }
 
-function resolveCalendarApiGroupReference(entitySlug: string | null, displayName: string | null) {
-  return (
-    (entitySlug ? resolveGroupReference(entitySlug) : null) ??
-    (displayName ? resolveGroupReference(displayName) : null) ??
-    null
-  )
-}
-
-function buildSyntheticCalendarVerifiedRelease(
-  group: string,
-  releaseTitle: string,
-  releaseDate: string,
-  stream: VerifiedRelease['stream'],
-  releaseKind: string | null | undefined,
-): VerifiedRelease {
-  const releaseRow = releaseCatalogByGroup.get(group)
-  const team = teamProfileMap.get(group)
-  const normalizedReleaseKind =
-    releaseKind === 'album' || releaseKind === 'ep' || releaseKind === 'single'
-      ? releaseKind
-      : stream === 'album'
-        ? 'album'
-        : 'single'
-  const releaseFormat: ReleaseFormat =
-    normalizedReleaseKind === 'album' || normalizedReleaseKind === 'ep' || normalizedReleaseKind === 'single'
-      ? normalizedReleaseKind
-      : stream === 'album'
-        ? 'album'
-        : 'single'
-
-  return {
-    group,
-    artist_name_mb: releaseRow?.artist_name_mb ?? group,
-    artist_mbid: releaseRow?.artist_mbid ?? '',
-    artist_source: releaseRow?.artist_source ?? team?.artistSource ?? '',
-    actType: getActType(group),
-    stream,
-    title: releaseTitle,
-    date: releaseDate,
-    source: releaseRow?.artist_source ?? team?.artistSource ?? '',
-    release_kind: normalizedReleaseKind,
-    release_format: releaseFormat,
-    context_tags: [],
-    dateValue: new Date(`${releaseDate}T00:00:00`),
-    isoDate: releaseDate,
-  }
-}
-
 function buildCalendarApiVerifiedRelease(item: CalendarMonthApiVerifiedRelease): VerifiedRelease | null {
   const entitySlug = readNonEmptyString(item.entity_slug)
   const displayName = readNonEmptyString(item.display_name)
   const releaseTitle = readNonEmptyString(item.release_title)
   const releaseDate = readNonEmptyString(item.release_date)
   const stream = item.stream === 'album' || item.stream === 'song' ? item.stream : null
-  const group = resolveCalendarApiGroupReference(entitySlug, displayName)
+  const group = resolveApiDisplayGroup(entitySlug, displayName)
 
   if (!group || !releaseTitle || !releaseDate || !stream) {
     return null
   }
 
-  return (
-    findVerifiedReleaseRecord(group, releaseTitle, releaseDate, stream, item.release_kind ?? undefined) ??
-    buildSyntheticCalendarVerifiedRelease(group, releaseTitle, releaseDate, stream, item.release_kind)
-  )
+  const releaseKind = normalizeApiReleaseKind(item.release_kind, stream === 'album' ? 'album' : 'single')
+
+  return {
+    group,
+    entitySlug: entitySlug ?? undefined,
+    displayName: displayName ?? group,
+    agencyName: normalizeAgencyName(readNonEmptyString(item.agency_name)),
+    artist_name_mb: displayName ?? group,
+    artist_mbid: '',
+    artist_source: readNonEmptyString(item.artist_source_url) ?? '',
+    actType: normalizeApiActType(readNonEmptyString(item.entity_type)),
+    stream,
+    title: releaseTitle,
+    date: releaseDate,
+    source: readNonEmptyString(item.source_url) ?? '',
+    release_kind: releaseKind,
+    release_format:
+      normalizeReleaseFormatValue(item.release_format) ||
+      (releaseKind === 'album' || releaseKind === 'ep' || releaseKind === 'single' ? releaseKind : 'single'),
+    context_tags: [],
+    dateValue: new Date(`${releaseDate}T00:00:00`),
+    isoDate: releaseDate,
+    release_id: readNonEmptyString(item.release_id) ?? undefined,
+  }
 }
 
 function buildCalendarApiUpcomingRow(item: CalendarMonthApiUpcomingItem): UpcomingCandidateRow | null {
   const entitySlug = readNonEmptyString(item.entity_slug)
   const displayName = readNonEmptyString(item.display_name)
   const headline = readNonEmptyString(item.headline)
-  const group = resolveCalendarApiGroupReference(entitySlug, displayName)
+  const group = resolveApiDisplayGroup(entitySlug, displayName)
   if (!group || !headline) {
     return null
   }
@@ -8431,33 +8461,14 @@ function buildCalendarApiUpcomingRow(item: CalendarMonthApiUpcomingItem): Upcomi
     item.date_status === 'confirmed' || item.date_status === 'scheduled' || item.date_status === 'rumor'
       ? item.date_status
       : 'rumor'
-  const localMatch =
-    dedupedUpcomingCandidates.find(
-      (candidate) =>
-        candidate.group === group &&
-        candidate.headline === headline &&
-        getUpcomingDatePrecisionValue(candidate) === datePrecision &&
-        (scheduledDate ? candidate.scheduled_date === scheduledDate : candidate.scheduled_month === scheduledMonth),
-    ) ?? null
-
-  if (localMatch) {
-    return {
-      ...localMatch,
-      scheduled_date: scheduledDate || localMatch.scheduled_date,
-      scheduled_month: scheduledMonth || localMatch.scheduled_month,
-      date_precision: datePrecision,
-      date_status: dateStatus,
-      release_format: normalizeReleaseFormatValue(item.release_format) || localMatch.release_format,
-      confidence:
-        typeof item.confidence_score === 'number' && Number.isFinite(item.confidence_score)
-          ? item.confidence_score
-          : localMatch.confidence,
-      event_key: readNonEmptyString(item.upcoming_signal_id) ?? localMatch.event_key,
-    }
-  }
+  const sourceUrl = readNonEmptyString(item.source_url) ?? ''
 
   return {
     group,
+    entitySlug: entitySlug ?? undefined,
+    displayName: displayName ?? group,
+    agencyName: normalizeAgencyName(readNonEmptyString(item.agency_name)),
+    actType: normalizeApiActType(readNonEmptyString(item.entity_type)),
     scheduled_date: scheduledDate,
     scheduled_month: scheduledMonth,
     date_precision: datePrecision,
@@ -8465,18 +8476,20 @@ function buildCalendarApiUpcomingRow(item: CalendarMonthApiUpcomingItem): Upcomi
     headline,
     release_format: normalizeReleaseFormatValue(item.release_format),
     context_tags: [],
-    source_type: 'pending',
-    source_url: '',
-    source_domain: '',
+    source_type: readNonEmptyString(item.source_type) ?? 'pending',
+    source_url: sourceUrl,
+    source_domain: readNonEmptyString(item.source_domain) ?? getSourceDomain(sourceUrl),
     published_at: '',
     confidence:
       typeof item.confidence_score === 'number' && Number.isFinite(item.confidence_score)
         ? item.confidence_score
         : 0,
-    evidence_summary: '',
-    tracking_status: watchlistByGroup.get(group)?.tracking_status ?? teamProfileMap.get(group)?.trackingStatus ?? 'watch_only',
+    evidence_summary: readNonEmptyString(item.evidence_summary) ?? '',
+    tracking_status: readNonEmptyString(item.tracking_status) ?? 'watch_only',
     search_term: '',
     event_key: readNonEmptyString(item.upcoming_signal_id) ?? undefined,
+    evidence_count:
+      typeof item.source_count === 'number' && Number.isFinite(item.source_count) ? item.source_count : undefined,
   }
 }
 
@@ -8689,42 +8702,16 @@ function useCalendarMonthResource({
   }
 }
 
-function resolveRadarGroupReference(entitySlug: string | null, displayName: string | null) {
-  return (
-    (entitySlug ? resolveGroupReference(entitySlug) : null) ??
-    (displayName ? resolveGroupReference(displayName) : null) ??
-    null
-  )
-}
-
-function buildRadarLatestRelease(
-  group: string,
-  summary: RadarApiReleaseSummary | null | undefined,
-  fallbackTeam: TeamProfile,
-): TeamLatestRelease | null {
+function buildRadarLatestRelease(summary: RadarApiReleaseSummary | null | undefined): TeamLatestRelease | null {
   if (!summary) {
-    return fallbackTeam.latestRelease
+    return null
   }
 
   const releaseTitle = readNonEmptyString(summary.release_title)
   const releaseDate = readNonEmptyString(summary.release_date)
   const stream = summary.stream === 'album' || summary.stream === 'song' ? summary.stream : null
   if (!releaseTitle || !releaseDate || !stream) {
-    return fallbackTeam.latestRelease
-  }
-
-  const verifiedRelease = findVerifiedReleaseRecord(group, releaseTitle, releaseDate, stream, summary.release_kind ?? undefined)
-  if (verifiedRelease) {
-    return buildVerifiedTeamLatestRelease(verifiedRelease)
-  }
-
-  if (
-    fallbackTeam.latestRelease &&
-    fallbackTeam.latestRelease.title === releaseTitle &&
-    fallbackTeam.latestRelease.date === releaseDate &&
-    fallbackTeam.latestRelease.stream === stream
-  ) {
-    return fallbackTeam.latestRelease
+    return null
   }
 
   const releaseKind = normalizeApiReleaseKind(summary.release_kind, stream === 'album' ? 'album' : 'single')
@@ -8732,20 +8719,22 @@ function buildRadarLatestRelease(
     title: releaseTitle,
     date: releaseDate,
     releaseKind,
-    releaseFormat: normalizeReleaseFormatValue(releaseKind),
+    releaseFormat:
+      normalizeReleaseFormatValue(summary.release_format) ||
+      (releaseKind === 'album' || releaseKind === 'ep' || releaseKind === 'single' ? releaseKind : ''),
     contextTags: [],
     streamLabel: stream,
     stream,
-    source: fallbackTeam.artistSource,
-    artistSource: fallbackTeam.artistSource,
-    verified: false,
+    source: readNonEmptyString(summary.source_url) ?? '',
+    artistSource: readNonEmptyString(summary.artist_source_url) ?? '',
+    verified: true,
   }
 }
 
 function buildRadarUpcomingSignal(
   group: string,
+  trackingStatus: string,
   summary: RadarApiUpcomingSummary | null | undefined,
-  fallbackTeam: TeamProfile,
 ): UpcomingCandidateRow | null {
   if (!summary || !readNonEmptyString(summary.headline)) {
     return null
@@ -8762,37 +8751,7 @@ function buildRadarUpcomingSignal(
     summary.date_status === 'confirmed' || summary.date_status === 'scheduled' || summary.date_status === 'rumor'
       ? summary.date_status
       : 'rumor'
-  const localMatch =
-    fallbackTeam.upcomingSignals.find(
-      (item) =>
-        item.headline === headline &&
-        item.date_precision === datePrecision &&
-        (scheduledDate ? item.scheduled_date === scheduledDate : item.scheduled_month === scheduledMonth),
-    ) ??
-    dedupedUpcomingCandidates.find(
-      (candidate) =>
-        candidate.group === group &&
-        candidate.headline === headline &&
-        getUpcomingDatePrecisionValue(candidate) === datePrecision &&
-        (scheduledDate ? candidate.scheduled_date === scheduledDate : candidate.scheduled_month === scheduledMonth),
-    ) ??
-    null
-
-  if (localMatch) {
-    return {
-      ...localMatch,
-      scheduled_date: scheduledDate || localMatch.scheduled_date,
-      scheduled_month: scheduledMonth || localMatch.scheduled_month,
-      date_precision: datePrecision,
-      date_status: dateStatus,
-      release_format: normalizeReleaseFormatValue(summary.release_format) || localMatch.release_format,
-      confidence:
-        typeof summary.confidence_score === 'number' && Number.isFinite(summary.confidence_score)
-          ? summary.confidence_score
-          : localMatch.confidence,
-      event_key: readNonEmptyString(summary.upcoming_signal_id) ?? localMatch.event_key,
-    }
-  }
+  const sourceUrl = readNonEmptyString(summary.source_url) ?? ''
 
   return {
     group,
@@ -8803,38 +8762,37 @@ function buildRadarUpcomingSignal(
     headline,
     release_format: normalizeReleaseFormatValue(summary.release_format),
     context_tags: [],
-    source_type: 'pending',
-    source_url: '',
-    source_domain: '',
-    published_at: '',
+    source_type: readNonEmptyString(summary.source_type) ?? 'pending',
+    source_url: sourceUrl,
+    source_domain: readNonEmptyString(summary.source_domain) ?? getSourceDomain(sourceUrl),
+    published_at: readNonEmptyString(summary.latest_seen_at) ?? '',
     confidence:
       typeof summary.confidence_score === 'number' && Number.isFinite(summary.confidence_score)
         ? summary.confidence_score
         : 0,
-    evidence_summary: '',
-    tracking_status: fallbackTeam.trackingStatus,
+    evidence_summary: readNonEmptyString(summary.evidence_summary) ?? '',
+    tracking_status: trackingStatus,
     search_term: '',
     event_key: readNonEmptyString(summary.upcoming_signal_id) ?? undefined,
+    evidence_count:
+      typeof summary.source_count === 'number' && Number.isFinite(summary.source_count) ? summary.source_count : undefined,
   }
 }
 
 function buildRadarLongGapEntry(item: RadarApiLongGapItem): LongGapRadarEntry | null {
-  const group = resolveRadarGroupReference(readNonEmptyString(item.entity_slug), readNonEmptyString(item.display_name))
+  const entitySlug = readNonEmptyString(item.entity_slug)
+  const group = resolveApiDisplayGroup(entitySlug, readNonEmptyString(item.display_name))
   if (!group) {
     return null
   }
 
-  const fallbackTeam = teamProfileMap.get(group)
-  if (!fallbackTeam) {
-    return null
-  }
-
-  const latestRelease = buildRadarLatestRelease(group, item.latest_release ?? null, fallbackTeam)
+  const latestRelease = buildRadarLatestRelease(item.latest_release ?? null)
   if (!latestRelease) {
     return null
   }
 
-  const latestSignal = buildRadarUpcomingSignal(group, item.latest_signal ?? null, fallbackTeam)
+  const trackingStatus = readNonEmptyString(item.tracking_status) ?? 'watch_only'
+  const latestSignal = buildRadarUpcomingSignal(group, trackingStatus, item.latest_signal ?? null)
   const gapDays =
     typeof item.gap_days === 'number' && Number.isFinite(item.gap_days)
       ? item.gap_days
@@ -8844,6 +8802,8 @@ function buildRadarLongGapEntry(item: RadarApiLongGapItem): LongGapRadarEntry | 
 
   return {
     group,
+    entitySlug: entitySlug ?? undefined,
+    agencyName: normalizeAgencyName(readNonEmptyString(item.agency_name)),
     watchReason: item.watch_reason === 'long_gap' ? 'long_gap' : 'long_gap',
     latestRelease,
     gapDays,
@@ -8853,22 +8813,22 @@ function buildRadarLongGapEntry(item: RadarApiLongGapItem): LongGapRadarEntry | 
 }
 
 function buildRadarRookieEntry(item: RadarApiRookieItem): RookieRadarEntry | null {
-  const group = resolveRadarGroupReference(readNonEmptyString(item.entity_slug), readNonEmptyString(item.display_name))
+  const entitySlug = readNonEmptyString(item.entity_slug)
+  const group = resolveApiDisplayGroup(entitySlug, readNonEmptyString(item.display_name))
   if (!group) {
     return null
   }
 
-  const fallbackTeam = teamProfileMap.get(group)
-  if (!fallbackTeam) {
-    return null
-  }
+  const trackingStatus = readNonEmptyString(item.tracking_status) ?? 'watch_only'
 
   return {
     group,
+    entitySlug: entitySlug ?? undefined,
+    agencyName: normalizeAgencyName(readNonEmptyString(item.agency_name)),
     debutYear: typeof item.debut_year === 'number' && Number.isFinite(item.debut_year) ? item.debut_year : null,
-    latestRelease: buildRadarLatestRelease(group, item.latest_release ?? null, fallbackTeam),
+    latestRelease: buildRadarLatestRelease(item.latest_release ?? null),
     hasUpcomingSignal: Boolean(item.has_upcoming_signal ?? item.latest_signal),
-    latestSignal: buildRadarUpcomingSignal(group, item.latest_signal ?? null, fallbackTeam),
+    latestSignal: buildRadarUpcomingSignal(group, trackingStatus, item.latest_signal ?? null),
   }
 }
 
@@ -10514,21 +10474,6 @@ function findVerifiedReleaseByKey(group: string, albumKey: string) {
   return (verifiedReleaseHistoryByGroup.get(group) ?? []).find((item) => getAlbumKey(item) === albumKey) ?? null
 }
 
-function findVerifiedReleaseRecord(
-  group: string,
-  releaseTitle: string,
-  releaseDate: string,
-  stream: TeamLatestRelease['stream'] | VerifiedRelease['stream'],
-  releaseKind?: string,
-) {
-  const normalizedStream = normalizeReleaseStream(stream, releaseKind)
-  return (
-    (releaseGroups.get(group) ?? []).find(
-      (item) => item.title === releaseTitle && item.date === releaseDate && item.stream === normalizedStream,
-    ) ?? null
-  )
-}
-
 function getReleaseDetailActionLabel(releaseKind: ReleaseFact['release_kind'], language: Language) {
   const teamCopy = TEAM_COPY[language]
   return releaseKind === 'single' ? teamCopy.releaseDetail : teamCopy.albumDetail
@@ -10821,6 +10766,10 @@ function buildSearchIndex(values: Array<string | null | undefined>): SearchIndex
   }
 }
 
+function matchesSearchValues(values: Array<string | null | undefined>, needle: SearchNeedle | null) {
+  return matchesSearchIndex(buildSearchIndex(values), needle)
+}
+
 function matchesSearchIndex(index: SearchIndex | undefined, needle: SearchNeedle | null) {
   if (!needle) {
     return true
@@ -10986,11 +10935,17 @@ function matchesReleaseFilters(
     selectedMyTeamsOnly: boolean
   },
 ) {
-  const matchesSearch = matchesSearchIndex(searchIndexByGroup.get(item.group), searchNeedle)
+  const matchesSearch =
+    item.displayName || item.entitySlug
+      ? matchesSearchValues([item.group, item.displayName, item.entitySlug, item.title], searchNeedle)
+      : matchesSearchIndex(searchIndexByGroup.get(item.group), searchNeedle)
   const matchesReleaseKind = selectedReleaseKind === 'all' || item.release_kind === selectedReleaseKind
   const matchesActType = selectedActType === 'all' || item.actType === selectedActType
   const matchesStatus = selectedDashboardStatus === 'all' || selectedDashboardStatus === 'verified'
-  const matchesAgency = matchesAgencyFilter(item.group, selectedAgency)
+  const matchesAgency =
+    item.agencyName !== undefined
+      ? getAgencyFilterValue(normalizeAgencyName(item.agencyName)) === selectedAgency || selectedAgency === 'all'
+      : matchesAgencyFilter(item.group, selectedAgency)
   const matchesMyTeams = matchesMyTeamsFilter(item.group, myTeamsSet, selectedMyTeamsOnly)
   return matchesSearch && matchesReleaseKind && matchesActType && matchesStatus && matchesAgency && matchesMyTeams
 }
@@ -11015,16 +10970,22 @@ function matchesUpcomingFilters(
     selectedMyTeamsOnly: boolean
   },
 ) {
-  const matchesSearch = matchesSearchIndex(searchIndexByGroup.get(item.group), searchNeedle)
+  const matchesSearch =
+    item.displayName || item.entitySlug
+      ? matchesSearchValues([item.group, item.displayName, item.entitySlug, item.headline], searchNeedle)
+      : matchesSearchIndex(searchIndexByGroup.get(item.group), searchNeedle)
   const matchesReleaseKind = selectedReleaseKind === 'all' || item.release_format === selectedReleaseKind
-  const matchesActType = selectedActType === 'all' || getActType(item.group) === selectedActType
+  const matchesActType = selectedActType === 'all' || (item.actType ?? getActType(item.group)) === selectedActType
   const matchesStatus =
     selectedDashboardStatus === 'all'
       ? true
       : selectedDashboardStatus === 'verified'
         ? false
         : item.date_status === selectedDashboardStatus
-  const matchesAgency = matchesAgencyFilter(item.group, selectedAgency)
+  const matchesAgency =
+    item.agencyName !== undefined
+      ? getAgencyFilterValue(normalizeAgencyName(item.agencyName)) === selectedAgency || selectedAgency === 'all'
+      : matchesAgencyFilter(item.group, selectedAgency)
   const matchesMyTeams = matchesMyTeamsFilter(item.group, myTeamsSet, selectedMyTeamsOnly)
   return matchesSearch && matchesReleaseKind && matchesActType && matchesStatus && matchesAgency && matchesMyTeams
 }
@@ -11049,7 +11010,13 @@ function filterCalendarMonthApiSnapshot(
 }
 
 function matchesRadarEntryFilters(
-  group: string,
+  entry: {
+    group: string
+    entitySlug?: string
+    agencyName?: string | null
+    latestRelease?: TeamLatestRelease | null
+    latestSignal?: UpcomingCandidateRow | null
+  },
   {
     searchNeedle,
     selectedAgency,
@@ -11063,9 +11030,12 @@ function matchesRadarEntryFilters(
   },
 ) {
   return (
-    matchesSearchIndex(searchIndexByGroup.get(group), searchNeedle) &&
-    matchesAgencyFilter(group, selectedAgency) &&
-    matchesMyTeamsFilter(group, myTeamsSet, selectedMyTeamsOnly)
+    matchesSearchValues([entry.group, entry.entitySlug, entry.latestRelease?.title, entry.latestSignal?.headline], searchNeedle) &&
+    (selectedAgency === 'all' ||
+      (entry.agencyName !== undefined
+        ? getAgencyFilterValue(normalizeAgencyName(entry.agencyName)) === selectedAgency
+        : matchesAgencyFilter(entry.group, selectedAgency))) &&
+    matchesMyTeamsFilter(entry.group, myTeamsSet, selectedMyTeamsOnly)
   )
 }
 
@@ -11079,8 +11049,8 @@ function filterRadarApiSnapshot(
   },
 ): RadarApiSnapshot {
   return {
-    longGapEntries: snapshot.longGapEntries.filter((item) => matchesRadarEntryFilters(item.group, filters)),
-    rookieEntries: snapshot.rookieEntries.filter((item) => matchesRadarEntryFilters(item.group, filters)),
+    longGapEntries: snapshot.longGapEntries.filter((item) => matchesRadarEntryFilters(item, filters)),
+    rookieEntries: snapshot.rookieEntries.filter((item) => matchesRadarEntryFilters(item, filters)),
   }
 }
 


### PR DESCRIPTION
## Summary
- make web calendar API rows render from backend payload fields instead of synthesizing from local maps
- expand calendar/radar projection payloads and route contracts with direct-render identity, agency, tracking, and source metadata
- keep search/filter/open-team behavior working with API-native calendar and radar snapshots

Closes #642