### PR TITLE
Retire preview backend mobile references

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,8 +363,8 @@ npm run build
 - preview backend는 `main`의 backend 관련 변경 시 자동 deploy
 - production backend는 `workflow_dispatch`에서 수동 승격
 - 두 경로 모두 backend `npm ci`, `npm run build`, `npm run test`를 선행한 뒤 Railway CLI deploy를 실행
-- GitHub Environment `preview`, `production`에 `RAILWAY_TOKEN`, `RAILWAY_PROJECT_ID`, `RAILWAY_ENVIRONMENT_ID`, `RAILWAY_SERVICE_ID`, `BACKEND_PUBLIC_URL`를 설정해야 함
-- preview deploy는 Railway provided domain을 resolve한 뒤 `preview/BACKEND_PUBLIC_URL`을 다시 동기화하고, 같은 URL로 live smoke와 freshness handoff를 검증함
+- live client runtime이 보는 값은 GitHub Environment `production`의 `BACKEND_PUBLIC_URL` 하나만 기준으로 삼음
+- production backend는 `RAILWAY_TOKEN`, `RAILWAY_PROJECT_ID`, `RAILWAY_ENVIRONMENT_ID`, `RAILWAY_SERVICE_ID`, `BACKEND_PUBLIC_URL`가 설정돼 있어야 함
 
 backend deploy topology와 rehearsal 규칙은 `docs/specs/backend/preview-staging-backend-path.md`, public read rate-limit 정책은 `docs/specs/backend/public-read-rate-limit-policy.md`, canonical live smoke fixture registry와 운영 entrypoint는 `backend/README.md`에 정리돼 있습니다.
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -308,7 +308,7 @@ preview에서 달라지면 안 되는 것:
 
 ## Temporary Tunnel Fallback For Mobile External QA
 
-stable public preview backend가 unavailable일 때만 임시 fallback으로 local backend를 HTTPS tunnel 뒤에 둔다.
+single live production backend가 unavailable일 때만 임시 fallback으로 local backend를 HTTPS tunnel 뒤에 둔다.
 
 예시:
 
@@ -330,7 +330,7 @@ cloudflared tunnel --url http://127.0.0.1:3213
 규칙:
 
 - tunnel은 임시 QA fallback일 뿐 production/preview deploy 대체가 아니다.
-- sign-off 기본 경로는 GitHub Environment `preview`의 `BACKEND_PUBLIC_URL`과 같은 stable public preview backend다.
+- sign-off 기본 경로는 GitHub Environment `production`의 `BACKEND_PUBLIC_URL`과 같은 live production backend다.
 - debug metadata에서 `Backend target = Temporary tunnel backend`를 확인해야 한다.
 
 ## Backend Deploy Path

--- a/docs/specs/backend/api-only-end-state-tracker.md
+++ b/docs/specs/backend/api-only-end-state-tracker.md
@@ -64,7 +64,7 @@
 - committed JSON snapshot과 bridge export는 demoted artifact로만 남는다.
 
 즉, 남아 있는 blocker는 더 이상 "client가 JSON을 primary runtime source로 쓴다"만이 아니다.
-남아 있는 문제는 preview host / production API health / live runtime evidence / data completeness 같은 운영/품질 blocker다.
+남아 있는 문제는 production API health / live runtime evidence / data completeness 같은 운영/품질 blocker다.
 
 ## 4. Remaining Linked Blockers
 
@@ -72,8 +72,6 @@
 
 | issue | blocker class | why it is still open |
 | --- | --- | --- |
