### PR TITLE
Stabilize Pages runtime target selection

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -69,6 +69,8 @@ jobs:
         env:
           VITE_API_BASE_URL: ${{ steps.resolve_pages_api_runtime.outputs.api_base_url }}
           VITE_BACKEND_TARGET_ENV: ${{ steps.resolve_pages_api_runtime.outputs.target_environment }}
+          VITE_RUNTIME_DECISION_REASON: ${{ steps.resolve_pages_api_runtime.outputs.decision_reason }}
+          VITE_RUNTIME_DECISION_SOURCE: ${{ steps.resolve_pages_api_runtime.outputs.source }}
         run: npm run build:pages-read-bridge
 
       - name: Verify Pages read bridge

--- a/README.md
+++ b/README.md
@@ -311,11 +311,12 @@ npm run dev
 ```
 
 - backend 연결로 띄우려면 `VITE_API_BASE_URL=http://localhost:3213 npm run dev`
-- GitHub Pages production build는 `VITE_API_BASE_URL`이 비어 있어도 `backend/reports/backend_freshness_handoff.json`의 production backend URL을 읽어 API runtime으로 빌드한다.
+- GitHub Pages production build는 `VITE_API_BASE_URL`이 비어 있어도 `backend/reports/backend_freshness_handoff.json`의 production backend URL을 읽어 active runtime target을 해석한다.
+- resolved API target이 `health/ready` probe를 통과하면 `runtime_mode=api`로 배포하고, target이 비어 있거나 비정상이면 `runtime_mode=bridge`로 의도적으로 내려서 broken live site를 피한다.
 - browser에서 separate API base URL을 쓸 때 backend는 `APP_ENV`와 `WEB_ALLOWED_ORIGINS`를 같이 맞춰야 한다. production 기본 origin은 `https://iamsomething.github.io`다.
 - committed JSON snapshot은 import/parity/debug artifact로 유지되지만, shipped web cut-over surface의 runtime source switch로는 더 이상 사용하지 않는다.
 - `web/.env.example`에는 Pages / preview rehearsal에서 쓰는 API base env baseline이 들어 있다.
-- `.github/workflows/deploy-pages.yml`은 GitHub Pages runtime을 `VITE_BACKEND_TARGET_ENV=bridge`로 고정하고, bridge 산출물만 빌드에 포함한다.
+- `.github/workflows/deploy-pages.yml`은 Pages runtime target을 먼저 해석한 뒤, healthy target이면 API mode를, unhealthy target이면 bridge mode를 사용한다.
 - bridge runtime이어도 `verify:pages-backend-handoff`는 latest backend freshness artifact가 `production/preview/local` 중 하나의 실제 backend target을 가리키는지 별도로 검증한다.
 - `npm run build`는 Pages read bridge(`web/public/__bridge/v1/**`)를 먼저 생성한다. bridge는 committed `web/src/data`가 아니라 `backend/exports/non_runtime_web_snapshots/**`를 우선 읽고, export가 없을 때만 local snapshot으로 fallback 한다.
 - `deploy-pages.yml`은 `backend/exports/non_runtime_web_snapshots/**` 변경도 함께 감지해서 Pages를 다시 빌드하고, `npm run verify:pages-read-bridge`, `npm run verify:pages-backend-target`, `npm run verify:pages-backend-handoff`로 bridge completeness, active backend target wiring, latest backend freshness handoff를 같이 gate로 막는다.

--- a/docs/specs/backend/api-only-end-state-tracker.md
+++ b/docs/specs/backend/api-only-end-state-tracker.md
@@ -19,7 +19,7 @@
 - shipped web surface는 backend read API만 primary runtime source로 사용한다.
 - committed JSON snapshot과 bridge export는 inspection/debug/export/reference artifact 역할만 가진다.
 - runtime regression guard가 local dataset direct import 회귀를 막는다.
