### PR TITLE
fix(backend): clarify runtime health cadence blocker

### DIFF
--- a/backend/reports/backend_json_parity_report.json
+++ b/backend/reports/backend_json_parity_report.json
@@ -1,9 +1,9 @@
 {
-  "generated_at": "2026-03-12T02:34:38.126295+00:00",
+  "generated_at": "2026-03-12T08:03:37.635667+00:00",
   "clean": false,
   "report_bundle": {
-    "generated_at": "2026-03-12T02:34:27.398Z",
-    "bundle_id": "post-sync-verification-3fc09490ed96",
+    "generated_at": "2026-03-12T08:03:35.379Z",
+    "bundle_id": "post-sync-verification-368ed485b22b",
     "bundle_kind": "post-sync-verification",
     "cadence_profile": "daily-upcoming",
     "source": {
@@ -25,11 +25,11 @@
       },
       "projection_refresh": {
         "path": "reports/projection_refresh_summary.json",
-        "generated_at": "2026-03-12T02:34:21.051Z"
+        "generated_at": "2026-03-12T08:03:06.277Z"
       },
       "historical_coverage": {
         "path": "reports/historical_release_detail_coverage_report.json",
-        "generated_at": "2026-03-11T00:00:00.000Z"
+        "generated_at": "2026-03-12T00:00:00.000Z"
       },
       "canonical_null_coverage": {
         "path": "reports/canonical_null_coverage_report.json",
@@ -47,7 +47,7 @@
       },
       "worker_cadence": {
         "path": "reports/worker_cadence_report.json",
-        "generated_at": "2026-03-12T02:34:22.427Z",
+        "generated_at": "2026-03-12T08:02:36.197Z",
         "primary_path_key": "daily_upcoming"
       },
       "service_link_gap_queues": {
@@ -79,7 +79,7 @@
       }
     },
     "summary_lines": [
-      "bundle id: post-sync-verification-3fc09490ed96",
+      "bundle id: post-sync-verification-368ed485b22b",
       "bundle kind: post-sync-verification",
       "cadence profile: daily-upcoming",
       "workflow: manual"
@@ -88,17 +88,17 @@
   "summary_lines": [
     "entity alias/search coverage: clean (mismatched entities=0)",
     "official links: drift (mismatched entities=62)",
-    "YouTube allowlists: clean (role mismatches=0, metadata mismatches=0)",
-    "latest verified release selection: clean (tracking mismatches=0, stream mismatches=0)",
+    "YouTube allowlists: drift (role mismatches=90, metadata mismatches=2)",
+    "latest verified release selection: drift (tracking mismatches=0, stream mismatches=1)",
     "upcoming counts / nearest: clean (month bucket mismatches=0)",
     "title-track / double-title: clean (mismatched releases=0)",
-    "YouTube Music / MV service-link state: clean (mismatched releases=0)",
-    "review-required counts (release scope): clean (mv_candidate_count_match=True, youtube_mv_status_counts_match=True)"
+    "YouTube Music / MV service-link state: drift (mismatched releases=2)",
+    "review-required counts (release scope): drift (mv_candidate_count_match=True, youtube_mv_status_counts_match=False)"
   ],
   "source_snapshot_counts": {
     "artist_profiles": 117,
     "youtube_allowlists": 117,
-    "release_details": 1771,
+    "release_details": 1770,
     "upcoming_candidates": 71,
     "watchlist": 108,
     "manual_review_queue": 67,
@@ -239,18 +239,190 @@
       "clean": false
     },
     "youtube_allowlists": {
-      "role_mismatches_count": 0,
-      "metadata_mismatches_count": 0,
-      "role_mismatches": [],
-      "metadata_mismatches": [],
-      "clean": true
+      "role_mismatches_count": 90,
+      "metadata_mismatches_count": 2,
+      "role_mismatches": [
+        {
+          "entity_slug": "82major",
+          "missing_channel_roles": [
+            {
+              "url": "https://www.youtube.com/@82major_official",
+              "role": "both"
+            }
+          ],
+          "extra_channel_roles": [
+            {
+              "url": "https://www.youtube.com/channel/UC6H_3Rv-q8Z23jtMofgPGsw",
+              "role": "both"
+            }
+          ]
+        },
+        {
+          "entity_slug": "8turn",
+          "missing_channel_roles": [
+            {
+              "url": "https://www.youtube.com/@8TURN.official",
+              "role": "both"
+            }
+          ],
+          "extra_channel_roles": [
+            {
+              "url": "https://www.youtube.com/channel/UCZzpLKZPTSNNycp-qQc2kLw",
+              "role": "both"
+            }
+          ]
+        },
+        {
+          "entity_slug": "ab6ix",
+          "missing_channel_roles": [
+            {
+              "url": "https://www.youtube.com/@AB6IX",
+              "role": "both"
+            }
+          ],
+          "extra_channel_roles": [
+            {
+              "url": "https://www.youtube.com/channel/UCwytna6i1rFCt13a3Qvuk-A",
+              "role": "both"
+            }
+          ]
+        },
+        {
+          "entity_slug": "aespa",
+          "missing_channel_roles": [
+            {
+              "url": "https://www.youtube.com/@aespa_official",
+              "role": "both"
+            }
+          ],
+          "extra_channel_roles": [
+            {
+              "url": "https://www.youtube.com/channel/UC9GtSLeksfK4yuJ_g1lgQbg",
+              "role": "both"
+            }
+          ]
+        },
+        {
+          "entity_slug": "all-h-ours",
+          "missing_channel_roles": [
+            {
+              "url": "https://www.youtube.com/@ALL_H_OURS",
+              "role": "both"
+            }
+          ],
+          "extra_channel_roles": []
+        },
+        {
+          "entity_slug": "allday-project",
+          "missing_channel_roles": [
+            {
+              "url": "https://www.youtube.com/@ALLDAY_PROJECT",
+              "role": "both"
+            }
+          ],
+          "extra_channel_roles": []
+        },
+        {
+          "entity_slug": "and-team",
+          "missing_channel_roles": [
+            {
+              "url": "https://www.youtube.com/@andteamofficial",
+              "role": "both"
+            }
+          ],
+          "extra_channel_roles": [
+            {
+              "url": "https://www.youtube.com/channel/UCHD1jo5RhijLfx5-0Ehe_cg",
+              "role": "both"
+            }
+          ]
+        },
+        {
+          "entity_slug": "artms",
+          "missing_channel_roles": [
+            {
+              "url": "https://www.youtube.com/@official_artms",
+              "role": "both"
+            }
+          ],
+          "extra_channel_roles": []
+        },
+        {
+          "entity_slug": "atbo",
+          "missing_channel_roles": [
+            {
+              "url": "https://www.youtube.com/@ATBO_ground",
+              "role": "both"
+            }
+          ],
+          "extra_channel_roles": [
+            {
+              "url": "https://www.youtube.com/channel/UCZeIyD0qf91yYwNiyIquSTg",
+              "role": "both"
+            }
+          ]
+        },
+        {
+          "entity_slug": "ateez",
+          "missing_channel_roles": [
+            {
+              "url": "https://www.youtube.com/@ATEEZofficial",
+              "role": "both"
+            }
+          ],
+          "extra_channel_roles": [
+            {
+              "url": "https://www.youtube.com/channel/UC2e4Ukj5Pfr7cb3KpJAFBdQ",
+              "role": "both"
+            }
+          ]
+        }
+      ],
+      "metadata_mismatches": [
+        {
+          "entity_slug": "hearts2hearts",
+          "channel_url": "https://www.youtube.com/@SMTOWN",
+          "diffs": {
+            "owner_type": {
+              "source": "team",
+              "db": "label"
+            },
+            "display_in_team_links": {
+              "source": true,
+              "db": false
+            }
+          }
+        },
+        {
+          "entity_slug": "wjsn",
+          "channel_url": "https://www.youtube.com/@officialstarship",
+          "diffs": {
+            "owner_type": {
+              "source": "team",
+              "db": "label"
+            },
+            "display_in_team_links": {
+              "source": true,
+              "db": false
+            }
+          }
+        }
+      ],
+      "clean": false
     },
     "latest_verified_release_selection": {
       "tracking_mismatches_count": 0,
       "tracking_mismatches": [],
-      "stream_mismatches_count": 0,
-      "stream_mismatches": [],
-      "clean": true
+      "stream_mismatches_count": 1,
+      "stream_mismatches": [
+        {
+          "entity_slug": "yena",
+          "stream": "album",
+          "source": "yena|blooming wings|2025-07-29|album",
+          "db": "yena|love catcher|2026-03-11|album"
+        }
+      ],
+      "clean": false
     },
     "upcoming_counts_and_nearest": {
       "source": {
@@ -319,9 +491,34 @@
       "clean": true
     },
     "release_service_links": {
-      "mismatched_release_services_count": 0,
-      "mismatches": [],
-      "clean": true
+      "mismatched_release_services_count": 2,
+      "mismatches": [
+        {
+          "entity_slug": "yena",
+          "release_date": "2026-03-11",
+          "stream": "album",
+          "service_type": "youtube_music",
+          "source": null,
+          "db": {
+            "url": null,
+            "status": "no_link",
+            "provenance": null
+          }
+        },
+        {
+          "entity_slug": "yena",
+          "release_date": "2026-03-11",
+          "stream": "album",
+          "service_type": "youtube_mv",
+          "source": null,
+          "db": {
+            "url": null,
+            "status": "unresolved",
+            "provenance": null
+          }
+        }
+      ],
+      "clean": false
     },
     "review_required_counts": {
       "source_review_type_counts": {
@@ -341,7 +538,7 @@
         "mv_candidate": 1616
       },
       "source_youtube_mv_status_counts": {
-        "unresolved": 1615,
+        "unresolved": 1614,
         "manual_override": 133,
         "relation_match": 21,
         "needs_review": 2,
@@ -356,8 +553,8 @@
       },
       "review_type_counts_match": true,
       "release_scope_review_type_counts_match": true,
-      "youtube_mv_status_counts_match": true,
-      "clean": true
+      "youtube_mv_status_counts_match": false,
+      "clean": false
     }
   }
 }

--- a/backend/reports/backend_shadow_read_report.json
+++ b/backend/reports/backend_shadow_read_report.json
@@ -1,9 +1,9 @@
 {
-  "generated_at": "2026-03-12T02:34:44.443Z",
+  "generated_at": "2026-03-12T08:03:43.500Z",
   "clean": false,
   "report_bundle": {
-    "generated_at": "2026-03-12T02:34:27.398Z",
-    "bundle_id": "post-sync-verification-3fc09490ed96",
+    "generated_at": "2026-03-12T08:03:35.379Z",
+    "bundle_id": "post-sync-verification-368ed485b22b",
     "bundle_kind": "post-sync-verification",
     "cadence_profile": "daily-upcoming",
     "source": {
@@ -25,11 +25,11 @@
       },
       "projection_refresh": {
         "path": "reports/projection_refresh_summary.json",
-        "generated_at": "2026-03-12T02:34:21.051Z"
+        "generated_at": "2026-03-12T08:03:06.277Z"
       },
       "historical_coverage": {
         "path": "reports/historical_release_detail_coverage_report.json",
-        "generated_at": "2026-03-11T00:00:00.000Z"
+        "generated_at": "2026-03-12T00:00:00.000Z"
       },
       "canonical_null_coverage": {
         "path": "reports/canonical_null_coverage_report.json",
@@ -47,7 +47,7 @@
       },
       "worker_cadence": {
         "path": "reports/worker_cadence_report.json",
-        "generated_at": "2026-03-12T02:34:22.427Z",
+        "generated_at": "2026-03-12T08:02:36.197Z",
         "primary_path_key": "daily_upcoming"
       },
       "service_link_gap_queues": {
@@ -79,7 +79,7 @@
       }
     },
     "summary_lines": [
-      "bundle id: post-sync-verification-3fc09490ed96",
+      "bundle id: post-sync-verification-368ed485b22b",
       "bundle kind: post-sync-verification",
       "cadence profile: daily-upcoming",
       "workflow: manual"
@@ -87,9 +87,9 @@
   },
   "bundle_consistency": {
     "status": "pass",
-    "expected_bundle_id": "post-sync-verification-3fc09490ed96",
+    "expected_bundle_id": "post-sync-verification-368ed485b22b",
     "observed": {
-      "parity_bundle": "post-sync-verification-3fc09490ed96",
+      "parity_bundle": "post-sync-verification-368ed485b22b",
       "shadow_bundle": null,
       "runtime_gate_bundle": null,
       "historical_coverage_generated_at": null,
@@ -102,17 +102,17 @@
     "exists": true,
     "path": "backend/reports/backend_json_parity_report.json",
     "clean": false,
-    "generated_at": "2026-03-12T02:34:38.126295+00:00",
-    "bundle_id": "post-sync-verification-3fc09490ed96",
+    "generated_at": "2026-03-12T08:03:37.635667+00:00",
+    "bundle_id": "post-sync-verification-368ed485b22b",
     "summary_lines": [
       "entity alias/search coverage: clean (mismatched entities=0)",
       "official links: drift (mismatched entities=62)",
-      "YouTube allowlists: clean (role mismatches=0, metadata mismatches=0)",
-      "latest verified release selection: clean (tracking mismatches=0, stream mismatches=0)",
+      "YouTube allowlists: drift (role mismatches=90, metadata mismatches=2)",
+      "latest verified release selection: drift (tracking mismatches=0, stream mismatches=1)",
       "upcoming counts / nearest: clean (month bucket mismatches=0)",
       "title-track / double-title: clean (mismatched releases=0)",
-      "YouTube Music / MV service-link state: clean (mismatched releases=0)",
-      "review-required counts (release scope): clean (mv_candidate_count_match=True, youtube_mv_status_counts_match=True)"
+      "YouTube Music / MV service-link state: drift (mismatched releases=2)",
+      "review-required counts (release scope): drift (mv_candidate_count_match=True, youtube_mv_status_counts_match=False)"
     ]
   },
   "self_check": {
@@ -163,14 +163,15 @@
   },
   "summary_lines": [
     "search: clean 4/5, drift 1/5",
-    "entity_detail: clean 4/4, drift 0/4",
+    "entity_detail: clean 1/4, drift 3/4",
     "release_detail: clean 3/3, drift 0/3",
     "calendar_month: clean 2/3, drift 1/3",
     "radar: clean 1/1, drift 0/1",
-    "missing rows or segments: 2 case(s)",
+    "missing rows or segments: 5 case(s)",
     "exact-vs-month-only drift: 2 case(s)",
     "field-shape mismatches: 1 case(s)",
-    "alias-match differences: 1 case(s)"
+    "alias-match differences: 1 case(s)",
+    "latest-release or next-upcoming drift: 1 case(s)"
   ],
   "cases": [
     {
@@ -218,6 +219,7 @@
         "entities": [
           {
             "entity_slug": "triples",
+            "canonical_path": "/artists/triples",
             "display_name": "tripleS",
             "canonical_name": "tripleS",
             "entity_type": "group",
@@ -238,6 +240,8 @@
           {
             "release_id": "0f9b4a68-5b21-554f-bc5e-11c41291becf",
             "canonical_path": "/v1/releases/0f9b4a68-5b21-554f-bc5e-11c41291becf",
+            "detail_path": "/artists/triples/releases/0f9b4a68-5b21-554f-bc5e-11c41291becf",
+            "entity_path": "/artists/triples",
             "entity_slug": "triples",
             "display_name": "tripleS",
             "release_title": "トキメティック",
@@ -252,8 +256,8 @@
         "upcoming": []
       },
       "actual_status_code": 200,
-      "request_id_sent": "shadow--v1-search-q-ed-8a-b8-eb-a6-ac-ed-94-8c-ec-97-90-ec-8a-a4-c81bdb45-5720-405d-b0ca-e7e8a7056caf",
-      "response_request_id": "shadow--v1-search-q-ed-8a-b8-eb-a6-ac-ed-94-8c-ec-97-90-ec-8a-a4-c81bdb45-5720-405d-b0ca-e7e8a7056caf"
+      "request_id_sent": "shadow--v1-search-q-ed-8a-b8-eb-a6-ac-ed-94-8c-ec-97-90-ec-8a-a4-6501801f-6797-446c-bcd0-bfe3e60fcd12",
+      "response_request_id": "shadow--v1-search-q-ed-8a-b8-eb-a6-ac-ed-94-8c-ec-97-90-ec-8a-a4-6501801f-6797-446c-bcd0-bfe3e60fcd12"
     },
     {
       "surface": "search",
@@ -325,6 +329,7 @@
         "entities": [
           {
             "entity_slug": "tomorrow-x-together",
+            "canonical_path": "/artists/tomorrow-x-together",
             "display_name": "TOMORROW X TOGETHER",
             "canonical_name": "TOMORROW X TOGETHER",
             "entity_type": "group",
@@ -353,6 +358,8 @@
           {
             "release_id": "d22706bb-fcc0-50d9-b853-34cd6d85c24f",
             "canonical_path": "/v1/releases/d22706bb-fcc0-50d9-b853-34cd6d85c24f",
+            "detail_path": "/artists/tomorrow-x-together/releases/d22706bb-fcc0-50d9-b853-34cd6d85c24f",
+            "entity_path": "/artists/tomorrow-x-together",
             "entity_slug": "tomorrow-x-together",
             "display_name": "TOMORROW X TOGETHER",
             "release_title": "Starkissed",
@@ -367,6 +374,7 @@
         "upcoming": [
           {
             "upcoming_signal_id": "085d1cb7-4a4c-5232-abb0-a982534217b2",
+            "entity_path": "/artists/tomorrow-x-together",
             "entity_slug": "tomorrow-x-together",
             "display_name": "TOMORROW X TOGETHER",
             "headline": "[NOTICE] Comeback Showcase to Celebrate the Release of TOMORROW X TOGETHER “7TH YEAR: A Moment of Stillness in the Thorns”",
@@ -378,6 +386,7 @@
             "confidence_score": 0.84,
             "source_type": "news_rss",
             "source_url": "https://news.google.com/rss/articles/CBMieEFVX3lxTE11U0FzM2s2dXpCcHhqME5ZMVdCSlB2MjJKT21JS0p0dmhocmxhcXI4UlVDdGRBRXJQTmZiS1NLV2VCdlNYVFBhQzdoa0RvRVRYcnV1RWtEa2JZTVR4VERGdVRZSWRQaFlJSHZWUG10NHBDSW9oMXMtQg?oc=5",
+            "source_domain": "news.google.com",
             "evidence_summary": "Future month reference: 2026-04. TOMORROW X TOGETHER made their first comeback after renewing their contract..8th mini album released on April 13th starnewskorea.com",
             "match_reason": "entity_exact",
             "matched_alias": "투바투"
@@ -385,8 +394,8 @@
         ]
       },
       "actual_status_code": 200,
-      "request_id_sent": "shadow--v1-search-q-ed-88-ac-eb-b0-94-ed-88-ac-6c4c238f-6d2d-47c4-95fe-61dcc15877f9",
-      "response_request_id": "shadow--v1-search-q-ed-88-ac-eb-b0-94-ed-88-ac-6c4c238f-6d2d-47c4-95fe-61dcc15877f9"
+      "request_id_sent": "shadow--v1-search-q-ed-88-ac-eb-b0-94-ed-88-ac-43dcab50-c64c-45d7-b464-2faeeb882440",
+      "response_request_id": "shadow--v1-search-q-ed-88-ac-eb-b0-94-ed-88-ac-43dcab50-c64c-45d7-b464-2faeeb882440"
     },
     {
       "surface": "search",
@@ -527,6 +536,7 @@
         "entities": [
           {
             "entity_slug": "yena",
+            "canonical_path": "/artists/yena",
             "display_name": "YENA",
             "canonical_name": "YENA",
             "entity_type": "solo",
@@ -547,6 +557,8 @@
           {
             "release_id": "cbc23da6-08cd-5cc9-991c-a3638f493d45",
             "canonical_path": "/v1/releases/cbc23da6-08cd-5cc9-991c-a3638f493d45",
+            "detail_path": "/artists/yena/releases/cbc23da6-08cd-5cc9-991c-a3638f493d45",
+            "entity_path": "/artists/yena",
             "entity_slug": "yena",
             "display_name": "YENA",
             "release_title": "LOVE CATCHER",
@@ -561,8 +573,8 @@
         "upcoming": []
       },
       "actual_status_code": 200,
-      "request_id_sent": "shadow--v1-search-q-ec-b5-9c-ec-98-88-eb-82-98-fc97f275-b757-44b8-87f5-6c8f5683a437",
-      "response_request_id": "shadow--v1-search-q-ec-b5-9c-ec-98-88-eb-82-98-fc97f275-b757-44b8-87f5-6c8f5683a437"
+      "request_id_sent": "shadow--v1-search-q-ec-b5-9c-ec-98-88-eb-82-98-f4712912-82ea-43c6-892a-17e8f3a93b3c",
+      "response_request_id": "shadow--v1-search-q-ec-b5-9c-ec-98-88-eb-82-98-f4712912-82ea-43c6-892a-17e8f3a93b3c"
     },
     {
       "surface": "search",
@@ -609,6 +621,7 @@
         "entities": [
           {
             "entity_slug": "ive",
+            "canonical_path": "/artists/ive",
             "display_name": "IVE",
             "canonical_name": "IVE",
             "entity_type": "group",
@@ -629,6 +642,8 @@
           {
             "release_id": "c339f501-52fe-599d-8d2d-bf5694ae4de4",
             "canonical_path": "/v1/releases/c339f501-52fe-599d-8d2d-bf5694ae4de4",
+            "detail_path": "/artists/ive/releases/c339f501-52fe-599d-8d2d-bf5694ae4de4",
+            "entity_path": "/artists/ive",
             "entity_slug": "ive",
             "display_name": "IVE",
             "release_title": "REVIVE+",
@@ -643,8 +658,8 @@
         "upcoming": []
       },
       "actual_status_code": 200,
-      "request_id_sent": "shadow--v1-search-q-revive-2b-59118f1b-b7f5-4ab3-85b5-fbb0a6ce927c",
-      "response_request_id": "shadow--v1-search-q-revive-2b-59118f1b-b7f5-4ab3-85b5-fbb0a6ce927c"
+      "request_id_sent": "shadow--v1-search-q-revive-2b-b3ee66f3-bc97-41f1-a7d5-24826151c611",
+      "response_request_id": "shadow--v1-search-q-revive-2b-b3ee66f3-bc97-41f1-a7d5-24826151c611"
     },
     {
       "surface": "search",
@@ -691,6 +706,7 @@
         "entities": [
           {
             "entity_slug": "qwer",
+            "canonical_path": "/artists/qwer",
             "display_name": "QWER",
             "canonical_name": "QWER",
             "entity_type": "group",
@@ -711,6 +727,8 @@
           {
             "release_id": "d9a85b3d-ed19-51bb-a6c4-e5e538401b50",
             "canonical_path": "/v1/releases/d9a85b3d-ed19-51bb-a6c4-e5e538401b50",
+            "detail_path": "/artists/qwer/releases/d9a85b3d-ed19-51bb-a6c4-e5e538401b50",
+            "entity_path": "/artists/qwer",
             "entity_slug": "qwer",
             "display_name": "QWER",
             "release_title": "흰수염고래",
@@ -725,17 +743,195 @@
         "upcoming": []
       },
       "actual_status_code": 200,
-      "request_id_sent": "shadow--v1-search-q-ed-9d-b0-ec-88-98-ec-97-bc-ea-b3-a0-eb-9e-98-ca83b86e-1c1c-495f-b6e1-5add53b9e2b5",
-      "response_request_id": "shadow--v1-search-q-ed-9d-b0-ec-88-98-ec-97-bc-ea-b3-a0-eb-9e-98-ca83b86e-1c1c-495f-b6e1-5add53b9e2b5"
+      "request_id_sent": "shadow--v1-search-q-ed-9d-b0-ec-88-98-ec-97-bc-ea-b3-a0-eb-9e-98-33313cd0-e2fb-4757-a057-9c30db5b74f5",
+      "response_request_id": "shadow--v1-search-q-ed-9d-b0-ec-88-98-ec-97-bc-ea-b3-a0-eb-9e-98-33313cd0-e2fb-4757-a057-9c30db5b74f5"
     },
     {
       "surface": "entity_detail",
       "input": {
         "slug": "yena"
       },
-      "clean": true,
-      "mismatch_categories": [],
-      "mismatches": [],
+      "clean": false,
+      "mismatch_categories": [
+        "missing rows or segments",
+        "latest-release or next-upcoming drift"
+      ],
+      "mismatches": [
+        {
+          "category": "missing rows or segments",
+          "path": "data.official_links.youtube",
+          "expected": "https://www.youtube.com/@YENA_OFFICIAL",
+          "actual": "https://www.youtube.com/@yena_official"
+        },
+        {
+          "category": "latest-release or next-upcoming drift",
+          "path": "data.latest_release",
+          "expected": {
+            "release_title": "LOVE CATCHER",
+            "release_date": "2026-03-11",
+            "stream": "album",
+            "release_kind": "ep",
+            "release_format": "ep",
+            "artwork": null
+          },
+          "actual": {
+            "release_title": "LOVE CATCHER",
+            "release_date": "2026-03-11",
+            "stream": "album",
+            "release_kind": "ep",
+            "release_format": "ep",
+            "artwork": {
+              "cover_image_url": "https://coverartarchive.org/release-group/a2762912-326e-4a07-bcb1-fbd6887ab3a1/front",
+              "thumbnail_image_url": "https://coverartarchive.org/release-group/a2762912-326e-4a07-bcb1-fbd6887ab3a1/front-250",
+              "artwork_source_type": "cover_art_archive",
+              "artwork_source_url": "https://coverartarchive.org/release-group/a2762912-326e-4a07-bcb1-fbd6887ab3a1",
+              "is_placeholder": false
+            }
+          }
+        },
+        {
+          "category": "missing rows or segments",
+          "path": "data.recent_albums",
+          "expected": [
+            {
+              "release_title": "LOVE CATCHER",
+              "release_date": "2026-03-11",
+              "stream": "album",
+              "release_kind": "ep",
+              "release_format": "ep",
+              "artwork": null
+            },
+            {
+              "release_title": "Blooming Wings",
+              "release_date": "2025-07-29",
+              "stream": "album",
+              "release_kind": "ep",
+              "release_format": "ep",
+              "artwork": {
+                "cover_image_url": "https://coverartarchive.org/release-group/9647039b-b615-443a-a476-d75de3c06039/front",
+                "thumbnail_image_url": "https://coverartarchive.org/release-group/9647039b-b615-443a-a476-d75de3c06039/front-250",
+                "artwork_source_type": "cover_art_archive",
+                "artwork_source_url": "https://coverartarchive.org/release-group/9647039b-b615-443a-a476-d75de3c06039",
+                "is_placeholder": false
+              }
+            },
+            {
+              "release_title": "GOOD MORNING",
+              "release_date": "2024-01-15",
+              "stream": "album",
+              "release_kind": "ep",
+              "release_format": "ep",
+              "artwork": {
+                "cover_image_url": "https://coverartarchive.org/release-group/c8b7a898-4e24-4450-aa3b-594a95912e65/front",
+                "thumbnail_image_url": "https://coverartarchive.org/release-group/c8b7a898-4e24-4450-aa3b-594a95912e65/front-250",
+                "artwork_source_type": "cover_art_archive",
+                "artwork_source_url": "https://coverartarchive.org/release-group/c8b7a898-4e24-4450-aa3b-594a95912e65",
+                "is_placeholder": false
+              }
+            },
+            {
+              "release_title": "SMARTPHONE",
+              "release_date": "2022-08-03",
+              "stream": "album",
+              "release_kind": "ep",
+              "release_format": "ep",
+              "artwork": {
+                "cover_image_url": "https://coverartarchive.org/release-group/a45ab2e0-1dc4-4938-a0e9-648dc6df2c13/front",
+                "thumbnail_image_url": "https://coverartarchive.org/release-group/a45ab2e0-1dc4-4938-a0e9-648dc6df2c13/front-250",
+                "artwork_source_type": "cover_art_archive",
+                "artwork_source_url": "https://coverartarchive.org/release-group/a45ab2e0-1dc4-4938-a0e9-648dc6df2c13",
+                "is_placeholder": false
+              }
+            },
+            {
+              "release_title": "ˣ‿ˣ (SMiLEY)",
+              "release_date": "2022-01-17",
+              "stream": "album",
+              "release_kind": "ep",
+              "release_format": "ep",
+              "artwork": {
+                "cover_image_url": "https://coverartarchive.org/release-group/20d67cb3-1f48-4637-b760-e9b6e501d80c/front",
+                "thumbnail_image_url": "https://coverartarchive.org/release-group/20d67cb3-1f48-4637-b760-e9b6e501d80c/front-250",
+                "artwork_source_type": "cover_art_archive",
+                "artwork_source_url": "https://coverartarchive.org/release-group/20d67cb3-1f48-4637-b760-e9b6e501d80c",
+                "is_placeholder": false
+              }
+            }
+          ],
+          "actual": [
+            {
+              "release_title": "LOVE CATCHER",
+              "release_date": "2026-03-11",
+              "stream": "album",
+              "release_kind": "ep",
+              "release_format": "ep",
+              "artwork": {
+                "cover_image_url": "https://coverartarchive.org/release-group/a2762912-326e-4a07-bcb1-fbd6887ab3a1/front",
+                "thumbnail_image_url": "https://coverartarchive.org/release-group/a2762912-326e-4a07-bcb1-fbd6887ab3a1/front-250",
+                "artwork_source_type": "cover_art_archive",
+                "artwork_source_url": "https://coverartarchive.org/release-group/a2762912-326e-4a07-bcb1-fbd6887ab3a1",
+                "is_placeholder": false
+              }
+            },
+            {
+              "release_title": "Blooming Wings",
+              "release_date": "2025-07-29",
+              "stream": "album",
+              "release_kind": "ep",
+              "release_format": "ep",
+              "artwork": {
+                "cover_image_url": "https://coverartarchive.org/release-group/9647039b-b615-443a-a476-d75de3c06039/front",
+                "thumbnail_image_url": "https://coverartarchive.org/release-group/9647039b-b615-443a-a476-d75de3c06039/front-250",
+                "artwork_source_type": "cover_art_archive",
+                "artwork_source_url": "https://coverartarchive.org/release-group/9647039b-b615-443a-a476-d75de3c06039",
+                "is_placeholder": false
+              }
+            },
+            {
+              "release_title": "GOOD MORNING",
+              "release_date": "2024-01-15",
+              "stream": "album",
+              "release_kind": "ep",
+              "release_format": "ep",
+              "artwork": {
+                "cover_image_url": "https://coverartarchive.org/release-group/c8b7a898-4e24-4450-aa3b-594a95912e65/front",
+                "thumbnail_image_url": "https://coverartarchive.org/release-group/c8b7a898-4e24-4450-aa3b-594a95912e65/front-250",
+                "artwork_source_type": "cover_art_archive",
+                "artwork_source_url": "https://coverartarchive.org/release-group/c8b7a898-4e24-4450-aa3b-594a95912e65",
+                "is_placeholder": false
+              }
+            },
+            {
+              "release_title": "SMARTPHONE",
+              "release_date": "2022-08-03",
+              "stream": "album",
+              "release_kind": "ep",
+              "release_format": "ep",
+              "artwork": {
+                "cover_image_url": "https://coverartarchive.org/release-group/a45ab2e0-1dc4-4938-a0e9-648dc6df2c13/front",
+                "thumbnail_image_url": "https://coverartarchive.org/release-group/a45ab2e0-1dc4-4938-a0e9-648dc6df2c13/front-250",
+                "artwork_source_type": "cover_art_archive",
+                "artwork_source_url": "https://coverartarchive.org/release-group/a45ab2e0-1dc4-4938-a0e9-648dc6df2c13",
+                "is_placeholder": false
+              }
+            },
+            {
+              "release_title": "ˣ‿ˣ (SMiLEY)",
+              "release_date": "2022-01-17",
+              "stream": "album",
+              "release_kind": "ep",
+              "release_format": "ep",
+              "artwork": {
+                "cover_image_url": "https://coverartarchive.org/release-group/20d67cb3-1f48-4637-b760-e9b6e501d80c/front",
+                "thumbnail_image_url": "https://coverartarchive.org/release-group/20d67cb3-1f48-4637-b760-e9b6e501d80c/front-250",
+                "artwork_source_type": "cover_art_archive",
+                "artwork_source_url": "https://coverartarchive.org/release-group/20d67cb3-1f48-4637-b760-e9b6e501d80c",
+                "is_placeholder": false
+              }
+            }
+          ]
+        }
+      ],
       "expected_snapshot": {
         "identity": {
           "entity_slug": "yena",
@@ -747,14 +943,14 @@
           "debut_year": null
         },
         "official_links": {
-          "youtube": "https://www.youtube.com/@yena_official",
+          "youtube": "https://www.youtube.com/@YENA_OFFICIAL",
           "x": "https://x.com/YENA_OFFICIAL",
           "instagram": "https://www.instagram.com/yena.jigumina"
         },
         "youtube_channels": {
-          "primary_team_channel_url": "https://www.youtube.com/@yena_official",
+          "primary_team_channel_url": "https://www.youtube.com/@YENA_OFFICIAL",
           "mv_allowlist_urls": [
-            "https://www.youtube.com/@yena_official"
+            "https://www.youtube.com/@YENA_OFFICIAL"
           ]
         },
         "tracking_state": {
@@ -770,13 +966,7 @@
           "stream": "album",
           "release_kind": "ep",
           "release_format": "ep",
-          "artwork": {
-            "cover_image_url": "https://coverartarchive.org/release-group/a2762912-326e-4a07-bcb1-fbd6887ab3a1/front",
-            "thumbnail_image_url": "https://coverartarchive.org/release-group/a2762912-326e-4a07-bcb1-fbd6887ab3a1/front-250",
-            "artwork_source_type": "cover_art_archive",
-            "artwork_source_url": "https://coverartarchive.org/release-group/a2762912-326e-4a07-bcb1-fbd6887ab3a1",
-            "is_placeholder": false
-          }
+          "artwork": null
         },
         "recent_albums": [
           {
@@ -786,13 +976,7 @@
             "stream": "album",
             "release_kind": "ep",
             "release_format": "ep",
-            "artwork": {
-              "cover_image_url": "https://coverartarchive.org/release-group/a2762912-326e-4a07-bcb1-fbd6887ab3a1/front",
-              "thumbnail_image_url": "https://coverartarchive.org/release-group/a2762912-326e-4a07-bcb1-fbd6887ab3a1/front-250",
-              "artwork_source_type": "cover_art_archive",
-              "artwork_source_url": "https://coverartarchive.org/release-group/a2762912-326e-4a07-bcb1-fbd6887ab3a1",
-              "is_placeholder": false
-            }
+            "artwork": null
           },
           {
             "release_id": "YENA::Blooming Wings::2025-07-29::album",
@@ -1110,17 +1294,26 @@
         "artist_source_url": "https://musicbrainz.org/artist/745c5b92-325f-451d-bd52-e6b95229c776"
       },
       "actual_status_code": 200,
-      "request_id_sent": "shadow--v1-entities-yena-9c6c32c7-1148-4750-a2ec-fdbf3c0a6bfe",
-      "response_request_id": "shadow--v1-entities-yena-9c6c32c7-1148-4750-a2ec-fdbf3c0a6bfe"
+      "request_id_sent": "shadow--v1-entities-yena-0f7c0998-420f-4990-9ea0-bed0bd79dd1d",
+      "response_request_id": "shadow--v1-entities-yena-0f7c0998-420f-4990-9ea0-bed0bd79dd1d"
     },
     {
       "surface": "entity_detail",
       "input": {
         "slug": "blackpink"
       },
-      "clean": true,
-      "mismatch_categories": [],
-      "mismatches": [],
+      "clean": false,
+      "mismatch_categories": [
+        "missing rows or segments"
+      ],
+      "mismatches": [
+        {
+          "category": "missing rows or segments",
+          "path": "data.official_links.youtube",
+          "expected": "https://www.youtube.com/@BLACKPINK",
+          "actual": "https://www.youtube.com/channel/UCOmHUn--16B90oW2L6FRR3A"
+        }
+      ],
       "expected_snapshot": {
         "identity": {
           "entity_slug": "blackpink",
@@ -1132,14 +1325,14 @@
           "debut_year": null
         },
         "official_links": {
-          "youtube": "https://www.youtube.com/channel/UCOmHUn--16B90oW2L6FRR3A",
+          "youtube": "https://www.youtube.com/@BLACKPINK",
           "x": "https://x.com/blackpink",
           "instagram": "https://www.instagram.com/blackpinkofficial"
         },
         "youtube_channels": {
-          "primary_team_channel_url": "https://www.youtube.com/channel/UCOmHUn--16B90oW2L6FRR3A",
+          "primary_team_channel_url": "https://www.youtube.com/@BLACKPINK",
           "mv_allowlist_urls": [
-            "https://www.youtube.com/channel/UCOmHUn--16B90oW2L6FRR3A",
+            "https://www.youtube.com/@BLACKPINK",
             "https://www.youtube.com/@YGEntertainment"
           ]
         },
@@ -1786,17 +1979,26 @@
         "artist_source_url": "https://musicbrainz.org/artist/48646387-1664-4c9a-9139-9bfd091b823c"
       },
       "actual_status_code": 200,
-      "request_id_sent": "shadow--v1-entities-blackpink-c24fdca5-09de-45d9-9714-f526bc06894d",
-      "response_request_id": "shadow--v1-entities-blackpink-c24fdca5-09de-45d9-9714-f526bc06894d"
+      "request_id_sent": "shadow--v1-entities-blackpink-d56dc09a-f840-4b2e-94ae-059dde665255",
+      "response_request_id": "shadow--v1-entities-blackpink-d56dc09a-f840-4b2e-94ae-059dde665255"
     },
     {
       "surface": "entity_detail",
       "input": {
         "slug": "and-team"
       },
-      "clean": true,
-      "mismatch_categories": [],
-      "mismatches": [],
+      "clean": false,
+      "mismatch_categories": [
+        "missing rows or segments"
+      ],
+      "mismatches": [
+        {
+          "category": "missing rows or segments",
+          "path": "data.official_links.youtube",
+          "expected": "https://www.youtube.com/@andteamofficial",
+          "actual": "https://www.youtube.com/channel/UCHD1jo5RhijLfx5-0Ehe_cg"
+        }
+      ],
       "expected_snapshot": {
         "identity": {
           "entity_slug": "and-team",
@@ -1808,14 +2010,14 @@
           "debut_year": null
         },
         "official_links": {
-          "youtube": "https://www.youtube.com/channel/UCHD1jo5RhijLfx5-0Ehe_cg",
+          "youtube": "https://www.youtube.com/@andteamofficial",
           "x": "https://x.com/andTEAMofficial",
           "instagram": "https://www.instagram.com/andteam_official"
         },
         "youtube_channels": {
-          "primary_team_channel_url": "https://www.youtube.com/channel/UCHD1jo5RhijLfx5-0Ehe_cg",
+          "primary_team_channel_url": "https://www.youtube.com/@andteamofficial",
           "mv_allowlist_urls": [
-            "https://www.youtube.com/channel/UCHD1jo5RhijLfx5-0Ehe_cg",
+            "https://www.youtube.com/@andteamofficial",
             "https://www.youtube.com/@HYBELABELS"
           ]
         },
@@ -2210,8 +2412,8 @@
         "artist_source_url": "https://musicbrainz.org/artist/bba737dc-7ec8-482d-b79f-68d949ef2c7f"
       },
       "actual_status_code": 200,
-      "request_id_sent": "shadow--v1-entities-and-team-42435c15-acdc-4030-bd5f-1787c286c687",
-      "response_request_id": "shadow--v1-entities-and-team-42435c15-acdc-4030-bd5f-1787c286c687"
+      "request_id_sent": "shadow--v1-entities-and-team-dc5ef5ae-5cd9-489e-86d7-943f268e088a",
+      "response_request_id": "shadow--v1-entities-and-team-dc5ef5ae-5cd9-489e-86d7-943f268e088a"
     },
     {
       "surface": "entity_detail",
@@ -2237,8 +2439,10 @@
           "instagram": "https://www.instagram.com/allday_project"
         },
         "youtube_channels": {
-          "primary_team_channel_url": null,
-          "mv_allowlist_urls": []
+          "primary_team_channel_url": "https://www.youtube.com/@ALLDAY_PROJECT",
+          "mv_allowlist_urls": [
+            "https://www.youtube.com/@ALLDAY_PROJECT"
+          ]
         },
         "tracking_state": {
           "tier": "manual",
@@ -2405,8 +2609,8 @@
         "artist_source_url": "https://musicbrainz.org/artist/ce5c564c-0fbe-429c-b93b-5d7e3109cf40"
       },
       "actual_status_code": 200,
-      "request_id_sent": "shadow--v1-entities-allday-project-6e3333b7-10ca-48d3-ba15-2c5a5a5a15b8",
-      "response_request_id": "shadow--v1-entities-allday-project-6e3333b7-10ca-48d3-ba15-2c5a5a5a15b8"
+      "request_id_sent": "shadow--v1-entities-allday-project-f150874c-7cd1-46e1-9a31-b2cf15c19122",
+      "response_request_id": "shadow--v1-entities-allday-project-f150874c-7cd1-46e1-9a31-b2cf15c19122"
     },
     {
       "surface": "release_detail",
@@ -2607,10 +2811,10 @@
       },
       "lookup_status_code": 200,
       "detail_status_code": 200,
-      "lookup_request_id_sent": "shadow--v1-releases-lookup-entity_slug-blackpink-title-deadline-date-2026-02-26-stream-album-912a646f-d467-4e00-b015-0bae1aac5632",
-      "lookup_response_request_id": "shadow--v1-releases-lookup-entity_slug-blackpink-title-deadline-date-2026-02-26-stream-album-912a646f-d467-4e00-b015-0bae1aac5632",
-      "detail_request_id_sent": "shadow--v1-releases-75d59b7a-9f0e-526c-9920-3a156c1a9e36-b05a973d-f617-4c23-b913-8145ed58e463",
-      "detail_response_request_id": "shadow--v1-releases-75d59b7a-9f0e-526c-9920-3a156c1a9e36-b05a973d-f617-4c23-b913-8145ed58e463"
+      "lookup_request_id_sent": "shadow--v1-releases-lookup-entity_slug-blackpink-title-deadline-date-2026-02-26-stream-album-8d5e01e2-fa9e-4e02-873f-4c42f8a7c3dd",
+      "lookup_response_request_id": "shadow--v1-releases-lookup-entity_slug-blackpink-title-deadline-date-2026-02-26-stream-album-8d5e01e2-fa9e-4e02-873f-4c42f8a7c3dd",
+      "detail_request_id_sent": "shadow--v1-releases-75d59b7a-9f0e-526c-9920-3a156c1a9e36-7ae0927f-03e1-45da-b60e-86db66ed4d69",
+      "detail_response_request_id": "shadow--v1-releases-75d59b7a-9f0e-526c-9920-3a156c1a9e36-7ae0927f-03e1-45da-b60e-86db66ed4d69"
     },
     {
       "surface": "release_detail",
@@ -2930,10 +3134,10 @@
       },
       "lookup_status_code": 200,
       "detail_status_code": 200,
-      "lookup_request_id_sent": "shadow--v1-releases-lookup-entity_slug-ive-title-revive-2b-date-2026-02-23-stream-album-ed5abff6-767c-488c-a045-1725f3ef5214",
-      "lookup_response_request_id": "shadow--v1-releases-lookup-entity_slug-ive-title-revive-2b-date-2026-02-23-stream-album-ed5abff6-767c-488c-a045-1725f3ef5214",
-      "detail_request_id_sent": "shadow--v1-releases-c339f501-52fe-599d-8d2d-bf5694ae4de4-566e358d-49e1-479b-b13e-80780d0d4918",
-      "detail_response_request_id": "shadow--v1-releases-c339f501-52fe-599d-8d2d-bf5694ae4de4-566e358d-49e1-479b-b13e-80780d0d4918"
+      "lookup_request_id_sent": "shadow--v1-releases-lookup-entity_slug-ive-title-revive-2b-date-2026-02-23-stream-album-e3852f6d-c18a-4062-b133-6082c5af5a04",
+      "lookup_response_request_id": "shadow--v1-releases-lookup-entity_slug-ive-title-revive-2b-date-2026-02-23-stream-album-e3852f6d-c18a-4062-b133-6082c5af5a04",
+      "detail_request_id_sent": "shadow--v1-releases-c339f501-52fe-599d-8d2d-bf5694ae4de4-a0e4cccb-b743-43de-a6e0-94a96001a851",
+      "detail_response_request_id": "shadow--v1-releases-c339f501-52fe-599d-8d2d-bf5694ae4de4-a0e4cccb-b743-43de-a6e0-94a96001a851"
     },
     {
       "surface": "release_detail",
@@ -3082,10 +3286,10 @@
       },
       "lookup_status_code": 200,
       "detail_status_code": 200,
-      "lookup_request_id_sent": "shadow--v1-releases-lookup-entity_slug-qwer-title-ed-9d-b0-ec-88-98-ec-97-bc-ea-b3-a0-eb-9e-98-date-2025-10-06-stream-song-3745dce0-281b-4377-bb2e-34edee2b0a0e",
-      "lookup_response_request_id": "shadow--v1-releases-lookup-entity_slug-qwer-title-ed-9d-b0-ec-88-98-ec-97-bc-ea-b3-a0-eb-9e-98-date-2025-10-06-stream-song-3745dce0-281b-4377-bb2e-34edee2b0a0e",
-      "detail_request_id_sent": "shadow--v1-releases-d9a85b3d-ed19-51bb-a6c4-e5e538401b50-a0175fba-0d48-428b-9dba-6dc589517533",
-      "detail_response_request_id": "shadow--v1-releases-d9a85b3d-ed19-51bb-a6c4-e5e538401b50-a0175fba-0d48-428b-9dba-6dc589517533"
+      "lookup_request_id_sent": "shadow--v1-releases-lookup-entity_slug-qwer-title-ed-9d-b0-ec-88-98-ec-97-bc-ea-b3-a0-eb-9e-98-date-2025-10-06-stream-song-ee8f578a-9ccd-474a-bf27-3142c5e5690e",
+      "lookup_response_request_id": "shadow--v1-releases-lookup-entity_slug-qwer-title-ed-9d-b0-ec-88-98-ec-97-bc-ea-b3-a0-eb-9e-98-date-2025-10-06-stream-song-ee8f578a-9ccd-474a-bf27-3142c5e5690e",
+      "detail_request_id_sent": "shadow--v1-releases-d9a85b3d-ed19-51bb-a6c4-e5e538401b50-0be59546-ac96-4a46-9567-b41c023804af",
+      "detail_response_request_id": "shadow--v1-releases-d9a85b3d-ed19-51bb-a6c4-e5e538401b50-0be59546-ac96-4a46-9567-b41c023804af"
     },
     {
       "surface": "calendar_month",
@@ -3631,6 +3835,9 @@
           "upcoming_signal_id": "909b6943-f6f5-5b45-a753-e625f9678735",
           "entity_slug": "p1harmony",
           "display_name": "P1Harmony",
+          "entity_type": null,
+          "agency_name": null,
+          "tracking_status": null,
           "headline": "P1Harmony's Hero's Return: 9th Mini-Album Drops March 12 - 조선일보",
           "scheduled_date": "2026-03-12",
           "scheduled_month": "2026-03",
@@ -3652,9 +3859,14 @@
                 "release_id": "[truncated]",
                 "entity_slug": "[truncated]",
                 "display_name": "[truncated]",
+                "entity_type": "[truncated]",
+                "agency_name": "[truncated]",
                 "release_title": "[truncated]",
                 "stream": "[truncated]",
                 "release_kind": "[truncated]",
+                "release_format": "[truncated]",
+                "source_url": "[truncated]",
+                "artist_source_url": "[truncated]",
                 "release_date": "[truncated]"
               }
             ],
@@ -3667,9 +3879,14 @@
                 "release_id": "[truncated]",
                 "entity_slug": "[truncated]",
                 "display_name": "[truncated]",
+                "entity_type": "[truncated]",
+                "agency_name": "[truncated]",
                 "release_title": "[truncated]",
                 "stream": "[truncated]",
                 "release_kind": "[truncated]",
+                "release_format": "[truncated]",
+                "source_url": "[truncated]",
+                "artist_source_url": "[truncated]",
                 "release_date": "[truncated]"
               }
             ],
@@ -3682,9 +3899,14 @@
                 "release_id": "[truncated]",
                 "entity_slug": "[truncated]",
                 "display_name": "[truncated]",
+                "entity_type": "[truncated]",
+                "agency_name": "[truncated]",
                 "release_title": "[truncated]",
                 "stream": "[truncated]",
                 "release_kind": "[truncated]",
+                "release_format": "[truncated]",
+                "source_url": "[truncated]",
+                "artist_source_url": "[truncated]",
                 "release_date": "[truncated]"
               }
             ],
@@ -3698,6 +3920,9 @@
                 "upcoming_signal_id": "[truncated]",
                 "entity_slug": "[truncated]",
                 "display_name": "[truncated]",
+                "entity_type": "[truncated]",
+                "agency_name": "[truncated]",
+                "tracking_status": "[truncated]",
                 "headline": "[truncated]",
                 "scheduled_date": "[truncated]",
                 "scheduled_month": "[truncated]",
@@ -3721,6 +3946,9 @@
                 "upcoming_signal_id": "[truncated]",
                 "entity_slug": "[truncated]",
                 "display_name": "[truncated]",
+                "entity_type": "[truncated]",
+                "agency_name": "[truncated]",
+                "tracking_status": "[truncated]",
                 "headline": "[truncated]",
                 "scheduled_date": "[truncated]",
                 "scheduled_month": "[truncated]",
@@ -3744,6 +3972,9 @@
                 "upcoming_signal_id": "[truncated]",
                 "entity_slug": "[truncated]",
                 "display_name": "[truncated]",
+                "entity_type": "[truncated]",
+                "agency_name": "[truncated]",
+                "tracking_status": "[truncated]",
                 "headline": "[truncated]",
                 "scheduled_date": "[truncated]",
                 "scheduled_month": "[truncated]",
@@ -3765,6 +3996,9 @@
             "upcoming_signal_id": "b349b515-3866-513b-89db-6c4325fa2853",
             "entity_slug": "ab6ix",
             "display_name": "AB6IX",
+            "entity_type": null,
+            "agency_name": null,
+            "tracking_status": null,
             "headline": "AB6IX announces March comeback with their first full album in 5 years - allkpop",
             "scheduled_date": null,
             "scheduled_month": "2026-03",
@@ -3782,6 +4016,9 @@
             "upcoming_signal_id": "40b00178-7b92-5b5a-9581-7795f8676c98",
             "entity_slug": "all-h-ours",
             "display_name": "ALL(H)OURS",
+            "entity_type": null,
+            "agency_name": null,
+            "tracking_status": null,
             "headline": "ALL(H)OURS Sets March Comeback With 5th Mini-Album ‘NO DOUBT’ - hellokpop",
             "scheduled_date": null,
             "scheduled_month": "2026-03",
@@ -3799,6 +4036,9 @@
             "upcoming_signal_id": "0dc840bb-7287-5cf6-bf60-229beee35d38",
             "entity_slug": "ab6ix",
             "display_name": "AB6IX",
+            "entity_type": null,
+            "agency_name": null,
+            "tracking_status": null,
             "headline": "AB6IX begins the countdown for their March comeback with the full album ‘SEVEN : CRIMSON HORIZON’ - allkpop",
             "scheduled_date": null,
             "scheduled_month": "2026-03",
@@ -3816,6 +4056,9 @@
             "upcoming_signal_id": "6ea3a5db-e83f-51fc-b33e-bf701cef4c24",
             "entity_slug": "ab6ix",
             "display_name": "AB6IX",
+            "entity_type": null,
+            "agency_name": null,
+            "tracking_status": null,
             "headline": "AB6IX Unveils 'So Sweet' Ahead of March Album - 조선일보",
             "scheduled_date": null,
             "scheduled_month": "2026-03",
@@ -3835,27 +4078,42 @@
             "release_id": "bd9eebee-c5fe-509e-8b08-8b76ef26499e",
             "entity_slug": "tunexx",
             "display_name": "TUNEXX",
+            "entity_type": null,
+            "agency_name": null,
             "release_title": "SET BY US ONLY",
             "stream": "album",
             "release_kind": "ep",
+            "release_format": null,
+            "source_url": null,
+            "artist_source_url": null,
             "release_date": "2026-03-03"
           },
           {
             "release_id": "6a1db562-83b4-5e9d-a00f-6ea0ebfb6680",
             "entity_slug": "h1-key",
             "display_name": "H1-KEY",
+            "entity_type": null,
+            "agency_name": null,
             "release_title": "LOVECHAPTER",
             "stream": "album",
             "release_kind": "ep",
+            "release_format": null,
+            "source_url": null,
+            "artist_source_url": null,
             "release_date": "2026-03-05"
           },
           {
             "release_id": "cbc23da6-08cd-5cc9-991c-a3638f493d45",
             "entity_slug": "yena",
             "display_name": "YENA",
+            "entity_type": null,
+            "agency_name": null,
             "release_title": "LOVE CATCHER",
             "stream": "album",
             "release_kind": "ep",
+            "release_format": null,
+            "source_url": null,
+            "artist_source_url": null,
             "release_date": "2026-03-11"
           }
         ],
@@ -3864,6 +4122,9 @@
             "upcoming_signal_id": "909b6943-f6f5-5b45-a753-e625f9678735",
             "entity_slug": "p1harmony",
             "display_name": "P1Harmony",
+            "entity_type": null,
+            "agency_name": null,
+            "tracking_status": null,
             "headline": "P1Harmony's Hero's Return: 9th Mini-Album Drops March 12 - 조선일보",
             "scheduled_date": "2026-03-12",
             "scheduled_month": "2026-03",
@@ -3881,6 +4142,9 @@
             "upcoming_signal_id": "d830b9ba-3993-55fe-9f8b-680fa46e2742",
             "entity_slug": "bts",
             "display_name": "BTS",
+            "entity_type": null,
+            "agency_name": null,
+            "tracking_status": null,
             "headline": "Arirang BTS drops highly anticipated comeback album March 20 after 3-year hiatus - artthreat.net",
             "scheduled_date": "2026-03-20",
             "scheduled_month": "2026-03",
@@ -3898,6 +4162,9 @@
             "upcoming_signal_id": "e35fd84c-870e-5b22-998d-4bf66de28a16",
             "entity_slug": "bts",
             "display_name": "BTS",
+            "entity_type": null,
+            "agency_name": null,
+            "tracking_status": null,
             "headline": "Gwanghwamun Square hosts BTS comeback concert March 21, expecting 260k fans - artthreat.net",
             "scheduled_date": "2026-03-21",
             "scheduled_month": "2026-03",
@@ -3915,6 +4182,9 @@
             "upcoming_signal_id": "b349b515-3866-513b-89db-6c4325fa2853",
             "entity_slug": "ab6ix",
             "display_name": "AB6IX",
+            "entity_type": null,
+            "agency_name": null,
+            "tracking_status": null,
             "headline": "AB6IX announces March comeback with their first full album in 5 years - allkpop",
             "scheduled_date": null,
             "scheduled_month": "2026-03",
@@ -3932,6 +4202,9 @@
             "upcoming_signal_id": "40b00178-7b92-5b5a-9581-7795f8676c98",
             "entity_slug": "all-h-ours",
             "display_name": "ALL(H)OURS",
+            "entity_type": null,
+            "agency_name": null,
+            "tracking_status": null,
             "headline": "ALL(H)OURS Sets March Comeback With 5th Mini-Album ‘NO DOUBT’ - hellokpop",
             "scheduled_date": null,
             "scheduled_month": "2026-03",
@@ -3949,6 +4222,9 @@
             "upcoming_signal_id": "0dc840bb-7287-5cf6-bf60-229beee35d38",
             "entity_slug": "ab6ix",
             "display_name": "AB6IX",
+            "entity_type": null,
+            "agency_name": null,
+            "tracking_status": null,
             "headline": "AB6IX begins the countdown for their March comeback with the full album ‘SEVEN : CRIMSON HORIZON’ - allkpop",
             "scheduled_date": null,
             "scheduled_month": "2026-03",
@@ -3966,6 +4242,9 @@
             "upcoming_signal_id": "6ea3a5db-e83f-51fc-b33e-bf701cef4c24",
             "entity_slug": "ab6ix",
             "display_name": "AB6IX",
+            "entity_type": null,
+            "agency_name": null,
+            "tracking_status": null,
             "headline": "AB6IX Unveils 'So Sweet' Ahead of March Album - 조선일보",
             "scheduled_date": null,
             "scheduled_month": "2026-03",
@@ -3982,8 +4261,8 @@
         ]
       },
       "actual_status_code": 200,
-      "request_id_sent": "shadow--v1-calendar-month-month-2026-03-ca2b80ca-5921-40e9-98c2-be15ade4bd23",
-      "response_request_id": "shadow--v1-calendar-month-month-2026-03-ca2b80ca-5921-40e9-98c2-be15ade4bd23"
+      "request_id_sent": "shadow--v1-calendar-month-month-2026-03-4eabaf10-6775-4abb-8b40-f8fcedd45808",
+      "response_request_id": "shadow--v1-calendar-month-month-2026-03-4eabaf10-6775-4abb-8b40-f8fcedd45808"
     },
     {
       "surface": "calendar_month",
@@ -4444,6 +4723,9 @@
           "upcoming_signal_id": "909b6943-f6f5-5b45-a753-e625f9678735",
           "entity_slug": "p1harmony",
           "display_name": "P1Harmony",
+          "entity_type": null,
+          "agency_name": null,
+          "tracking_status": null,
           "headline": "P1Harmony's Hero's Return: 9th Mini-Album Drops March 12 - 조선일보",
           "scheduled_date": "2026-03-12",
           "scheduled_month": "2026-03",
@@ -4466,6 +4748,9 @@
                 "upcoming_signal_id": "[truncated]",
                 "entity_slug": "[truncated]",
                 "display_name": "[truncated]",
+                "entity_type": "[truncated]",
+                "agency_name": "[truncated]",
+                "tracking_status": "[truncated]",
                 "headline": "[truncated]",
                 "scheduled_date": "[truncated]",
                 "scheduled_month": "[truncated]",
@@ -4489,6 +4774,9 @@
                 "upcoming_signal_id": "[truncated]",
                 "entity_slug": "[truncated]",
                 "display_name": "[truncated]",
+                "entity_type": "[truncated]",
+                "agency_name": "[truncated]",
+                "tracking_status": "[truncated]",
                 "headline": "[truncated]",
                 "scheduled_date": "[truncated]",
                 "scheduled_month": "[truncated]",
@@ -4510,6 +4798,9 @@
             "upcoming_signal_id": "b2ce87e3-5912-5b58-aa78-e4366e3e13ba",
             "entity_slug": "and-team",
             "display_name": "&TEAM",
+            "entity_type": null,
+            "agency_name": null,
+            "tracking_status": null,
             "headline": "&TEAM sets April comeback with Japanese mini album ‘We on Fire’ - allkpop",
             "scheduled_date": null,
             "scheduled_month": "2026-04",
@@ -4527,6 +4818,9 @@
             "upcoming_signal_id": "5b6fc554-bccf-5dea-906d-4c5cebb58b96",
             "entity_slug": "kickflip",
             "display_name": "KickFlip",
+            "entity_type": null,
+            "agency_name": null,
+            "tracking_status": null,
             "headline": "KickFlip announces April comeback - Music Mundial",
             "scheduled_date": null,
             "scheduled_month": "2026-04",
@@ -4544,6 +4838,9 @@
             "upcoming_signal_id": "2d6a22f6-f4ec-5b46-aba0-fccfc75e3df9",
             "entity_slug": "kickflip",
             "display_name": "KickFlip",
+            "entity_type": null,
+            "agency_name": null,
+            "tracking_status": null,
             "headline": "KickFlip announces April comeback with their 4th mini-album - allkpop",
             "scheduled_date": null,
             "scheduled_month": "2026-04",
@@ -4561,6 +4858,9 @@
             "upcoming_signal_id": "40e933d3-cd90-5fed-ab51-b94953ab2132",
             "entity_slug": "kickflip",
             "display_name": "KickFlip",
+            "entity_type": null,
+            "agency_name": null,
+            "tracking_status": null,
             "headline": "KickFlip wraps first nationwide fan-con tour and announces April comeback - allkpop",
             "scheduled_date": null,
             "scheduled_month": "2026-04",
@@ -4578,6 +4878,9 @@
             "upcoming_signal_id": "daea5bae-dfed-53cf-ad37-05f6f469621d",
             "entity_slug": "young-posse",
             "display_name": "YOUNG POSSE",
+            "entity_type": null,
+            "agency_name": null,
+            "tracking_status": null,
             "headline": "YOUNG POSSE announces April comeback with new digital single - allkpop",
             "scheduled_date": null,
             "scheduled_month": "2026-04",
@@ -4595,6 +4898,9 @@
             "upcoming_signal_id": "b09afdd8-a6b8-55cf-b938-f05e57f2162a",
             "entity_slug": "kiss-of-life",
             "display_name": "KISS OF LIFE",
+            "entity_type": null,
+            "agency_name": null,
+            "tracking_status": null,
             "headline": "KISS OF LIFE Teases April Comeback with 'COMING SOON' Video - 조선일보",
             "scheduled_date": null,
             "scheduled_month": "2026-04",
@@ -4612,6 +4918,9 @@
             "upcoming_signal_id": "e9edf786-686c-5b65-aee4-f28df14d1016",
             "entity_slug": "le-sserafim",
             "display_name": "LE SSERAFIM",
+            "entity_type": null,
+            "agency_name": null,
+            "tracking_status": null,
             "headline": "LE SSERAFIM and TWS Set for April Comebacks as K-Pop Return Rush Intensifies - DIPE.CO.KR",
             "scheduled_date": null,
             "scheduled_month": "2026-04",
@@ -4629,6 +4938,9 @@
             "upcoming_signal_id": "8b7be2bc-53e3-5b0f-b090-71d79518f967",
             "entity_slug": "tws",
             "display_name": "TWS",
+            "entity_type": null,
+            "agency_name": null,
+            "tracking_status": null,
             "headline": "LE SSERAFIM and TWS Set for April Comebacks as K-Pop Return Rush Intensifies - DIPE.CO.KR",
             "scheduled_date": null,
             "scheduled_month": "2026-04",
@@ -4646,6 +4958,9 @@
             "upcoming_signal_id": "9e39b332-708c-5b76-a9c6-82102bae2e2e",
             "entity_slug": "tws",
             "display_name": "TWS",
+            "entity_type": null,
+            "agency_name": null,
+            "tracking_status": null,
             "headline": "LE SSERAFIM and TWS join April comeback lineup - allkpop",
             "scheduled_date": null,
             "scheduled_month": "2026-04",
@@ -4663,6 +4978,9 @@
             "upcoming_signal_id": "d0cf2b3a-95a2-5bcf-b184-d47dc3a2739b",
             "entity_slug": "tws",
             "display_name": "TWS",
+            "entity_type": null,
+            "agency_name": null,
+            "tracking_status": null,
             "headline": "TWS Set for a High-Energy Spring Comeback Confirmed for April - OtakuKart",
             "scheduled_date": null,
             "scheduled_month": "2026-04",
@@ -4683,6 +5001,9 @@
             "upcoming_signal_id": "035200de-6d2f-5866-97b4-e76b78528077",
             "entity_slug": "plave",
             "display_name": "PLAVE",
+            "entity_type": null,
+            "agency_name": null,
+            "tracking_status": null,
             "headline": "PLAVE Sets April 7 Comeback After Million-Seller Run | Outlook Respawn - Outlook Respawn",
             "scheduled_date": "2026-04-07",
             "scheduled_month": "2026-04",
@@ -4700,6 +5021,9 @@
             "upcoming_signal_id": "085d1cb7-4a4c-5232-abb0-a982534217b2",
             "entity_slug": "tomorrow-x-together",
             "display_name": "TOMORROW X TOGETHER",
+            "entity_type": null,
+            "agency_name": null,
+            "tracking_status": null,
             "headline": "[NOTICE] Comeback Showcase to Celebrate the Release of TOMORROW X TOGETHER “7TH YEAR: A Moment of Stillness in the Thorns”",
             "scheduled_date": "2026-04-13",
             "scheduled_month": "2026-04",
@@ -4717,6 +5041,9 @@
             "upcoming_signal_id": "b2ce87e3-5912-5b58-aa78-e4366e3e13ba",
             "entity_slug": "and-team",
             "display_name": "&TEAM",
+            "entity_type": null,
+            "agency_name": null,
+            "tracking_status": null,
             "headline": "&TEAM sets April comeback with Japanese mini album ‘We on Fire’ - allkpop",
             "scheduled_date": null,
             "scheduled_month": "2026-04",
@@ -4734,6 +5061,9 @@
             "upcoming_signal_id": "5b6fc554-bccf-5dea-906d-4c5cebb58b96",
             "entity_slug": "kickflip",
             "display_name": "KickFlip",
+            "entity_type": null,
+            "agency_name": null,
+            "tracking_status": null,
             "headline": "KickFlip announces April comeback - Music Mundial",
             "scheduled_date": null,
             "scheduled_month": "2026-04",
@@ -4751,6 +5081,9 @@
             "upcoming_signal_id": "2d6a22f6-f4ec-5b46-aba0-fccfc75e3df9",
             "entity_slug": "kickflip",
             "display_name": "KickFlip",
+            "entity_type": null,
+            "agency_name": null,
+            "tracking_status": null,
             "headline": "KickFlip announces April comeback with their 4th mini-album - allkpop",
             "scheduled_date": null,
             "scheduled_month": "2026-04",
@@ -4768,6 +5101,9 @@
             "upcoming_signal_id": "40e933d3-cd90-5fed-ab51-b94953ab2132",
             "entity_slug": "kickflip",
             "display_name": "KickFlip",
+            "entity_type": null,
+            "agency_name": null,
+            "tracking_status": null,
             "headline": "KickFlip wraps first nationwide fan-con tour and announces April comeback - allkpop",
             "scheduled_date": null,
             "scheduled_month": "2026-04",
@@ -4785,6 +5121,9 @@
             "upcoming_signal_id": "daea5bae-dfed-53cf-ad37-05f6f469621d",
             "entity_slug": "young-posse",
             "display_name": "YOUNG POSSE",
+            "entity_type": null,
+            "agency_name": null,
+            "tracking_status": null,
             "headline": "YOUNG POSSE announces April comeback with new digital single - allkpop",
             "scheduled_date": null,
             "scheduled_month": "2026-04",
@@ -4802,6 +5141,9 @@
             "upcoming_signal_id": "b09afdd8-a6b8-55cf-b938-f05e57f2162a",
             "entity_slug": "kiss-of-life",
             "display_name": "KISS OF LIFE",
+            "entity_type": null,
+            "agency_name": null,
+            "tracking_status": null,
             "headline": "KISS OF LIFE Teases April Comeback with 'COMING SOON' Video - 조선일보",
             "scheduled_date": null,
             "scheduled_month": "2026-04",
@@ -4819,6 +5161,9 @@
             "upcoming_signal_id": "e9edf786-686c-5b65-aee4-f28df14d1016",
             "entity_slug": "le-sserafim",
             "display_name": "LE SSERAFIM",
+            "entity_type": null,
+            "agency_name": null,
+            "tracking_status": null,
             "headline": "LE SSERAFIM and TWS Set for April Comebacks as K-Pop Return Rush Intensifies - DIPE.CO.KR",
             "scheduled_date": null,
             "scheduled_month": "2026-04",
@@ -4836,6 +5181,9 @@
             "upcoming_signal_id": "8b7be2bc-53e3-5b0f-b090-71d79518f967",
             "entity_slug": "tws",
             "display_name": "TWS",
+            "entity_type": null,
+            "agency_name": null,
+            "tracking_status": null,
             "headline": "LE SSERAFIM and TWS Set for April Comebacks as K-Pop Return Rush Intensifies - DIPE.CO.KR",
             "scheduled_date": null,
             "scheduled_month": "2026-04",
@@ -4853,6 +5201,9 @@
             "upcoming_signal_id": "9e39b332-708c-5b76-a9c6-82102bae2e2e",
             "entity_slug": "tws",
             "display_name": "TWS",
+            "entity_type": null,
+            "agency_name": null,
+            "tracking_status": null,
             "headline": "LE SSERAFIM and TWS join April comeback lineup - allkpop",
             "scheduled_date": null,
             "scheduled_month": "2026-04",
@@ -4870,6 +5221,9 @@
             "upcoming_signal_id": "d0cf2b3a-95a2-5bcf-b184-d47dc3a2739b",
             "entity_slug": "tws",
             "display_name": "TWS",
+            "entity_type": null,
+            "agency_name": null,
+            "tracking_status": null,
             "headline": "TWS Set for a High-Energy Spring Comeback Confirmed for April - OtakuKart",
             "scheduled_date": null,
             "scheduled_month": "2026-04",
@@ -4886,8 +5240,8 @@
         ]
       },
       "actual_status_code": 200,
-      "request_id_sent": "shadow--v1-calendar-month-month-2026-04-c2cbcfe4-8856-4011-b8ba-a785dbc86cb3",
-      "response_request_id": "shadow--v1-calendar-month-month-2026-04-c2cbcfe4-8856-4011-b8ba-a785dbc86cb3"
+      "request_id_sent": "shadow--v1-calendar-month-month-2026-04-17040305-0eef-4fe8-b0b7-04af8e7c3566",
+      "response_request_id": "shadow--v1-calendar-month-month-2026-04-17040305-0eef-4fe8-b0b7-04af8e7c3566"
     },
     {
       "surface": "calendar_month",
@@ -5279,6 +5633,9 @@
           "upcoming_signal_id": "909b6943-f6f5-5b45-a753-e625f9678735",
           "entity_slug": "p1harmony",
           "display_name": "P1Harmony",
+          "entity_type": null,
+          "agency_name": null,
+          "tracking_status": null,
           "headline": "P1Harmony's Hero's Return: 9th Mini-Album Drops March 12 - 조선일보",
           "scheduled_date": "2026-03-12",
           "scheduled_month": "2026-03",
@@ -5300,9 +5657,14 @@
                 "release_id": "[truncated]",
                 "entity_slug": "[truncated]",
                 "display_name": "[truncated]",
+                "entity_type": "[truncated]",
+                "agency_name": "[truncated]",
                 "release_title": "[truncated]",
                 "stream": "[truncated]",
                 "release_kind": "[truncated]",
+                "release_format": "[truncated]",
+                "source_url": "[truncated]",
+                "artist_source_url": "[truncated]",
                 "release_date": "[truncated]"
               }
             ],
