### PR TITLE
Align live smoke report defaults

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -410,6 +410,7 @@ artifact:
 
 - preview: `backend/reports/live_backend_smoke_preview.json`
 - production: `backend/reports/live_backend_smoke_production.json`
+- `--report-path`를 생략하면 target별 기본 경로를 자동 사용한다.
 - preview freshness handoff: `backend/reports/backend_freshness_handoff_preview.json`
 - production freshness handoff: `backend/reports/backend_freshness_handoff_production.json`
 - repo-tracked Pages gate artifact: `backend/reports/backend_freshness_handoff.json`
@@ -427,6 +428,7 @@ manual smoke 예시:
 ```bash
 cd backend
 npm run smoke:live -- --target preview --base-url https://preview.example.com --report-path ./reports/live_backend_smoke_preview.json
+npm run smoke:live -- --target production --base-url https://idol-song-app-production.up.railway.app
 ```
 
 fixture registry를 바꿔서 deploy gate를 재현하고 싶으면 `--fixtures-path`로 다른 JSON을 넘기면 된다.

--- a/backend/scripts/run-live-smoke-checks.mjs
+++ b/backend/scripts/run-live-smoke-checks.mjs
@@ -8,17 +8,21 @@ import { performance } from 'node:perf_hooks';
 const DEFAULT_TIMEOUT_MS = 5000;
 const DEFAULT_TARGET = 'preview';
 const DEFAULT_READY_STATUSES = ['ready', 'degraded'];
-const DEFAULT_REPORT_PATH = resolve(process.cwd(), './reports/live_backend_smoke_report.json');
 const DEFAULT_FIXTURES_PATH = resolve(process.cwd(), './fixtures/live_backend_smoke_fixtures.json');
 const VALID_STREAMS = new Set(['album', 'song']);
 const VALID_FIXTURE_SURFACES = new Set(['search', 'calendar_month', 'radar', 'entity_detail', 'release_detail']);
+
+function getDefaultReportPath(target) {
+  const normalizedTarget = typeof target === 'string' && target.trim().length > 0 ? target.trim() : DEFAULT_TARGET;
+  return resolve(process.cwd(), `./reports/live_backend_smoke_${normalizedTarget}.json`);
+}
 
 function parseArgs(argv) {
   const options = {
     baseUrl: null,
     target: DEFAULT_TARGET,
     timeoutMs: DEFAULT_TIMEOUT_MS,
-    reportPath: DEFAULT_REPORT_PATH,
+    reportPath: null,
     fixturesPath: DEFAULT_FIXTURES_PATH,
     allowReadyStatuses: [...DEFAULT_READY_STATUSES],
     skipReady: false,
@@ -46,7 +50,7 @@ function parseArgs(argv) {
     }
 
     if (value === '--report-path') {
-      options.reportPath = resolve(process.cwd(), argv[index + 1] ?? DEFAULT_REPORT_PATH);
+      options.reportPath = resolve(process.cwd(), argv[index + 1] ?? getDefaultReportPath(options.target));
       index += 1;
       continue;
     }
@@ -90,6 +94,7 @@ function parseArgs(argv) {
   return {
     ...options,
     baseUrl: options.baseUrl.replace(/\/+$/, ''),
+    reportPath: options.reportPath ?? getDefaultReportPath(options.target),
   };
 }
 


### PR DESCRIPTION
## Summary\n- make live smoke default report paths target-specific so production runs write to the production artifact by default\n- update backend README examples to reflect the production smoke path\n- verify production smoke against the live Railway backend\n\n## Testing\n- cd backend && npm run smoke:live -- --target production --base-url https://idol-song-app-production.up.railway.app\n- git diff --check\n\nCloses #708