-- Pages production deploy는 backend freshness handoff가 가리키는 production API URL을 active runtime target으로 사용한다.
+- Pages production deploy는 backend freshness handoff가 가리키는 production API URL을 우선 target으로 해석하고, target이 healthy할 때만 active runtime target으로 사용한다.
 
 관련 근거:
 
@@ -58,13 +58,13 @@
 현재 repo는 implementation 관점에서 아래까지 도달했다.
 
 - web cut-over surface는 backend-primary runtime으로 정리되어 있다.
-- Pages deploy는 `bridge`가 아니라 production backend API를 active runtime target으로 빌드한다.
+- Pages deploy는 production backend API를 우선 target으로 해석한다. 다만 target이 unhealthy하면 broken live runtime 대신 bridge mode로 내려간다.
 - mobile preview / production profile은 backend-primary runtime으로 정리되어 있다.
 - scheduled workflow는 `web/src/data`를 운영 truth로 커밋하지 않는다.
 - committed JSON snapshot과 bridge export는 demoted artifact로만 남는다.
 
-즉, 남아 있는 blocker는 더 이상 "client가 JSON을 primary runtime source로 쓴다"가 아니다.
-남아 있는 문제는 preview host / live runtime evidence / data completeness 같은 운영/품질 blocker다.
+즉, 남아 있는 blocker는 더 이상 "client가 JSON을 primary runtime source로 쓴다"만이 아니다.
+남아 있는 문제는 preview host / production API health / live runtime evidence / data completeness 같은 운영/품질 blocker다.
 
 ## 4. Remaining Linked Blockers
 

--- a/web/scripts/build-pages-read-bridge.mjs
+++ b/web/scripts/build-pages-read-bridge.mjs
@@ -11,6 +11,8 @@ const bridgeBaseRoot = path.join(webRoot, 'public', '__bridge')
 const bridgeRoot = path.join(bridgeBaseRoot, 'v1')
 const normalizedApiBaseUrl = normalizeApiBaseUrl(process.env.VITE_API_BASE_URL ?? '')
 const declaredTargetEnvironment = normalizeTargetEnvironment(process.env.VITE_BACKEND_TARGET_ENV ?? '')
+const runtimeDecisionReason = String(process.env.VITE_RUNTIME_DECISION_REASON ?? '').trim() || null
+const runtimeDecisionSource = String(process.env.VITE_RUNTIME_DECISION_SOURCE ?? '').trim() || null
 const runtimeMode = normalizedApiBaseUrl ? 'api' : 'bridge'
 const targetClassification = classifyBackendTarget(normalizedApiBaseUrl)
 const targetEnvironment = declaredTargetEnvironment || (runtimeMode === 'bridge' ? 'bridge' : targetClassification)
