### PR TITLE
Fix live smoke readiness validation

### DIFF
--- a/backend/scripts/run-live-smoke-checks.mjs
+++ b/backend/scripts/run-live-smoke-checks.mjs
@@ -422,12 +422,6 @@ function buildReadyCheck() {
     fixtureKey: null,
     async execute(options) {
       const request = await requestJson(`${options.baseUrl}/ready`, 'ready', options);
-      const envelopeError = validateJsonEnvelope(request);
-
-      if (envelopeError) {
-        return buildFailure(envelopeError, [request], request.status);
-      }
-
       const readyStatus = request.body?.status;
       const databaseStatus =
         request.body &&


### PR DESCRIPTION
## Summary
- treat /ready as a readiness payload instead of a read API envelope in live smoke
- allow production deploy to gate on the actual readiness status
- keep canonical fixture smoke aligned with the recovered backend runtime

## Testing
- cd backend && npm run smoke:live -- --target production --base-url https://idol-song-app-production.up.railway.app --report-path ./reports/live_backend_smoke_production.local-noskip.json
- git diff --check