### PR TITLE
Fix scheduled workflow condition guards

### DIFF
--- a/.github/workflows/backend-quality.yml
+++ b/.github/workflows/backend-quality.yml
@@ -32,6 +32,10 @@ jobs:
         working-directory: backend
         run: npm ci
 
+      - name: Verify workflow condition guards
+        working-directory: backend
+        run: npm run workflow:verify
+
       - name: Build backend
         working-directory: backend
         run: npm run build

--- a/.github/workflows/catalog-enrichment-refresh.yml
+++ b/.github/workflows/catalog-enrichment-refresh.yml
@@ -15,6 +15,8 @@ concurrency:
 jobs:
   enrich:
     runs-on: ubuntu-latest
+    env:
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
 
     steps:
       - name: Check out repository
@@ -37,8 +39,6 @@ jobs:
             web/package-lock.json
 
       - name: Install Python dependencies
-        env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
         run: |
           python -m pip install --upgrade pip
           pip install requests
@@ -47,13 +47,12 @@ jobs:
           fi
 
       - name: Install backend dependencies
-        if: ${{ secrets.DATABASE_URL != '' }}
+        if: ${{ env.DATABASE_URL != '' }}
         working-directory: backend
         run: npm ci
 
       - name: Run slower catalog enrichment path
         env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
           BACKEND_PUBLIC_URL: ${{ vars.VITE_API_BASE_URL }}
         run: |
           python youtube_channel_allowlists.py

--- a/.github/workflows/weekly-kpop-scan.yml
+++ b/.github/workflows/weekly-kpop-scan.yml
@@ -15,6 +15,8 @@ concurrency:
 jobs:
   scan:
     runs-on: ubuntu-latest
+    env:
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
 
     steps:
       - name: Check out repository
@@ -37,8 +39,6 @@ jobs:
             web/package-lock.json
 
       - name: Install Python dependencies
-        env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
         run: |
           python -m pip install --upgrade pip
           pip install requests
@@ -47,13 +47,12 @@ jobs:
           fi
 
       - name: Install backend dependencies
-        if: ${{ secrets.DATABASE_URL != '' }}
+        if: ${{ env.DATABASE_URL != '' }}
         working-directory: backend
         run: npm ci
 
       - name: Rebuild watchlist and refresh upcoming signals
         env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
           BACKEND_PUBLIC_URL: ${{ vars.VITE_API_BASE_URL }}
           MOBILE_PUSH_DELIVERY_ENABLED: ${{ vars.MOBILE_PUSH_DELIVERY_ENABLED }}
         run: |

--- a/backend/README.md
+++ b/backend/README.md
@@ -659,6 +659,7 @@ python3 sync_trusted_upcoming_notification_events.py
 - `backend/reports/trusted_upcoming_notification_event_summary.json`
 - `backend/reports/trusted_upcoming_operator_alert_report.md`
 - `backend/reports/workflow_schedule_diagnostics.json`
+- `backend/reports/workflow_condition_guard_report.json`
 
 scheduled workflow는 두 cadence로 나뉜다.
 
@@ -837,6 +838,10 @@ npm run gap:workbenches
 먼저 `workflow_schedule_diagnostics.json`을 본다. 이 artifact는 repo default branch,
 GitHub Actions permissions, workflow state, recent scheduled run count, actionable hint를
 한 번에 모아서 schedule delivery 조사 시작점을 고정한다.
+같은 시점에 `npm run workflow:verify`도 같이 본다. scheduled workflow가 `push`에서도 즉시
+`workflow file issue`로 죽는다면, 먼저 workflow YAML 안의 `if:` condition에서 `secrets.*`
+를 직접 참조하는 패턴이 없는지 확인해야 한다. secret이 필요한 conditional은 job/step `env`
+로 먼저 올린 뒤 `if: ${{ env.NAME != '' }}` 형태로 써야 한다.
 - `backend/reports/trusted_upcoming_notification_event_summary.json`
 - `backend/reports/trusted_upcoming_operator_alert_report.md`
 - `backend/reports/backend_gap_audit_report.json`