@@ -5315,9 +5677,14 @@
                 "release_id": "[truncated]",
                 "entity_slug": "[truncated]",
                 "display_name": "[truncated]",
+                "entity_type": "[truncated]",
+                "agency_name": "[truncated]",
                 "release_title": "[truncated]",
                 "stream": "[truncated]",
                 "release_kind": "[truncated]",
+                "release_format": "[truncated]",
+                "source_url": "[truncated]",
+                "artist_source_url": "[truncated]",
                 "release_date": "[truncated]"
               }
             ],
@@ -5330,18 +5697,28 @@
                 "release_id": "[truncated]",
                 "entity_slug": "[truncated]",
                 "display_name": "[truncated]",
+                "entity_type": "[truncated]",
+                "agency_name": "[truncated]",
                 "release_title": "[truncated]",
                 "stream": "[truncated]",
                 "release_kind": "[truncated]",
+                "release_format": "[truncated]",
+                "source_url": "[truncated]",
+                "artist_source_url": "[truncated]",
                 "release_date": "[truncated]"
               },
               {
                 "release_id": "[truncated]",
                 "entity_slug": "[truncated]",
                 "display_name": "[truncated]",
+                "entity_type": "[truncated]",
+                "agency_name": "[truncated]",
                 "release_title": "[truncated]",
                 "stream": "[truncated]",
                 "release_kind": "[truncated]",
+                "release_format": "[truncated]",
+                "source_url": "[truncated]",
+                "artist_source_url": "[truncated]",
                 "release_date": "[truncated]"
               }
             ],
