### PR TITLE
Switch Pages deploy to API runtime

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -44,6 +44,14 @@ jobs:
         working-directory: web
         run: npm ci
 
+      - name: Resolve Pages API runtime target
+        id: resolve_pages_api_runtime
+        working-directory: web
+        env:
+          VITE_API_BASE_URL: ${{ vars.VITE_API_BASE_URL }}
+          VITE_BACKEND_TARGET_ENV: production
+        run: node ./scripts/resolve-pages-api-runtime.mjs
+
       - name: Run web runtime policy tests
         working-directory: web
         run: npm run test:runtime-policy
@@ -56,34 +64,39 @@ jobs:
         working-directory: web
         run: npm run lint
 
-      - name: Build Pages read bridge
+      - name: Build Pages bridge artifact
         working-directory: web
         env:
-          VITE_BACKEND_TARGET_ENV: bridge
+          VITE_API_BASE_URL: ${{ steps.resolve_pages_api_runtime.outputs.api_base_url }}
+          VITE_BACKEND_TARGET_ENV: ${{ steps.resolve_pages_api_runtime.outputs.target_environment }}
         run: npm run build:pages-read-bridge
 
       - name: Verify Pages read bridge
         working-directory: web
         env:
-          VITE_BACKEND_TARGET_ENV: bridge
+          VITE_API_BASE_URL: ${{ steps.resolve_pages_api_runtime.outputs.api_base_url }}
+          VITE_BACKEND_TARGET_ENV: ${{ steps.resolve_pages_api_runtime.outputs.target_environment }}
         run: npm run verify:pages-read-bridge
 
       - name: Verify Pages backend target
         working-directory: web
         env:
-          VITE_BACKEND_TARGET_ENV: bridge
+          VITE_API_BASE_URL: ${{ steps.resolve_pages_api_runtime.outputs.api_base_url }}
+          VITE_BACKEND_TARGET_ENV: ${{ steps.resolve_pages_api_runtime.outputs.target_environment }}
         run: npm run verify:pages-backend-target
 
       - name: Verify backend freshness handoff
         working-directory: web
         env:
-          VITE_BACKEND_TARGET_ENV: bridge
+          VITE_API_BASE_URL: ${{ steps.resolve_pages_api_runtime.outputs.api_base_url }}
+          VITE_BACKEND_TARGET_ENV: ${{ steps.resolve_pages_api_runtime.outputs.target_environment }}
         run: npm run verify:pages-backend-handoff
 
       - name: Build site
         working-directory: web
         env:
-          VITE_BACKEND_TARGET_ENV: bridge
+          VITE_API_BASE_URL: ${{ steps.resolve_pages_api_runtime.outputs.api_base_url }}
+          VITE_BACKEND_TARGET_ENV: ${{ steps.resolve_pages_api_runtime.outputs.target_environment }}
         run: npm run build
 
       - name: Upload artifact

--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ npm run dev
 ```
 
 - backend 연결로 띄우려면 `VITE_API_BASE_URL=http://localhost:3213 npm run dev`
+- GitHub Pages production build는 `VITE_API_BASE_URL`이 비어 있어도 `backend/reports/backend_freshness_handoff.json`의 production backend URL을 읽어 API runtime으로 빌드한다.
 - browser에서 separate API base URL을 쓸 때 backend는 `APP_ENV`와 `WEB_ALLOWED_ORIGINS`를 같이 맞춰야 한다. production 기본 origin은 `https://iamsomething.github.io`다.
 - committed JSON snapshot은 import/parity/debug artifact로 유지되지만, shipped web cut-over surface의 runtime source switch로는 더 이상 사용하지 않는다.
 - `web/.env.example`에는 Pages / preview rehearsal에서 쓰는 API base env baseline이 들어 있다.

--- a/docs/assets/distribution/web_pages_api_runtime_local_2026-03-13.md
+++ b/docs/assets/distribution/web_pages_api_runtime_local_2026-03-13.md
@@ -1,0 +1,35 @@
+# Web Pages API Runtime Local Verification (2026-03-13)
+
+## Goal
+
+- GitHub Pages production build가 더 이상 `bridge`를 active runtime target으로 쓰지 않도록 검증
+- `VITE_API_BASE_URL`이 비어 있어도 `backend_freshness_handoff.json`의 production backend URL로 Pages runtime target을 해석하는지 확인
+
+## Commands
+
+```bash
+cd /Users/gimtaehun/Desktop/idol-song-app/web
+node --test ./scripts/lib/pagesApiRuntimeConfig.test.mjs
+node ./scripts/resolve-pages-api-runtime.mjs
+npm run test:runtime-policy
+VITE_API_BASE_URL=https://api.idol-song-app.example.com VITE_BACKEND_TARGET_ENV=production npm run build:pages-read-bridge
+VITE_API_BASE_URL=https://api.idol-song-app.example.com VITE_BACKEND_TARGET_ENV=production npm run verify:pages-backend-target
+VITE_API_BASE_URL=https://api.idol-song-app.example.com VITE_BACKEND_TARGET_ENV=production npm run verify:pages-backend-handoff
+VITE_API_BASE_URL=https://api.idol-song-app.example.com VITE_BACKEND_TARGET_ENV=production npm run build
+npm run lint
+
+cd /Users/gimtaehun/Desktop/idol-song-app
+git diff --check
+```
+
+## Observed
+
+- `resolve-pages-api-runtime.mjs` fallback source: `backend_freshness_handoff`
+- resolved `apiBaseUrl`: `https://api.idol-song-app.example.com`
+- `build-pages-read-bridge` output:
+  - `runtimeMode = api`
+  - `targetEnvironment = production`
+  - `effectiveTarget = https://api.idol-song-app.example.com`
+- `verify-pages-backend-target` passed with `runtimeMode = api`
+- `verify-pages-backend-handoff` passed against production handoff artifact
+- `npm run build`, `npm run lint`, `git diff --check` all passed

