### PR TITLE
Add progress controls for enrichment passes

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,13 @@ python build_release_details_musicbrainz.py --cohorts latest,recent
 python build_mv_manual_review_queue.py
 ```
 
+오래 걸리는 pass를 작게 확인할 때는 progress와 row limit를 같이 건다. progress는 `stderr`로만 찍히기 때문에 기존 JSON stdout consumer는 깨지지 않는다.
+
+```bash
+python build_release_details_musicbrainz.py --cohorts latest,recent --max-rows 25 --progress-every 5
+python backfill_release_detail_mvs.py --cohorts latest,recent --max-rows 25 --progress-every 5
+```
+
 Neon canonical DB까지 같이 최신화하려면 아래를 이어서 실행한다.
 
 ```bash

--- a/backend/README.md
+++ b/backend/README.md
@@ -585,6 +585,13 @@ python3 ../build_release_details_musicbrainz.py --cohorts latest,recent
 python3 ../build_mv_manual_review_queue.py
 ```
 
+긴 pass를 안전하게 확인할 때는 row limit와 stderr progress를 같이 건다.
+
+```bash
+python3 ../build_release_details_musicbrainz.py --cohorts latest,recent --max-rows 25 --progress-every 5
+python3 ../backfill_release_detail_mvs.py --cohorts latest,recent --max-rows 25 --progress-every 5
+```
+
 ## Release Pipeline Dual-Write
 
 기존 JSON export를 유지한 채 release hydration / service-link / MV review 흐름만 canonical DB에 다시 쓰려면 아래 명령을 사용한다.

--- a/backfill_release_detail_mvs.py
+++ b/backfill_release_detail_mvs.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import sys
 import time
 import urllib.parse
 import urllib.request
@@ -40,6 +41,34 @@ CANDIDATE_TITLE_MARKER_PATTERN = re.compile(
 )
 AUTO_ACCEPTED_YOUTUBE_PROVENANCE = "youtube search auto-accepted via allowlist/title/date/view scoring"
 VIDEO_CHANNEL_URL_CACHE: dict[str, str] = {}
+
+
+def parse_positive_int_arg(raw_value: str) -> int:
+    try:
+        parsed = int(raw_value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("must be a positive integer") from error
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return parsed
+
+
+def should_emit_progress(current_index: int, total_rows: int, progress_every: int) -> bool:
+    if total_rows <= 0:
+        return False
+    return current_index == 1 or current_index == total_rows or current_index % progress_every == 0
+
+
+def emit_progress(current_index: int, total_rows: int, detail: dict[str, Any]) -> None:
+    print(
+        (
+            "[backfill_release_detail_mvs] "
+            f"{current_index}/{total_rows} "
+            f"{detail['group']} / {detail['release_title']} / {detail['release_date']} / {detail['stream']}"
+        ),
+        file=sys.stderr,
+        flush=True,
+    )
 
 
 def load_json(path: Path) -> Any:
@@ -495,12 +524,20 @@ def choose_track_search_resolution(
     return None, None
 
 
-def choose_resolutions(details: list[dict[str, Any]], profiles_by_group: dict[str, dict[str, Any]], allowlists_by_group: dict[str, dict[str, Any]]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+def choose_resolutions(
+    details: list[dict[str, Any]],
+    profiles_by_group: dict[str, dict[str, Any]],
+    allowlists_by_group: dict[str, dict[str, Any]],
+    progress_every: int | None = None,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     reference = now_utc()
     resolutions: list[dict[str, Any]] = []
     review_rows: list[dict[str, Any]] = []
 
-    for detail in details:
+    total_rows = len(details)
+    for current_index, detail in enumerate(details, start=1):
+        if progress_every is not None and should_emit_progress(current_index, total_rows, progress_every):
+            emit_progress(current_index, total_rows, detail)
         current_status = detail.get("youtube_video_status") or release_detail_builder.YOUTUBE_VIDEO_STATUS_UNRESOLVED
         auto_accepted_override = detail.get("youtube_video_provenance") == AUTO_ACCEPTED_YOUTUBE_PROVENANCE
         if current_status not in {
@@ -764,6 +801,17 @@ def main() -> None:
         "--cohorts",
         help="Comma-separated release cohorts to scope the pass (latest,recent,historical).",
     )
+    parser.add_argument(
+        "--max-rows",
+        type=parse_positive_int_arg,
+        help="Limit the current scoped pass to the first N matching release-detail rows.",
+    )
+    parser.add_argument(
+        "--progress-every",
+        type=parse_positive_int_arg,
+        default=25,
+        help="Emit stderr progress after every N inspected rows during the current pass.",
+    )
     args = parser.parse_args()
 
     details = load_json(DETAILS_PATH)
@@ -786,8 +834,25 @@ def main() -> None:
             for detail in details
             if infer_release_cohort(detail.get("release_date", ""), reference_date) in scoped_cohorts
         ]
+    total_scoped_rows = len(details)
+    if args.max_rows is not None:
+        details = details[: args.max_rows]
+    print(
+        (
+            "[backfill_release_detail_mvs] "
+            f"processing {len(details)}/{total_scoped_rows} scoped rows "
+            f"(progress_every={args.progress_every})"
+        ),
+        file=sys.stderr,
+        flush=True,
+    )
 
-    resolutions, review_rows = choose_resolutions(details, profiles_by_group, allowlists_by_group)
+    resolutions, review_rows = choose_resolutions(
+        details,
+        profiles_by_group,
+        allowlists_by_group,
+        progress_every=args.progress_every,
+    )
     reevaluated_keys = {
         release_detail_builder.get_detail_key(detail["group"], detail["release_title"], detail["release_date"], detail["stream"])
         for detail in details
@@ -808,12 +873,16 @@ def main() -> None:
     if scoped_groups is not None:
         report["execution_scope"] = {
             "groups": sorted(scoped_groups),
-            "scoped_rows": len(details),
         }
+    if report.get("execution_scope") is None:
+        report["execution_scope"] = {}
     if scoped_cohorts is not None:
-        report.setdefault("execution_scope", {})
         report["execution_scope"]["cohorts"] = sorted(scoped_cohorts)
-        report["execution_scope"]["scoped_rows"] = len(details)
+    report["execution_scope"]["scoped_rows_total"] = total_scoped_rows
+    report["execution_scope"]["selected_rows"] = len(details)
+    report["execution_scope"]["progress_every"] = args.progress_every
+    if args.max_rows is not None:
+        report["execution_scope"]["max_rows"] = args.max_rows
 
     write_json(OVERRIDES_PATH, merged_overrides)
     write_json(DETAILS_PATH, updated_details)

--- a/build_release_details_musicbrainz.py
+++ b/build_release_details_musicbrainz.py
@@ -2,6 +2,7 @@ import argparse
 import csv
 import json
 import re
+import sys
 import unicodedata
 from collections import Counter
 from datetime import date
@@ -98,6 +99,49 @@ CANONICAL_MV_COHORT_TARGETS = {
     "2021-2023": {"single": 0.5, "ep": 0.35, "album": 0.28},
     "2024+": {"single": 0.72, "ep": 0.55, "album": 0.4},
 }
+
+
+def parse_positive_int_arg(raw_value: str) -> int:
+    try:
+        parsed = int(raw_value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("must be a positive integer") from error
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return parsed
+
+
+def enrich_execution_scope(
+    execution_scope: Optional[Dict],
+    total_scoped_rows: int,
+    selected_rows: int,
+    max_rows: Optional[int],
+    progress_every: int,
+) -> Dict:
+    scope = dict(execution_scope or {})
+    scope["scoped_rows_total"] = total_scoped_rows
+    scope["selected_rows"] = selected_rows
+    if max_rows is not None:
+        scope["max_rows"] = max_rows
+    scope["progress_every"] = progress_every
+    return scope
+
+
+def should_emit_progress(current_index: int, total_rows: int, progress_every: int) -> bool:
+    if total_rows <= 0:
+        return False
+    return current_index == 1 or current_index == total_rows or current_index % progress_every == 0
+
+
+def emit_progress(prefix: str, current_index: int, total_rows: int, row: Dict) -> None:
+    print(
+        (
+            f"[{prefix}] {current_index}/{total_rows} "
+            f"{row['group']} / {row['release_title']} / {row['release_date']} / {row['stream']}"
+        ),
+        file=sys.stderr,
+        flush=True,
+    )
 
 
 def optional_text(value: object) -> Optional[str]:
@@ -2234,6 +2278,17 @@ def main() -> None:
         "--cohorts",
         help="Comma-separated release cohorts to rebuild (latest,recent,historical). When set, only scoped rows are recomputed and merged back into the full snapshot.",
     )
+    parser.add_argument(
+        "--max-rows",
+        type=parse_positive_int_arg,
+        help="Limit the current scoped rebuild to the first N matching rows for safer targeted reruns.",
+    )
+    parser.add_argument(
+        "--progress-every",
+        type=parse_positive_int_arg,
+        default=25,
+        help="Emit stderr progress after every N processed rows during the current pass.",
+    )
     args = parser.parse_args()
     scoped_groups = None
     if args.groups:
@@ -2258,6 +2313,34 @@ def main() -> None:
         for item in latest_snapshot_items
         if matches_execution_scope(item, scoped_groups, scoped_cohorts, reference_date)
     ]
+    total_scoped_rows = len(scoped_items)
+    if args.max_rows is not None:
+        scoped_items = scoped_items[: args.max_rows]
+    scoped_keys = {
+        get_detail_key(item["group"], item["release_title"], item["release_date"], item["stream"])
+        for item in scoped_items
+    }
+    scoped_latest_snapshot_items = [
+        item
+        for item in scoped_latest_snapshot_items
+        if get_detail_key(item["group"], item["release_title"], item["release_date"], item["stream"]) in scoped_keys
+    ]
+    execution_scope = enrich_execution_scope(
+        execution_scope,
+        total_scoped_rows=total_scoped_rows,
+        selected_rows=len(scoped_items),
+        max_rows=args.max_rows,
+        progress_every=args.progress_every,
+    )
+    print(
+        (
+            "[build_release_details_musicbrainz] "
+            f"processing {len(scoped_items)}/{total_scoped_rows} scoped rows "
+            f"(progress_every={args.progress_every})"
+        ),
+        file=sys.stderr,
+        flush=True,
+    )
     song_release_index = build_song_release_index(items)
     existing_details = {
         get_detail_key(row["group"], row["release_title"], row["release_date"], row["stream"]): row
@@ -2279,7 +2362,9 @@ def main() -> None:
     applied_overrides = 0
     relaxed_match_count = 0
 
-    for item in scoped_items:
+    for current_index, item in enumerate(scoped_items, start=1):
+        if should_emit_progress(current_index, len(scoped_items), args.progress_every):
+            emit_progress("build_release_details_musicbrainz", current_index, len(scoped_items), item)
         attempts: List[Dict] = []
         used_relaxed_match = False
         existing = existing_details.get(

--- a/docs/assets/distribution/backend_enrichment_progress_controls_local_2026-03-12.md
+++ b/docs/assets/distribution/backend_enrichment_progress_controls_local_2026-03-12.md
@@ -1,0 +1,60 @@
+# Backend Enrichment Progress Controls Local Verification
+
+- Date: 2026-03-12
+- Scope: `#664`
+
+## What changed
+
+- Added `--max-rows` to `build_release_details_musicbrainz.py`
+- Added `--max-rows` to `backfill_release_detail_mvs.py`
+- Added `--progress-every` to both scripts
+- Progress logs now go to `stderr` only so JSON `stdout` remains machine-readable
+
+## Verification
+
+```bash
+python3 -m py_compile build_release_details_musicbrainz.py backfill_release_detail_mvs.py test_build_release_details_musicbrainz.py test_backfill_release_detail_mvs.py
+source .venv/bin/activate
+python -m unittest test_build_release_details_musicbrainz.py test_backfill_release_detail_mvs.py
+```
+
+- Result: `20` tests passed
+
+## Scoped smoke checks
+
+Builder smoke was run with temp output paths and `--skip-acquisition`:
+
+```bash
+python build_release_details_musicbrainz.py --skip-acquisition --cohorts latest,recent --max-rows 3 --progress-every 2
+```
+
+- `execution_scope.selected_rows = 3`
+- `execution_scope.scoped_rows_total = 815`
+- `execution_scope.max_rows = 3`
+- `execution_scope.progress_every = 2`
+- stderr preview:
+  - `processing 3/815 scoped rows`
+  - `1/3 &TEAM / Blind Love / 2023-05-07 / song`
+  - `2/3 &TEAM / First Howling : WE / 2023-06-14 / album`
+  - `3/3 &TEAM / First Howling : NOW / 2023-11-15 / album`
+
+Backfill smoke was run with temp copies of `releaseDetails` / `release_detail_overrides` and patched query fetch:
+
+```bash
+python backfill_release_detail_mvs.py --cohorts latest,recent --max-rows 3 --progress-every 2
+```
+
+- `execution_scope.selected_rows = 3`
+- `execution_scope.scoped_rows_total = 815`
+- `execution_scope.max_rows = 3`
+- `execution_scope.progress_every = 2`
+- stderr preview:
+  - `processing 3/815 scoped rows`
+  - `1/3 &TEAM / Blind Love / 2023-05-07 / song`
+  - `2/3 &TEAM / First Howling : WE / 2023-06-14 / album`
+  - `3/3 &TEAM / First Howling : NOW / 2023-11-15 / album`
+
+## Notes
+
+- No runtime snapshot files were intentionally mutated during smoke verification.
+- The new controls are for targeted reruns only; default full-pass behavior is unchanged.