@@ -168,6 +170,8 @@ await writeBridgeJson(path.join(bridgeRoot, 'meta', 'backend-target.json'), {
     effective_target: effectiveTarget,
     bridge_base_url: '/__bridge/v1',
     diagnostics_path: '/__bridge/v1/meta/backend-target.json',
+    runtime_decision_reason: runtimeDecisionReason,
+    runtime_decision_source: runtimeDecisionSource,
     surfaces: {
       search: runtimeMode,
       entity_detail: runtimeMode,

--- a/web/scripts/lib/pagesApiRuntimeConfig.mjs
+++ b/web/scripts/lib/pagesApiRuntimeConfig.mjs
@@ -62,6 +62,7 @@ export async function resolvePagesApiRuntimeConfig({
   repoRoot,
   configuredApiBaseUrl,
   configuredTargetEnvironment,
+  probeApiTarget,
 }) {
   const normalizedConfiguredApiBaseUrl = normalizeApiBaseUrl(configuredApiBaseUrl)
   const normalizedConfiguredTargetEnvironment = normalizeTargetEnvironment(configuredTargetEnvironment)
@@ -99,11 +100,91 @@ export async function resolvePagesApiRuntimeConfig({
     )
   }
 
+  const runtimeProbe = await (probeApiTarget ?? probePagesApiTarget)(resolvedApiBaseUrl)
+
+  if (!runtimeProbe.healthy) {
+    return {
+      apiBaseUrl: '',
+      targetEnvironment: 'bridge',
+      targetClassification: 'bridge',
+      runtimeMode: 'bridge',
+      decisionReason: 'api_target_unhealthy',
+      source: normalizedConfiguredApiBaseUrl ? 'env' : 'backend_freshness_handoff',
+      resolvedApiBaseUrl,
+      resolvedTargetEnvironment,
+      resolvedTargetClassification: resolvedClassification,
+      runtimeProbe,
+      handoffPath,
+    }
+  }
+
   return {
     apiBaseUrl: resolvedApiBaseUrl,
     targetEnvironment: resolvedTargetEnvironment,
     targetClassification: resolvedClassification,
+    runtimeMode: 'api',
+    decisionReason: 'api_target_healthy',
     source: normalizedConfiguredApiBaseUrl ? 'env' : 'backend_freshness_handoff',
+    resolvedApiBaseUrl,
+    resolvedTargetEnvironment,
+    resolvedTargetClassification: resolvedClassification,
+    runtimeProbe,
     handoffPath,
+  }
+}
+
+export async function probePagesApiTarget(
+  apiBaseUrl,
+  {
+    fetchImpl = fetch,
+    timeoutMs = 5000,
+    probePaths = ['/health', '/ready'],
+  } = {},
+) {
+  const normalizedApiBaseUrl = normalizeApiBaseUrl(apiBaseUrl)
+
+  for (const probePath of probePaths) {
+    const probeUrl = `${normalizedApiBaseUrl}${probePath}`
+    try {
+      const response = await fetchImpl(probeUrl, {
+        method: 'GET',
+        redirect: 'follow',
+        signal: AbortSignal.timeout(timeoutMs),
+      })
+
+      if (response.ok) {
+        return {
+          healthy: true,
+          probeUrl,
+          probePath,
+          status: response.status,
+          error: null,
+        }
+      }
+
+      return {
+        healthy: false,
+        probeUrl,
+        probePath,
+        status: response.status,
+        error: `unexpected_status_${response.status}`,
+      }
+    } catch (error) {
+      return {
+        healthy: false,
+        probeUrl,
+        probePath,
+        status: null,
+        error: error instanceof Error ? error.message : String(error),
+      }
+    }
+  }
+
+  return {
+    healthy: false,
+    probeUrl: null,
+    probePath: null,
+    status: null,
+    error: 'no_probe_paths',
   }
 }

--- a/web/scripts/lib/pagesApiRuntimeConfig.test.mjs
+++ b/web/scripts/lib/pagesApiRuntimeConfig.test.mjs
@@ -2,7 +2,7 @@ import path from 'node:path'
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
-import { classifyBackendTarget, resolvePagesApiRuntimeConfig } from './pagesApiRuntimeConfig.mjs'
+import { classifyBackendTarget, probePagesApiTarget, resolvePagesApiRuntimeConfig } from './pagesApiRuntimeConfig.mjs'
 
 const repoRoot = path.resolve(import.meta.dirname, '..', '..', '..')
 
@@ -19,10 +19,19 @@ test('resolvePagesApiRuntimeConfig uses explicit env override when present', asy
     repoRoot,
     configuredApiBaseUrl: 'https://api.idol-song-app.example.com/',
     configuredTargetEnvironment: 'production',
+    probeApiTarget: async () => ({
+      healthy: true,
+      probeUrl: 'https://api.idol-song-app.example.com/health',
+      probePath: '/health',
+      status: 200,
+      error: null,
+    }),
   })
 
   assert.equal(config.apiBaseUrl, 'https://api.idol-song-app.example.com')
   assert.equal(config.targetEnvironment, 'production')
+  assert.equal(config.runtimeMode, 'api')
+  assert.equal(config.decisionReason, 'api_target_healthy')
   assert.equal(config.source, 'env')
 })
 
