### PR TITLE
Fix Pages bridge deploy target checks

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -59,36 +59,31 @@ jobs:
       - name: Build Pages read bridge
         working-directory: web
         env:
-          VITE_API_BASE_URL: ${{ vars.VITE_API_BASE_URL }}
-          VITE_BACKEND_TARGET_ENV: production
+          VITE_BACKEND_TARGET_ENV: bridge
         run: npm run build:pages-read-bridge
 
       - name: Verify Pages read bridge
         working-directory: web
         env:
-          VITE_API_BASE_URL: ${{ vars.VITE_API_BASE_URL }}
-          VITE_BACKEND_TARGET_ENV: production
+          VITE_BACKEND_TARGET_ENV: bridge
         run: npm run verify:pages-read-bridge
 
       - name: Verify Pages backend target
         working-directory: web
         env:
-          VITE_API_BASE_URL: ${{ vars.VITE_API_BASE_URL }}
-          VITE_BACKEND_TARGET_ENV: production
+          VITE_BACKEND_TARGET_ENV: bridge
         run: npm run verify:pages-backend-target
 
       - name: Verify backend freshness handoff
         working-directory: web
         env:
-          VITE_API_BASE_URL: ${{ vars.VITE_API_BASE_URL }}
-          VITE_BACKEND_TARGET_ENV: production
+          VITE_BACKEND_TARGET_ENV: bridge
         run: npm run verify:pages-backend-handoff
 
       - name: Build site
         working-directory: web
         env:
-          VITE_API_BASE_URL: ${{ vars.VITE_API_BASE_URL }}
-          VITE_BACKEND_TARGET_ENV: production
+          VITE_BACKEND_TARGET_ENV: bridge
         run: npm run build
 
       - name: Upload artifact

--- a/README.md
+++ b/README.md
@@ -313,7 +313,8 @@ npm run dev
 - browser에서 separate API base URL을 쓸 때 backend는 `APP_ENV`와 `WEB_ALLOWED_ORIGINS`를 같이 맞춰야 한다. production 기본 origin은 `https://iamsomething.github.io`다.
 - committed JSON snapshot은 import/parity/debug artifact로 유지되지만, shipped web cut-over surface의 runtime source switch로는 더 이상 사용하지 않는다.
 - `web/.env.example`에는 Pages / preview rehearsal에서 쓰는 API base env baseline이 들어 있다.
-- `.github/workflows/deploy-pages.yml`은 GitHub Pages build에 `VITE_API_BASE_URL`과 `VITE_BACKEND_TARGET_ENV=production`을 함께 주입한다.
+- `.github/workflows/deploy-pages.yml`은 GitHub Pages runtime을 `VITE_BACKEND_TARGET_ENV=bridge`로 고정하고, bridge 산출물만 빌드에 포함한다.
+- bridge runtime이어도 `verify:pages-backend-handoff`는 latest backend freshness artifact가 `production/preview/local` 중 하나의 실제 backend target을 가리키는지 별도로 검증한다.
 - `npm run build`는 Pages read bridge(`web/public/__bridge/v1/**`)를 먼저 생성한다. bridge는 committed `web/src/data`가 아니라 `backend/exports/non_runtime_web_snapshots/**`를 우선 읽고, export가 없을 때만 local snapshot으로 fallback 한다.
 - `deploy-pages.yml`은 `backend/exports/non_runtime_web_snapshots/**` 변경도 함께 감지해서 Pages를 다시 빌드하고, `npm run verify:pages-read-bridge`, `npm run verify:pages-backend-target`, `npm run verify:pages-backend-handoff`로 bridge completeness, active backend target wiring, latest backend freshness handoff를 같이 gate로 막는다.
 - `backend/reports/backend_freshness_handoff.json`은 latest release sync, latest upcoming sync, projection refresh 순서와 Pages target URL 정합성을 요약한 deploy-time artifact다.

--- a/web/public/__bridge/v1/meta/backend-target.json
+++ b/web/public/__bridge/v1/meta/backend-target.json
@@ -3,7 +3,7 @@
     "request_id": "bridge-backend-target"
   },
   "data": {
-    "generated_at": "2026-03-12T16:37:56.366Z",
+    "generated_at": "2026-03-12T16:44:16.439Z",
     "runtime_mode": "bridge",
     "target_environment": "bridge",
     "target_classification": "bridge",

--- a/web/scripts/verify-pages-backend-handoff.mjs
+++ b/web/scripts/verify-pages-backend-handoff.mjs
@@ -26,27 +26,40 @@ ensurePass('target_binding', checks.target_binding)
 const handoffTargetEnvironment = normalizeTargetEnvironment(target.environment ?? '')
 const handoffTargetClassification = normalizeTargetClassification(target.classification ?? '')
 const handoffApiBaseUrl = normalizeApiBaseUrl(target.backend_public_url ?? '')
+const isBridgeRuntime = expectedTargetEnvironment === 'bridge' && !expectedApiBaseUrl
 
 if (handoff.status !== 'pass') {
   throw new Error(`Backend freshness handoff status must be pass. Got ${String(handoff.status)}.`)
 }
 
-if (handoffTargetEnvironment !== expectedTargetEnvironment) {
-  throw new Error(
-    `Backend freshness handoff target environment mismatch. Expected ${expectedTargetEnvironment}, got ${handoffTargetEnvironment || '(empty)'}.`,
-  )
-}
+if (isBridgeRuntime) {
+  if (!handoffApiBaseUrl) {
+    throw new Error('Bridge runtime still requires backend freshness handoff to resolve a non-empty backend_public_url.')
+  }
 
-if (handoffTargetClassification && handoffTargetClassification !== expectedTargetClassification) {
-  throw new Error(
-    `Backend freshness handoff target classification mismatch. Expected ${expectedTargetClassification}, got ${handoffTargetClassification || '(empty)'}.`,
-  )
-}
+  if (!handoffTargetEnvironment || handoffTargetEnvironment === 'bridge') {
+    throw new Error(
+      `Bridge runtime requires a non-bridge backend freshness handoff target. Got ${handoffTargetEnvironment || '(empty)'}.`,
+    )
+  }
+} else {
+  if (handoffTargetEnvironment !== expectedTargetEnvironment) {
+    throw new Error(
+      `Backend freshness handoff target environment mismatch. Expected ${expectedTargetEnvironment}, got ${handoffTargetEnvironment || '(empty)'}.`,
+    )
+  }
 
-if (handoffApiBaseUrl && handoffApiBaseUrl !== expectedApiBaseUrl) {
-  throw new Error(
-    `Backend freshness handoff API base mismatch. Expected ${expectedApiBaseUrl || '(empty)'}, got ${handoffApiBaseUrl || '(empty)'}.`,
-  )
+  if (handoffTargetClassification && handoffTargetClassification !== expectedTargetClassification) {
+    throw new Error(
+      `Backend freshness handoff target classification mismatch. Expected ${expectedTargetClassification}, got ${handoffTargetClassification || '(empty)'}.`,
+    )
+  }
+
+  if (handoffApiBaseUrl && handoffApiBaseUrl !== expectedApiBaseUrl) {
+    throw new Error(
+      `Backend freshness handoff API base mismatch. Expected ${expectedApiBaseUrl || '(empty)'}, got ${handoffApiBaseUrl || '(empty)'}.`,
+    )
+  }
 }
 
 console.log(


### PR DESCRIPTION
## Summary\n- keep deploy-pages in bridge runtime mode instead of requiring a production API target\n- continue validating backend freshness handoff against a real non-bridge backend target\n- document the bridge-runtime Pages deploy contract\n\nCloses #681