--- a/docs/specs/backend/api-only-end-state-tracker.md
+++ b/docs/specs/backend/api-only-end-state-tracker.md
@@ -17,8 +17,9 @@
 ### 2.1 Web client
 
 - shipped web surface는 backend read API만 primary runtime source로 사용한다.
-- committed JSON snapshot은 import/debug/export/reference artifact 역할만 가진다.
+- committed JSON snapshot과 bridge export는 inspection/debug/export/reference artifact 역할만 가진다.
 - runtime regression guard가 local dataset direct import 회귀를 막는다.
+- Pages production deploy는 backend freshness handoff가 가리키는 production API URL을 active runtime target으로 사용한다.
 
 관련 근거:
 
@@ -57,9 +58,10 @@
 현재 repo는 implementation 관점에서 아래까지 도달했다.
 
 - web cut-over surface는 backend-primary runtime으로 정리되어 있다.
+- Pages deploy는 `bridge`가 아니라 production backend API를 active runtime target으로 빌드한다.
 - mobile preview / production profile은 backend-primary runtime으로 정리되어 있다.
 - scheduled workflow는 `web/src/data`를 운영 truth로 커밋하지 않는다.
-- committed JSON snapshot은 demoted artifact로만 남는다.
+- committed JSON snapshot과 bridge export는 demoted artifact로만 남는다.
 
 즉, 남아 있는 blocker는 더 이상 "client가 JSON을 primary runtime source로 쓴다"가 아니다.
 남아 있는 문제는 preview host / live runtime evidence / data completeness 같은 운영/품질 blocker다.

--- a/web/scripts/lib/pagesApiRuntimeConfig.mjs
+++ b/web/scripts/lib/pagesApiRuntimeConfig.mjs
@@ -1,0 +1,109 @@
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+
+export function normalizeApiBaseUrl(value) {
+  const normalized = String(value ?? '').trim()
+  if (!normalized) {
+    return ''
+  }
+
+  return normalized.replace(/\/+$/, '')
+}
+
+export function normalizeTargetEnvironment(value) {
+  const normalized = String(value ?? '').trim().toLowerCase()
+  return normalized === 'production' || normalized === 'preview' || normalized === 'local' || normalized === 'bridge'
+    ? normalized
+    : ''
+}
+
+export function classifyBackendTarget(apiBaseUrl) {
+  if (!apiBaseUrl) {
+    return 'bridge'
+  }
+
+  try {
+    const hostname = new URL(apiBaseUrl).hostname.toLowerCase()
+    if (
+      hostname === 'localhost' ||
+      hostname === '127.0.0.1' ||
+      hostname.endsWith('.local') ||
+      hostname.startsWith('127.')
+    ) {
+      return 'local'
+    }
+
+    if (
+      hostname.includes('preview') ||
+      hostname.includes('staging') ||
+      hostname.includes('dev') ||
+      hostname.includes('test')
+    ) {
+      return 'preview'
+    }
+
+    return 'production'
+  } catch {
+    return 'unknown'
+  }
+}
+
+export async function readBackendHandoffTarget(handoffPath) {
+  const contents = await readFile(handoffPath, 'utf8')
+  const payload = JSON.parse(contents)
+  return {
+    backendPublicUrl: normalizeApiBaseUrl(payload?.target?.backend_public_url ?? ''),
+    targetEnvironment: normalizeTargetEnvironment(payload?.target?.environment ?? ''),
+    targetClassification: classifyBackendTarget(payload?.target?.backend_public_url ?? ''),
+  }
+}
+
+export async function resolvePagesApiRuntimeConfig({
+  repoRoot,
+  configuredApiBaseUrl,
+  configuredTargetEnvironment,
+}) {
+  const normalizedConfiguredApiBaseUrl = normalizeApiBaseUrl(configuredApiBaseUrl)
+  const normalizedConfiguredTargetEnvironment = normalizeTargetEnvironment(configuredTargetEnvironment)
+  const handoffPath = path.join(repoRoot, 'backend', 'reports', 'backend_freshness_handoff.json')
+  const handoffTarget = await readBackendHandoffTarget(handoffPath)
+  const resolvedApiBaseUrl = normalizedConfiguredApiBaseUrl || handoffTarget.backendPublicUrl
+
+  if (!resolvedApiBaseUrl) {
+    throw new Error(
+      'Unable to resolve a Pages API base URL. Set VITE_API_BASE_URL or provide backend/reports/backend_freshness_handoff.json with target.backend_public_url.',
+    )
+  }
+
+  let resolvedTargetEnvironment = normalizedConfiguredTargetEnvironment || handoffTarget.targetEnvironment
+  if (!resolvedTargetEnvironment || resolvedTargetEnvironment === 'bridge') {
+    resolvedTargetEnvironment = 'production'
+  }
+
+  let parsedUrl
+  try {
+    parsedUrl = new URL(resolvedApiBaseUrl)
+  } catch {
+    throw new Error(`Resolved Pages API base URL is not a valid absolute URL: ${resolvedApiBaseUrl}`)
+  }
+
+  if (parsedUrl.protocol !== 'https:') {
+    throw new Error(`Resolved Pages API base URL must use https: ${resolvedApiBaseUrl}`)
+  }
+
+  const resolvedClassification = classifyBackendTarget(resolvedApiBaseUrl)
+
+  if (resolvedTargetEnvironment !== resolvedClassification) {
+    throw new Error(
+      `Resolved Pages target environment ${resolvedTargetEnvironment} does not match classified API target ${resolvedClassification}.`,
+    )
+  }
+
+  return {
+    apiBaseUrl: resolvedApiBaseUrl,
+    targetEnvironment: resolvedTargetEnvironment,
+    targetClassification: resolvedClassification,
+    source: normalizedConfiguredApiBaseUrl ? 'env' : 'backend_freshness_handoff',
+    handoffPath,
+  }
+}