-| [#525](https://github.com/iAmSomething/idol-song-app/issues/525) | preview infra | stable public preview backend URL이 아직 정상 provisioning되지 않았다. |
-| [#624](https://github.com/iAmSomething/idol-song-app/issues/624) | external-device verification | external iPhone / Android validation이 stable preview host에 아직 완전히 정착되지 않았다. |
 | [#626](https://github.com/iAmSomething/idol-song-app/issues/626) | runtime health evidence | first real daily cadence window 이후 refreshed runtime bundle로 남은 runtime-health blocker를 재판정해야 한다. |
 | [#625](https://github.com/iAmSomething/idol-song-app/issues/625) | catalog completeness (MV) | latest / recent cohort의 canonical MV floor가 readiness threshold를 아직 못 넘겼다. |
 | [#627](https://github.com/iAmSomething/idol-song-app/issues/627) | catalog completeness (title-track) | latest / recent cohort의 title-track floor가 readiness threshold를 아직 못 넘겼다. |
@@ -82,7 +80,6 @@
 
 위 5개 issue가 모두 닫히면 다음을 동시에 만족한다.
 
-- preview / external-device path가 stable public backend URL 기준으로 고정된다.
 - runtime-health / readiness bundle이 first scheduled cadence evidence까지 포함한 최신 상태로 고정된다.
 - latest / recent user-facing cohort의 title-track / canonical MV blocker가 readiness threshold 아래에 더 이상 남지 않는다.
 

--- a/docs/specs/mobile/configuration-environment-spec.md
+++ b/docs/specs/mobile/configuration-environment-spec.md
@@ -53,16 +53,15 @@
 - local xcconfig는 machine-local override만 담고 git에 커밋하지 않는다.
 - `expo prebuild --clean` 또는 `expo run:ios`를 다시 돌릴 때도 같은 `EXPO_IOS_*` 값이 들어가야 native regeneration과 checked-in project가 같은 identifier를 유지한다.
 
-## 7.2 Public preview backend and tunnel fallback
-- external iPhone/Android QA의 기본 경로는 stable public preview backend다.
+## 7.2 Production backend and tunnel fallback
+- external iPhone/Android QA의 기본 경로는 single live production backend다.
 - mobile preview 예시 env는 `mobile/.env.preview.example`를 기준으로 둔다.
-- stable preview backend의 source of truth는 GitHub Environment `preview`의 `BACKEND_PUBLIC_URL`이다.
-- preview backend deploy workflow는 Railway provided domain을 resolve한 뒤 같은 값을 `BACKEND_PUBLIC_URL`에 다시 동기화해야 한다.
+- preview profile도 user-facing data는 GitHub Environment `production`의 `BACKEND_PUBLIC_URL`만 읽는다.
 - debug metadata에서는 최소 아래를 확인 가능해야 한다.
   - active API base URL
   - active API host
-  - backend target label (`Public preview backend`, `Temporary tunnel backend`, `Custom backend target`, `Missing backend target`)
-- stable preview backend가 unavailable일 때만 temporary tunnel fallback을 허용한다.
+  - backend target label (`Live production backend`, `Temporary tunnel backend`, `Custom backend target`, `Missing backend target`)
+- production backend가 unavailable일 때만 temporary tunnel fallback을 허용한다.
 - tunnel fallback 예시 env는 `mobile/.env.preview.tunnel.example`를 기준으로 둔다.
 - tunnel fallback은 release sign-off 기본 경로가 아니라 emergency QA 우회 경로다.
 

--- a/docs/specs/mobile/ios-preview-signing-personal-team.md
+++ b/docs/specs/mobile/ios-preview-signing-personal-team.md
@@ -51,7 +51,7 @@ PRODUCT_BUNDLE_IDENTIFIER = com.example.idolsongapp.preview
 cd mobile
 export EXPO_IOS_APPLE_TEAM_ID=ABCDE12345
 export EXPO_IOS_BUNDLE_IDENTIFIER=com.example.idolsongapp.preview
-export EXPO_PUBLIC_API_BASE_URL="$(gh variable get BACKEND_PUBLIC_URL --env preview --repo iAmSomething/idol-song-app)"
+export EXPO_PUBLIC_API_BASE_URL="$(gh variable get BACKEND_PUBLIC_URL --env production --repo iAmSomething/idol-song-app)"
 npm run config:preview
 npm run qa:preview:ios:sim
 ```

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -176,8 +176,8 @@ preview QA runtime용 native prebuild / simulator 실행:
 
 ```bash
 cd mobile
-EXPO_PUBLIC_API_BASE_URL="$(gh variable get BACKEND_PUBLIC_URL --env preview --repo iAmSomething/idol-song-app)" npm run qa:preview:ios:prebuild
-EXPO_PUBLIC_API_BASE_URL="$(gh variable get BACKEND_PUBLIC_URL --env preview --repo iAmSomething/idol-song-app)" npm run qa:preview:ios:sim
+EXPO_PUBLIC_API_BASE_URL="$(gh variable get BACKEND_PUBLIC_URL --env production --repo iAmSomething/idol-song-app)" npm run qa:preview:ios:prebuild
+EXPO_PUBLIC_API_BASE_URL="$(gh variable get BACKEND_PUBLIC_URL --env production --repo iAmSomething/idol-song-app)" npm run qa:preview:ios:sim
 ```
 
 personal Apple team으로 iOS preview signing override를 준비하려면:
@@ -203,8 +203,8 @@ Android 쪽 native prebuild baseline:
 
 ```bash
 cd mobile
-EXPO_PUBLIC_API_BASE_URL="$(gh variable get BACKEND_PUBLIC_URL --env preview --repo iAmSomething/idol-song-app)" npm run qa:preview:android:prebuild
-EXPO_PUBLIC_API_BASE_URL="$(gh variable get BACKEND_PUBLIC_URL --env preview --repo iAmSomething/idol-song-app)" npm run qa:preview:android:emu
+EXPO_PUBLIC_API_BASE_URL="$(gh variable get BACKEND_PUBLIC_URL --env production --repo iAmSomething/idol-song-app)" npm run qa:preview:android:prebuild
+EXPO_PUBLIC_API_BASE_URL="$(gh variable get BACKEND_PUBLIC_URL --env production --repo iAmSomething/idol-song-app)" npm run qa:preview:android:emu
 ```
 
 Android preview QA rerun을 emulator 안정화 설정과 함께 준비하려면:
@@ -213,7 +213,7 @@ Android preview QA rerun을 emulator 안정화 설정과 함께 준비하려면:
 cd mobile
 npm run qa:preview:android:avd:prepare
 npm run qa:preview:android:avd:launch
-EXPO_PUBLIC_API_BASE_URL="$(gh variable get BACKEND_PUBLIC_URL --env preview --repo iAmSomething/idol-song-app)" npm run qa:preview:android:emu
+EXPO_PUBLIC_API_BASE_URL="$(gh variable get BACKEND_PUBLIC_URL --env production --repo iAmSomething/idol-song-app)" npm run qa:preview:android:emu
 ```
 
 참고:
@@ -236,16 +236,16 @@ cd mobile
 cp .env.preview.example .env
 ```
 
-public preview backend가 unavailable일 때만 임시 tunnel fallback을 쓴다.
+production backend가 unavailable일 때만 임시 tunnel fallback을 쓴다.
 
 ```bash
 cd mobile
 cp .env.preview.tunnel.example .env
 ```
 
-## external device preview backend baseline
+## external device backend baseline
 
-stable public preview backend를 쓰는 기본 경로:
+single live production backend를 쓰는 기본 경로:
 
 ```bash
 cd mobile
@@ -270,19 +270,19 @@ iPhone / Android 외부 기기 QA minimum steps:
 
 1. 같은 Wi-Fi 또는 reachability 가능한 네트워크에 host machine과 device를 둔다.
 2. `mobile/.env.preview.example`을 `.env`로 복사한다.
-3. `gh variable get BACKEND_PUBLIC_URL --env preview --repo iAmSomething/idol-song-app`로 stable preview URL을 확인하고 `.env`에 같은 값을 넣는다.
-4. `npm run config:preview`로 `EXPO_PUBLIC_API_BASE_URL`이 preview GitHub Environment의 `BACKEND_PUBLIC_URL`과 같은지 확인한다.
+3. `gh variable get BACKEND_PUBLIC_URL --env production --repo iAmSomething/idol-song-app`로 live production URL을 확인하고 `.env`에 같은 값을 넣는다.
+4. `npm run config:preview`로 `EXPO_PUBLIC_API_BASE_URL`이 production GitHub Environment의 `BACKEND_PUBLIC_URL`과 같은지 확인한다.
 5. 같은 출력에서 `services.expoProjectId`도 비어 있지 않은지 확인한다.
 6. 앱 안 `알림` 진입점에서 권한 요청과 등록 상태를 바로 확인할 수 있다.
 7. preview dev client를 열고 Expo CLI가 보여주는 QR 또는 deep link로 runtime에 붙는다.
 8. hidden debug route `idolsongapp-preview://debug/metadata`에서 아래 값을 확인한다.
-   - `Backend target = Public preview backend`
-   - `API base URL = <preview BACKEND_PUBLIC_URL>`
-   - `API host = <preview host>`
+   - `Backend target = Live production backend`
+   - `API base URL = <production BACKEND_PUBLIC_URL>`
+   - `API host = <production host>`
 
 ## temporary tunnel fallback
 
-stable public preview backend가 내려가 있거나 준비 전일 때만 임시 fallback으로 tunnel을 쓴다.
+live production backend가 내려가 있거나 준비 전일 때만 임시 fallback으로 tunnel을 쓴다.
 
 권장 예시:
 
@@ -305,7 +305,7 @@ APP_ENV=preview npx expo start --dev-client --host tunnel --port 8082
 
 tunnel fallback 규칙:
 
-- 정식 sign-off / distribution 기본 경로는 GitHub Environment `preview`의 `BACKEND_PUBLIC_URL`과 같은 stable public preview backend다.
+- 정식 sign-off / distribution 기본 경로는 GitHub Environment `production`의 `BACKEND_PUBLIC_URL`과 같은 single live backend다.
 - backend target이 tunnel이면 debug metadata에서 `Backend target = Temporary tunnel backend`가 보여야 한다.
 - tunnel은 속도/안정성/도메인 수명이 불안정하므로 regression spot-check 용도로만 쓴다.
 

--- a/mobile/scripts/prepare-ios-preview-signing.sh
+++ b/mobile/scripts/prepare-ios-preview-signing.sh
@@ -66,7 +66,7 @@ Prepared iOS signing override:
 Next steps:
   export EXPO_IOS_APPLE_TEAM_ID=$TEAM_ID
   export EXPO_IOS_BUNDLE_IDENTIFIER=$BUNDLE_ID
-  export EXPO_PUBLIC_API_BASE_URL="$(gh variable get BACKEND_PUBLIC_URL --env preview --repo iAmSomething/idol-song-app)"
+  export EXPO_PUBLIC_API_BASE_URL="$(gh variable get BACKEND_PUBLIC_URL --env production --repo iAmSomething/idol-song-app)"
   npm run config:preview
   npm run qa:preview:ios:sim
 EOF

--- a/mobile/src/config/debugMetadata.test.ts
+++ b/mobile/src/config/debugMetadata.test.ts
@@ -95,7 +95,7 @@ describe('debug metadata helpers', () => {
     });
   });
 
-  test('labels the stable preview backend and tunnel fallback distinctly', () => {
+  test('labels the live production backend and tunnel fallback distinctly', () => {
     expect(
       getDebugMetadata({
         ...previewRuntimeState,
@@ -103,11 +103,11 @@ describe('debug metadata helpers', () => {
           ...previewRuntimeConfig,
           services: {
             ...previewRuntimeConfig.services,
-            apiBaseUrl: 'https://idol-song-app-preview.up.railway.app',
+            apiBaseUrl: 'https://idol-song-app-production.up.railway.app',
           },
         },
       }).backendTargetLabel,
-    ).toBe('Public preview backend');
+    ).toBe('Live production backend');
 
     expect(
       getDebugMetadata({
@@ -129,7 +129,7 @@ describe('debug metadata helpers', () => {
           ...previewRuntimeConfig,
           services: {
             ...previewRuntimeConfig.services,
-            apiBaseUrl: 'https://idol-song-app-production.up.railway.app',
+            apiBaseUrl: 'https://api.example.com',
           },
         },
       }).backendTargetLabel,

--- a/mobile/src/config/debugMetadata.ts
+++ b/mobile/src/config/debugMetadata.ts
@@ -21,7 +21,7 @@ export type MobileDebugMetadata = {
   apiHost: string | null;
   backendTargetLabel:
     | 'Missing backend target'
-    | 'Public preview backend'
+    | 'Live production backend'
     | 'Temporary tunnel backend'
     | 'Custom backend target';
   analyticsEnabled: boolean;
@@ -31,7 +31,7 @@ export type MobileDebugMetadata = {
   latestAnalyticsEvent: string | null;
 };
 
-const LEGACY_PUBLIC_PREVIEW_API_HOST = 'api.idol-song-app.example.com';
+const LEGACY_PUBLIC_API_HOST = 'api.idol-song-app.example.com';
 const TUNNEL_API_HOST_SUFFIXES = ['trycloudflare.com', 'ngrok-free.app', 'ngrok.io', 'loca.lt'] as const;
 
 function getBackendTargetLabel(apiBaseUrl: string | null): MobileDebugMetadata['backendTargetLabel'] {
@@ -44,12 +44,12 @@ function getBackendTargetLabel(apiBaseUrl: string | null): MobileDebugMetadata['
     return 'Temporary tunnel backend';
   }
 
-  if (host === LEGACY_PUBLIC_PREVIEW_API_HOST) {
-    return 'Public preview backend';
+  if (host === LEGACY_PUBLIC_API_HOST) {
+    return 'Live production backend';
   }
 
-  if (host.endsWith('.up.railway.app') && !host.includes('production')) {
-    return 'Public preview backend';
+  if (host.endsWith('.up.railway.app') && host.includes('production')) {
+    return 'Live production backend';
   }
 
   return 'Custom backend target';


### PR DESCRIPTION
## Summary\n- switch external-device QA and preview profile docs/scripts to use the production backend URL\n- relabel mobile debug metadata around live production vs tunnel targets\n- remove preview-backend blockers from the API-only end-state tracker\n\n## Testing\n- cd mobile && /usr/local/bin/node ./node_modules/jest/bin/jest.js --runInBand src/config/debugMetadata.test.ts\n- cd mobile && npm run lint\n- cd mobile && /usr/local/bin/node ./node_modules/typescript/bin/tsc --noEmit\n- git diff --check\n\nCloses #624\nCloses #525