@@ -5354,9 +5731,14 @@
                 "release_id": "[truncated]",
                 "entity_slug": "[truncated]",
                 "display_name": "[truncated]",
+                "entity_type": "[truncated]",
+                "agency_name": "[truncated]",
                 "release_title": "[truncated]",
                 "stream": "[truncated]",
                 "release_kind": "[truncated]",
+                "release_format": "[truncated]",
+                "source_url": "[truncated]",
+                "artist_source_url": "[truncated]",
                 "release_date": "[truncated]"
               }
             ],
@@ -5369,9 +5751,14 @@
                 "release_id": "[truncated]",
                 "entity_slug": "[truncated]",
                 "display_name": "[truncated]",
+                "entity_type": "[truncated]",
+                "agency_name": "[truncated]",
                 "release_title": "[truncated]",
                 "stream": "[truncated]",
                 "release_kind": "[truncated]",
+                "release_format": "[truncated]",
+                "source_url": "[truncated]",
+                "artist_source_url": "[truncated]",
                 "release_date": "[truncated]"
               }
             ],
@@ -5384,9 +5771,14 @@
                 "release_id": "[truncated]",
                 "entity_slug": "[truncated]",
                 "display_name": "[truncated]",
+                "entity_type": "[truncated]",
+                "agency_name": "[truncated]",
                 "release_title": "[truncated]",
                 "stream": "[truncated]",
                 "release_kind": "[truncated]",