--- a/web/scripts/lib/pagesApiRuntimeConfig.test.mjs
+++ b/web/scripts/lib/pagesApiRuntimeConfig.test.mjs
@@ -1,0 +1,39 @@
+import path from 'node:path'
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { classifyBackendTarget, resolvePagesApiRuntimeConfig } from './pagesApiRuntimeConfig.mjs'
+
+const repoRoot = path.resolve(import.meta.dirname, '..', '..', '..')
+
+test('classifyBackendTarget recognizes production hosts', () => {
+  assert.equal(classifyBackendTarget('https://api.idol-song-app.example.com'), 'production')
+})
+
+test('classifyBackendTarget recognizes preview hosts', () => {
+  assert.equal(classifyBackendTarget('https://preview-api.idol-song-app.example.com'), 'preview')
+})
+
+test('resolvePagesApiRuntimeConfig uses explicit env override when present', async () => {
+  const config = await resolvePagesApiRuntimeConfig({
+    repoRoot,
+    configuredApiBaseUrl: 'https://api.idol-song-app.example.com/',
+    configuredTargetEnvironment: 'production',
+  })
+
+  assert.equal(config.apiBaseUrl, 'https://api.idol-song-app.example.com')
+  assert.equal(config.targetEnvironment, 'production')
+  assert.equal(config.source, 'env')
+})
+
+test('resolvePagesApiRuntimeConfig falls back to backend freshness handoff target', async () => {
+  const config = await resolvePagesApiRuntimeConfig({
+    repoRoot,
+    configuredApiBaseUrl: '',
+    configuredTargetEnvironment: '',
+  })
+
+  assert.equal(config.apiBaseUrl, 'https://api.idol-song-app.example.com')
+  assert.equal(config.targetEnvironment, 'production')
+  assert.equal(config.source, 'backend_freshness_handoff')
+})

--- a/web/scripts/resolve-pages-api-runtime.mjs
+++ b/web/scripts/resolve-pages-api-runtime.mjs
@@ -1,0 +1,39 @@
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { appendFile } from 'node:fs/promises'
+
+import { resolvePagesApiRuntimeConfig } from './lib/pagesApiRuntimeConfig.mjs'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const webRoot = path.resolve(__dirname, '..')
+const repoRoot = path.resolve(webRoot, '..')
+
+const config = await resolvePagesApiRuntimeConfig({
+  repoRoot,
+  configuredApiBaseUrl: process.env.VITE_API_BASE_URL ?? '',
+  configuredTargetEnvironment: process.env.VITE_BACKEND_TARGET_ENV ?? '',
+})
+
+if (process.env.GITHUB_OUTPUT) {
+  await appendFile(
+    process.env.GITHUB_OUTPUT,
+    `api_base_url=${config.apiBaseUrl}\n` +
+      `target_environment=${config.targetEnvironment}\n` +
+      `target_classification=${config.targetClassification}\n` +
+      `source=${config.source}\n`,
+  )
+}
+
+console.log(
+  JSON.stringify(
+    {
+      apiBaseUrl: config.apiBaseUrl,
+      targetEnvironment: config.targetEnvironment,
+      targetClassification: config.targetClassification,
+      source: config.source,
+      handoffPath: path.relative(repoRoot, config.handoffPath),
+    },
+    null,
+    2,
+  ),
+)


### PR DESCRIPTION
## Summary\n- resolve the Pages API runtime target from VITE_API_BASE_URL or backend freshness handoff\n- build and verify Pages in production API mode instead of bridge mode\n- document the API-only Pages deploy contract and local verification evidence\n\nCloses #691