### PR TITLE
Audit web UI bridge coverage and fix broken detail routes

### DIFF
--- a/.github/workflows/web-quality.yml
+++ b/.github/workflows/web-quality.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Run web runtime policy tests
         run: npm run test:runtime-policy
 
+      - name: Run Pages read bridge tests
+        run: npm run test:pages-read-bridge
+
       - name: Verify web runtime policy
         run: npm run verify:runtime-policy
 
@@ -53,3 +56,6 @@ jobs:
 
       - name: Run web build
         run: npm run build
+
+      - name: Verify Pages read bridge
+        run: npm run verify:pages-read-bridge

--- a/web/package.json
+++ b/web/package.json
@@ -9,6 +9,7 @@
     "build": "npm run build:pages-read-bridge && tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
+    "test:pages-read-bridge": "node --test ./scripts/lib/pagesReadBridgeCalendar.test.mjs ./scripts/lib/pagesReadBridgeCoverage.test.mjs",
     "test:runtime-policy": "node --test ./scripts/lib/runtimeImportBoundary.test.mjs",
     "verify:runtime-policy": "node ./scripts/verify-runtime-policy.mjs",
     "verify:timeout": "tsx ./scripts/verify-backend-timeout.ts",

--- a/web/public/__bridge/v1/entities/yena.json
+++ b/web/public/__bridge/v1/entities/yena.json
@@ -32,7 +32,7 @@
       "stream": "album",
       "release_kind": "ep",
       "release_format": "ep",
-      "representative_song_title": null,
+      "representative_song_title": "",
       "spotify_url": null,
       "youtube_music_url": null,
       "youtube_mv_url": null,

--- a/web/public/__bridge/v1/meta/backend-target.json
+++ b/web/public/__bridge/v1/meta/backend-target.json
@@ -3,7 +3,7 @@
     "request_id": "bridge-backend-target"
   },
   "data": {
-    "generated_at": "2026-03-12T17:02:34.316Z",
+    "generated_at": "2026-03-12T17:25:01.737Z",
     "runtime_mode": "bridge",
     "target_environment": "bridge",
     "target_classification": "bridge",

--- a/web/public/__bridge/v1/releases/details/bridge-release-cc830546.json
+++ b/web/public/__bridge/v1/releases/details/bridge-release-cc830546.json
@@ -1,0 +1,31 @@
+{
+  "meta": {
+    "request_id": "bridge-release-detail-bridge-release-cc830546"
+  },
+  "data": {
+    "release": {
+      "release_id": "bridge-release-cc830546",
+      "release_title": "LOVE CATCHER",
+      "release_date": "2026-03-11",
+      "stream": "album",
+      "release_kind": "ep"
+    },
+    "artwork": null,
+    "service_links": {
+      "spotify": {
+        "url": null
+      },
+      "youtube_music": {
+        "url": null
+      }
+    },
+    "tracks": [],
+    "mv": {
+      "url": null,
+      "video_id": null,
+      "status": "unresolved",
+      "provenance": "bridge.release_summary_fallback"
+    },
+    "notes": "Bridge summary fallback generated from verified release summary."
+  }
+}

--- a/web/public/__bridge/v1/releases/lookups/lookup-2c835de7.json
+++ b/web/public/__bridge/v1/releases/lookups/lookup-2c835de7.json
@@ -1,0 +1,9 @@
+{
+  "meta": {
+    "request_id": "bridge-release-lookup-lookup-2c835de7"
+  },
+  "data": {
+    "release_id": "bridge-release-cc830546",
+    "canonical_path": "/artists/yena/releases/love-catcher?date=2026-03-11&stream=album"
+  }
+}

--- a/web/public/__bridge/v1/releases/lookups/lookup-4fb71b75.json
+++ b/web/public/__bridge/v1/releases/lookups/lookup-4fb71b75.json
@@ -1,0 +1,9 @@
+{
+  "meta": {
+    "request_id": "bridge-release-lookup-lookup-4fb71b75"
+  },
+  "data": {
+    "release_id": "bridge-release-cc830546",
+    "canonical_path": "/artists/yena/releases/love-catcher?date=2026-03-11&stream=album"
+  }
+}

--- a/web/public/__bridge/v1/releases/lookups/lookup-c872f286.json
+++ b/web/public/__bridge/v1/releases/lookups/lookup-c872f286.json
@@ -1,0 +1,9 @@
+{
+  "meta": {
+    "request_id": "bridge-release-lookup-lookup-c872f286"
+  },
+  "data": {
+    "release_id": "bridge-release-cc830546",
+    "canonical_path": "/artists/yena/releases/love-catcher?date=2026-03-11&stream=album"
+  }
+}

--- a/web/public/__bridge/v1/search/index.json
+++ b/web/public/__bridge/v1/search/index.json
@@ -3714,7 +3714,7 @@
           "stream": "album",
           "release_kind": "ep",
           "release_format": "ep",
-          "representative_song_title": null,
+          "representative_song_title": "",
           "spotify_url": null,
           "youtube_music_url": null,
           "youtube_mv_url": null,
@@ -35041,6 +35041,23 @@
           "ZEROBASEONE RE-FLOW",
           "제로베이스원 RE-FLOW",
           "제베원 RE-FLOW"
+        ]
+      },
+      {
+        "release_id": "bridge-release-cc830546",
+        "detail_path": "/artists/yena/releases/love-catcher?date=2026-03-11&stream=album",
+        "entity_path": "/artists/yena",
+        "entity_slug": "yena",
+        "display_name": "YENA",
+        "release_title": "LOVE CATCHER",
+        "release_date": "2026-03-11",
+        "stream": "album",
+        "release_kind": "ep",
+        "release_format": "ep",
+        "search_terms": [
+          "LOVE CATCHER",
+          "YENA LOVE CATCHER",
+          "최예나 LOVE CATCHER"
         ]
       }
     ],