+                "release_format": "[truncated]",
+                "source_url": "[truncated]",
+                "artist_source_url": "[truncated]",
                 "release_date": "[truncated]"
               }
             ],
@@ -5399,18 +5791,28 @@
                 "release_id": "[truncated]",
                 "entity_slug": "[truncated]",
                 "display_name": "[truncated]",
+                "entity_type": "[truncated]",
+                "agency_name": "[truncated]",
                 "release_title": "[truncated]",
                 "stream": "[truncated]",
                 "release_kind": "[truncated]",
+                "release_format": "[truncated]",
+                "source_url": "[truncated]",
+                "artist_source_url": "[truncated]",
                 "release_date": "[truncated]"
               },
               {
                 "release_id": "[truncated]",
                 "entity_slug": "[truncated]",
                 "display_name": "[truncated]",
+                "entity_type": "[truncated]",
+                "agency_name": "[truncated]",
                 "release_title": "[truncated]",
                 "stream": "[truncated]",
                 "release_kind": "[truncated]",
+                "release_format": "[truncated]",
+                "source_url": "[truncated]",
+                "artist_source_url": "[truncated]",
                 "release_date": "[truncated]"
               }
             ],
@@ -5423,18 +5825,28 @@
                 "release_id": "[truncated]",
                 "entity_slug": "[truncated]",
                 "display_name": "[truncated]",
+                "entity_type": "[truncated]",
+                "agency_name": "[truncated]",
                 "release_title": "[truncated]",
                 "stream": "[truncated]",
                 "release_kind": "[truncated]",
+                "release_format": "[truncated]",
+                "source_url": "[truncated]",
+                "artist_source_url": "[truncated]",
                 "release_date": "[truncated]"
               },
               {
                 "release_id": "[truncated]",
                 "entity_slug": "[truncated]",
                 "display_name": "[truncated]",
+                "entity_type": "[truncated]",
+                "agency_name": "[truncated]",
                 "release_title": "[truncated]",
                 "stream": "[truncated]",
                 "release_kind": "[truncated]",
+                "release_format": "[truncated]",
+                "source_url": "[truncated]",
+                "artist_source_url": "[truncated]",
                 "release_date": "[truncated]"
               }
             ],
@@ -5447,18 +5859,28 @@
                 "release_id": "[truncated]",
                 "entity_slug": "[truncated]",
                 "display_name": "[truncated]",
+                "entity_type": "[truncated]",
+                "agency_name": "[truncated]",
                 "release_title": "[truncated]",
                 "stream": "[truncated]",
                 "release_kind": "[truncated]",
+                "release_format": "[truncated]",
+                "source_url": "[truncated]",
+                "artist_source_url": "[truncated]",
                 "release_date": "[truncated]"
               },
               {
                 "release_id": "[truncated]",
                 "entity_slug": "[truncated]",
                 "display_name": "[truncated]",
+                "entity_type": "[truncated]",
+                "agency_name": "[truncated]",
                 "release_title": "[truncated]",
                 "stream": "[truncated]",
                 "release_kind": "[truncated]",
+                "release_format": "[truncated]",
+                "source_url": "[truncated]",
+                "artist_source_url": "[truncated]",
                 "release_date": "[truncated]"
               }
             ],
@@ -5471,9 +5893,14 @@
                 "release_id": "[truncated]",
                 "entity_slug": "[truncated]",
                 "display_name": "[truncated]",
+                "entity_type": "[truncated]",
+                "agency_name": "[truncated]",
                 "release_title": "[truncated]",
                 "stream": "[truncated]",
                 "release_kind": "[truncated]",
+                "release_format": "[truncated]",
+                "source_url": "[truncated]",
+                "artist_source_url": "[truncated]",
                 "release_date": "[truncated]"
               }
             ],
@@ -5486,18 +5913,28 @@
                 "release_id": "[truncated]",
                 "entity_slug": "[truncated]",
                 "display_name": "[truncated]",
+                "entity_type": "[truncated]",
+                "agency_name": "[truncated]",
                 "release_title": "[truncated]",
                 "stream": "[truncated]",
                 "release_kind": "[truncated]",
+                "release_format": "[truncated]",
+                "source_url": "[truncated]",
+                "artist_source_url": "[truncated]",
                 "release_date": "[truncated]"
               },
               {
                 "release_id": "[truncated]",
                 "entity_slug": "[truncated]",
                 "display_name": "[truncated]",
+                "entity_type": "[truncated]",
+                "agency_name": "[truncated]",
                 "release_title": "[truncated]",
                 "stream": "[truncated]",
                 "release_kind": "[truncated]",
+                "release_format": "[truncated]",
+                "source_url": "[truncated]",
+                "artist_source_url": "[truncated]",
                 "release_date": "[truncated]"
               }
             ],
@@ -5510,18 +5947,28 @@
                 "release_id": "[truncated]",
                 "entity_slug": "[truncated]",
                 "display_name": "[truncated]",
+                "entity_type": "[truncated]",
+                "agency_name": "[truncated]",
                 "release_title": "[truncated]",
                 "stream": "[truncated]",
                 "release_kind": "[truncated]",
+                "release_format": "[truncated]",
+                "source_url": "[truncated]",
+                "artist_source_url": "[truncated]",
                 "release_date": "[truncated]"
               },
               {
                 "release_id": "[truncated]",
                 "entity_slug": "[truncated]",
                 "display_name": "[truncated]",
+                "entity_type": "[truncated]",
+                "agency_name": "[truncated]",
                 "release_title": "[truncated]",
                 "stream": "[truncated]",
                 "release_kind": "[truncated]",
+                "release_format": "[truncated]",
+                "source_url": "[truncated]",
+                "artist_source_url": "[truncated]",
                 "release_date": "[truncated]"
               }
             ],
@@ -5534,116 +5981,176 @@
             "release_id": "f52f59c6-a551-5dd2-b5b6-2c9e465f3828",
             "entity_slug": "triples",
             "display_name": "tripleS",
+            "entity_type": null,
+            "agency_name": null,
             "release_title": "tripleS ∞! < SecretHimitsuBimil >",
             "stream": "album",
             "release_kind": "album",
