### PR TITLE
Refine same-day trusted promotion evidence

### DIFF
--- a/docs/specs/backend/same-day-release-acceptance-loop.md
+++ b/docs/specs/backend/same-day-release-acceptance-loop.md
@@ -105,3 +105,26 @@ scheduled verification chain은 `report:bundle` 전에 반드시 `npm run same-d
 
 hourly workflow는 `same_day_release_targets.py`로 active window를 먼저 계산한 뒤,
 eligible group만 `hydrate_release_windows.py`에 넘긴다.
+
+## Trusted Promotion Evidence
+
+same-day provisional promotion은 generic 기사 링크를 그대로 믿지 않는다.
+promotion evidence는 아래 kind로 분류된 경우에만 guarded provisional release를 만들 수 있다.
+
+1. `official_notice`
+   - `agency_notice`, `weverse_notice`
+2. `official_social`
+   - `official_social` + `x.com`, `instagram.com`, `facebook.com`, `tiktok.com`
+3. `official_youtube`
+   - `youtube.com`, `youtu.be`, `music.youtube.com`
+4. `trusted_catalog`
+   - `musicbrainz.org`, `open.spotify.com`, `spotify.com`, `melon.com`
+
+promotion row는 `detail_provenance`에 evidence kind를 남긴다.
+
+- `trusted_upcoming_signal.same_day_official_notice`
+- `trusted_upcoming_signal.same_day_official_social`
+- `trusted_upcoming_signal.same_day_official_youtube`
+- `trusted_upcoming_signal.same_day_trusted_catalog`
+
+`news_rss` 일반 기사 링크만 있는 경우에는 same-day provisional promotion을 만들지 않고, 기존 review / delayed catalog path로 남긴다.

--- a/hydrate_release_windows.py
+++ b/hydrate_release_windows.py
@@ -110,7 +110,6 @@ SPECIAL_PROJECT_PATTERN = re.compile(
     r"\b(project|special single|special album|anniversary|tribute|season song|special track)\b",
     re.IGNORECASE,
 )
-TRUSTED_PROMOTION_SOURCE_TYPES = {"agency_notice", "weverse_notice", "official_social", "news_rss"}
 QUOTED_TITLE_PATTERN = re.compile(r"[\"'“”‘’]([^\"'“”‘’]{2,120}?)['\"“”‘’]")
 EVIDENCE_TITLE_PATTERNS = (
     re.compile(
@@ -122,10 +121,51 @@ EVIDENCE_TITLE_PATTERNS = (
         re.IGNORECASE,
     ),
 )
+YOUTUBE_HOSTS = {
+    "youtube.com",
+    "www.youtube.com",
+    "m.youtube.com",
+    "music.youtube.com",
+    "youtu.be",
+}
+TRUSTED_CATALOG_HOSTS = {
+    "musicbrainz.org",
+    "www.musicbrainz.org",
+    "open.spotify.com",
+    "spotify.com",
+    "www.spotify.com",
+    "www.melon.com",
+    "melon.com",
+}
+OFFICIAL_SOCIAL_HOSTS = {
+    "x.com",
+    "www.x.com",
+    "twitter.com",
+    "www.twitter.com",
+    "instagram.com",
+    "www.instagram.com",
+    "facebook.com",
+    "www.facebook.com",
+    "tiktok.com",
+    "www.tiktok.com",
+}
+PROMOTION_DETAIL_PROVENANCE = {
+    "official_notice": "trusted_upcoming_signal.same_day_official_notice",
+    "official_social": "trusted_upcoming_signal.same_day_official_social",
+    "official_youtube": "trusted_upcoming_signal.same_day_official_youtube",
+    "trusted_catalog": "trusted_upcoming_signal.same_day_trusted_catalog",
+}
 
 
 def load_json(path: Path) -> Any:
     return json.loads(path.read_text(encoding="utf-8"))
+
+
+def optional_text(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
 
 
 def write_json(path: Path, rows: Any) -> bool:
@@ -248,9 +288,11 @@ def parse_published_at(value: str) -> float:
 def source_rank(source_type: str) -> int:
     if source_type in {"agency_notice", "weverse_notice"}:
         return 0
-    if source_type == "news_rss":
+    if source_type == "official_social":
         return 1
-    return 2
+    if source_type == "news_rss":
+        return 2
+    return 9
 
 
 def status_rank(date_status: str) -> int:
@@ -295,6 +337,39 @@ def choose_representative_targets(rows: list[dict[str, Any]]) -> list[dict[str, 
         selected.values(),
         key=lambda row: (row["scheduled_date"], row["group"].lower()),
     )
+
+
+def normalize_source_host(source_url: str) -> Optional[str]:
+    if not source_url:
+        return None
+    parsed = urlparse(source_url)
+    host = (parsed.netloc or parsed.path).strip().lower()
+    if not host:
+        return None
+    if "/" in host:
+        host = host.split("/", 1)[0]
+    return host.removeprefix("www.")
+
+
+def classify_same_day_promotion_evidence(target: dict[str, Any]) -> Optional[str]:
+    source_type = optional_text(target.get("source_type")) or ""
+    source_host = normalize_source_host(optional_text(target.get("source_url")) or "")
+
+    if source_host in {"youtube.com", "m.youtube.com", "music.youtube.com", "youtu.be"}:
+        return "official_youtube"
+    if source_host in {"musicbrainz.org", "open.spotify.com", "spotify.com", "melon.com"}:
+        return "trusted_catalog"
+    if source_type in {"agency_notice", "weverse_notice"}:
+        return "official_notice"
+    if source_type == "official_social" and source_host in {
+        "x.com",
+        "twitter.com",
+        "instagram.com",
+        "facebook.com",
+        "tiktok.com",
+    }:
+        return "official_social"
+    return None
 
 
 def derive_due_targets(rows: list[dict[str, Any]], run_date: date, group_filter: str) -> list[dict[str, Any]]:
@@ -779,11 +854,12 @@ def build_provisional_release_candidate(targets: list[dict[str, Any]], preflight
             continue
         if scheduled_date > run_date or row.get("candidate_releases"):
             continue
-        if target.get("source_type") not in TRUSTED_PROMOTION_SOURCE_TYPES:
-            continue
         if target.get("date_status") not in {"confirmed", "scheduled"}:
             continue
         if float(target.get("confidence", 0) or 0) < 0.75:
+            continue
+        evidence_kind = classify_same_day_promotion_evidence(target)
+        if evidence_kind is None:
             continue
 
         title = extract_title_from_text(target.get("headline", "")) or extract_title_from_text(
@@ -806,11 +882,12 @@ def build_provisional_release_candidate(targets: list[dict[str, Any]], preflight
             "release_format": release_kind,
             "context_tags": target.get("context_tags") or [],
             "detail_status": release_detail_builder.DETAIL_STATUS_REVIEW,
-            "detail_provenance": "trusted_upcoming_signal.provisional_release_fast_path",
+            "detail_provenance": PROMOTION_DETAIL_PROVENANCE[evidence_kind],
             "detail_notes": (
-                "Provisional release promoted from a trusted exact-date upcoming signal after the scheduled date elapsed; "
+                f"Provisional release promoted from trusted same-day evidence ({evidence_kind}) after the scheduled date elapsed; "
                 "canonical catalog verification is still pending."
             ),
+            "promotion_evidence_kind": evidence_kind,
         }
 
     return None

--- a/test_hydrate_release_windows.py
+++ b/test_hydrate_release_windows.py
@@ -1,0 +1,110 @@
+import unittest
+from datetime import date
+
+import hydrate_release_windows as module
+
+
+def make_target(**overrides):
+    target = {
+        "group": "Example Group",
+        "scheduled_date": "2026-03-12",
+        "date_precision": "exact",
+        "source_type": "official_social",
+        "source_url": "https://www.instagram.com/p/example",
+        "date_status": "confirmed",
+        "confidence": 0.91,
+        "headline": "Example Group returns with 'Signal'",
+        "evidence_summary": "",
+        "release_format": "single",
+        "context_tags": [],
+        "phase": "d_day",
+    }
+    target.update(overrides)
+    return target
+
+
+def make_preflight(**overrides):
+    row = {
+        "scheduled_date": "2026-03-12",
+        "phase": "d_day",
+        "candidate_releases": [],
+    }
+    row.update(overrides)
+    return row
+
+
+class HydrateReleaseWindowsTests(unittest.TestCase):
+    def test_representative_target_prefers_official_social_over_news(self):
+        rows = [
+            make_target(source_type="news_rss", source_url="https://news.google.com/example", headline="news"),
+            make_target(source_type="official_social", source_url="https://www.instagram.com/p/example", headline="official"),
+        ]
+
+        selected = module.choose_representative_targets(rows)
+
+        self.assertEqual(len(selected), 1)
+        self.assertEqual(selected[0]["headline"], "official")
+
+    def test_promotes_from_official_social_evidence(self):
+        candidate = module.build_provisional_release_candidate(
+            [make_target()],
+            [make_preflight()],
+            date(2026, 3, 12),
+        )
+
+        self.assertIsNotNone(candidate)
+        self.assertEqual(candidate["promotion_evidence_kind"], "official_social")
+        self.assertEqual(candidate["detail_provenance"], "trusted_upcoming_signal.same_day_official_social")
+        self.assertEqual(candidate["title"], "Signal")
+
+    def test_promotes_from_official_youtube_evidence(self):
+        candidate = module.build_provisional_release_candidate(
+            [
+                make_target(
+                    source_url="https://www.youtube.com/watch?v=abc123",
+                    headline="Example Group drops 'Signal' official MV",
+                )
+            ],
+            [make_preflight()],
+            date(2026, 3, 12),
+        )
+
+        self.assertIsNotNone(candidate)
+        self.assertEqual(candidate["promotion_evidence_kind"], "official_youtube")
+        self.assertEqual(candidate["detail_provenance"], "trusted_upcoming_signal.same_day_official_youtube")
+
+    def test_promotes_from_trusted_catalog_even_if_source_type_is_news(self):
+        candidate = module.build_provisional_release_candidate(
+            [
+                make_target(
+                    source_type="news_rss",
+                    source_url="https://open.spotify.com/album/example",
+                    headline="Example Group 'Signal' now on Spotify",
+                )
+            ],
+            [make_preflight()],
+            date(2026, 3, 12),
+        )
+
+        self.assertIsNotNone(candidate)
+        self.assertEqual(candidate["promotion_evidence_kind"], "trusted_catalog")
+        self.assertEqual(candidate["detail_provenance"], "trusted_upcoming_signal.same_day_trusted_catalog")
+
+    def test_does_not_promote_generic_news_rss_evidence(self):
+        candidate = module.build_provisional_release_candidate(
+            [
+                make_target(
+                    source_type="news_rss",
+                    source_url="https://news.google.com/example",
+                    headline="Example Group to return with 'Signal'",
+                )
+            ],
+            [make_preflight()],
+            date(2026, 3, 12),
+        )
+
+        self.assertIsNone(candidate)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary\n- classify same-day provisional promotion evidence into official notice, official social, official YouTube, and trusted catalog kinds\n- stop generic news RSS rows from promoting provisional same-day releases\n- add regression tests and document the trusted promotion evidence contract\n\nCloses #672