### PR TITLE
Harden stale web runtime recovery

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -9,7 +9,7 @@
     "build": "npm run build:pages-read-bridge && tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test:search-runtime": "tsx --test ./src/lib/bridgeSearch.test.ts",
+    "test:search-runtime": "tsx --test ./src/lib/bridgeSearch.test.ts ./src/lib/runtimeRefresh.test.ts",
     "test:pages-read-bridge": "node --test ./scripts/lib/pagesReadBridgeCalendar.test.mjs ./scripts/lib/pagesReadBridgeCoverage.test.mjs",
     "test:runtime-policy": "node --test ./scripts/lib/runtimeImportBoundary.test.mjs",
     "verify:runtime-policy": "node ./scripts/verify-runtime-policy.mjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -27,6 +27,7 @@ import {
   type SurfaceStatusSource,
 } from './lib/surfaceStatus'
 import { buildBridgeSearchApiData, type BridgeSearchIndex } from './lib/bridgeSearch'
+import { shouldReloadForRuntimeRefresh } from './lib/runtimeRefresh'
 
 type ReleaseFact = {
   title: string
@@ -1989,6 +1990,8 @@ void [
 type BackendTargetDiagnosticsResponse = {
   data?: {
     generated_at?: string | null
+    runtime_mode?: string | null
+    effective_target?: string | null
   }
   error?: {
     code?: string | null
@@ -2031,7 +2034,13 @@ function storeBridgeGeneration(value: string) {
 
 async function fetchBridgeTargetDiagnostics(
   signal: AbortSignal,
-): Promise<{ generatedAt: string | null; errorCode: string | null; traceId: string | null }> {
+): Promise<{
+  generatedAt: string | null
+  runtimeMode: string | null
+  effectiveTarget: string | null
+  errorCode: string | null
+  traceId: string | null
+}> {
   const cacheBust = `ts=${Date.now().toString(36)}`
   const result = await fetchJsonWithTimeout<BackendTargetDiagnosticsResponse>(
     `${BACKEND_TARGET_DIAGNOSTICS_PATH}${BACKEND_TARGET_DIAGNOSTICS_PATH.includes('?') ? '&' : '?'}${cacheBust}`,
@@ -2048,6 +2057,8 @@ async function fetchBridgeTargetDiagnostics(
   if (!result.ok || !result.body?.data) {
     return {
       generatedAt: null,
+      runtimeMode: null,
+      effectiveTarget: null,
       errorCode: result.body?.error?.code ?? `bridge_target_${result.status}`,
       traceId: result.responseRequestId ?? result.requestId,
     }
@@ -2055,17 +2066,19 @@ async function fetchBridgeTargetDiagnostics(
 
   return {
     generatedAt: readNonEmptyString(result.body.data.generated_at),
+    runtimeMode: readNonEmptyString(result.body.data.runtime_mode),
+    effectiveTarget: readNonEmptyString(result.body.data.effective_target),
     errorCode: null,
     traceId: result.responseRequestId ?? result.requestId,
   }
 }
 
-function useBridgeDeploymentRefresh() {
+function useRuntimeDeploymentRefresh() {
   const initialGeneration = readStoredBridgeGeneration()
   const generationRef = useRef<string | null>(initialGeneration)
 
   useEffect(() => {
-    if (BACKEND_API_BASE_URL || typeof window === 'undefined' || typeof document === 'undefined') {
+    if (typeof window === 'undefined' || typeof document === 'undefined') {
       return
     }
 
@@ -2074,7 +2087,7 @@ function useBridgeDeploymentRefresh() {
     const syncGeneration = async (reloadOnChange: boolean) => {
       const controller = new AbortController()
       try {
-        const { generatedAt } = await fetchBridgeTargetDiagnostics(controller.signal)
+        const { generatedAt, runtimeMode, effectiveTarget } = await fetchBridgeTargetDiagnostics(controller.signal)
         if (cancelled || !generatedAt) {
           return
         }
@@ -2083,7 +2096,16 @@ function useBridgeDeploymentRefresh() {
         generationRef.current = generatedAt
         storeBridgeGeneration(generatedAt)
 
-        if (!previousGeneration || previousGeneration === generatedAt) {
+        const shouldReload = shouldReloadForRuntimeRefresh({
+          previousGeneration,
+          nextGeneration: generatedAt,
+          currentRuntimeMode: ACTIVE_WEB_BACKEND_TARGET_MODE,
+          currentEffectiveTarget: ACTIVE_WEB_BACKEND_TARGET,
+          diagnosticsRuntimeMode: runtimeMode,
+          diagnosticsEffectiveTarget: effectiveTarget,
+        })
+
+        if (!shouldReload) {
           return
         }
 
@@ -2127,7 +2149,7 @@ function useBridgeDeploymentRefresh() {
 }
 
 function App() {
-  useBridgeDeploymentRefresh()
+  useRuntimeDeploymentRefresh()
   const latestMonthKey = CURRENT_KST_ISO.slice(0, 7)
   const [selectedMonthKey, setSelectedMonthKey] = useState(latestMonthKey)
   const [selectedDayIso, setSelectedDayIso] = useState('')

--- a/web/src/lib/runtimeRefresh.test.ts
+++ b/web/src/lib/runtimeRefresh.test.ts
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { shouldReloadForRuntimeRefresh } from './runtimeRefresh'
+
+test('does not reload before a generation baseline exists', () => {
+  assert.equal(
+    shouldReloadForRuntimeRefresh({
+      previousGeneration: null,
+      nextGeneration: '2026-03-13T00:00:00.000Z',
+      currentRuntimeMode: 'api',
+      currentEffectiveTarget: 'https://api.idol-song-app.example.com',
+      diagnosticsRuntimeMode: 'api',
+      diagnosticsEffectiveTarget: 'https://api.idol-song-app.example.com',
+    }),
+    false,
+  )
+})
+
+test('reloads when the deployed generation changes', () => {
+  assert.equal(
+    shouldReloadForRuntimeRefresh({
+      previousGeneration: '2026-03-12T23:00:00.000Z',
+      nextGeneration: '2026-03-13T00:00:00.000Z',
+      currentRuntimeMode: 'bridge',
+      currentEffectiveTarget: '/__bridge/v1',
+      diagnosticsRuntimeMode: 'api',
+      diagnosticsEffectiveTarget: 'https://api.idol-song-app.example.com',
+    }),
+    true,
+  )
+})
+
+test('reloads when runtime mode drifts even if generation is unchanged', () => {
+  assert.equal(
+    shouldReloadForRuntimeRefresh({
+      previousGeneration: '2026-03-13T00:00:00.000Z',
+      nextGeneration: '2026-03-13T00:00:00.000Z',
+      currentRuntimeMode: 'bridge',
+      currentEffectiveTarget: '/__bridge/v1',
+      diagnosticsRuntimeMode: 'api',
+      diagnosticsEffectiveTarget: 'https://api.idol-song-app.example.com',
+    }),
+    true,
+  )
+})
+
+test('reloads when effective target drifts even if runtime mode matches', () => {
+  assert.equal(
+    shouldReloadForRuntimeRefresh({
+      previousGeneration: '2026-03-13T00:00:00.000Z',
+      nextGeneration: '2026-03-13T00:00:00.000Z',
+      currentRuntimeMode: 'api',
+      currentEffectiveTarget: 'https://old-api.idol-song-app.example.com/',
+      diagnosticsRuntimeMode: 'api',
+      diagnosticsEffectiveTarget: 'https://api.idol-song-app.example.com',
+    }),
+    true,
+  )
+})
+
+test('does not reload when generation and runtime target are stable', () => {
+  assert.equal(
+    shouldReloadForRuntimeRefresh({
+      previousGeneration: '2026-03-13T00:00:00.000Z',
+      nextGeneration: '2026-03-13T00:00:00.000Z',
+      currentRuntimeMode: 'api',
+      currentEffectiveTarget: 'https://api.idol-song-app.example.com/',
+      diagnosticsRuntimeMode: 'api',
+      diagnosticsEffectiveTarget: 'https://api.idol-song-app.example.com',
+    }),
+    false,
+  )
+})

--- a/web/src/lib/runtimeRefresh.ts
+++ b/web/src/lib/runtimeRefresh.ts
@@ -1,0 +1,57 @@
+export type RuntimeRefreshMode = 'api' | 'bridge'
+
+type ShouldReloadForRuntimeRefreshInput = {
+  previousGeneration: string | null
+  nextGeneration: string | null
+  currentRuntimeMode: RuntimeRefreshMode
+  currentEffectiveTarget: string | null
+  diagnosticsRuntimeMode: string | null
+  diagnosticsEffectiveTarget: string | null
+}
+
+function normalizeTarget(value: string | null): string | null {
+  if (!value) {
+    return null
+  }
+
+  const normalized = value.trim().replace(/\/+$/, '')
+  return normalized.length > 0 ? normalized : null
+}
+
+export function shouldReloadForRuntimeRefresh({
+  previousGeneration,
+  nextGeneration,
+  currentRuntimeMode,
+  currentEffectiveTarget,
+  diagnosticsRuntimeMode,
+  diagnosticsEffectiveTarget,
+}: ShouldReloadForRuntimeRefreshInput): boolean {
+  if (!nextGeneration || !previousGeneration) {
+    return false
+  }
+
+  if (previousGeneration !== nextGeneration) {
+    return true
+  }
+
+  const normalizedDiagnosticsMode = diagnosticsRuntimeMode === 'api' || diagnosticsRuntimeMode === 'bridge'
+    ? diagnosticsRuntimeMode
+    : null
+
+  if (normalizedDiagnosticsMode && normalizedDiagnosticsMode !== currentRuntimeMode) {
+    return true
+  }
+
+  const normalizedCurrentTarget = normalizeTarget(currentEffectiveTarget)
+  const normalizedDiagnosticsTarget = normalizeTarget(diagnosticsEffectiveTarget)
+
+  if (
+    normalizedCurrentTarget &&
+    normalizedDiagnosticsTarget &&
+    normalizedCurrentTarget !== normalizedDiagnosticsTarget
+  ) {
+    return true
+  }
+
+  return false
+}


### PR DESCRIPTION
## Summary
- watch backend-target diagnostics in both bridge and api runtime modes
- auto-reload stale already-open tabs when a new deployment generation or runtime target is detected
- add runtime refresh regression coverage for generation, mode, and effective target drift

## Testing
- cd web && npm run test:search-runtime
- cd web && npm run lint
- cd web && npm run build
- git diff --check