+            "release_format": null,
+            "source_url": null,
+            "artist_source_url": null,
             "release_date": "2025-10-01"
           },
           {
             "release_id": "297299cc-138e-52c1-9430-c10c22f95415",
             "entity_slug": "bae173",
             "display_name": "BAE173",
+            "entity_type": null,
+            "agency_name": null,
             "release_title": "One day",
             "stream": "song",
             "release_kind": "single",
+            "release_format": null,
+            "source_url": null,
+            "artist_source_url": null,
             "release_date": "2025-10-02"
           },
           {
             "release_id": "f49d9a86-bd1b-53a8-8c31-7f8163cdbb29",
             "entity_slug": "g-i-dle",
             "display_name": "(G)I-DLE",
+            "entity_type": null,
+            "agency_name": null,
             "release_title": "i‐dle",
             "stream": "album",
             "release_kind": "ep",
+            "release_format": null,
+            "source_url": null,
+            "artist_source_url": null,
             "release_date": "2025-10-03"
           },
           {
             "release_id": "05a34ac3-1116-5cc7-a9b8-8d5127790193",
             "entity_slug": "bae173",
             "display_name": "BAE173",
+            "entity_type": null,
+            "agency_name": null,
             "release_title": "What’s wrong?",
             "stream": "song",
             "release_kind": "single",
+            "release_format": null,
+            "source_url": null,
+            "artist_source_url": null,
             "release_date": "2025-10-03"
           },
           {
             "release_id": "d9a85b3d-ed19-51bb-a6c4-e5e538401b50",
             "entity_slug": "qwer",
             "display_name": "QWER",
+            "entity_type": null,
+            "agency_name": null,
             "release_title": "흰수염고래",
             "stream": "song",
             "release_kind": "single",
+            "release_format": null,
+            "source_url": null,
+            "artist_source_url": null,
             "release_date": "2025-10-06"
           },
           {
             "release_id": "184a3749-a2e9-5309-b0be-2dc995e48e3f",
             "entity_slug": "onewe",
             "display_name": "ONEWE",
+            "entity_type": null,
+            "agency_name": null,
             "release_title": "MAZE : AD ASTRA",
             "stream": "album",
             "release_kind": "ep",
+            "release_format": null,
+            "source_url": null,
+            "artist_source_url": null,
             "release_date": "2025-10-07"
           },
           {
             "release_id": "da4197ce-7ce3-5a60-ad58-185d842c716d",
             "entity_slug": "itzy",
             "display_name": "ITZY",
+            "entity_type": null,
+            "agency_name": null,
             "release_title": "Collector",
             "stream": "album",
             "release_kind": "album",
+            "release_format": null,
+            "source_url": null,
+            "artist_source_url": null,
             "release_date": "2025-10-08"
           },
           {
             "release_id": "ee1e9da9-904f-5f37-aa38-11f9a05bce84",
             "entity_slug": "babymonster",
             "display_name": "BABYMONSTER",
+            "entity_type": null,
+            "agency_name": null,
             "release_title": "WE GO UP",
             "stream": "album",
             "release_kind": "ep",
+            "release_format": null,
+            "source_url": null,
+            "artist_source_url": null,
             "release_date": "2025-10-10"
           },
           {
             "release_id": "5a3a11fe-195d-50c4-a215-347eba0e018e",
             "entity_slug": "twice",
             "display_name": "TWICE",
+            "entity_type": null,
+            "agency_name": null,
             "release_title": "TEN: The Story Goes On",
             "stream": "album",
             "release_kind": "album",
+            "release_format": null,
+            "source_url": null,
+            "artist_source_url": null,
             "release_date": "2025-10-10"
           },
           {
             "release_id": "510353ab-c5c1-5461-80ce-eaeb26f94a12",
             "entity_slug": "nmixx",
             "display_name": "NMIXX",
+            "entity_type": null,
+            "agency_name": null,
             "release_title": "Blue Valentine",
             "stream": "album",
             "release_kind": "album",
+            "release_format": null,
+            "source_url": null,
+            "artist_source_url": null,
             "release_date": "2025-10-13"
           },
           {
             "release_id": "c0c2c69b-8f5c-53e9-a9b1-115b6e82e886",
             "entity_slug": "tws",
             "display_name": "TWS",
+            "entity_type": null,
+            "agency_name": null,
             "release_title": "play hard",
             "stream": "album",
             "release_kind": "ep",
+            "release_format": null,
+            "source_url": null,
+            "artist_source_url": null,
             "release_date": "2025-10-13"
           },
           {
             "release_id": "4fc193c7-cc0a-5d88-b656-d9615f60e359",
             "entity_slug": "bae173",
             "display_name": "BAE173",
+            "entity_type": null,
+            "agency_name": null,
             "release_title": "NEW CHAPTER : DESEAR",
             "stream": "album",
             "release_kind": "ep",
+            "release_format": null,
+            "source_url": null,
+            "artist_source_url": null,
             "release_date": "2025-10-14"
           }
         ],
         "scheduled_list": []
       },
       "actual_status_code": 200,
-      "request_id_sent": "shadow--v1-calendar-month-month-2025-10-0c7b6ff6-5559-45ed-91df-e859b4b9a979",
-      "response_request_id": "shadow--v1-calendar-month-month-2025-10-0c7b6ff6-5559-45ed-91df-e859b4b9a979"
+      "request_id_sent": "shadow--v1-calendar-month-month-2025-10-201b58bc-5c55-45a4-9c6b-f2647b45bbf8",
+      "response_request_id": "shadow--v1-calendar-month-month-2025-10-201b58bc-5c55-45a4-9c6b-f2647b45bbf8"
     },
     {
       "surface": "radar",
@@ -6179,7 +6686,13 @@
           "release_format": "ep",
           "scheduled_date": "2026-03-12",
           "confidence_score": 0.82,
-          "upcoming_signal_id": "909b6943-f6f5-5b45-a753-e625f9678735"
+          "upcoming_signal_id": "909b6943-f6f5-5b45-a753-e625f9678735",
+          "scheduled_month": null,
+          "source_url": null,
+          "source_type": null,
+          "source_domain": null,
+          "evidence_summary": null,
+          "latest_seen_at": null
         },
         "weekly_upcoming": [
           {
@@ -6191,7 +6704,13 @@
             "release_format": "ep",
             "scheduled_date": "2026-03-12",
             "confidence_score": 0.82,
-            "upcoming_signal_id": "909b6943-f6f5-5b45-a753-e625f9678735"
+            "upcoming_signal_id": "909b6943-f6f5-5b45-a753-e625f9678735",
+            "scheduled_month": null,
+            "source_url": null,
+            "source_type": null,
+            "source_domain": null,
+            "evidence_summary": null,
+            "latest_seen_at": null
           }
         ],
         "change_feed": [
@@ -6222,23 +6741,23 @@
           {
             "kind": "verified_release",
             "stream": "album",
-            "release_id": "75d59b7a-9f0e-526c-9920-3a156c1a9e36",
-            "entity_slug": "blackpink",
-            "occurred_at": "2026-03-12T02:33:59.504Z",
-            "display_name": "BLACKPINK",
-            "release_date": "2026-02-27",
-            "release_kind": "ep",
-            "release_title": "DEADLINE"
-          },
-          {
-            "kind": "verified_release",
-            "stream": "album",
             "release_id": "e3526174-e804-56f2-9d50-17f9f817a351",
             "entity_slug": "blackpink",
             "occurred_at": "2026-03-12T02:33:59.504Z",
             "display_name": "BLACKPINK",
             "release_date": "2026-02-26",
             "release_kind": null,
+            "release_title": "DEADLINE"
+          },
+          {
+            "kind": "verified_release",
+            "stream": "album",
+            "release_id": "75d59b7a-9f0e-526c-9920-3a156c1a9e36",
+            "entity_slug": "blackpink",
+            "occurred_at": "2026-03-12T02:33:59.504Z",
+            "display_name": "BLACKPINK",
+            "release_date": "2026-02-27",
+            "release_kind": "ep",
             "release_title": "DEADLINE"
           },
           {
@@ -6345,14 +6864,21 @@
               "scheduled_date": null,
               "scheduled_month": null,
               "confidence_score": 0.68,
-              "upcoming_signal_id": "07644eff-2a2b-5123-88fa-3fe71ccc4d9c"
+              "upcoming_signal_id": "07644eff-2a2b-5123-88fa-3fe71ccc4d9c",
+              "source_url": null,
+              "source_type": null,
+              "source_domain": null,
+              "evidence_summary": null
             },
             "latest_release": {
               "stream": "song",
               "release_id": "d4653d95-ae29-57d2-be3e-e5cb2b7267c3",
               "release_date": "2023-06-09",
               "release_kind": "single",
-              "release_title": "Take Two"
+              "release_title": "Take Two",
+              "release_format": null,
+              "source_url": null,
+              "artist_source_url": null
             },
             "has_upcoming_signal": true
           },
@@ -6370,14 +6896,21 @@
               "scheduled_date": null,
               "scheduled_month": "2026-03",
               "confidence_score": 0.46,
-              "upcoming_signal_id": "6ea3a5db-e83f-51fc-b33e-bf701cef4c24"
+              "upcoming_signal_id": "6ea3a5db-e83f-51fc-b33e-bf701cef4c24",
+              "source_url": null,
+              "source_type": null,
+              "source_domain": null,
+              "evidence_summary": null
             },
             "latest_release": {
               "stream": "album",
               "release_id": "403a26f7-5bc4-5feb-95ae-2f4de4798ea9",
               "release_date": "2024-10-10",
               "release_kind": "ep",
-              "release_title": "BORN LIKE THIS"
+              "release_title": "BORN LIKE THIS",
+              "release_format": null,
+              "source_url": null,
+              "artist_source_url": null
             },
             "has_upcoming_signal": true
           },
@@ -6392,7 +6925,10 @@
               "release_id": "2d662b2e-7f45-5ed3-85de-ffa1f3e16b72",
               "release_date": "2021-06-16",
               "release_kind": "single",
-              "release_title": "Back To You"
+              "release_title": "Back To You",
+              "release_format": null,
+              "source_url": null,
+              "artist_source_url": null
             },
             "has_upcoming_signal": false
           },
@@ -6407,7 +6943,10 @@
               "release_id": "7e1f4bf1-04af-5ec8-a8f5-c8071b6c4b6b",
               "release_date": "2022-07-15",
               "release_kind": "ep",
-              "release_title": "Light Sweeper"
+              "release_title": "Light Sweeper",
+              "release_format": null,
+              "source_url": null,
+              "artist_source_url": null
             },
             "has_upcoming_signal": false
           },
@@ -6422,7 +6961,10 @@
               "release_id": "5ac11b84-f93e-5c0b-9349-8ffc18ae9ebb",
               "release_date": "2022-10-11",
               "release_kind": "ep",
-              "release_title": "MIC ON"
+              "release_title": "MIC ON",
+              "release_format": null,
+              "source_url": null,
+              "artist_source_url": null
             },
             "has_upcoming_signal": false
           },
@@ -6437,7 +6979,10 @@
               "release_id": "c0d7e03c-7b01-51dd-ae48-c4e76e903510",
               "release_date": "2023-11-27",
               "release_kind": "ep",
-              "release_title": "MUST HAVE"
+              "release_title": "MUST HAVE",
+              "release_format": null,
+              "source_url": null,
+              "artist_source_url": null
             },
             "has_upcoming_signal": false
           },
@@ -6452,7 +6997,10 @@
               "release_id": "5193c862-8921-5dae-924a-112400ccf545",
               "release_date": "2024-02-28",
               "release_kind": "ep",
-              "release_title": "NOMAD"
+              "release_title": "NOMAD",
+              "release_format": null,
+              "source_url": null,
+              "artist_source_url": null
             },
             "has_upcoming_signal": false
           },
@@ -6467,7 +7015,10 @@
               "release_id": "9770e2a8-80f0-5d42-ad00-5f59038a4684",
               "release_date": "2024-06-10",
               "release_kind": "ep",
-              "release_title": "Sweetie but Saltie"
+              "release_title": "Sweetie but Saltie",
+              "release_format": null,
+              "source_url": null,
+              "artist_source_url": null
             },
             "has_upcoming_signal": false
           },
@@ -6482,7 +7033,10 @@
               "release_id": "8980d7d8-9090-5447-a4df-6ae0f0ba990f",
               "release_date": "2024-06-19",
               "release_kind": "ep",
-              "release_title": "LUNCH‐BOX"
+              "release_title": "LUNCH‐BOX",
+              "release_format": null,
+              "source_url": null,
+              "artist_source_url": null
             },
             "has_upcoming_signal": false
           },
@@ -6497,7 +7051,10 @@
               "release_id": "5aeb168e-dad8-554e-aec1-0d8882c4da4a",
               "release_date": "2024-06-21",
               "release_kind": "single",
-              "release_title": "Supernatural"
+              "release_title": "Supernatural",
+              "release_format": null,
+              "source_url": null,
+              "artist_source_url": null
             },
             "has_upcoming_signal": false
           },
@@ -6512,7 +7069,10 @@
               "release_id": "f21dbb3d-c0b5-57ae-84b3-36f25041d237",
               "release_date": "2024-06-24",
               "release_kind": "ep",
-              "release_title": "Cosmic"
+              "release_title": "Cosmic",
+              "release_format": null,
+              "source_url": null,
+              "artist_source_url": null
             },
             "has_upcoming_signal": false
           },
@@ -6527,7 +7087,10 @@
               "release_id": "f4a2b5b1-c9e2-5a1a-9cd6-56afa855ef8f",
               "release_date": "2024-07-09",
               "release_kind": "ep",
-              "release_title": "Bliss"
+              "release_title": "Bliss",
+              "release_format": null,
+              "source_url": null,
+              "artist_source_url": null
             },
             "has_upcoming_signal": false
           }
@@ -6546,14 +7109,21 @@
               "scheduled_date": null,
               "scheduled_month": null,
               "confidence_score": 0.68,
-              "upcoming_signal_id": "d81d7432-3d57-5f0c-b049-c11807aace85"
+              "upcoming_signal_id": "d81d7432-3d57-5f0c-b049-c11807aace85",
+              "source_url": null,
+              "source_type": null,
+              "source_domain": null,
+              "evidence_summary": null
             },
             "latest_release": {
               "stream": "song",
               "release_id": "e5976e68-a795-52dd-b40e-a72493038dd3",
               "release_date": "2026-02-26",
               "release_kind": "single",
-              "release_title": "Shut Up"
+              "release_title": "Shut Up",
+              "release_format": null,
+              "source_url": null,
+              "artist_source_url": null
             },
             "has_upcoming_signal": true
           },
@@ -6570,14 +7140,21 @@
               "scheduled_date": null,
               "scheduled_month": null,
               "confidence_score": 0.68,
-              "upcoming_signal_id": "113ba3c1-a52d-56c0-a58d-d3b204addf15"
+              "upcoming_signal_id": "113ba3c1-a52d-56c0-a58d-d3b204addf15",
+              "source_url": null,
+              "source_type": null,
+              "source_domain": null,
+              "evidence_summary": null
             },
             "latest_release": {
               "stream": "song",
               "release_id": "06aa603b-b554-52a8-b9e4-47c6a6764e53",
               "release_date": "2026-02-20",
               "release_kind": "single",
-              "release_title": "RUDE!"
+              "release_title": "RUDE!",
+              "release_format": null,
+              "source_url": null,
+              "artist_source_url": null
             },
             "has_upcoming_signal": true
           },
@@ -6594,14 +7171,21 @@
               "scheduled_date": null,
               "scheduled_month": null,
               "confidence_score": 0.56,
-              "upcoming_signal_id": "aeed763b-0ed9-50c7-8045-f1273a07df45"
+              "upcoming_signal_id": "aeed763b-0ed9-50c7-8045-f1273a07df45",
+              "source_url": null,
+              "source_type": null,
+              "source_domain": null,
+              "evidence_summary": null
             },
             "latest_release": {
               "stream": "album",
               "release_id": "da1a7f42-5755-5649-b235-e8568b2e4a58",
               "release_date": "2026-01-25",
               "release_kind": "ep",
-              "release_title": "Delulu Pack"
+              "release_title": "Delulu Pack",
+              "release_format": null,
+              "source_url": null,
+              "artist_source_url": null
             },
             "has_upcoming_signal": true
           },
@@ -6618,14 +7202,21 @@
               "scheduled_date": null,
               "scheduled_month": "2026-04",
               "confidence_score": 0.76,
-              "upcoming_signal_id": "5b6fc554-bccf-5dea-906d-4c5cebb58b96"
+              "upcoming_signal_id": "5b6fc554-bccf-5dea-906d-4c5cebb58b96",
+              "source_url": null,
+              "source_type": null,
+              "source_domain": null,
+              "evidence_summary": null
             },
             "latest_release": {
               "stream": "song",
               "release_id": "f8f95da5-91f9-53f5-bef1-fa14153369f3",
               "release_date": "2026-01-20",
               "release_kind": "single",
-              "release_title": "From KickFlip, To WeFlip"
+              "release_title": "From KickFlip, To WeFlip",
+              "release_format": null,
+              "source_url": null,
+              "artist_source_url": null
             },
             "has_upcoming_signal": true
           },
@@ -6639,7 +7230,10 @@
               "release_id": "c00920b0-930d-5662-9874-82603c0ad5f7",
               "release_date": "2025-12-08",
               "release_kind": "ep",
-              "release_title": "ALLDAY PROJECT"
+              "release_title": "ALLDAY PROJECT",
+              "release_format": null,
+              "source_url": null,
+              "artist_source_url": null
             },
             "has_upcoming_signal": false
           },
@@ -6653,7 +7247,10 @@
               "release_id": "f6355382-6712-52f4-87ff-593f96ca7869",
               "release_date": "2025-11-11",
               "release_kind": "ep",
-              "release_title": "blackout"
+              "release_title": "blackout",
+              "release_format": null,
+              "source_url": null,
+              "artist_source_url": null
             },
             "has_upcoming_signal": false
           },
@@ -6667,7 +7264,10 @@
               "release_id": "52e2b10d-b9bf-55d0-ae7c-0aae46a013dc",
               "release_date": "2025-11-05",
               "release_kind": "ep",
-              "release_title": "UXLXVE"
+              "release_title": "UXLXVE",
+              "release_format": null,
+              "source_url": null,
+              "artist_source_url": null
             },
             "has_upcoming_signal": false
           },
@@ -6681,15 +7281,18 @@
               "release_id": "40006299-e74f-5b9e-9174-36fa3fe552b3",
               "release_date": "2025-07-16",
               "release_kind": "ep",
-              "release_title": "sweet tang"
+              "release_title": "sweet tang",
+              "release_format": null,
+              "source_url": null,
+              "artist_source_url": null
             },
             "has_upcoming_signal": false
           }
         ]
       },
       "actual_status_code": 200,
-      "request_id_sent": "shadow--v1-radar-fa14d16f-9789-4936-9977-055adbc2aa66",
-      "response_request_id": "shadow--v1-radar-fa14d16f-9789-4936-9977-055adbc2aa66"
+      "request_id_sent": "shadow--v1-radar-08006eb7-326c-416f-be77-4d7269963586",
+      "response_request_id": "shadow--v1-radar-08006eb7-326c-416f-be77-4d7269963586"
     }
   ]
 }

