### PR TITLE
Improve MV backfill batch reruns

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,9 +221,10 @@ python build_mv_manual_review_queue.py
 ```bash
 python build_release_details_musicbrainz.py --cohorts latest,recent --max-rows 25 --progress-every 5
 python backfill_release_detail_mvs.py --cohorts latest,recent --max-rows 25 --progress-every 5
+python backfill_release_detail_mvs.py --cohorts latest,recent --row-offset 25 --max-rows 25 --progress-every 5
 ```
 
-`backfill_release_detail_mvs.py`는 이제 첫 번째 title track만 보지 않고 최대 2개의 title track과 `official music video` / no-suffix fallback query까지 포함해서 candidate breadth를 넓힌다. 긴 latest/recent pass를 다시 돌리기 전에 이 경로를 우선 쓴다.
+`backfill_release_detail_mvs.py`는 이제 첫 번째 title track만 보지 않고 최대 2개의 title track과 `official music video` / no-suffix fallback query까지 포함해서 candidate breadth를 넓힌다. 긴 latest/recent pass를 다시 돌릴 때는 `--max-rows`와 `--row-offset`을 같이 써서 batch를 이어가고, 외부 검색 단발 실패는 빈 결과로 흡수해 whole run이 죽지 않게 한다.
 
 Neon canonical DB까지 같이 최신화하려면 아래를 이어서 실행한다.
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -596,9 +596,10 @@ python3 ../build_mv_manual_review_queue.py
 ```bash
 python3 ../build_release_details_musicbrainz.py --cohorts latest,recent --max-rows 25 --progress-every 5
 python3 ../backfill_release_detail_mvs.py --cohorts latest,recent --max-rows 25 --progress-every 5
+python3 ../backfill_release_detail_mvs.py --cohorts latest,recent --row-offset 25 --max-rows 25 --progress-every 5
 ```
 
-`backfill_release_detail_mvs.py`는 latest/recent blocker rerun에서 최대 2개의 title track, `official music video` suffix, no-suffix fallback까지 query plan에 포함한다. candidate breadth를 먼저 넓힌 뒤 full rerun을 태우는 기준으로 쓴다.
+`backfill_release_detail_mvs.py`는 latest/recent blocker rerun에서 최대 2개의 title track, `official music video` suffix, no-suffix fallback까지 query plan에 포함한다. candidate breadth를 먼저 넓힌 뒤 full rerun을 태우는 기준으로 쓰고, 긴 pass는 `--row-offset`과 `--max-rows`를 함께 써서 batch를 이어간다. 외부 검색 단발 실패는 빈 결과로 흡수해 전체 rerun이 중단되지 않게 한다.
 
 ## Release Pipeline Dual-Write
 

--- a/backfill_release_detail_mvs.py
+++ b/backfill_release_detail_mvs.py
@@ -53,6 +53,16 @@ def parse_positive_int_arg(raw_value: str) -> int:
     return parsed
 
 
+def parse_non_negative_int_arg(raw_value: str) -> int:
+    try:
+        parsed = int(raw_value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("must be a non-negative integer") from error
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("must be a non-negative integer")
+    return parsed
+
+
 def should_emit_progress(current_index: int, total_rows: int, progress_every: int) -> bool:
     if total_rows <= 0:
         return False
@@ -201,14 +211,28 @@ def resolve_video_channel_url(video_id: str) -> str:
 def fetch_query_candidates(query: str, reference: datetime) -> list[dict[str, Any]]:
     search_url = "https://www.youtube.com/results?hl=en&search_query=" + urllib.parse.quote_plus(query)
     request = urllib.request.Request(search_url, headers={"User-Agent": USER_AGENT})
-    with urllib.request.urlopen(request, timeout=20) as response:
-        html = response.read().decode("utf-8", "ignore")
+    try:
+        with urllib.request.urlopen(request, timeout=20) as response:
+            html = response.read().decode("utf-8", "ignore")
+    except Exception as exc:  # noqa: BLE001
+        print(
+            f"[backfill_release_detail_mvs] query fetch failed for {query!r}: {exc}",
+            file=sys.stderr,
+        )
+        return []
 
     match = re.search(r"var ytInitialData = (\{.*?\});</script>", html)
     if not match:
         return []
 
-    data = json.loads(match.group(1))
+    try:
+        data = json.loads(match.group(1))
+    except json.JSONDecodeError as exc:
+        print(
+            f"[backfill_release_detail_mvs] query parse failed for {query!r}: {exc}",
+            file=sys.stderr,
+        )
+        return []
     sections = data["contents"]["twoColumnSearchResultsRenderer"]["primaryContents"]["sectionListRenderer"]["contents"]
     candidates: list[dict[str, Any]] = []
     for section in sections:
@@ -808,6 +832,12 @@ def main() -> None:
         help="Limit the current scoped pass to the first N matching release-detail rows.",
     )
     parser.add_argument(
+        "--row-offset",
+        type=parse_non_negative_int_arg,
+        default=0,
+        help="Skip the first N matching scoped rows before applying --max-rows.",
+    )
+    parser.add_argument(
         "--progress-every",
         type=parse_positive_int_arg,
         default=25,
@@ -836,6 +866,8 @@ def main() -> None:
             if infer_release_cohort(detail.get("release_date", ""), reference_date) in scoped_cohorts
         ]
     total_scoped_rows = len(details)