--- a/backend/package.json
+++ b/backend/package.json
@@ -28,6 +28,7 @@
     "export:web-snapshots": "node ./scripts/build-non-runtime-web-snapshot-export.mjs",
     "artifact:retention": "node ./scripts/build-runtime-artifact-retention-report.mjs",
     "duplicate:inventory": "node ./scripts/build-non-runtime-duplicate-inventory-report.mjs",
+    "workflow:verify": "node ./scripts/verify-workflow-condition-guards.mjs",
     "curation:export": "node ./scripts/build-manual-curation-bundles.mjs",
     "curation:import": "node ./scripts/import-manual-curation-bundles.mjs",
     "runtime:gate": "node ./scripts/build-runtime-gate-report.mjs",

--- a/backend/reports/workflow_condition_guard_report.json
+++ b/backend/reports/workflow_condition_guard_report.json
@@ -1,0 +1,8 @@
+{
+  "generated_at": "2026-03-12T08:52:53.594Z",
+  "status": "pass",
+  "summary_lines": [
+    "workflow condition guard: no direct secrets usage found in if conditions"
+  ],
+  "violations": []
+}

--- a/backend/scripts/lib/workflowConditionGuard.mjs
+++ b/backend/scripts/lib/workflowConditionGuard.mjs
@@ -1,0 +1,64 @@
+import { readdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const WORKFLOW_CONDITION_RULE_ID = 'no_secrets_in_if';
+const WORKFLOW_FILE_PATTERN = /\.ya?ml$/i;
+const SECRETS_IN_IF_PATTERN = /^\s*(?:-\s*)?if:\s*\$\{\{.*\bsecrets\./;
+
+async function* walkWorkflows(rootDirectory, relativeDirectory = '.') {
+  const absoluteDirectory = path.join(rootDirectory, relativeDirectory);
+  const entries = await readdir(absoluteDirectory, { withFileTypes: true });
+  for (const entry of entries) {
+    const relativePath = relativeDirectory === '.' ? entry.name : path.join(relativeDirectory, entry.name);
+    if (entry.isDirectory()) {
+      yield* walkWorkflows(rootDirectory, relativePath);
+      continue;
+    }
+    if (entry.isFile() && WORKFLOW_FILE_PATTERN.test(entry.name)) {
+      yield relativePath;
+    }
+  }
+}
+
+export async function collectWorkflowConditionViolations(repoDir) {
+  const workflowRoot = path.join(repoDir, '.github', 'workflows');
+  const violations = [];
+
+  for await (const relativeWorkflowPath of walkWorkflows(workflowRoot)) {
+    const relativePath = path.join('.github', 'workflows', relativeWorkflowPath);
+    const content = await readFile(path.join(repoDir, relativePath), 'utf8');
+    const lines = content.split(/\r?\n/);
+    lines.forEach((line, index) => {
+      if (!SECRETS_IN_IF_PATTERN.test(line)) {
+        return;
+      }
+      violations.push({
+        workflow_path: relativePath,
+        line: index + 1,
+        rule_id: WORKFLOW_CONDITION_RULE_ID,
+        reason: 'GitHub Actions does not allow direct secrets context usage inside if conditions.',
+        snippet: line.trim(),
+      });
+    });
+  }
+
+  return violations.sort((left, right) => {
+    if (left.workflow_path === right.workflow_path) {
+      return left.line - right.line;
+    }
+    return left.workflow_path.localeCompare(right.workflow_path);
+  });
+}
+
+export function buildWorkflowConditionGuardReport({ violations }) {
+  return {
+    generated_at: new Date().toISOString(),
+    status: violations.length === 0 ? 'pass' : 'fail',
+    summary_lines: [
+      violations.length === 0
+        ? 'workflow condition guard: no direct secrets usage found in if conditions'
+        : `workflow condition guard: ${violations.length} invalid if condition(s) use secrets context directly`,
+    ],
+    violations,
+  };
+}

--- a/backend/scripts/lib/workflowConditionGuard.test.mjs
+++ b/backend/scripts/lib/workflowConditionGuard.test.mjs
@@ -1,0 +1,58 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import os from 'node:os';
+import path from 'node:path';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+
+import {
+  buildWorkflowConditionGuardReport,
+  collectWorkflowConditionViolations,
+} from './workflowConditionGuard.mjs';
+
+test('collectWorkflowConditionViolations reports direct secrets usage inside if conditions', async () => {
+  const repoDir = await mkdtemp(path.join(os.tmpdir(), 'idol-workflow-guard-'));
+  try {
+    await mkdir(path.join(repoDir, '.github', 'workflows'), { recursive: true });
+    await writeFile(
+      path.join(repoDir, '.github', 'workflows', 'broken.yml'),
+      [
+        'name: Broken Workflow',
+        'jobs:',
+        '  test:',
+        '    steps:',
+        "      - if: ${{ secrets.DATABASE_URL != '' }}",
+        "        run: echo 'broken'",
+        '',
+      ].join('\n'),
+      'utf8',
+    );
+
+    const violations = await collectWorkflowConditionViolations(repoDir);
+
+    assert.equal(violations.length, 1);
+    assert.equal(violations[0].workflow_path, '.github/workflows/broken.yml');
+    assert.equal(violations[0].line, 5);
+    assert.equal(violations[0].rule_id, 'no_secrets_in_if');
+  } finally {
+    await rm(repoDir, { recursive: true, force: true });
+  }
+});
+
+test('buildWorkflowConditionGuardReport summarizes pass and fail states', () => {
+  const passReport = buildWorkflowConditionGuardReport({ violations: [] });
+  assert.equal(passReport.status, 'pass');
+
+  const failReport = buildWorkflowConditionGuardReport({
+    violations: [
+      {
+        workflow_path: '.github/workflows/broken.yml',
+        line: 5,
+        rule_id: 'no_secrets_in_if',
+        reason: 'GitHub Actions does not allow direct secrets context usage inside if conditions.',
+        snippet: "if: ${{ secrets.DATABASE_URL != '' }}",
+      },
+    ],
+  });
+  assert.equal(failReport.status, 'fail');
+  assert.match(failReport.summary_lines[0], /1 invalid if condition/);
+});

--- a/backend/scripts/verify-workflow-condition-guards.mjs
+++ b/backend/scripts/verify-workflow-condition-guards.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  buildWorkflowConditionGuardReport,
+  collectWorkflowConditionViolations,
+} from './lib/workflowConditionGuard.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const BACKEND_DIR = path.resolve(__dirname, '..');
+const REPO_DIR = path.resolve(BACKEND_DIR, '..');
+const DEFAULT_REPORT_PATH = path.join(BACKEND_DIR, 'reports', 'workflow_condition_guard_report.json');
+
+function parseArgs(argv) {
+  const options = {
+    reportPath: DEFAULT_REPORT_PATH,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === '--report-path') {
+      options.reportPath = path.resolve(BACKEND_DIR, argv[index + 1] ?? '');
+      index += 1;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${token}`);
+  }
+
+  return options;
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const violations = await collectWorkflowConditionViolations(REPO_DIR);
+  const report = buildWorkflowConditionGuardReport({ violations });
+
+  await mkdir(path.dirname(options.reportPath), { recursive: true });
+  await writeFile(options.reportPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+
+  console.log(
+    JSON.stringify(
+      {
+        status: report.status,
+        violation_count: report.violations.length,
+        report_path: path.relative(REPO_DIR, options.reportPath),
+      },
+      null,
+      2,
+    ),
+  );
+
+  if (report.status !== 'pass') {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/docs/assets/distribution/backend_schedule_root_cause_local_2026-03-12.md
+++ b/docs/assets/distribution/backend_schedule_root_cause_local_2026-03-12.md
@@ -1,0 +1,45 @@
+# Backend Schedule Delivery Root Cause Local Verification
+
+- Date: 2026-03-12
+- Scope: `#660`
+
+## Root cause
+
+Both scheduled worker workflows were still failing as `workflow file issue` on push-derived validation runs.
+The offending pattern was direct `secrets.*` usage inside workflow `if:` conditionals:
+
+- `.github/workflows/weekly-kpop-scan.yml`
+- `.github/workflows/catalog-enrichment-refresh.yml`
+
+GitHub Actions requires secret-dependent conditionals to read from `env`, not directly from `secrets` in `if:`.
+
+## Fix
+
+- Moved `DATABASE_URL` to job-level `env`
+- Changed install step conditionals from:
+  - `if: ${{ secrets.DATABASE_URL != '' }}`
+- To:
+  - `if: ${{ env.DATABASE_URL != '' }}`
+- Added a repo guard:
+  - `cd backend && npm run workflow:verify`
+
+## Verification
+
+```bash
+cd backend
+node --test ./scripts/lib/workflowConditionGuard.test.mjs
+npm run workflow:verify
+npm run build
+```
+
+## Observed result
+
+- `workflow_condition_guard_report.json.status = pass`
+- `workflow_condition_guard_report.json.violation_count = 0`
+- backend build passes
+
+## Remaining blocker
+
+This fixes the workflow-file root cause and adds a regression guard, but it does not fabricate a real
+`event=schedule` sample. `#660` still needs the next actual scheduled delivery before cadence/runtime
+artifacts can fully clear.

--- a/docs/specs/backend/migration-operations-runbook.md
+++ b/docs/specs/backend/migration-operations-runbook.md
@@ -45,6 +45,7 @@
 | canonical null coverage | `cd backend && npm run null:coverage` | `backend/reports/canonical_null_coverage_report.json` |
 | canonical null recheck queue | `cd backend && npm run null:recheck` | `backend/reports/canonical_null_recheck_queue.json` |
 | null coverage trend | `cd backend && npm run null:trend` | `backend/reports/null_coverage_trend_report.json` |
+| workflow condition guard | `cd backend && npm run workflow:verify` | `backend/reports/workflow_condition_guard_report.json` |
 | report bundle metadata | `cd backend && npm run report:bundle -- --bundle-kind post-sync-verification --cadence-profile daily-upcoming` | `backend/reports/report_bundle_metadata.json` |
 | backend freshness handoff | `cd backend && npm run freshness:handoff -- --target production --backend-public-url <url>` | `backend/reports/backend_freshness_handoff.json` |
 | backend-vs-JSON parity | `python3 build_backend_json_parity_report.py` | `backend/reports/backend_json_parity_report.json` |
@@ -136,6 +137,7 @@ cd ..
 - migration readiness scorecard에서 blocker-grade category가 `fail`이면 milestone / cutover decision을 advance하지 않는다.
 - worker cadence가 `warming_up`면 `created_at` 기준 first due를 보고 다음 scheduled sample을 기다린다.
 - worker cadence가 `scheduled_evidence_missing`면 `scheduled_runs=0` 자체가 아니라 "expected window를 놓쳤다"는 의미로 보고, 먼저 `workflow_schedule_diagnostics.json`에서 repo default branch / Actions permissions / workflow state / actionable hint를 확인한 뒤 workflow enablement / schedule delivery를 조사한다.
+- scheduled workflow가 `push`에서도 `workflow file issue`로 즉시 실패하면, `npm run workflow:verify`를 먼저 돌려서 `if:` condition 안에 `secrets.*` 직접 참조가 없는지 확인한다. secret 기반 분기는 `env`로 올린 뒤 `if: ${{ env.NAME != '' }}` 형태로 유지한다.
 
 ## 6. Representative Refresh Path
 


### PR DESCRIPTION
## Summary
- move scheduled worker workflows away from direct `secrets.*` usage inside `if:` conditions
- add a workflow guard script and backend-quality gate to catch the same regression in PRs
- document the root cause and local verification for the schedule delivery investigation

Refs #660