--- a/backend/reports/live_backend_smoke_report.json
+++ b/backend/reports/live_backend_smoke_report.json
@@ -1,0 +1,227 @@
+{
+  "generated_at": "2026-03-12T08:06:21.802Z",
+  "started_at": "2026-03-12T08:06:20.537Z",
+  "target": "preview",
+  "base_url": "https://idol-song-app-production.up.railway.app",
+  "timeout_ms": 5000,
+  "fixtures_path": "/Users/gimtaehun/Desktop/idol-song-app/backend/fixtures/live_backend_smoke_fixtures.json",
+  "fixture_keys": [
+    "search-yena",
+    "calendar-2026-03",
+    "radar-default",
+    "entity-yena",
+    "release-ive-revive-plus"
+  ],
+  "ready_statuses_allowed": [
+    "ready",
+    "degraded"
+  ],
+  "ready_check_skipped": false,
+  "summary": {
+    "total_checks": 7,
+    "fixture_checks": 5,
+    "passed_checks": 0,
+    "failed_checks": 7,
+    "ok": false,
+    "by_surface": {
+      "health": {
+        "total": 1,
+        "passed": 0,
+        "failed": 1
+      },
+      "readiness": {
+        "total": 1,
+        "passed": 0,
+        "failed": 1
+      },
+      "search": {
+        "total": 1,
+        "passed": 0,
+        "failed": 1
+      },
+      "calendar_month": {
+        "total": 1,
+        "passed": 0,
+        "failed": 1
+      },
+      "radar": {
+        "total": 1,
+        "passed": 0,
+        "failed": 1
+      },
+      "entity_detail": {
+        "total": 1,
+        "passed": 0,
+        "failed": 1
+      },
+      "release_detail": {
+        "total": 1,
+        "passed": 0,
+        "failed": 1
+      }
+    }
+  },
+  "checks": [
+    {
+      "label": "health",
+      "surface": "health",
+      "fixture_key": null,
+      "ok": false,
+      "status": 502,
+      "duration_ms": 480.05,
+      "error": "Expected 200 from /health, received 502",
+      "requests": [
+        {
+          "label": "health",
+          "path": "/health",
+          "status": 502,
+          "request_id_sent": "live-smoke-health-664be8fc-f471-4318-bfda-afe59d1681b4",
+          "response_request_id": null,
+          "headers": {
+            "content-type": "application/json"
+          },
+          "body_preview": "{\"status\":\"error\",\"code\":502,\"message\":\"Application failed to respond\",\"request_id\":\"rg0sWPtAS3mVRSvlacI7Nw\"}",
+          "network_error": null
+        }
+      ]
+    },
+    {
+      "label": "ready",
+      "surface": "readiness",
+      "fixture_key": null,
+      "ok": false,
+      "status": 502,
+      "duration_ms": 291.51,
+      "error": "Expected 200 from /ready, received 502",
+      "requests": [
+        {
+          "label": "ready",
+          "path": "/ready",
+          "status": 502,
+          "request_id_sent": "live-smoke-ready-79be8a61-f9b5-4523-aaf4-ed76e5804e24",
+          "response_request_id": null,
+          "headers": {
+            "content-type": "application/json"
+          },
+          "body_preview": "{\"status\":\"error\",\"code\":502,\"message\":\"Application failed to respond\",\"request_id\":\"FGpmGQBiRv28Fo9oacI7Nw\"}",
+          "network_error": null
+        }
+      ]
+    },
+    {
+      "label": "fixture:search-yena",
+      "surface": "search",
+      "fixture_key": "search-yena",
+      "ok": false,
+      "status": 502,
+      "duration_ms": 98.98,
+      "error": "Expected 200 from /v1/search?q=%EC%B5%9C%EC%98%88%EB%82%98, received 502",
+      "requests": [
+        {
+          "label": "search-yena",
+          "path": "/v1/search?q=%EC%B5%9C%EC%98%88%EB%82%98",
+          "status": 502,
+          "request_id_sent": "live-smoke-search-yena-f70e5a67-87b3-4626-a78f-5a30d6e20dc3",
+          "response_request_id": null,
+          "headers": {
+            "content-type": "application/json"
+          },
+          "body_preview": "{\"status\":\"error\",\"code\":502,\"message\":\"Application failed to respond\",\"request_id\":\"srt5btYDSeuLPaMMacI7Nw\"}",
+          "network_error": null
+        }
+      ]
+    },
+    {
+      "label": "fixture:calendar-2026-03",
+      "surface": "calendar_month",
+      "fixture_key": "calendar-2026-03",
+      "ok": false,
+      "status": 502,
+      "duration_ms": 97.79,
+      "error": "Expected 200 from /v1/calendar/month?month=2026-03, received 502",
+      "requests": [
+        {
+          "label": "calendar-2026-03",
+          "path": "/v1/calendar/month?month=2026-03",
+          "status": 502,
+          "request_id_sent": "live-smoke-calendar-2026-03-f297933b-6994-41d5-a965-df937741672a",
+          "response_request_id": null,
+          "headers": {
+            "content-type": "application/json"
+          },
+          "body_preview": "{\"status\":\"error\",\"code\":502,\"message\":\"Application failed to respond\",\"request_id\":\"cX9Ny0VlRxGhmNpFacI7Nw\"}",
+          "network_error": null
+        }
+      ]
+    },
+    {
+      "label": "fixture:radar-default",
+      "surface": "radar",
+      "fixture_key": "radar-default",
+      "ok": false,
+      "status": 502,
+      "duration_ms": 97.66,
+      "error": "Expected 200 from /v1/radar, received 502",
+      "requests": [
+        {
+          "label": "radar-default",
+          "path": "/v1/radar",
+          "status": 502,
+          "request_id_sent": "live-smoke-radar-default-d62c6e82-c0c9-47ce-a39c-c8254ea40df5",
+          "response_request_id": null,
+          "headers": {
+            "content-type": "application/json"
+          },
+          "body_preview": "{\"status\":\"error\",\"code\":502,\"message\":\"Application failed to respond\",\"request_id\":\"zWvdKnPBTaSaO7x_acI7Nw\"}",
+          "network_error": null
+        }
+      ]
+    },
+    {
+      "label": "fixture:entity-yena",
+      "surface": "entity_detail",
+      "fixture_key": "entity-yena",
+      "ok": false,
+      "status": 502,
+      "duration_ms": 97.9,
+      "error": "Expected 200 from /v1/entities/yena, received 502",
+      "requests": [
+        {
+          "label": "entity-yena",
+          "path": "/v1/entities/yena",
+          "status": 502,
+          "request_id_sent": "live-smoke-entity-yena-5a3ffeaf-eb5f-485d-baf0-125e59ad3442",
+          "response_request_id": null,
+          "headers": {
+            "content-type": "application/json"
+          },
+          "body_preview": "{\"status\":\"error\",\"code\":502,\"message\":\"Application failed to respond\",\"request_id\":\"HyGoyksBRwyh2Lx6acI7Nw\"}",
+          "network_error": null
+        }
+      ]
+    },
+    {
+      "label": "fixture:release-ive-revive-plus",
+      "surface": "release_detail",
+      "fixture_key": "release-ive-revive-plus",
+      "ok": false,
+      "status": 502,
+      "duration_ms": 98.39,
+      "error": "Expected 200 from /v1/releases/lookup?entity_slug=ive&title=REVIVE%2B&date=2026-02-23&stream=album, received 502",
+      "requests": [
+        {
+          "label": "release-ive-revive-plus-lookup",
+          "path": "/v1/releases/lookup?entity_slug=ive&title=REVIVE%2B&date=2026-02-23&stream=album",
+          "status": 502,
+          "request_id_sent": "live-smoke-release-ive-revive-plus-lookup-e103c60a-c7a1-4377-9ac8-dfccd10cef07",
+          "response_request_id": null,
+          "headers": {
+            "content-type": "application/json"
+          },
+          "body_preview": "{\"status\":\"error\",\"code\":502,\"message\":\"Application failed to respond\",\"request_id\":\"-wo3cJo1Tra7Ny60acI7Nw\"}",
+          "network_error": null
+        }
+      ]
+    }
+  ]
+}