+    if args.row_offset:
+        details = details[args.row_offset :]
     if args.max_rows is not None:
         details = details[: args.max_rows]
     print(
@@ -882,6 +914,7 @@ def main() -> None:
     report["execution_scope"]["scoped_rows_total"] = total_scoped_rows
     report["execution_scope"]["selected_rows"] = len(details)
     report["execution_scope"]["progress_every"] = args.progress_every
+    report["execution_scope"]["row_offset"] = args.row_offset
     if args.max_rows is not None:
         report["execution_scope"]["max_rows"] = args.max_rows
 

--- a/docs/specs/backend/README.md
+++ b/docs/specs/backend/README.md
@@ -94,7 +94,7 @@
 29. scoped blocker rerun note
    - `build_release_details_musicbrainz.py --cohorts latest,recent` 로 latest/recent row만 재계산할 수 있다
    - full snapshot은 유지하고 review queue / coverage report만 같은 execution scope로 다시 만든다
-   - 긴 rerun은 `--max-rows` 와 `--progress-every` 를 같이 써서 작은 batch로 확인한다
+   - 긴 rerun은 `--max-rows`, `--row-offset`, `--progress-every` 를 같이 써서 작은 batch를 이어서 확인한다
 
 ## 읽는 순서
 

--- a/test_backfill_release_detail_mvs.py
+++ b/test_backfill_release_detail_mvs.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import argparse
 import io
 import unittest
-from datetime import date
+from datetime import date, datetime
+from urllib.error import URLError
 from unittest.mock import patch
 
 import backfill_release_detail_mvs as backfill
@@ -16,6 +17,13 @@ class BackfillReleaseDetailMvQueryTests(unittest.TestCase):
     def test_parse_positive_int_arg_rejects_zero(self) -> None:
         with self.assertRaises(argparse.ArgumentTypeError):
             backfill.parse_positive_int_arg("0")
+
+    def test_parse_non_negative_int_arg_accepts_zero(self) -> None:
+        self.assertEqual(backfill.parse_non_negative_int_arg("0"), 0)
+
+    def test_parse_non_negative_int_arg_rejects_negative_values(self) -> None:
+        with self.assertRaises(argparse.ArgumentTypeError):
+            backfill.parse_non_negative_int_arg("-1")
 
     def test_build_queries_prefers_primary_name_then_korean_alias_then_release_title(self) -> None:
         detail = {
@@ -189,6 +197,13 @@ class BackfillReleaseDetailMvQueryTests(unittest.TestCase):
         self.assertEqual(backfill.infer_release_cohort("2025-12-01", reference_date), "latest")
         self.assertEqual(backfill.infer_release_cohort("2024-04-01", reference_date), "recent")
         self.assertEqual(backfill.infer_release_cohort("2021-03-10", reference_date), "historical")
+
+    @patch.object(backfill.urllib.request, "urlopen", side_effect=URLError("boom"))
+    def test_fetch_query_candidates_returns_empty_when_request_fails(self, _: object) -> None:
+        self.assertEqual(
+            backfill.fetch_query_candidates("YENA LOVE CATCHER official mv", datetime(2026, 3, 12)),
+            [],
+        )
 
     @patch.object(backfill, "REQUEST_DELAY_SECONDS", 0)
     def test_choose_resolutions_uses_track_search_for_unresolved_album_rows(self) -> None:


### PR DESCRIPTION
## Summary\n- make YouTube MV query fetch failures non-fatal so long latest/recent reruns do not abort on transient network errors\n- add row-offset support so latest/recent MV blocker passes can be resumed in smaller batches\n- document and test the new batch rerun flow\n\nRefs #625