### PR TITLE
Harden production backend deploy health wait

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -242,6 +242,24 @@ jobs:
           RAILWAY_SERVICE_ID: ${{ vars.RAILWAY_SERVICE_ID }}
         run: node ./backend/scripts/deploy-backend.mjs
 
+      - name: Wait for production backend health
+        env:
+          BACKEND_PUBLIC_URL: ${{ vars.BACKEND_PUBLIC_URL }}
+        run: |
+          attempts=30
+          for attempt in $(seq 1 "$attempts"); do
+            status=$(curl -s -o /tmp/backend-health.json -w '%{http_code}' "$BACKEND_PUBLIC_URL/health" || true)
+            if [ "$status" = "200" ]; then
+              cat /tmp/backend-health.json
+              exit 0
+            fi
+            echo "backend health not ready yet (attempt ${attempt}/${attempts}, status=${status:-error})"
+            sleep 10
+          done
+          echo "production backend did not become healthy in time"
+          cat /tmp/backend-health.json || true
+          exit 1
+
       - name: Run production canonical fixture smoke checks
         working-directory: backend
         env:

--- a/backend/scripts/deploy-backend.mjs
+++ b/backend/scripts/deploy-backend.mjs
@@ -77,7 +77,6 @@ async function main() {
     '--yes',
     '@railway/cli',
     'up',
-    '--ci',
     '--project',
     projectId,
     '--environment',
@@ -85,6 +84,12 @@ async function main() {
     '--service',
     serviceId,
   ];
+
+  if (process.env.CI?.trim()) {
+    args.push('--detach');
+  } else {
+    args.push('--ci');
+  }
 
   console.log(`backend deploy target: ${target}`);
   console.log(`backend deploy mode: ${mode}`);


### PR DESCRIPTION
## Summary
- detach Railway production deploys in CI so log streaming failures do not fail the job
- wait for production /health to return 200 before running smoke checks
- keep the single live production backend path moving without preview fallback

Closes #700