### PR TITLE
Align production live smoke fixtures with canonical data

### DIFF
--- a/backend/fixtures/live_backend_smoke_fixtures.json
+++ b/backend/fixtures/live_backend_smoke_fixtures.json
@@ -25,8 +25,8 @@
           "date": "2026-03-03"
         },
         "exact_upcoming": {
-          "entity_slug": "yena",
-          "scheduled_date": "2026-03-11"
+          "entity_slug": "bts",
+          "scheduled_date": "2026-03-20"
         },
         "require_month_only_bucket": true
       }
@@ -36,7 +36,7 @@
       "surface": "radar",
       "request": {},
       "expect": {
-        "long_gap_entity_slug": "weeekly",
+        "long_gap_entity_slug": "bts",
         "rookie_entity_slug": "allday-project"
       }
     },
@@ -49,7 +49,6 @@
       "expect": {
         "entity_slug": "yena",
         "display_name": "YENA",
-        "next_upcoming_date": "2026-03-11",
         "official_youtube_required": true
       }
     },


### PR DESCRIPTION
## Summary
- update stale production live-smoke fixtures to current canonical same-day state
- keep YENA entity smoke aligned after same-day release suppression
- align radar and calendar smoke expectations with current production data

## Testing
- cd backend && node --test ./scripts/lib/workerCadenceEvidence.test.mjs ./scripts/lib/live-smoke-fixtures.test.ts
- cd backend && npm run smoke:live -- --target production --base-url https://idol-song-app-production.up.railway.app --skip-ready --report-path ./reports/live_backend_smoke_production.local.json
- git diff --check