--- a/docs/specs/backend/README.md
+++ b/docs/specs/backend/README.md
@@ -91,6 +91,7 @@
 28. scoped blocker rerun note
    - `build_release_details_musicbrainz.py --cohorts latest,recent` 로 latest/recent row만 재계산할 수 있다
    - full snapshot은 유지하고 review queue / coverage report만 같은 execution scope로 다시 만든다
+   - 긴 rerun은 `--max-rows` 와 `--progress-every` 를 같이 써서 작은 batch로 확인한다
 
 ## 읽는 순서
 

--- a/test_backfill_release_detail_mvs.py
+++ b/test_backfill_release_detail_mvs.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import argparse
+import io
 import unittest
 from datetime import date
 from unittest.mock import patch
@@ -8,6 +10,13 @@ import backfill_release_detail_mvs as backfill
 
 
 class BackfillReleaseDetailMvQueryTests(unittest.TestCase):
+    def test_parse_positive_int_arg_accepts_positive_values(self) -> None:
+        self.assertEqual(backfill.parse_positive_int_arg("4"), 4)
+
+    def test_parse_positive_int_arg_rejects_zero(self) -> None:
+        with self.assertRaises(argparse.ArgumentTypeError):
+            backfill.parse_positive_int_arg("0")
+
     def test_build_queries_prefers_primary_name_then_korean_alias_then_release_title(self) -> None:
         detail = {
             "group": "IVE",
@@ -205,6 +214,60 @@ class BackfillReleaseDetailMvQueryTests(unittest.TestCase):
         self.assertEqual(resolutions[0]["youtube_video_id"], "abc123")
         self.assertEqual(resolutions[0]["inferred_title_tracks"], ["캐치 캐치"])
         self.assertEqual(resolutions[0]["title_track_basis"], "track_search")
+
+    @patch.object(backfill, "REQUEST_DELAY_SECONDS", 0)
+    def test_choose_resolutions_emits_progress_to_stderr_without_changing_resolution(self) -> None:
+        details = [
+            {
+                "group": "YENA",
+                "release_title": "LOVE CATCHER",
+                "release_date": "2026-03-11",
+                "stream": "album",
+                "release_kind": "ep",
+                "youtube_video_status": "unresolved",
+                "tracks": [
+                    {"title": "캐치 캐치"},
+                ],
+            }
+        ]
+        profiles_by_group = {"YENA": {"display_name": "YENA", "aliases": [], "search_aliases": ["최예나"]}}
+        allowlists_by_group = {
+            "YENA": {
+                "mv_allowlist_match_keys": ["channel:uckrdegnm3mqzxhk2mfnojmw"],
+                "mv_source_channels": [
+                    {
+                        "channel_url": "https://www.youtube.com/channel/UCkrDEGNM3mqZXHk2MfnOjMw",
+                        "owner_type": "team",
+                    }
+                ],
+            }
+        }
+
+        def fake_fetch_query_candidates(query: str, reference: object) -> list[dict[str, object]]:
+            return [
+                {
+                    "video_id": "abc123",
+                    "title": "YENA(최예나) - '캐치 캐치' M/V",
+                    "channel_url": "https://www.youtube.com/channel/UCkrDEGNM3mqZXHk2MfnOjMw",
+                    "view_count": 1000,
+                    "published_at": "2026-03-11T09:00:00Z",
+                    "query": query,
+                }
+            ]
+
+        stderr_buffer = io.StringIO()
+        with patch.object(backfill, "fetch_query_candidates", side_effect=fake_fetch_query_candidates):
+            with patch("sys.stderr", stderr_buffer):
+                resolutions, review_rows = backfill.choose_resolutions(
+                    details,
+                    profiles_by_group,
+                    allowlists_by_group,
+                    progress_every=1,
+                )
+
+        self.assertEqual(len(review_rows), 0)
+        self.assertEqual(len(resolutions), 1)
+        self.assertIn("[backfill_release_detail_mvs] 1/1 YENA / LOVE CATCHER", stderr_buffer.getvalue())
 
 
 if __name__ == "__main__":

--- a/test_build_release_details_musicbrainz.py
+++ b/test_build_release_details_musicbrainz.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import argparse
 import unittest
 from datetime import date
 
@@ -7,6 +8,13 @@ import build_release_details_musicbrainz as builder
 
 
 class BuildReleaseDetailsMusicBrainzTitleTrackTests(unittest.TestCase):
+    def test_parse_positive_int_arg_accepts_positive_values(self) -> None:
+        self.assertEqual(builder.parse_positive_int_arg("5"), 5)
+
+    def test_parse_positive_int_arg_rejects_zero(self) -> None:
+        with self.assertRaises(argparse.ArgumentTypeError):
+            builder.parse_positive_int_arg("0")
+
     def test_parse_scoped_cohorts_accepts_supported_values(self) -> None:
         self.assertEqual(
             builder.parse_scoped_cohorts("latest,recent"),
@@ -42,6 +50,26 @@ class BuildReleaseDetailsMusicBrainzTitleTrackTests(unittest.TestCase):
 
         self.assertTrue(builder.mv_backfill_scope_matches(matching_summary, execution_scope))
         self.assertFalse(builder.mv_backfill_scope_matches(mismatched_summary, execution_scope))
+
+    def test_enrich_execution_scope_adds_selected_rows_and_progress_metadata(self) -> None:
+        enriched = builder.enrich_execution_scope(
+            {"groups": ["YENA"]},
+            total_scoped_rows=10,
+            selected_rows=3,
+            max_rows=3,
+            progress_every=2,
+        )
+
+        self.assertEqual(
+            enriched,
+            {
+                "groups": ["YENA"],
+                "scoped_rows_total": 10,
+                "selected_rows": 3,
+                "max_rows": 3,
+                "progress_every": 2,
+            },
+        )
 
     def test_exact_title_match_outranks_nearby_single_fallback(self) -> None:
         detail = {


### PR DESCRIPTION
## Summary
- add --max-rows and stderr progress controls to scoped release-detail rebuild passes
- add regression tests for positive-int parsing and progress-aware backfill behavior
- document small-batch rerun usage and keep a local verification note

Closes #664