@@ -31,9 +40,50 @@ test('resolvePagesApiRuntimeConfig falls back to backend freshness handoff targe
     repoRoot,
     configuredApiBaseUrl: '',
     configuredTargetEnvironment: '',
+    probeApiTarget: async () => ({
+      healthy: true,
+      probeUrl: 'https://api.idol-song-app.example.com/health',
+      probePath: '/health',
+      status: 200,
+      error: null,
+    }),
   })
 
   assert.equal(config.apiBaseUrl, 'https://api.idol-song-app.example.com')
   assert.equal(config.targetEnvironment, 'production')
+  assert.equal(config.runtimeMode, 'api')
   assert.equal(config.source, 'backend_freshness_handoff')
+})
+
+test('resolvePagesApiRuntimeConfig falls back to bridge when API target is unhealthy', async () => {
+  const config = await resolvePagesApiRuntimeConfig({
+    repoRoot,
+    configuredApiBaseUrl: 'https://api.idol-song-app.example.com/',
+    configuredTargetEnvironment: 'production',
+    probeApiTarget: async () => ({
+      healthy: false,
+      probeUrl: 'https://api.idol-song-app.example.com/health',
+      probePath: '/health',
+      status: 502,
+      error: 'unexpected_status_502',
+    }),
+  })
+
+  assert.equal(config.apiBaseUrl, '')
+  assert.equal(config.targetEnvironment, 'bridge')
+  assert.equal(config.targetClassification, 'bridge')
+  assert.equal(config.runtimeMode, 'bridge')
+  assert.equal(config.decisionReason, 'api_target_unhealthy')
+  assert.equal(config.resolvedApiBaseUrl, 'https://api.idol-song-app.example.com')
+  assert.equal(config.runtimeProbe.status, 502)
+})
+
+test('probePagesApiTarget reports unexpected status as unhealthy', async () => {
+  const result = await probePagesApiTarget('https://api.idol-song-app.example.com', {
+    fetchImpl: async () => new Response('bad gateway', { status: 502 }),
+  })
+
+  assert.equal(result.healthy, false)
+  assert.equal(result.status, 502)
+  assert.equal(result.error, 'unexpected_status_502')
 })

--- a/web/scripts/resolve-pages-api-runtime.mjs
+++ b/web/scripts/resolve-pages-api-runtime.mjs
@@ -20,6 +20,8 @@ if (process.env.GITHUB_OUTPUT) {
     `api_base_url=${config.apiBaseUrl}\n` +
       `target_environment=${config.targetEnvironment}\n` +
       `target_classification=${config.targetClassification}\n` +
+      `runtime_mode=${config.runtimeMode}\n` +
+      `decision_reason=${config.decisionReason}\n` +
       `source=${config.source}\n`,
   )
 }
@@ -30,6 +32,12 @@ console.log(
       apiBaseUrl: config.apiBaseUrl,
       targetEnvironment: config.targetEnvironment,
       targetClassification: config.targetClassification,
+      runtimeMode: config.runtimeMode,
+      decisionReason: config.decisionReason,
+      resolvedApiBaseUrl: config.resolvedApiBaseUrl,
+      resolvedTargetEnvironment: config.resolvedTargetEnvironment,
+      resolvedTargetClassification: config.resolvedTargetClassification,
+      runtimeProbe: config.runtimeProbe,
       source: config.source,
       handoffPath: path.relative(repoRoot, config.handoffPath),
     },


### PR DESCRIPTION
## Summary
- add a deploy-time health probe for the resolved Pages API target
- intentionally fall back to bridge mode when the resolved API target is unhealthy instead of shipping a broken live API runtime
- record runtime decision metadata and update docs for the temporary bridge downgrade behavior

## Testing
- cd web && npm run build
- cd web && npm run lint
- cd web && node --test ./scripts/lib/pagesApiRuntimeConfig.test.mjs
- cd web && node ./scripts/resolve-pages-api-runtime.mjs
- cd web && npm run verify:pages-read-bridge
- cd web && npm run verify:pages-backend-target
- cd web && npm run verify:pages-backend-handoff
- git diff --check