--- a/web/scripts/build-pages-read-bridge.mjs
+++ b/web/scripts/build-pages-read-bridge.mjs
@@ -29,8 +29,13 @@ const releaseRowByGroup = new Map(releaseRows.map((row) => [row.group, row]))
 const releaseHistoryByGroup = new Map(releaseHistory.map((row) => [row.group, row]))
 const watchlistByGroup = new Map(watchlist.map((row) => [row.group, row]))
 const bestReleaseDetailRows = selectBestReleaseDetailRows(releaseDetails)
+const bridgeReleaseDetailRows = buildBridgeReleaseDetailRows({
+  explicitRows: bestReleaseDetailRows,
+  releaseRows,
+  releaseHistoryRows: releaseHistory,
+})
 const releaseDetailByKey = new Map(
-  bestReleaseDetailRows.map((row) => [
+  bridgeReleaseDetailRows.map((row) => [
     getReleaseKey(row.group, row.release_title, row.release_date, normalizeReleaseStream(row.stream, row.release_kind)),
     row,
   ]),
@@ -53,7 +58,7 @@ await mkdir(path.join(bridgeRoot, 'search'), { recursive: true })
 const releaseLookupEntries = new Map()
 let releaseDetailCount = 0
 
-for (const row of bestReleaseDetailRows) {
+for (const row of bridgeReleaseDetailRows) {
   const stream = normalizeReleaseStream(row.stream, row.release_kind)
   const releaseKey = getReleaseKey(row.group, row.release_title, row.release_date, stream)
   const releaseId = `bridge-release-${hashBridgeKey(releaseKey)}`
@@ -117,7 +122,7 @@ for (const [entitySlug, payload] of entityPayloads) {
 
 const searchIndexPayload = buildBridgeSearchIndex({
   entityPayloads,
-  releaseDetailRows: bestReleaseDetailRows,
+  releaseDetailRows: bridgeReleaseDetailRows,
   upcomingRows: upcomingCandidates,
   artistProfileByGroup,
   suppressedUpcomingState: collectSuppressedUpcomingState(releaseRows),
@@ -838,6 +843,87 @@ function buildReleaseDetailPayload(row, releaseId, artwork) {
           }
         : null,
     notes: readString(row.notes) || null,
+  }
+}
+
+function buildBridgeReleaseDetailRows({ explicitRows, releaseRows, releaseHistoryRows }) {
+  const rowsByKey = new Map()
+
+  for (const row of explicitRows) {
+    const key = getReleaseKey(row.group, row.release_title, row.release_date, normalizeReleaseStream(row.stream, row.release_kind))
+    rowsByKey.set(key, row)
+  }
+
+  for (const historyRow of releaseHistoryRows) {
+    const group = historyRow.group
+    const releases = Array.isArray(historyRow.releases) ? historyRow.releases : []
+    for (const release of releases) {
+      const synthetic = buildSyntheticReleaseDetailRow(group, release, release.stream)
+      if (!synthetic) {
+        continue
+      }
+
+      const key = getReleaseKey(
+        synthetic.group,
+        synthetic.release_title,
+        synthetic.release_date,
+        normalizeReleaseStream(synthetic.stream, synthetic.release_kind),
+      )
+      if (!rowsByKey.has(key)) {
+        rowsByKey.set(key, synthetic)
+      }
+    }
+  }
+
+  for (const releaseRow of releaseRows) {
+    for (const [stream, fact] of [
+      ['song', releaseRow.latest_song],
+      ['album', releaseRow.latest_album],
+    ]) {
+      const synthetic = buildSyntheticReleaseDetailRow(releaseRow.group, fact, stream)
+      if (!synthetic) {
+        continue
+      }
+
+      const key = getReleaseKey(
+        synthetic.group,
+        synthetic.release_title,
+        synthetic.release_date,
+        normalizeReleaseStream(synthetic.stream, synthetic.release_kind),
+      )
+      if (!rowsByKey.has(key)) {
+        rowsByKey.set(key, synthetic)
+      }
+    }
+  }
+
+  return Array.from(rowsByKey.values())
+}
+
+function buildSyntheticReleaseDetailRow(group, fact, stream) {
+  if (!fact || !readString(fact.title) || !readString(fact.date)) {
+    return null
+  }
+
+  const normalizedStream = normalizeReleaseStream(stream, fact.release_kind)
+  return {
+    group,
+    release_title: readString(fact.title),
+    release_date: readString(fact.date),
+    stream: normalizedStream,
+    release_kind: readString(fact.release_kind) || (normalizedStream === 'album' ? 'album' : 'single'),
+    detail_status: 'bridge_summary_fallback',
+    detail_provenance: 'bridge.release_summary_fallback',
+    title_track_status: 'unresolved',
+    title_track_provenance: 'bridge.release_summary_fallback',
+    tracks: [],
+    spotify_url: null,
+    youtube_music_url: null,
+    youtube_video_url: null,
+    youtube_video_id: null,
+    youtube_video_status: 'unresolved',
+    youtube_video_provenance: 'bridge.release_summary_fallback',
+    notes: 'Bridge summary fallback generated from verified release summary.',
   }
 }
 

--- a/web/scripts/lib/pagesReadBridgeCoverage.mjs
+++ b/web/scripts/lib/pagesReadBridgeCoverage.mjs
@@ -1,0 +1,418 @@
+import { readdir, readFile } from 'node:fs/promises'
+import path from 'node:path'
+
+export async function auditPagesReadBridge({ webRoot }) {
+  const bridgeRoot = path.join(webRoot, 'public', '__bridge', 'v1')
+  const entitiesDir = path.join(bridgeRoot, 'entities')
+  const releaseDetailsDir = path.join(bridgeRoot, 'releases', 'details')
+  const releaseLookupsDir = path.join(bridgeRoot, 'releases', 'lookups')
+  const calendarMonthsDir = path.join(bridgeRoot, 'calendar', 'months')
+
+  const entityFiles = (await readdir(entitiesDir)).filter((name) => name.endsWith('.json')).sort()
+  const releaseDetailFiles = (await readdir(releaseDetailsDir)).filter((name) => name.endsWith('.json')).sort()
+  const releaseLookupFiles = (await readdir(releaseLookupsDir)).filter((name) => name.endsWith('.json')).sort()
+  const calendarMonthFiles = (await readdir(calendarMonthsDir)).filter((name) => name.endsWith('.json')).sort()
+
+  const entityFileSlugs = new Set(entityFiles.map((name) => name.replace(/\.json$/u, '')))
+  const releaseDetailIds = new Set(releaseDetailFiles.map((name) => name.replace(/\.json$/u, '')))
+  const releaseLookupIds = new Set(releaseLookupFiles.map((name) => name.replace(/\.json$/u, '')))
+
+  const entityPayloadEntries = await Promise.all(
+    entityFiles.map(async (name) => {
+      const slug = name.replace(/\.json$/u, '')
+      return [slug, await readJson(path.join(entitiesDir, name))]
+    }),
+  )
+  const entityPayloadBySlug = new Map(entityPayloadEntries)
+
+  const searchIndex = await readJson(path.join(bridgeRoot, 'search', 'index.json'))
+  const radar = await readJson(path.join(bridgeRoot, 'radar.json'))
+  const backendTarget = await readJson(path.join(bridgeRoot, 'meta', 'backend-target.json'))
+  const calendarMonths = await Promise.all(
+    calendarMonthFiles.map(async (name) => ({
+      monthKey: name.replace(/\.json$/u, ''),
+      payload: await readJson(path.join(calendarMonthsDir, name)),
+    })),
+  )
+
+  const errors = []
+
+  for (const [entitySlug, payload] of entityPayloadBySlug) {
+    const identitySlug = readString(payload?.data?.identity?.entity_slug)
+    if (identitySlug !== entitySlug) {
+      pushError(
+        errors,
+        'entity_slug_mismatch',
+        `Bridge entity asset ${entitySlug} must expose the same identity.entity_slug.`,
+        { entitySlug, identitySlug },
+      )
+    }
+
+    validateOptionalUrl(errors, payload?.data?.official_links?.youtube, 'entity_official_youtube_invalid', {
+      entitySlug,
+      field: 'official_links.youtube',
+    })
+    validateOptionalUrl(errors, payload?.data?.official_links?.x, 'entity_official_x_invalid', {
+      entitySlug,
+      field: 'official_links.x',
+    })
+    validateOptionalUrl(errors, payload?.data?.official_links?.instagram, 'entity_official_instagram_invalid', {
+      entitySlug,
+      field: 'official_links.instagram',
+    })
+    validateOptionalUrl(errors, payload?.data?.youtube_channels?.primary_team_channel_url, 'entity_primary_channel_invalid', {
+      entitySlug,
+      field: 'youtube_channels.primary_team_channel_url',
+    })
+
+    ensureReleaseReference(
+      errors,
+      releaseDetailIds,
+      payload?.data?.latest_release,
+      'entity_latest_release_missing_detail',
+      { entitySlug },
+    )
+
+    for (const recentRelease of ensureArray(payload?.data?.recent_albums)) {
+      ensureReleaseReference(errors, releaseDetailIds, recentRelease, 'entity_recent_release_missing_detail', {
+        entitySlug,
+      })
+    }
+
+    for (const timelineEntry of ensureArray(payload?.data?.source_timeline)) {
+      validateOptionalUrl(errors, timelineEntry?.source_url, 'entity_timeline_source_invalid', {
+        entitySlug,
+        headline: readString(timelineEntry?.headline) ?? null,
+      })
+    }
+  }
+
+  const searchEntities = ensureArray(searchIndex?.data?.entities)
+  for (const entry of searchEntities) {
+    const entitySlug = readString(entry?.entity_slug)
+    if (!entitySlug) {
+      pushError(errors, 'search_entity_missing_slug', 'Bridge search entity rows must expose entity_slug.', {
+        row: entry ?? null,
+      })
+      continue
+    }
+
+    ensureEntityReference(errors, entityFileSlugs, entitySlug, 'search_entity_missing_asset', { entitySlug })
+    ensureEntitySearchTerms(errors, entry, 'search_entity_missing_exact_terms')
+    ensureReleaseReference(errors, releaseDetailIds, entry?.latest_release, 'search_entity_latest_release_missing_detail', {
+      entitySlug,
+    })
+  }
+
+  const searchReleases = ensureArray(searchIndex?.data?.releases)
+  for (const entry of searchReleases) {
+    const entitySlug = readString(entry?.entity_slug)
+    const releaseTitle = readString(entry?.release_title)
+    const releaseDate = readString(entry?.release_date)
+    const stream = normalizeReleaseStream(readString(entry?.stream), readString(entry?.release_kind))
+    if (!entitySlug || !releaseTitle || !releaseDate || !stream) {
+      pushError(errors, 'search_release_missing_fields', 'Bridge search release rows must expose slug/title/date/stream.', {
+        entitySlug,
+        releaseTitle,
+        releaseDate,
+        stream,
+      })
+      continue
+    }
+
+    ensureEntityReference(errors, entityFileSlugs, entitySlug, 'search_release_missing_entity_asset', { entitySlug })
+    ensureLookupReference(
+      errors,
+      releaseLookupIds,
+      entitySlug,
+      releaseTitle,
+      releaseDate,
+      stream,
+      'search_release_missing_lookup',
+    )
+    ensureReleaseReference(errors, releaseDetailIds, entry, 'search_release_missing_detail', { entitySlug })
+  }
+
+  const searchUpcoming = ensureArray(searchIndex?.data?.upcoming)
+  for (const entry of searchUpcoming) {
+    const entitySlug = readString(entry?.entity_slug)
+    if (!entitySlug) {
+      pushError(errors, 'search_upcoming_missing_slug', 'Bridge search upcoming rows must expose entity_slug.', {
+        row: entry ?? null,
+      })
+      continue
+    }
+
+    ensureEntityReference(errors, entityFileSlugs, entitySlug, 'search_upcoming_missing_entity_asset', { entitySlug })
+    validateOptionalUrl(errors, entry?.source_url, 'search_upcoming_source_invalid', {
+      entitySlug,
+      headline: readString(entry?.headline) ?? null,
+    })
+  }
+
+  for (const { monthKey, payload } of calendarMonths) {
+    const days = ensureArray(payload?.data?.days)
+    const scheduledList = ensureArray(payload?.data?.scheduled_list)
+    const monthOnlyUpcoming = ensureArray(payload?.data?.month_only_upcoming)
+
+    for (const day of days) {
+      const dayDate = readString(day?.date)
+      const verifiedRows = ensureArray(day?.verified_releases)
+      const exactUpcomingRows = ensureArray(day?.exact_upcoming)
+      const verifiedEntityDateKeys = new Set()
+
+      for (const verified of verifiedRows) {
+        const entitySlug = readString(verified?.entity_slug)
+        const releaseDate = readString(verified?.release_date)
+        if (entitySlug && releaseDate) {
+          verifiedEntityDateKeys.add(`${entitySlug}::${releaseDate}`)
+        }
+
+        if (entitySlug) {
+          ensureEntityReference(errors, entityFileSlugs, entitySlug, 'calendar_verified_missing_entity_asset', {
+            monthKey,
+            date: dayDate,
+            entitySlug,
+          })
+        }
+        ensureReleaseReference(errors, releaseDetailIds, verified, 'calendar_verified_missing_detail', {
+          monthKey,
+          date: dayDate,
+          entitySlug,
+        })
+      }
+
+      for (const upcoming of exactUpcomingRows) {
+        const entitySlug = readString(upcoming?.entity_slug)
+        const scheduledDate = readString(upcoming?.scheduled_date)
+        if (entitySlug) {
+          ensureEntityReference(errors, entityFileSlugs, entitySlug, 'calendar_exact_upcoming_missing_entity_asset', {
+            monthKey,
+            date: dayDate,
+            entitySlug,
+          })
+        }
+        validateOptionalUrl(errors, upcoming?.source_url, 'calendar_exact_upcoming_source_invalid', {
+          monthKey,
+          date: dayDate,
+          entitySlug,
+        })
+        if (entitySlug && scheduledDate && verifiedEntityDateKeys.has(`${entitySlug}::${scheduledDate}`)) {
+          pushError(
+            errors,
+            'calendar_stale_same_day_upcoming',
+            'Bridge calendar must not keep same-day exact upcoming rows when a verified release exists for the same entity/date.',
+            { monthKey, date: dayDate, entitySlug, scheduledDate },
+          )
+        }
+      }
+    }
+
+    for (const upcoming of [...scheduledList, ...monthOnlyUpcoming]) {
+      const entitySlug = readString(upcoming?.entity_slug)
+      if (!entitySlug) {
+        pushError(errors, 'calendar_scheduled_missing_slug', 'Bridge scheduled rows must expose entity_slug.', {
+          monthKey,
+          row: upcoming ?? null,
+        })
+        continue
+      }
+
+      ensureEntityReference(errors, entityFileSlugs, entitySlug, 'calendar_scheduled_missing_entity_asset', {
+        monthKey,
+        entitySlug,
+      })
+    }
+  }
+
+  for (const entry of ensureArray(radar?.data?.long_gap)) {
+    const entitySlug = readString(entry?.entity_slug)
+    if (!entitySlug) {
+      pushError(errors, 'radar_long_gap_missing_slug', 'Radar long-gap rows must expose entity_slug.', { row: entry ?? null })
+      continue
+    }
+
+    ensureEntityReference(errors, entityFileSlugs, entitySlug, 'radar_long_gap_missing_entity_asset', { entitySlug })
+  }
+
+  for (const entry of ensureArray(radar?.data?.rookie)) {
+    const entitySlug = readString(entry?.entity_slug)
+    if (!entitySlug) {
+      pushError(errors, 'radar_rookie_missing_slug', 'Radar rookie rows must expose entity_slug.', { row: entry ?? null })
+      continue
+    }
+
+    ensureEntityReference(errors, entityFileSlugs, entitySlug, 'radar_rookie_missing_entity_asset', { entitySlug })
+  }
+
+  for (const releaseId of releaseDetailIds) {
+    const detail = await readJson(path.join(releaseDetailsDir, `${releaseId}.json`))
+    validateOptionalUrl(errors, detail?.data?.artwork?.cover_image_url, 'release_artwork_invalid', {
+      releaseId,
+      field: 'artwork.cover_image_url',
+    })
+    validateOptionalUrl(errors, detail?.data?.service_links?.spotify?.url, 'release_spotify_invalid', {
+      releaseId,
+      field: 'service_links.spotify.url',
+    })
+    validateOptionalUrl(errors, detail?.data?.service_links?.youtube_music?.url, 'release_youtube_music_invalid', {
+      releaseId,
+      field: 'service_links.youtube_music.url',
+    })
+    validateOptionalUrl(errors, detail?.data?.mv?.url, 'release_mv_url_invalid', {
+      releaseId,
+      field: 'mv.url',
+    })
+  }
+
+  return {
+    summary: {
+      runtimeMode: readString(backendTarget?.data?.runtime_mode) ?? null,
+      targetEnvironment: readString(backendTarget?.data?.target_environment) ?? null,
+      entityAssets: entityFiles.length,
+      releaseDetailAssets: releaseDetailFiles.length,
+      releaseLookupAssets: releaseLookupFiles.length,
+      calendarMonths: calendarMonthFiles.length,
+      searchEntities: searchEntities.length,
+      searchReleases: searchReleases.length,
+      searchUpcoming: searchUpcoming.length,
+      radarLongGap: ensureArray(radar?.data?.long_gap).length,
+      radarRookie: ensureArray(radar?.data?.rookie).length,
+      errorCount: errors.length,
+    },
+    errors,
+  }
+}
+
+function ensureEntitySearchTerms(errors, entry, code) {
+  const entitySlug = readString(entry?.entity_slug)
+  const displayName = readString(entry?.display_name)
+  const canonicalName = readString(entry?.canonical_name)
+  const searchTerms = new Set(ensureArray(entry?.search_terms).map((term) => normalizeSearchTerm(term)).filter(Boolean))
+
+  for (const expectedTerm of [displayName, canonicalName]) {
+    const normalized = normalizeSearchTerm(expectedTerm)
+    if (!normalized) {
+      continue
+    }
+
+    if (!searchTerms.has(normalized)) {
+      pushError(errors, code, 'Bridge search entity rows must include exact-match terms for display and canonical names.', {
+        entitySlug,
+        missingTerm: expectedTerm,
+      })
+    }
+  }
+}
+
+function ensureEntityReference(errors, entityFileSlugs, entitySlug, code, context) {
+  if (!entityFileSlugs.has(entitySlug)) {
+    pushError(errors, code, 'Bridge route points at an entity detail asset that does not exist.', context)
+  }
+}
+
+function ensureReleaseReference(errors, releaseDetailIds, releaseSummary, code, context) {
+  if (!releaseSummary) {
+    return
+  }
+
+  const releaseId = readString(releaseSummary?.release_id)
+  if (!releaseId) {
+    pushError(errors, code, 'Bridge route points at a release detail asset without a release_id.', context)
+    return
+  }
+
+  if (!releaseDetailIds.has(releaseId)) {
+    pushError(errors, code, 'Bridge route points at a release detail asset that does not exist.', {
+      ...context,
+      releaseId,
+    })
+  }
+}
+
+function ensureLookupReference(errors, releaseLookupIds, entitySlug, releaseTitle, releaseDate, stream, code) {
+  const lookupId = buildReleaseLookupAssetId(entitySlug, releaseTitle, releaseDate, stream)
+  if (!releaseLookupIds.has(lookupId)) {
+    pushError(errors, code, 'Bridge route points at a release lookup asset that does not exist.', {
+      entitySlug,
+      releaseTitle,
+      releaseDate,
+      stream,
+      lookupId,
+    })
+  }
+}
+
+function validateOptionalUrl(errors, url, code, context) {
+  const normalized = readString(url)
+  if (!normalized) {
+    return
+  }
+
+  try {
+    const target = new URL(normalized)
+    if (target.protocol !== 'https:') {
+      pushError(errors, code, 'Bridge/runtime links must use https URLs when present.', {
+        ...context,
+        url: normalized,
+      })
+    }
+  } catch {
+    pushError(errors, code, 'Bridge/runtime links must be valid absolute URLs when present.', {
+      ...context,
+      url: normalized,
+    })
+  }
+}
+
+function buildReleaseLookupAssetId(entitySlug, releaseTitle, releaseDate, stream) {
+  return `lookup-${hashBridgeKey([entitySlug, releaseTitle, releaseDate, stream].join('::'))}`
+}
+
+function hashBridgeKey(value) {
+  let hash = 2166136261
+
+  for (const character of value) {
+    hash ^= character.charCodeAt(0)
+    hash = Math.imul(hash, 16777619)
+  }
+
+  return (hash >>> 0).toString(16).padStart(8, '0')
+}
+
+function normalizeReleaseStream(stream, releaseKind) {
+  if (stream === 'album' || releaseKind === 'album' || releaseKind === 'ep') {
+    return 'album'
+  }
+
+  return 'song'
+}
+
+function normalizeSearchTerm(value) {
+  return String(value ?? '')
+    .normalize('NFKC')
+    .toLowerCase()
+    .replace(/[\s\-_./]+/gu, '')
+    .trim()
+}
+
+function ensureArray(value) {
+  return Array.isArray(value) ? value : []
+}
+
+function readString(value) {
+  return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+function pushError(errors, code, message, context) {
+  errors.push({
+    code,
+    message,
+    context,
+  })
+}
+
+async function readJson(targetPath) {
+  const contents = await readFile(targetPath, 'utf8')
+  return JSON.parse(contents)
+}

--- a/web/scripts/lib/pagesReadBridgeCoverage.test.mjs
+++ b/web/scripts/lib/pagesReadBridgeCoverage.test.mjs
@@ -1,0 +1,178 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+
+import { auditPagesReadBridge } from './pagesReadBridgeCoverage.mjs'
+
+async function withBridgeFixture(callback) {
+  const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'idol-song-app-bridge-coverage-'))
+  const webRoot = path.join(rootDir, 'web')
+  const bridgeRoot = path.join(webRoot, 'public', '__bridge', 'v1')
+
+  fs.mkdirSync(path.join(bridgeRoot, 'calendar', 'months'), { recursive: true })
+  fs.mkdirSync(path.join(bridgeRoot, 'entities'), { recursive: true })
+  fs.mkdirSync(path.join(bridgeRoot, 'releases', 'details'), { recursive: true })
+  fs.mkdirSync(path.join(bridgeRoot, 'releases', 'lookups'), { recursive: true })
+  fs.mkdirSync(path.join(bridgeRoot, 'search'), { recursive: true })
+  fs.mkdirSync(path.join(bridgeRoot, 'meta'), { recursive: true })
+
+  try {
+    await callback({ webRoot, bridgeRoot })
+  } finally {
+    fs.rmSync(rootDir, { recursive: true, force: true })
+  }
+}
+
+function writeJson(targetPath, data) {
+  fs.mkdirSync(path.dirname(targetPath), { recursive: true })
+  fs.writeFileSync(targetPath, JSON.stringify(data, null, 2))
+}
+
+function hashBridgeKey(value) {
+  let hash = 2166136261
+
+  for (const character of value) {
+    hash ^= character.charCodeAt(0)
+    hash = Math.imul(hash, 16777619)
+  }
+
+  return (hash >>> 0).toString(16).padStart(8, '0')
+}
+
+function lookupId(entitySlug, releaseTitle, releaseDate, stream) {
+  return `lookup-${hashBridgeKey([entitySlug, releaseTitle, releaseDate, stream].join('::'))}`
+}
+
+test('auditPagesReadBridge passes for a complete bridge fixture', async () => {
+  await withBridgeFixture(async ({ webRoot, bridgeRoot }) => {
+    writeJson(path.join(bridgeRoot, 'meta', 'backend-target.json'), {
+      data: { runtime_mode: 'bridge', target_environment: 'bridge' },
+    })
+    writeJson(path.join(bridgeRoot, 'entities', 'yena.json'), {
+      data: {
+        identity: { entity_slug: 'yena', display_name: 'YENA', canonical_name: 'YENA' },
+        official_links: {
+          youtube: 'https://www.youtube.com/@YENA_OFFICIAL',
+          x: 'https://x.com/YENA_OFFICIAL',
+          instagram: 'https://www.instagram.com/yena.jigumina',
+        },
+        youtube_channels: {
+          primary_team_channel_url: 'https://www.youtube.com/@YENA_OFFICIAL',
+        },
+        latest_release: { release_id: 'release-1' },
+        recent_albums: [{ release_id: 'release-1' }],
+        source_timeline: [{ headline: 'timeline', source_url: 'https://example.com/source' }],
+      },
+    })
+    writeJson(path.join(bridgeRoot, 'releases', 'details', 'release-1.json'), {
+      data: {
+        service_links: {
+          spotify: { url: 'https://open.spotify.com/album/test' },
+          youtube_music: { url: 'https://music.youtube.com/playlist?list=test' },
+        },
+        mv: { url: 'https://www.youtube.com/watch?v=test' },
+      },
+    })
+    writeJson(path.join(bridgeRoot, 'releases', 'lookups', `${lookupId('yena', 'LOVE CATCHER', '2026-03-11', 'album')}.json`), {
+      data: { release_id: 'release-1' },
+    })
+    writeJson(path.join(bridgeRoot, 'search', 'index.json'), {
+      data: {
+        entities: [
+          {
+            entity_slug: 'yena',
+            display_name: 'YENA',
+            canonical_name: 'YENA',
+            search_terms: ['YENA'],
+            latest_release: { release_id: 'release-1' },
+          },
+        ],
+        releases: [
+          {
+            entity_slug: 'yena',
+            release_title: 'LOVE CATCHER',
+            release_date: '2026-03-11',
+            stream: 'album',
+            detail_path: '/artists/yena/releases/love-catcher?date=2026-03-11&stream=album',
+            release_id: 'release-1',
+          },
+        ],
+        upcoming: [],
+      },
+    })
+    writeJson(path.join(bridgeRoot, 'calendar', 'months', '2026-03.json'), {
+      data: {
+        days: [
+          {
+            date: '2026-03-11',
+            verified_releases: [{ entity_slug: 'yena', release_id: 'release-1', release_date: '2026-03-11' }],
+            exact_upcoming: [],
+          },
+        ],
+        scheduled_list: [],
+        month_only_upcoming: [],
+      },
+    })
+    writeJson(path.join(bridgeRoot, 'radar.json'), {
+      data: {
+        long_gap: [{ entity_slug: 'yena' }],
+        rookie: [{ entity_slug: 'yena' }],
+      },
+    })
+
+    const result = await auditPagesReadBridge({ webRoot })
+    assert.equal(result.errors.length, 0)
+    assert.equal(result.summary.searchEntities, 1)
+  })
+})
+
+test('auditPagesReadBridge reports missing entity assets and stale same-day upcoming rows', async () => {
+  await withBridgeFixture(async ({ webRoot, bridgeRoot }) => {
+    writeJson(path.join(bridgeRoot, 'meta', 'backend-target.json'), {
+      data: { runtime_mode: 'bridge', target_environment: 'bridge' },
+    })
+    writeJson(path.join(bridgeRoot, 'search', 'index.json'), {
+      data: {
+        entities: [
+          {
+            entity_slug: 'hearts2hearts',
+            display_name: 'Hearts2Hearts',
+            canonical_name: 'Hearts2Hearts',
+            search_terms: ['Hearts2Hearts'],
+            latest_release: null,
+          },
+        ],
+        releases: [],
+        upcoming: [],
+      },
+    })
+    writeJson(path.join(bridgeRoot, 'calendar', 'months', '2026-03.json'), {
+      data: {
+        days: [
+          {
+            date: '2026-03-12',
+            verified_releases: [{ entity_slug: 'p1harmony', release_id: 'release-1', release_date: '2026-03-12' }],
+            exact_upcoming: [{ entity_slug: 'p1harmony', scheduled_date: '2026-03-12' }],
+          },
+        ],
+        scheduled_list: [],
+        month_only_upcoming: [],
+      },
+    })
+    writeJson(path.join(bridgeRoot, 'radar.json'), {
+      data: { long_gap: [], rookie: [] },
+    })
+
+    const result = await auditPagesReadBridge({ webRoot })
+    assert.equal(
+      result.errors.some((error) => error.code === 'search_entity_missing_asset'),
+      true,
+    )
+    assert.equal(
+      result.errors.some((error) => error.code === 'calendar_stale_same_day_upcoming'),
+      true,
+    )
+  })
+})

--- a/web/scripts/verify-pages-read-bridge.mjs
+++ b/web/scripts/verify-pages-read-bridge.mjs
@@ -1,10 +1,21 @@
 import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { auditPagesReadBridge } from './lib/pagesReadBridgeCoverage.mjs'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const webRoot = path.resolve(__dirname, '..')
 const bridgeRoot = path.join(webRoot, 'public', '__bridge', 'v1')
+const coverage = await auditPagesReadBridge({ webRoot })
+
+if (coverage.errors.length > 0) {
+  throw new Error(
+    [
+      `Bridge coverage audit found ${coverage.errors.length} issue(s).`,
+      ...coverage.errors.slice(0, 10).map((error) => `${error.code}: ${error.message} ${JSON.stringify(error.context)}`),
+    ].join('\n'),
+  )
+}
 
 const calendarMonth = await readJson(path.join(bridgeRoot, 'calendar', 'months', '2026-02.json'))
 const sameDayCalendarMonth = await readJson(path.join(bridgeRoot, 'calendar', 'months', '2026-03.json'))
@@ -88,6 +99,7 @@ console.log(
       searchRequestId: searchIndex?.meta?.request_id ?? null,
       lookupRequestId: lookup?.meta?.request_id ?? null,
       detailRequestId: detail?.meta?.request_id ?? null,
+      coverageSummary: coverage.summary,
       releaseId: lookup.data.release_id,
       trackCount: detail.data.tracks.length,
     },


### PR DESCRIPTION
## Summary\n- add exhaustive Pages read bridge coverage checks for search, entity detail, release detail, calendar, radar, and user-facing links\n- generate fallback bridge release detail assets for verified releases that are missing explicit detail rows\n- run the new bridge verification in web quality so broken runtime actions fail before deploy\n\n## Testing\n- cd web && npm run test:pages-read-bridge\n- cd web && npm run lint\n- cd web && npm run build\n- cd web && npm run verify:pages-read-bridge\n- git diff --check\n\nCloses #687