### PR TITLE
Expand MV query planning for blocker cohorts

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,8 @@ python build_release_details_musicbrainz.py --cohorts latest,recent --max-rows 2
 python backfill_release_detail_mvs.py --cohorts latest,recent --max-rows 25 --progress-every 5
 ```
 
+`backfill_release_detail_mvs.py`는 이제 첫 번째 title track만 보지 않고 최대 2개의 title track과 `official music video` / no-suffix fallback query까지 포함해서 candidate breadth를 넓힌다. 긴 latest/recent pass를 다시 돌리기 전에 이 경로를 우선 쓴다.
+
 Neon canonical DB까지 같이 최신화하려면 아래를 이어서 실행한다.
 
 ```bash

--- a/backend/README.md
+++ b/backend/README.md
@@ -592,6 +592,8 @@ python3 ../build_release_details_musicbrainz.py --cohorts latest,recent --max-ro
 python3 ../backfill_release_detail_mvs.py --cohorts latest,recent --max-rows 25 --progress-every 5
 ```
 
+`backfill_release_detail_mvs.py`는 latest/recent blocker rerun에서 최대 2개의 title track, `official music video` suffix, no-suffix fallback까지 query plan에 포함한다. candidate breadth를 먼저 넓힌 뒤 full rerun을 태우는 기준으로 쓴다.
+
 ## Release Pipeline Dual-Write
 
 기존 JSON export를 유지한 채 release hydration / service-link / MV review 흐름만 canonical DB에 다시 쓰려면 아래 명령을 사용한다.

--- a/backfill_release_detail_mvs.py
+++ b/backfill_release_detail_mvs.py
@@ -26,11 +26,11 @@ OVERRIDES_PATH = ROOT / "release_detail_overrides.json"
 REPORT_PATH = ROOT / "mv_coverage_report.json"
 USER_AGENT = "Mozilla/5.0"
 REQUEST_DELAY_SECONDS = 0.05
-MAX_RESULTS_PER_QUERY = 8
-MAX_QUERIES_PER_RELEASE = 8
+MAX_RESULTS_PER_QUERY = 12
+MAX_QUERIES_PER_RELEASE = 12
 MAX_TRACK_CANDIDATES_PER_RELEASE = 3
 MAX_NAME_VARIANTS_PER_TRACK_SEARCH = 1
-QUERY_SUFFIXES = ("official mv", "mv")
+QUERY_SUFFIXES = ("official mv", "official music video", "mv", "")
 HANGUL_PATTERN = re.compile(r"[가-힣]")
 RELEASE_TITLE_FALLBACK_MIN_DATE = "2025-01-01"
 TITLE_TRACK_EXCLUSION_PATTERN = re.compile(
@@ -287,7 +287,10 @@ def pick_title_variants(detail: dict[str, Any]) -> list[str]:
 
     variants: list[str] = []
     seen: set[str] = set()
-    append_unique(variants, seen, title_tracks[0] if title_tracks else detail.get("release_title"))
+    for title_track in title_tracks[:2]:
+        append_unique(variants, seen, title_track)
+    if not variants:
+        append_unique(variants, seen, detail.get("release_title"))
     release_title = detail.get("release_title", "")
     primary_title = variants[0] if variants else ""
     if release_title and release_title.casefold() != primary_title.casefold():
@@ -304,14 +307,12 @@ def build_queries(detail: dict[str, Any], profile: dict[str, Any] | None) -> lis
     queries: list[str] = []
     seen: set[str] = set()
 
-    primary_title = titles[0]
-    fallback_title = titles[1] if len(titles) > 1 else ""
     query_plan: list[tuple[str, str, str]] = []
 
-    for name in names:
-        query_plan.extend((name, primary_title, suffix) for suffix in QUERY_SUFFIXES)
-    if fallback_title:
-        query_plan.extend((names[0], fallback_title, suffix) for suffix in QUERY_SUFFIXES)
+    for title_index, title in enumerate(titles):
+        name_variants = names if title_index == 0 else names[:1]
+        for name in name_variants:
+            query_plan.extend((name, title, suffix) for suffix in QUERY_SUFFIXES)
 
     for name, title, suffix in query_plan:
         query = " ".join(part for part in [name, title, suffix] if part).strip()

--- a/docs/assets/distribution/backend_mv_query_plan_expansion_local_2026-03-12.md
+++ b/docs/assets/distribution/backend_mv_query_plan_expansion_local_2026-03-12.md
@@ -1,0 +1,29 @@
+# Backend MV Query Plan Expansion Local Check (2026-03-12)
+
+## Scope
+- broaden `backfill_release_detail_mvs.py` query planning for latest/recent MV recovery work
+- keep the change limited to search-plan generation and runtime-safe caps
+
+## Changes Verified
+- `QUERY_SUFFIXES` now includes:
+  - `official mv`
+  - `official music video`
+  - `mv`
+  - no-suffix fallback
+- `pick_title_variants()` now keeps up to two explicit title tracks before falling back to the release title
+- `build_queries()` now:
+  - uses all name variants for the primary title
+  - uses the primary group name for secondary title variants
+  - caps the total at `MAX_QUERIES_PER_RELEASE = 12`
+- `MAX_RESULTS_PER_QUERY` increased from `8` to `12`
+
+## Local Verification
+- `source .venv/bin/activate && python -m unittest test_backfill_release_detail_mvs.py`
+- representative expectations covered by tests:
+  - `IVE / REVIVE+` includes query variants for `BLACKHOLE` and `BANG BANG`
+  - `(G)I-DLE / Mono` includes `official music video` and no-suffix fallbacks
+  - `ZEROBASEONE / NEVER SAY NEVER` keeps both title tracks plus release-title fallback order
+
+## Notes
+- This change improves MV candidate discovery breadth but does not itself claim readiness-gate closure.
+- Full latest/recent backfill rerun should be executed separately after merge because external YouTube queries remain time-consuming.

--- a/test_backfill_release_detail_mvs.py
+++ b/test_backfill_release_detail_mvs.py
@@ -36,11 +36,17 @@ class BackfillReleaseDetailMvQueryTests(unittest.TestCase):
             backfill.build_queries(detail, profile),
             [
                 "IVE BLACKHOLE official mv",
+                "IVE BLACKHOLE official music video",
                 "IVE BLACKHOLE mv",
+                "IVE BLACKHOLE",
                 "아이브 BLACKHOLE official mv",
+                "아이브 BLACKHOLE official music video",
                 "아이브 BLACKHOLE mv",
-                "IVE REVIVE+ official mv",
-                "IVE REVIVE+ mv",
+                "아이브 BLACKHOLE",
+                "IVE BANG BANG official mv",
+                "IVE BANG BANG official music video",
+                "IVE BANG BANG mv",
+                "IVE BANG BANG",
             ],
         )
 
@@ -62,12 +68,33 @@ class BackfillReleaseDetailMvQueryTests(unittest.TestCase):
             backfill.build_queries(detail, profile),
             [
                 "(G)I-DLE Mono official mv",
+                "(G)I-DLE Mono official music video",
                 "(G)I-DLE Mono mv",
+                "(G)I-DLE Mono",
                 "아이들 Mono official mv",
+                "아이들 Mono official music video",
                 "아이들 Mono mv",
+                "아이들 Mono",
                 "i-dle Mono official mv",
+                "i-dle Mono official music video",
                 "i-dle Mono mv",
+                "i-dle Mono",
             ],
+        )
+
+    def test_build_queries_keeps_release_title_as_primary_fallback_after_two_title_tracks(self) -> None:
+        detail = {
+            "group": "ZEROBASEONE",
+            "release_title": "NEVER SAY NEVER",
+            "tracks": [
+                {"title": "SLAM DUNK", "is_title_track": True},
+                {"title": "BLUE", "is_title_track": True},
+            ],
+        }
+
+        self.assertEqual(
+            backfill.pick_title_variants(detail),
+            ["SLAM DUNK", "BLUE", "NEVER SAY NEVER"],
         )
 
     def test_infer_title_track_from_candidate_title_matches_unique_track(self) -> None:


### PR DESCRIPTION
## Summary\n- broaden MV query planning for blocker cohort reruns with extra suffixes and a no-suffix fallback\n- include up to two explicit title tracks in the query plan before falling back to the release title\n- document the new latest/recent rerun behavior and capture local verification evidence\n\n## Verification\n- source .venv/bin/activate && python3 -m py_compile backfill_release_detail_mvs.py test_backfill_release_detail_mvs.py\n- source .venv/bin/activate && python -m unittest test_backfill_release_detail_mvs.py\n- source .venv/bin/activate && python3 - <<'PY'\n  import backfill_release_detail_mvs as backfill\n  ...\n  PY\n- git diff --check\n\nRefs #625