--- a/backend/reports/migration_readiness_scorecard.json
+++ b/backend/reports/migration_readiness_scorecard.json
@@ -1,14 +1,14 @@
 {
-  "generated_at": "2026-03-12T02:34:45.081Z",
+  "generated_at": "2026-03-12T08:04:24.853Z",
   "report_bundle": null,
   "bundle_consistency": {
     "status": "pass",
     "expected_bundle_id": null,
     "observed": {
-      "parity_bundle": "post-sync-verification-3fc09490ed96",
-      "shadow_bundle": "post-sync-verification-3fc09490ed96",
-      "runtime_gate_bundle": "post-sync-verification-3fc09490ed96",
-      "historical_coverage_generated_at": "2026-03-11T00:00:00.000Z",
+      "parity_bundle": "post-sync-verification-368ed485b22b",
+      "shadow_bundle": "post-sync-verification-368ed485b22b",
+      "runtime_gate_bundle": "post-sync-verification-368ed485b22b",
+      "historical_coverage_generated_at": "2026-03-12T00:00:00.000Z",
       "canonical_null_coverage_generated_at": "2026-03-12T02:34:23.746Z",
       "null_coverage_trend_generated_at": "2026-03-12T02:34:25.709Z"
     },
@@ -63,7 +63,7 @@
           "pass": 0.85,
           "needs_review": 0.6
         },
-        "blockerRule": "Preview and production mobile profiles must default to backend-api, and bundled-static cannot remain the normal shipping mode outside development or degraded fallback."
+        "blockerRule": "Development, preview, and production mobile profiles must default to backend-api, and bundled data must remain fixture-only rather than a shipped active runtime mode."
       },
       {
         "key": "catalog_completeness",
@@ -94,15 +94,16 @@
   },
   "overall": {
     "status": "fail",
-    "score_ratio": 0.7417,
-    "score_percent": 74.2,
-    "weighted_points": 74.17,
+    "score_ratio": 0.6592,
+    "score_percent": 65.9,
+    "weighted_points": 65.92,
     "total_weight": 100,
     "blocker_categories": [
       {
         "key": "backend_runtime_health",
         "label": "Backend runtime health",
         "blocker_reasons": [
+          "worker_cadence=fail",
           "stage_gate:shadow_to_web_cutover=fail",
           "stage_gate:web_cutover_to_json_demotion=fail"
         ]
@@ -111,13 +112,14 @@
         "key": "backend_deploy_parity",
         "label": "Backend deploy parity",
         "blocker_reasons": [
-          "parity_clean=false (latest_verified_release_selection drift=0)"
+          "parity_clean=false (latest_verified_release_selection drift=1)"
         ]
       },
       {
         "key": "web_backend_only_stability",
         "label": "Web backend-only stability",
         "blocker_reasons": [
+          "entity_detail clean_ratio=0.25",
           "calendar_month clean_ratio=0.67"
         ]
       },
@@ -143,18 +145,19 @@
       "weight": 25,
       "blocker": true,
       "status": "fail",
-      "score_ratio": 0.7,
-      "score_percent": 70,
-      "weighted_points": 17.5,
+      "score_ratio": 0.52,
+      "score_percent": 52,
+      "weighted_points": 13,
       "blocker_reasons": [
+        "worker_cadence=fail",
         "stage_gate:shadow_to_web_cutover=fail",
         "stage_gate:web_cutover_to_json_demotion=fail"
       ],
       "summary_lines": [
         "api latency: needs_review (worst p95=1148.96ms)",
         "api error rate: needs_review (error rate=0)",
-        "projection freshness: pass (lag=0.4m)",
-        "worker cadence: needs_review (cadence_status=warming_up, deadline=2026-03-12T12:00:00.000Z)",
+        "projection freshness: pass (lag=0.63m)",
+        "worker cadence: fail (cadence_status=scheduled_evidence_missing, missed_windows=6)",
         "parity dependency: fail",
         "shadow dependency: fail",
         "historical catalog completeness dependency: fail",
@@ -192,8 +195,8 @@
           "projection_freshness": {
             "status": "pass",
             "observed": {
-              "projection_generated_at": "2026-03-12T02:34:21.051Z",
-              "lag_minutes": 0.4
+              "projection_generated_at": "2026-03-12T08:03:06.277Z",
+              "lag_minutes": 0.63
             },
             "thresholds": {
               "passLagMinutes": 20,
@@ -201,21 +204,21 @@
             }
           },
           "worker_cadence": {
-            "status": "needs_review",
+            "status": "fail",
             "observed": {
               "primary_path_key": "daily_upcoming",
               "cadence_label": "daily",
               "scheduled_failure_rate": null,
               "last_success_age_hours": null,
               "scheduled_runs": 0,
-              "cadence_status": "warming_up",
+              "cadence_status": "scheduled_evidence_missing",
               "scheduled_evidence": {
-                "status": "warming_up",
-                "reason": "Workflow schedule is configured, but the first scheduled sample window is still in warm-up.",
+                "status": "scheduled_evidence_missing",
+                "reason": "Expected scheduled run windows have elapsed without a recorded scheduled sample.",
                 "cadence_label": "daily",
                 "workflow_created_at": "2026-03-06T07:34:09.000Z",
-                "workflow_updated_at": "2026-03-11T13:45:16.000Z",
-                "schedule_reference_at": "2026-03-11T13:45:16.000Z",
+                "workflow_updated_at": "2026-03-12T03:34:12.000Z",
+                "schedule_reference_at": "2026-03-06T07:34:09.000Z",
                 "workflow_state": "active",
                 "workflow_html_url": "https://github.com/iAmSomething/idol-song-app/blob/main/.github/workflows/weekly-kpop-scan.yml",
                 "parsed_schedule": {
@@ -224,12 +227,12 @@
                   "hour": 0
                 },
                 "warmup_grace_hours": 12,
-                "first_expected_run_at": "2026-03-12T00:00:00.000Z",
+                "first_expected_run_at": "2026-03-07T00:00:00.000Z",
                 "next_expected_run_at": "2026-03-13T00:00:00.000Z",
-                "warmup_deadline_at": "2026-03-12T12:00:00.000Z",
-                "expected_scheduled_runs_by_now": 1,
+                "warmup_deadline_at": "2026-03-07T12:00:00.000Z",
+                "expected_scheduled_runs_by_now": 6,
                 "observed_scheduled_runs": 0,
-                "missed_scheduled_windows": 1
+                "missed_scheduled_windows": 6
               }
             },
             "thresholds": {
@@ -256,17 +259,17 @@
       "score_percent": 40,
       "weighted_points": 8,
       "blocker_reasons": [
-        "parity_clean=false (latest_verified_release_selection drift=0)"
+        "parity_clean=false (latest_verified_release_selection drift=1)"
       ],
       "summary_lines": [
         "entity alias/search coverage: clean (mismatched entities=0)",
         "official links: drift (mismatched entities=62)",
-        "YouTube allowlists: clean (role mismatches=0, metadata mismatches=0)",
-        "latest verified release selection: clean (tracking mismatches=0, stream mismatches=0)",
+        "YouTube allowlists: drift (role mismatches=90, metadata mismatches=2)",
+        "latest verified release selection: drift (tracking mismatches=0, stream mismatches=1)",
         "upcoming counts / nearest: clean (month bucket mismatches=0)",
         "title-track / double-title: clean (mismatched releases=0)",
-        "YouTube Music / MV service-link state: clean (mismatched releases=0)",
-        "review-required counts (release scope): clean (mv_candidate_count_match=True, youtube_mv_status_counts_match=True)"
+        "YouTube Music / MV service-link state: drift (mismatched releases=2)",
+        "review-required counts (release scope): drift (mv_candidate_count_match=True, youtube_mv_status_counts_match=False)"
       ],
       "evidence": {
         "parity_clean": false,
@@ -282,9 +285,16 @@
         "parity_drift_checks": {
           "tracking_mismatches_count": 0,
           "tracking_mismatches": [],
-          "stream_mismatches_count": 0,
-          "stream_mismatches": [],
-          "clean": true
+          "stream_mismatches_count": 1,
+          "stream_mismatches": [
+            {
+              "entity_slug": "yena",
+              "stream": "album",
+              "source": "yena|blooming wings|2025-07-29|album",
+              "db": "yena|love catcher|2026-03-11|album"
+            }
+          ],
+          "clean": false
         }
       }
     },
@@ -294,22 +304,24 @@
       "weight": 20,
       "blocker": true,
       "status": "fail",
-      "score_ratio": 0.9033,
-      "score_percent": 90.3,
-      "weighted_points": 18.07,
+      "score_ratio": 0.7158,
+      "score_percent": 71.6,
+      "weighted_points": 14.32,
       "blocker_reasons": [
+        "entity_detail clean_ratio=0.25",
         "calendar_month clean_ratio=0.67"
       ],
       "summary_lines": [
         "search: clean 4/5, drift 1/5",
-        "entity_detail: clean 4/4, drift 0/4",
+        "entity_detail: clean 1/4, drift 3/4",
         "release_detail: clean 3/3, drift 0/3",
         "calendar_month: clean 2/3, drift 1/3",
         "radar: clean 1/1, drift 0/1",
-        "missing rows or segments: 2 case(s)",
+        "missing rows or segments: 5 case(s)",
         "exact-vs-month-only drift: 2 case(s)",
         "field-shape mismatches: 1 case(s)",
-        "alias-match differences: 1 case(s)"
+        "alias-match differences: 1 case(s)",
+        "latest-release or next-upcoming drift: 1 case(s)"
       ],
       "evidence": {
         "clean": false,
@@ -363,9 +375,9 @@
             "ratio": 0.8
           },
           "entity_detail": {
-            "clean": 4,
+            "clean": 1,
             "total": 4,
-            "ratio": 1
+            "ratio": 0.25
           },
           "release_detail": {
             "clean": 3,
@@ -396,18 +408,18 @@
       "weighted_points": 15,
       "blocker_reasons": [],
       "summary_lines": [
-        "profile defaults: development=bundled-static, preview=backend-api, production=backend-api",
+        "profile defaults: development=backend-api, preview=backend-api, production=backend-api",
         "debug metadata exposes backend-primary policy"
       ],
       "evidence": {
         "expected_modes": {
-          "development": "bundled-static",
+          "development": "backend-api",
           "preview": "backend-api",
           "production": "backend-api"
         },
         "backend_primary_selection": true,
         "debug_policy_aligned": true,
-        "bundled_static_primary_only_in_development": true
+        "backend_api_primary_in_all_profiles": true
       }
     },
     {
@@ -433,7 +445,7 @@
         "detail trusted coverage: 1770/1770 (100.0%), pre-2024 1153/1153 (100.0%)",
         "title-track resolved coverage: 1201/1770 (67.8%), pre-2024 752/1153 (65.2%), review queue 569",
         "canonical MV coverage: 153/1770 (8.6%), pre-2024 74/1153 (6.4%), mv review 2",
-        "external acquisition pass: YTM attempted 113, resolved 0; MV attempted 56, resolved 0, review 2",
+        "external acquisition pass: YTM attempted 0, resolved 0; MV attempted 0, resolved 0, review 2",
         "youtube MV search pass: attempted 54, resolved 41, review 13, unresolved 1616, coverage lift +1",
         "migration-critical first slice: title-track 18/18 (100.0%), canonical MV 18/18 (100.0%), gate pass",
         "worst title-track cohort: 2021-2023 ep 31.4% / target 74.0%",
@@ -490,7 +502,7 @@
             },
             "cutover_ready": true,
             "cutover_status": "pass",
-            "generated_at": "2026-03-11",
+            "generated_at": "2026-03-12",
             "summary_lines": [
               "detail_payload gate: pass (100.0% vs 100.0%)",
               "detail_trusted gate: pass (100.0% vs 100.0%)",
@@ -566,10 +578,10 @@
     }
   ],
   "summary_lines": [
-    "overall readiness: fail (74.2/100)",
-    "Backend runtime health: fail (70/100) [BLOCKER] - stage_gate:shadow_to_web_cutover=fail",
-    "Backend deploy parity: fail (40/100) [BLOCKER] - parity_clean=false (latest_verified_release_selection drift=0)",
-    "Web backend-only stability: fail (90.3/100) [BLOCKER] - calendar_month clean_ratio=0.67",
+    "overall readiness: fail (65.9/100)",
+    "Backend runtime health: fail (52/100) [BLOCKER] - worker_cadence=fail",
+    "Backend deploy parity: fail (40/100) [BLOCKER] - parity_clean=false (latest_verified_release_selection drift=1)",
+    "Web backend-only stability: fail (71.6/100) [BLOCKER] - entity_detail clean_ratio=0.25",
     "Mobile runtime mode: pass (100/100) - no blocker reason",
     "Catalog completeness: fail (78/100) [BLOCKER] - title_track_resolved overall=67.9 pre_2024=65.2",
     "bundle consistency: pass"

--- a/backend/reports/migration_readiness_scorecard.md
+++ b/backend/reports/migration_readiness_scorecard.md
@@ -1,36 +1,36 @@
 # Migration Readiness Scorecard
 
-Generated at: 2026-03-12T02:34:45.081Z
+Generated at: 2026-03-12T08:04:24.853Z
 
 ## Overall
 
 - status: `fail`
-- score: `74.2/100`
+- score: `65.9/100`
 - cutover blocked: `true`
 
 ## Blockers
 
-- Backend runtime health: stage_gate:shadow_to_web_cutover=fail; stage_gate:web_cutover_to_json_demotion=fail
-- Backend deploy parity: parity_clean=false (latest_verified_release_selection drift=0)
-- Web backend-only stability: calendar_month clean_ratio=0.67
+- Backend runtime health: worker_cadence=fail; stage_gate:shadow_to_web_cutover=fail; stage_gate:web_cutover_to_json_demotion=fail
+- Backend deploy parity: parity_clean=false (latest_verified_release_selection drift=1)
+- Web backend-only stability: entity_detail clean_ratio=0.25; calendar_month clean_ratio=0.67
 - Catalog completeness: title_track_resolved overall=67.9 pre_2024=65.2; canonical_mv overall=8.6 pre_2024=6.4; releases.title_track latest 75.2% < 95.0%; release_service_links.youtube_mv latest 26.3% < 80.0%; releases.title_track recent 69.0% < 85.0%; release_service_links.youtube_mv recent 1.8% < 55.0%
 
 ## Category Table
 
 | Category | Weight | Score | Status | Blocker | Primary reason |
 | --- | ---: | ---: | --- | --- | --- |
-| Backend runtime health | 25 | 70 | fail | yes | stage_gate:shadow_to_web_cutover=fail |
-| Backend deploy parity | 20 | 40 | fail | yes | parity_clean=false (latest_verified_release_selection drift=0) |
-| Web backend-only stability | 20 | 90.3 | fail | yes | calendar_month clean_ratio=0.67 |
+| Backend runtime health | 25 | 52 | fail | yes | worker_cadence=fail |
+| Backend deploy parity | 20 | 40 | fail | yes | parity_clean=false (latest_verified_release_selection drift=1) |
+| Web backend-only stability | 20 | 71.6 | fail | yes | entity_detail clean_ratio=0.25 |
 | Mobile runtime mode | 15 | 100 | pass | yes | - |
 | Catalog completeness | 20 | 78 | fail | yes | title_track_resolved overall=67.9 pre_2024=65.2 |
 
 ## Summary Lines
 
-- overall readiness: fail (74.2/100)
-- Backend runtime health: fail (70/100) [BLOCKER] - stage_gate:shadow_to_web_cutover=fail
-- Backend deploy parity: fail (40/100) [BLOCKER] - parity_clean=false (latest_verified_release_selection drift=0)
-- Web backend-only stability: fail (90.3/100) [BLOCKER] - calendar_month clean_ratio=0.67
+- overall readiness: fail (65.9/100)
+- Backend runtime health: fail (52/100) [BLOCKER] - worker_cadence=fail
+- Backend deploy parity: fail (40/100) [BLOCKER] - parity_clean=false (latest_verified_release_selection drift=1)
+- Web backend-only stability: fail (71.6/100) [BLOCKER] - entity_detail clean_ratio=0.25
 - Mobile runtime mode: pass (100/100) - no blocker reason
 - Catalog completeness: fail (78/100) [BLOCKER] - title_track_resolved overall=67.9 pre_2024=65.2
 - bundle consistency: pass

--- a/backend/reports/projection_refresh_summary.json
+++ b/backend/reports/projection_refresh_summary.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-03-12T02:34:21.051Z",
+  "generated_at": "2026-03-12T08:03:06.277Z",
   "row_counts": {
     "entity_search_documents": 117,
     "calendar_month_projection": 216,

--- a/backend/reports/report_bundle_metadata.json
+++ b/backend/reports/report_bundle_metadata.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-03-12T02:34:27.398Z",
-  "bundle_id": "post-sync-verification-3fc09490ed96",
+  "generated_at": "2026-03-12T08:03:35.379Z",
+  "bundle_id": "post-sync-verification-368ed485b22b",
   "bundle_kind": "post-sync-verification",
   "cadence_profile": "daily-upcoming",
   "source": {
@@ -22,11 +22,11 @@
     },
     "projection_refresh": {
       "path": "reports/projection_refresh_summary.json",
-      "generated_at": "2026-03-12T02:34:21.051Z"
+      "generated_at": "2026-03-12T08:03:06.277Z"
     },
     "historical_coverage": {
       "path": "reports/historical_release_detail_coverage_report.json",
-      "generated_at": "2026-03-11T00:00:00.000Z"
+      "generated_at": "2026-03-12T00:00:00.000Z"
     },
     "canonical_null_coverage": {
       "path": "reports/canonical_null_coverage_report.json",
@@ -44,7 +44,7 @@
     },
     "worker_cadence": {
       "path": "reports/worker_cadence_report.json",
-      "generated_at": "2026-03-12T02:34:22.427Z",
+      "generated_at": "2026-03-12T08:02:36.197Z",
       "primary_path_key": "daily_upcoming"
     },
     "service_link_gap_queues": {
@@ -76,7 +76,7 @@
     }
   },
   "summary_lines": [
-    "bundle id: post-sync-verification-3fc09490ed96",
+    "bundle id: post-sync-verification-368ed485b22b",
     "bundle kind: post-sync-verification",
     "cadence profile: daily-upcoming",
     "workflow: manual"

--- a/backend/reports/runtime_gate_report.json
+++ b/backend/reports/runtime_gate_report.json
@@ -1,8 +1,8 @@
 {
-  "generated_at": "2026-03-12T02:34:44.806Z",
+  "generated_at": "2026-03-12T08:03:43.790Z",
   "report_bundle": {
-    "generated_at": "2026-03-12T02:34:27.398Z",
-    "bundle_id": "post-sync-verification-3fc09490ed96",
+    "generated_at": "2026-03-12T08:03:35.379Z",
+    "bundle_id": "post-sync-verification-368ed485b22b",
     "bundle_kind": "post-sync-verification",
     "cadence_profile": "daily-upcoming",
     "source": {
@@ -24,11 +24,11 @@
       },
       "projection_refresh": {
         "path": "reports/projection_refresh_summary.json",
-        "generated_at": "2026-03-12T02:34:21.051Z"
+        "generated_at": "2026-03-12T08:03:06.277Z"
       },
       "historical_coverage": {
         "path": "reports/historical_release_detail_coverage_report.json",
-        "generated_at": "2026-03-11T00:00:00.000Z"
+        "generated_at": "2026-03-12T00:00:00.000Z"
       },
       "canonical_null_coverage": {
         "path": "reports/canonical_null_coverage_report.json",
@@ -46,7 +46,7 @@
       },
       "worker_cadence": {
         "path": "reports/worker_cadence_report.json",
-        "generated_at": "2026-03-12T02:34:22.427Z",
+        "generated_at": "2026-03-12T08:02:36.197Z",
         "primary_path_key": "daily_upcoming"
       },
       "service_link_gap_queues": {
@@ -78,7 +78,7 @@
       }
     },
     "summary_lines": [
-      "bundle id: post-sync-verification-3fc09490ed96",
+      "bundle id: post-sync-verification-368ed485b22b",
       "bundle kind: post-sync-verification",
       "cadence profile: daily-upcoming",
       "workflow: manual"
@@ -86,12 +86,12 @@
   },
   "bundle_consistency": {
     "status": "pass",
-    "expected_bundle_id": "post-sync-verification-3fc09490ed96",
+    "expected_bundle_id": "post-sync-verification-368ed485b22b",
     "observed": {
-      "parity_bundle": "post-sync-verification-3fc09490ed96",
-      "shadow_bundle": "post-sync-verification-3fc09490ed96",
+      "parity_bundle": "post-sync-verification-368ed485b22b",
+      "shadow_bundle": "post-sync-verification-368ed485b22b",
       "runtime_gate_bundle": null,
-      "historical_coverage_generated_at": "2026-03-11T00:00:00.000Z",
+      "historical_coverage_generated_at": "2026-03-12T00:00:00.000Z",
       "canonical_null_coverage_generated_at": "2026-03-12T02:34:23.746Z",
       "null_coverage_trend_generated_at": "2026-03-12T02:34:25.709Z"
     },
@@ -133,8 +133,8 @@
   "summary_lines": [
     "api latency: needs_review (worst p95=1148.96ms)",
     "api error rate: needs_review (error rate=0)",
-    "projection freshness: pass (lag=0.4m)",
-    "worker cadence: needs_review (cadence_status=warming_up, deadline=2026-03-12T12:00:00.000Z)",
+    "projection freshness: pass (lag=0.63m)",
+    "worker cadence: fail (cadence_status=scheduled_evidence_missing, missed_windows=6)",
     "parity dependency: fail",
     "shadow dependency: fail",
     "historical catalog completeness dependency: fail",
@@ -171,8 +171,8 @@
     "projection_freshness": {
       "status": "pass",
       "observed": {
-        "projection_generated_at": "2026-03-12T02:34:21.051Z",
-        "lag_minutes": 0.4
+        "projection_generated_at": "2026-03-12T08:03:06.277Z",
+        "lag_minutes": 0.63
       },
       "thresholds": {
         "passLagMinutes": 20,
@@ -180,21 +180,21 @@
       }
     },
     "worker_cadence": {
-      "status": "needs_review",
+      "status": "fail",
       "observed": {
         "primary_path_key": "daily_upcoming",
         "cadence_label": "daily",
         "scheduled_failure_rate": null,
         "last_success_age_hours": null,
         "scheduled_runs": 0,
-        "cadence_status": "warming_up",
+        "cadence_status": "scheduled_evidence_missing",
         "scheduled_evidence": {
-          "status": "warming_up",
-          "reason": "Workflow schedule is configured, but the first scheduled sample window is still in warm-up.",
+          "status": "scheduled_evidence_missing",
+          "reason": "Expected scheduled run windows have elapsed without a recorded scheduled sample.",
           "cadence_label": "daily",
           "workflow_created_at": "2026-03-06T07:34:09.000Z",
-          "workflow_updated_at": "2026-03-11T13:45:16.000Z",
-          "schedule_reference_at": "2026-03-11T13:45:16.000Z",
+          "workflow_updated_at": "2026-03-12T03:34:12.000Z",
+          "schedule_reference_at": "2026-03-06T07:34:09.000Z",
           "workflow_state": "active",
           "workflow_html_url": "https://github.com/iAmSomething/idol-song-app/blob/main/.github/workflows/weekly-kpop-scan.yml",
           "parsed_schedule": {
@@ -203,12 +203,12 @@
             "hour": 0
           },
           "warmup_grace_hours": 12,
-          "first_expected_run_at": "2026-03-12T00:00:00.000Z",
+          "first_expected_run_at": "2026-03-07T00:00:00.000Z",
           "next_expected_run_at": "2026-03-13T00:00:00.000Z",
-          "warmup_deadline_at": "2026-03-12T12:00:00.000Z",
-          "expected_scheduled_runs_by_now": 1,
+          "warmup_deadline_at": "2026-03-07T12:00:00.000Z",
+          "expected_scheduled_runs_by_now": 6,
           "observed_scheduled_runs": 0,
-          "missed_scheduled_windows": 1
+          "missed_scheduled_windows": 6
         }
       },
       "thresholds": {
@@ -224,16 +224,16 @@
       "status": "fail",
       "observed": {
         "clean": false,
-        "generated_at": "2026-03-12T02:34:38.126295+00:00",
+        "generated_at": "2026-03-12T08:03:37.635667+00:00",
         "summary_lines": [
           "entity alias/search coverage: clean (mismatched entities=0)",
           "official links: drift (mismatched entities=62)",
-          "YouTube allowlists: clean (role mismatches=0, metadata mismatches=0)",
-          "latest verified release selection: clean (tracking mismatches=0, stream mismatches=0)",
+          "YouTube allowlists: drift (role mismatches=90, metadata mismatches=2)",
+          "latest verified release selection: drift (tracking mismatches=0, stream mismatches=1)",
           "upcoming counts / nearest: clean (month bucket mismatches=0)",
           "title-track / double-title: clean (mismatched releases=0)",
-          "YouTube Music / MV service-link state: clean (mismatched releases=0)",
-          "review-required counts (release scope): clean (mv_candidate_count_match=True, youtube_mv_status_counts_match=True)"
+          "YouTube Music / MV service-link state: drift (mismatched releases=2)",
+          "review-required counts (release scope): drift (mv_candidate_count_match=True, youtube_mv_status_counts_match=False)"
         ]
       },
       "label": "backend_json_parity_report"
@@ -242,17 +242,18 @@
       "status": "fail",
       "observed": {
         "clean": false,
-        "generated_at": "2026-03-12T02:34:44.443Z",
+        "generated_at": "2026-03-12T08:03:43.500Z",
         "summary_lines": [
           "search: clean 4/5, drift 1/5",
-          "entity_detail: clean 4/4, drift 0/4",
+          "entity_detail: clean 1/4, drift 3/4",
           "release_detail: clean 3/3, drift 0/3",
           "calendar_month: clean 2/3, drift 1/3",
           "radar: clean 1/1, drift 0/1",
-          "missing rows or segments: 2 case(s)",
+          "missing rows or segments: 5 case(s)",
           "exact-vs-month-only drift: 2 case(s)",
           "field-shape mismatches: 1 case(s)",
-          "alias-match differences: 1 case(s)"
+          "alias-match differences: 1 case(s)",
+          "latest-release or next-upcoming drift: 1 case(s)"
         ]
       },
       "label": "backend_shadow_read_report"
@@ -261,7 +262,7 @@
       "status": "fail",
       "observed": {
         "clean": false,
-        "generated_at": "2026-03-11",
+        "generated_at": "2026-03-12",
         "summary_lines": [
           "detail payload gate: pass (total 100.0%, pre-2024 100.0%)",
           "detail trusted gate: pass (total 100.0%, pre-2024 100.0%)",
@@ -479,12 +480,12 @@
       "status": "pass",
       "observed": {
         "status": "pass",
-        "expected_bundle_id": "post-sync-verification-3fc09490ed96",
+        "expected_bundle_id": "post-sync-verification-368ed485b22b",
         "observed": {
-          "parity_bundle": "post-sync-verification-3fc09490ed96",
-          "shadow_bundle": "post-sync-verification-3fc09490ed96",
+          "parity_bundle": "post-sync-verification-368ed485b22b",
+          "shadow_bundle": "post-sync-verification-368ed485b22b",
           "runtime_gate_bundle": null,
-          "historical_coverage_generated_at": "2026-03-11T00:00:00.000Z",
+          "historical_coverage_generated_at": "2026-03-12T00:00:00.000Z",
           "canonical_null_coverage_generated_at": "2026-03-12T02:34:23.746Z",
           "null_coverage_trend_generated_at": "2026-03-12T02:34:25.709Z"
         },

--- a/backend/reports/worker_cadence_report.json
+++ b/backend/reports/worker_cadence_report.json
@@ -1,10 +1,10 @@
 {
-  "generated_at": "2026-03-12T02:34:22.427Z",
+  "generated_at": "2026-03-12T08:02:36.197Z",
   "repo": "iAmSomething/idol-song-app",
   "sample_limit": 12,
   "primary_path_key": "daily_upcoming",
   "summary_lines": [
-    "[primary] daily_upcoming: cadence=daily, status=warming_up, first_due=2026-03-12T00:00:00.000Z, deadline=2026-03-12T12:00:00.000Z",
+    "[primary] daily_upcoming: cadence=daily, status=scheduled_evidence_missing, observed=0, expected_by_now=6, missed_windows=6",
     "[secondary] catalog_enrichment: cadence=weekly, status=warming_up, first_due=2026-03-15T01:00:00.000Z, deadline=2026-03-16T01:00:00.000Z"
   ],
   "topology": {
@@ -42,15 +42,15 @@
       },
       "workflow_metadata": {
         "created_at": "2026-03-06T16:34:09.000+09:00",
-        "updated_at": "2026-03-11T22:45:16.000+09:00",
+        "updated_at": "2026-03-12T12:34:12.000+09:00",
         "state": "active",
         "html_url": "https://github.com/iAmSomething/idol-song-app/blob/main/.github/workflows/weekly-kpop-scan.yml"
       },
-      "cadence_status": "warming_up",
+      "cadence_status": "scheduled_evidence_missing",
       "sample_limit": 12,
       "sample_window": {
-        "newest_created_at": "2026-03-12T01:46:04.000Z",
-        "oldest_created_at": "2026-03-11T19:03:59.000Z"
+        "newest_created_at": "2026-03-12T07:55:14.000Z",
+        "oldest_created_at": "2026-03-12T05:45:49.000Z"
       },
       "totals": {
         "all_runs": 12,
@@ -75,12 +75,12 @@
         "max_success_gap_hours": null
       },
       "scheduled_evidence": {
-        "status": "warming_up",
-        "reason": "Workflow schedule is configured, but the first scheduled sample window is still in warm-up.",
+        "status": "scheduled_evidence_missing",
+        "reason": "Expected scheduled run windows have elapsed without a recorded scheduled sample.",
         "cadence_label": "daily",
         "workflow_created_at": "2026-03-06T07:34:09.000Z",
-        "workflow_updated_at": "2026-03-11T13:45:16.000Z",
-        "schedule_reference_at": "2026-03-11T13:45:16.000Z",
+        "workflow_updated_at": "2026-03-12T03:34:12.000Z",
+        "schedule_reference_at": "2026-03-06T07:34:09.000Z",
         "workflow_state": "active",
         "workflow_html_url": "https://github.com/iAmSomething/idol-song-app/blob/main/.github/workflows/weekly-kpop-scan.yml",
         "parsed_schedule": {
@@ -89,68 +89,68 @@
           "hour": 0
         },
         "warmup_grace_hours": 12,
-        "first_expected_run_at": "2026-03-12T00:00:00.000Z",
+        "first_expected_run_at": "2026-03-07T00:00:00.000Z",
         "next_expected_run_at": "2026-03-13T00:00:00.000Z",
-        "warmup_deadline_at": "2026-03-12T12:00:00.000Z",
-        "expected_scheduled_runs_by_now": 1,
+        "warmup_deadline_at": "2026-03-07T12:00:00.000Z",
+        "expected_scheduled_runs_by_now": 6,
         "observed_scheduled_runs": 0,
-        "missed_scheduled_windows": 1
+        "missed_scheduled_windows": 6
       },
       "latest_runs": [
         {
-          "database_id": 22982908071,
+          "database_id": 22991974885,
           "event": "push",
           "status": "completed",
           "conclusion": "failure",
-          "created_at": "2026-03-12T01:46:04.000Z",
-          "started_at": "2026-03-12T01:46:04.000Z",
-          "updated_at": "2026-03-12T01:46:04.000Z",
+          "created_at": "2026-03-12T07:55:14.000Z",
+          "started_at": "2026-03-12T07:55:14.000Z",
+          "updated_at": "2026-03-12T07:55:14.000Z",
           "duration_minutes": 0,
-          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22982908071"
+          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22991974885"
         },
         {
-          "database_id": 22982884333,
+          "database_id": 22991966889,
           "event": "push",
           "status": "completed",
           "conclusion": "failure",
-          "created_at": "2026-03-12T01:44:57.000Z",
-          "started_at": "2026-03-12T01:44:57.000Z",
-          "updated_at": "2026-03-12T01:44:57.000Z",
+          "created_at": "2026-03-12T07:54:57.000Z",
+          "started_at": "2026-03-12T07:54:57.000Z",
+          "updated_at": "2026-03-12T07:54:57.000Z",
           "duration_minutes": 0,
-          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22982884333"
+          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22991966889"
         },
         {
-          "database_id": 22981563157,
+          "database_id": 22991640234,
           "event": "push",
           "status": "completed",
           "conclusion": "failure",
-          "created_at": "2026-03-12T00:49:36.000Z",
-          "started_at": "2026-03-12T00:49:36.000Z",
-          "updated_at": "2026-03-12T00:49:36.000Z",
+          "created_at": "2026-03-12T07:44:19.000Z",
+          "started_at": "2026-03-12T07:44:19.000Z",
+          "updated_at": "2026-03-12T07:44:19.000Z",
           "duration_minutes": 0,
-          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22981563157"
+          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22991640234"
         },
         {
-          "database_id": 22981550223,
+          "database_id": 22991630384,
           "event": "push",
           "status": "completed",
           "conclusion": "failure",
-          "created_at": "2026-03-12T00:49:04.000Z",
-          "started_at": "2026-03-12T00:49:04.000Z",
-          "updated_at": "2026-03-12T00:49:04.000Z",
+          "created_at": "2026-03-12T07:44:00.000Z",
+          "started_at": "2026-03-12T07:44:00.000Z",
+          "updated_at": "2026-03-12T07:44:00.000Z",
           "duration_minutes": 0,
-          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22981550223"
+          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22991630384"
         },
         {
-          "database_id": 22971327584,
+          "database_id": 22991234264,
           "event": "push",
           "status": "completed",
           "conclusion": "failure",
-          "created_at": "2026-03-11T19:46:36.000Z",
-          "started_at": "2026-03-11T19:46:36.000Z",
-          "updated_at": "2026-03-11T19:46:36.000Z",
+          "created_at": "2026-03-12T07:30:31.000Z",
+          "started_at": "2026-03-12T07:30:31.000Z",
+          "updated_at": "2026-03-12T07:30:31.000Z",
           "duration_minutes": 0,
-          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22971327584"
+          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22991234264"
         }
       ],
       "latest_scheduled_runs": []
@@ -186,15 +186,15 @@
       },
       "workflow_metadata": {
         "created_at": "2026-03-11T16:14:52.000+09:00",
-        "updated_at": "2026-03-12T03:16:17.000+09:00",
+        "updated_at": "2026-03-12T16:30:31.000+09:00",
         "state": "active",
         "html_url": "https://github.com/iAmSomething/idol-song-app/blob/main/.github/workflows/catalog-enrichment-refresh.yml"
       },
       "cadence_status": "warming_up",
       "sample_limit": 12,
       "sample_window": {
-        "newest_created_at": "2026-03-12T01:46:04.000Z",
-        "oldest_created_at": "2026-03-11T19:03:58.000Z"
+        "newest_created_at": "2026-03-12T07:55:13.000Z",
+        "oldest_created_at": "2026-03-12T05:45:48.000Z"
       },
       "totals": {
         "all_runs": 12,
@@ -223,8 +223,8 @@
         "reason": "Workflow schedule is configured, but the first scheduled sample window is still in warm-up.",
         "cadence_label": "weekly",
         "workflow_created_at": "2026-03-11T07:14:52.000Z",
-        "workflow_updated_at": "2026-03-11T18:16:17.000Z",
-        "schedule_reference_at": "2026-03-11T18:16:17.000Z",
+        "workflow_updated_at": "2026-03-12T07:30:31.000Z",
+        "schedule_reference_at": "2026-03-11T07:14:52.000Z",
         "workflow_state": "active",
         "workflow_html_url": "https://github.com/iAmSomething/idol-song-app/blob/main/.github/workflows/catalog-enrichment-refresh.yml",
         "parsed_schedule": {
@@ -243,59 +243,59 @@
       },
       "latest_runs": [
         {
-          "database_id": 22982908132,
+          "database_id": 22991974701,
           "event": "push",
           "status": "completed",
           "conclusion": "failure",
-          "created_at": "2026-03-12T01:46:04.000Z",
-          "started_at": "2026-03-12T01:46:04.000Z",
-          "updated_at": "2026-03-12T01:46:04.000Z",
+          "created_at": "2026-03-12T07:55:13.000Z",
+          "started_at": "2026-03-12T07:55:13.000Z",
+          "updated_at": "2026-03-12T07:55:13.000Z",
           "duration_minutes": 0,
-          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22982908132"
+          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22991974701"
         },
         {
-          "database_id": 22982884202,
+          "database_id": 22991967037,
           "event": "push",
           "status": "completed",
           "conclusion": "failure",
-          "created_at": "2026-03-12T01:44:57.000Z",
-          "started_at": "2026-03-12T01:44:57.000Z",
-          "updated_at": "2026-03-12T01:44:57.000Z",
+          "created_at": "2026-03-12T07:54:58.000Z",
+          "started_at": "2026-03-12T07:54:58.000Z",
+          "updated_at": "2026-03-12T07:54:58.000Z",
           "duration_minutes": 0,
-          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22982884202"
+          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22991967037"
         },
         {
-          "database_id": 22981562996,
+          "database_id": 22991640066,
           "event": "push",
           "status": "completed",
           "conclusion": "failure",
-          "created_at": "2026-03-12T00:49:36.000Z",
-          "started_at": "2026-03-12T00:49:36.000Z",
-          "updated_at": "2026-03-12T00:49:36.000Z",
+          "created_at": "2026-03-12T07:44:19.000Z",
+          "started_at": "2026-03-12T07:44:19.000Z",
+          "updated_at": "2026-03-12T07:44:19.000Z",
           "duration_minutes": 0,
-          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22981562996"
+          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22991640066"
         },
         {
-          "database_id": 22981550459,
+          "database_id": 22991630556,
           "event": "push",
           "status": "completed",
           "conclusion": "failure",
-          "created_at": "2026-03-12T00:49:04.000Z",
-          "started_at": "2026-03-12T00:49:04.000Z",
-          "updated_at": "2026-03-12T00:49:04.000Z",
+          "created_at": "2026-03-12T07:44:00.000Z",
+          "started_at": "2026-03-12T07:44:00.000Z",
+          "updated_at": "2026-03-12T07:44:00.000Z",
           "duration_minutes": 0,
-          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22981550459"
+          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22991630556"
         },
         {
-          "database_id": 22971327345,
+          "database_id": 22991234422,
           "event": "push",
           "status": "completed",
           "conclusion": "failure",
-          "created_at": "2026-03-11T19:46:36.000Z",
-          "started_at": "2026-03-11T19:46:36.000Z",
-          "updated_at": "2026-03-11T19:46:36.000Z",
+          "created_at": "2026-03-12T07:30:31.000Z",
+          "started_at": "2026-03-12T07:30:31.000Z",
+          "updated_at": "2026-03-12T07:30:31.000Z",
           "duration_minutes": 0,
-          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22971327345"
+          "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22991234422"
         }
       ],
       "latest_scheduled_runs": []
@@ -303,8 +303,8 @@
   },
   "workflow": "weekly-kpop-scan.yml",
   "sample_window": {
-    "newest_created_at": "2026-03-12T01:46:04.000Z",
-    "oldest_created_at": "2026-03-11T19:03:59.000Z"
+    "newest_created_at": "2026-03-12T07:55:14.000Z",
+    "oldest_created_at": "2026-03-12T05:45:49.000Z"
   },
   "totals": {
     "all_runs": 12,
@@ -329,12 +329,12 @@
     "max_success_gap_hours": null
   },
   "scheduled_evidence": {
-    "status": "warming_up",
-    "reason": "Workflow schedule is configured, but the first scheduled sample window is still in warm-up.",
+    "status": "scheduled_evidence_missing",
+    "reason": "Expected scheduled run windows have elapsed without a recorded scheduled sample.",
     "cadence_label": "daily",
     "workflow_created_at": "2026-03-06T07:34:09.000Z",
-    "workflow_updated_at": "2026-03-11T13:45:16.000Z",
-    "schedule_reference_at": "2026-03-11T13:45:16.000Z",
+    "workflow_updated_at": "2026-03-12T03:34:12.000Z",
+    "schedule_reference_at": "2026-03-06T07:34:09.000Z",
     "workflow_state": "active",
     "workflow_html_url": "https://github.com/iAmSomething/idol-song-app/blob/main/.github/workflows/weekly-kpop-scan.yml",
     "parsed_schedule": {
@@ -343,68 +343,68 @@
       "hour": 0
     },
     "warmup_grace_hours": 12,
-    "first_expected_run_at": "2026-03-12T00:00:00.000Z",
+    "first_expected_run_at": "2026-03-07T00:00:00.000Z",
     "next_expected_run_at": "2026-03-13T00:00:00.000Z",
-    "warmup_deadline_at": "2026-03-12T12:00:00.000Z",
-    "expected_scheduled_runs_by_now": 1,
+    "warmup_deadline_at": "2026-03-07T12:00:00.000Z",
+    "expected_scheduled_runs_by_now": 6,
     "observed_scheduled_runs": 0,
-    "missed_scheduled_windows": 1
+    "missed_scheduled_windows": 6
   },
   "latest_runs": [
     {
-      "database_id": 22982908071,
+      "database_id": 22991974885,
       "event": "push",
       "status": "completed",
       "conclusion": "failure",
-      "created_at": "2026-03-12T01:46:04.000Z",
-      "started_at": "2026-03-12T01:46:04.000Z",
-      "updated_at": "2026-03-12T01:46:04.000Z",
+      "created_at": "2026-03-12T07:55:14.000Z",
+      "started_at": "2026-03-12T07:55:14.000Z",
+      "updated_at": "2026-03-12T07:55:14.000Z",
       "duration_minutes": 0,
-      "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22982908071"
+      "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22991974885"
     },
     {
-      "database_id": 22982884333,
+      "database_id": 22991966889,
       "event": "push",
       "status": "completed",
       "conclusion": "failure",
-      "created_at": "2026-03-12T01:44:57.000Z",
-      "started_at": "2026-03-12T01:44:57.000Z",
-      "updated_at": "2026-03-12T01:44:57.000Z",
+      "created_at": "2026-03-12T07:54:57.000Z",
+      "started_at": "2026-03-12T07:54:57.000Z",
+      "updated_at": "2026-03-12T07:54:57.000Z",
       "duration_minutes": 0,
-      "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22982884333"
+      "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22991966889"
     },
     {
-      "database_id": 22981563157,
+      "database_id": 22991640234,
       "event": "push",
       "status": "completed",
       "conclusion": "failure",
-      "created_at": "2026-03-12T00:49:36.000Z",
-      "started_at": "2026-03-12T00:49:36.000Z",
-      "updated_at": "2026-03-12T00:49:36.000Z",
+      "created_at": "2026-03-12T07:44:19.000Z",
+      "started_at": "2026-03-12T07:44:19.000Z",
+      "updated_at": "2026-03-12T07:44:19.000Z",
       "duration_minutes": 0,
-      "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22981563157"
+      "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22991640234"
     },
     {
-      "database_id": 22981550223,
+      "database_id": 22991630384,
       "event": "push",
       "status": "completed",
       "conclusion": "failure",
-      "created_at": "2026-03-12T00:49:04.000Z",
-      "started_at": "2026-03-12T00:49:04.000Z",
-      "updated_at": "2026-03-12T00:49:04.000Z",
+      "created_at": "2026-03-12T07:44:00.000Z",
+      "started_at": "2026-03-12T07:44:00.000Z",
+      "updated_at": "2026-03-12T07:44:00.000Z",
       "duration_minutes": 0,
-      "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22981550223"
+      "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22991630384"
     },
     {
-      "database_id": 22971327584,
+      "database_id": 22991234264,
       "event": "push",
       "status": "completed",
       "conclusion": "failure",
-      "created_at": "2026-03-11T19:46:36.000Z",
-      "started_at": "2026-03-11T19:46:36.000Z",
-      "updated_at": "2026-03-11T19:46:36.000Z",
+      "created_at": "2026-03-12T07:30:31.000Z",
+      "started_at": "2026-03-12T07:30:31.000Z",
+      "updated_at": "2026-03-12T07:30:31.000Z",
       "duration_minutes": 0,
-      "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22971327584"
+      "html_url": "https://github.com/iAmSomething/idol-song-app/actions/runs/22991234264"
     }
   ],
   "latest_scheduled_runs": []

--- a/backend/scripts/build-migration-readiness-scorecard.mjs
+++ b/backend/scripts/build-migration-readiness-scorecard.mjs
@@ -502,7 +502,7 @@ function buildMobileRuntimeModeCategory(runtimeSourceText, datasetSourceText, de
       expected_modes: expectedModes,
       backend_primary_selection: backendPrimarySelection,
       debug_policy_aligned: debugPolicyAligned,
-      bundled_static_primary_only_in_development: developmentBundled && previewBackend && productionBackend,
+      backend_api_primary_in_all_profiles: developmentBackend && previewBackend && productionBackend,
     },
   };
 }

--- a/backend/scripts/lib/workerCadenceEvidence.mjs
+++ b/backend/scripts/lib/workerCadenceEvidence.mjs
@@ -123,10 +123,7 @@ export function buildScheduledEvidenceSummary({
   const workflowUpdatedAt = toDate(workflowMetadata?.updated_at);
   const nowDate = toDate(now);
   const warmupGraceHours = WARMUP_GRACE_HOURS_BY_CADENCE[cadenceLabel] ?? WARMUP_GRACE_HOURS_BY_CADENCE.custom;
-  const scheduleReferenceAt =
-    normalizedObservedRuns === 0 && workflowUpdatedAt && workflowCreatedAt && workflowUpdatedAt > workflowCreatedAt
-      ? workflowUpdatedAt
-      : workflowCreatedAt;
+  const scheduleReferenceAt = workflowCreatedAt ?? workflowUpdatedAt;
   const firstExpectedRunAt =
     workflowRegistered && scheduleReferenceAt && parsedSchedule
       ? nextScheduledOccurrenceAfter(scheduleReferenceAt, parsedSchedule)
@@ -153,12 +150,12 @@ export function buildScheduledEvidenceSummary({
   } else if (normalizedObservedRuns > 0) {
     status = 'has_scheduled_evidence';
     reason = 'Scheduled cadence evidence is present.';
-  } else if (warmupDeadlineAt && nowDate && nowDate <= warmupDeadlineAt) {
-    status = 'warming_up';
-    reason = 'Workflow schedule is configured, but the first scheduled sample window is still in warm-up.';
   } else if (firstExpectedRunAt && expectedScheduledRunsByNow > 0) {
     status = 'scheduled_evidence_missing';
     reason = 'Expected scheduled run windows have elapsed without a recorded scheduled sample.';
+  } else if (warmupDeadlineAt && nowDate && nowDate <= warmupDeadlineAt) {
+    status = 'warming_up';
+    reason = 'Workflow schedule is configured, but the first scheduled sample window is still in warm-up.';
   }
 
   return {

--- a/backend/scripts/lib/workerCadenceEvidence.test.mjs
+++ b/backend/scripts/lib/workerCadenceEvidence.test.mjs
@@ -69,7 +69,7 @@ test('buildScheduledEvidenceSummary marks daily cadence as missing after several
   assert.equal(summary.missed_scheduled_windows, 5);
 });
 
-test('buildScheduledEvidenceSummary uses workflow updated_at as warm-up reference when no scheduled runs exist yet', () => {
+test('buildScheduledEvidenceSummary does not reset cadence warm-up from workflow updated_at churn', () => {
   const summary = buildScheduledEvidenceSummary({
     workflowRegistered: true,
     workflowMetadata: {
@@ -84,11 +84,11 @@ test('buildScheduledEvidenceSummary uses workflow updated_at as warm-up referenc
     now: '2026-03-11T16:10:01.000Z',
   });
 
-  assert.equal(summary.status, 'warming_up');
-  assert.equal(summary.schedule_reference_at, '2026-03-11T13:45:16.000Z');
-  assert.equal(summary.expected_scheduled_runs_by_now, 0);
-  assert.equal(summary.missed_scheduled_windows, 0);
-  assert.equal(summary.first_expected_run_at, '2026-03-12T00:00:00.000Z');
+  assert.equal(summary.status, 'scheduled_evidence_missing');
+  assert.equal(summary.schedule_reference_at, '2026-03-06T07:34:09.000Z');
+  assert.equal(summary.expected_scheduled_runs_by_now, 5);
+  assert.equal(summary.missed_scheduled_windows, 5);
+  assert.equal(summary.first_expected_run_at, '2026-03-07T00:00:00.000Z');
 });
 
 test('buildScheduledEvidenceSummary keeps weekly cadence in warm-up before the first due window', () => {

--- a/docs/assets/distribution/backend_runtime_health_followup_local_2026-03-12.md
+++ b/docs/assets/distribution/backend_runtime_health_followup_local_2026-03-12.md
@@ -1,0 +1,54 @@
+## Backend Runtime Health Follow-up Local Evidence
+
+- Date: 2026-03-12 (Asia/Seoul)
+- Issue: #626
+- Branch: `codex/dev/626-fix-worker-cadence-runtime-gate`
+
+## Commands
+
+```bash
+cd /Users/gimtaehun/Desktop/idol-song-app/backend
+node --test ./scripts/lib/workerCadenceEvidence.test.mjs
+
+source ~/.config/idol-song-app/neon.env
+npm run projection:refresh
+npm run worker:cadence
+npm run report:bundle -- --bundle-kind post-sync-verification --cadence-profile daily-upcoming
+
+cd /Users/gimtaehun/Desktop/idol-song-app
+source .venv/bin/activate
+python3 build_backend_json_parity_report.py --bundle-path backend/reports/report_bundle_metadata.json
+
+cd /Users/gimtaehun/Desktop/idol-song-app/backend
+npm run shadow:verify -- --bundle-path ./reports/report_bundle_metadata.json
+npm run runtime:gate -- --bundle-path ./reports/report_bundle_metadata.json
+npm run migration:scorecard -- --bundle-path ./reports/report_bundle_metadata.json
+npm run smoke:live -- --base-url https://idol-song-app-production.up.railway.app --target preview
+```
+
+## Results
+
+- `worker_cadence_report.json`
+  - `topology.daily_upcoming.cadence_status = scheduled_evidence_missing`
+  - `topology.daily_upcoming.scheduled_evidence.schedule_reference_at = 2026-03-06T07:34:09.000Z`
+  - `topology.daily_upcoming.scheduled_evidence.expected_scheduled_runs_by_now = 6`
+  - `topology.daily_upcoming.scheduled_evidence.missed_scheduled_windows = 6`
+- `runtime_gate_report.json`
+  - `runtime_checks.projection_freshness.status = pass`
+  - `runtime_checks.worker_cadence.status = fail`
+  - `runtime_checks.worker_cadence.observed.cadence_status = scheduled_evidence_missing`
+  - `summary_lines` now identify the blocker as `worker cadence: fail (cadence_status=scheduled_evidence_missing, missed_windows=6)`
+- `migration_readiness_scorecard.json`
+  - `overall.status = fail`
+  - `overall.score_percent = 65.9`
+  - `backend_runtime_health.blocker_reasons` includes `worker_cadence=fail`
+- `live_backend_smoke_report.json`
+  - current preview target (`https://idol-song-app-production.up.railway.app`) returned `502` for `/health`, `/ready`, and all fixture checks
+  - this confirms preview/external smoke remains blocked outside the scope of the cadence/freshness fix
+
+## Notes
+
+- The runtime-health blocker is no longer hidden behind `warming_up`.
+- Freshness is current; the surviving runtime blocker is missing scheduled GitHub Actions cadence evidence for the daily upcoming workflow.
+- Preview live smoke still fails on the currently configured preview target and remains tracked separately under preview rollout work.
+- Remaining parity/shadow/catalog blockers are still present but are outside the scope of `#626`.

--- a/docs/specs/backend/migration-operations-runbook.md
+++ b/docs/specs/backend/migration-operations-runbook.md
@@ -134,7 +134,7 @@ cd ..
 - shadow clean이 아니면 cutover advance를 멈춘다.
 - runtime gate가 `fail`이면 refresh는 끝났더라도 cutover 근거로 쓰지 않는다.
 - migration readiness scorecard에서 blocker-grade category가 `fail`이면 milestone / cutover decision을 advance하지 않는다.
-- worker cadence가 `warming_up`면 first due / deadline을 보고 다음 scheduled sample을 기다린다.
+- worker cadence가 `warming_up`면 `created_at` 기준 first due를 보고 다음 scheduled sample을 기다린다.
 - worker cadence가 `scheduled_evidence_missing`면 `scheduled_runs=0` 자체가 아니라 "expected window를 놓쳤다"는 의미로 보고, workflow enablement / schedule delivery부터 확인한다.
 
 ## 6. Representative Refresh Path

--- a/docs/specs/backend/migration-runtime-gates.md
+++ b/docs/specs/backend/migration-runtime-gates.md
@@ -50,10 +50,10 @@ runtime gate는 아래 산출물을 기본 입력으로 사용한다.
 worker cadence evidence에는 gate 상태와 별개로 아래 cadence status를 함께 남긴다.
 
 - `warming_up`
-  - workflow schedule은 설정됐지만, 첫 scheduled sample window가 아직 도래하지 않았거나 grace 안에 있다
+  - workflow schedule은 설정됐지만, `created_at` 기준 첫 scheduled sample window가 아직 도래하지 않았다
   - runtime gate에서는 `needs_review`로 해석한다
 - `scheduled_evidence_missing`
-  - 첫 scheduled sample window와 warm-up grace가 지난 뒤에도 scheduled sample이 기록되지 않았다
+  - 첫 scheduled sample window가 지난 뒤에도 scheduled sample이 기록되지 않았다
   - runtime gate에서는 `fail`로 해석한다
 
 ## 5. Gate Definitions
@@ -136,8 +136,9 @@ worker cadence evidence에는 gate 상태와 별개로 아래 cadence status를 
 - slow path는 historical enrichment / readiness evidence용으로 separate cadence를 가진다
 - preview에서는 cadence가 production보다 낮아도 되지만, rehearsal 직전에는 같은 순서로 한 번 이상 검증한다
 - scheduled sample이 0건이어도 바로 null-based fail로 보지 않는다
-  - 첫 scheduled run이 아직 오지 않았으면 `warming_up`
-  - expected scheduled window가 이미 여러 번 지났으면 `scheduled_evidence_missing`
+  - 첫 scheduled run due time이 아직 오지 않았으면 `warming_up`
+  - 첫 due time이 한 번이라도 지났으면 `scheduled_evidence_missing`
+- workflow file이 수정돼도 warm-up reference는 `updated_at`로 밀리지 않는다
 - `scheduled_evidence_missing`는 "evidence가 부족하다"가 아니라 "예상된 scheduled execution이 관측되지 않았다"는 운영 실패 신호다
 
 ### 5.5 Report Bundle Consistency


### PR DESCRIPTION
## Summary
- stop resetting worker cadence warm-up from workflow `updated_at` churn and mark missed first scheduled windows as `scheduled_evidence_missing`
- refresh projection, cadence, parity, shadow, runtime gate, scorecard, and live smoke artifacts for the updated runtime-health bundle
- fix migration readiness scorecard generation so it reflects the current all-profiles backend-api mobile policy

## Verification
- `cd backend && node --test ./scripts/lib/workerCadenceEvidence.test.mjs`
- `source ~/.config/idol-song-app/neon.env && cd backend && npm run projection:refresh`
- `source ~/.config/idol-song-app/neon.env && cd backend && npm run worker:cadence`
- `source ~/.config/idol-song-app/neon.env && cd backend && npm run report:bundle -- --bundle-kind post-sync-verification --cadence-profile daily-upcoming`
- `source ~/.config/idol-song-app/neon.env && source .venv/bin/activate && python build_backend_json_parity_report.py --bundle-path backend/reports/report_bundle_metadata.json`
- `source ~/.config/idol-song-app/neon.env && cd backend && npm run shadow:verify -- --bundle-path ./reports/report_bundle_metadata.json`
- `source ~/.config/idol-song-app/neon.env && cd backend && npm run runtime:gate -- --bundle-path ./reports/report_bundle_metadata.json`
- `source ~/.config/idol-song-app/neon.env && cd backend && npm run migration:scorecard -- --bundle-path ./reports/report_bundle_metadata.json`
- `cd backend && npm run smoke:live -- --base-url https://idol-song-app-production.up.railway.app --target preview`
- `git diff --check`

Closes #626
Follow-up: #660
