### PR TITLE
Restore backend-native team compare and related acts

### DIFF
--- a/backend/src/route-contract.test.ts
+++ b/backend/src/route-contract.test.ts
@@ -348,6 +348,56 @@ function buildP1HarmonyEntityDetailPayload() {
   };
 }
 
+function buildChuuEntityDetailPayload() {
+  return {
+    identity: {
+      entity_slug: 'chuu',
+      display_name: 'CHUU',
+      canonical_name: 'CHUU',
+      entity_type: 'solo',
+      agency_name: 'ATRP',
+      debut_year: 2023,
+      badge_image_url: null,
+      badge_source_url: null,
+      badge_source_label: null,
+      badge_kind: null,
+      representative_image_url: null,
+      representative_image_source: null,
+    },
+    official_links: {
+      youtube: 'https://www.youtube.com/@chuuofficial',
+      x: 'https://x.com/chuu_atrp',
+      instagram: 'https://www.instagram.com/chuuo3o',
+    },
+    youtube_channels: {
+      primary_team_channel_url: 'https://www.youtube.com/@chuuofficial',
+      mv_allowlist_urls: ['https://www.youtube.com/@chuuofficial'],
+    },
+    tracking_state: {
+      tier: 'tracked',
+      watch_reason: null,
+      tracking_status: 'watch_only',
+    },
+    next_upcoming: null,
+    latest_release: {
+      release_id: 'aaaaaaaa-1111-4222-8333-aaaaaaaaaaaa',
+      release_title: 'Only cry in the rain',
+      release_date: '2026-02-10',
+      stream: 'album',
+      release_kind: 'single',
+      release_format: 'single',
+      representative_song_title: 'Only cry in the rain',
+      spotify_url: null,
+      youtube_music_url: null,
+      youtube_mv_url: null,
+      artwork: null,
+    },
+    recent_albums: [],
+    source_timeline: [],
+    artist_source_url: 'https://www.youtube.com/@chuuofficial',
+  };
+}
+
 function buildReleaseDetailPayload(releaseId: string) {
   return {
     release: {
@@ -1062,6 +1112,35 @@ class FakeDb {
       return this.result<Row>(rows);
     }
 
+    if (normalizedSql.includes('from entity_detail_projection') && normalizedSql.includes('where entity_slug <> $1')) {
+      if (params[0] === 'yena') {
+        return this.result<Row>([
+          {
+            entity_slug: 'p1harmony',
+            payload: buildP1HarmonyEntityDetailPayload(),
+            generated_at: NOW,
+          } as unknown as Row,
+          {
+            entity_slug: 'chuu',
+            payload: buildChuuEntityDetailPayload(),
+            generated_at: NOW,
+          } as unknown as Row,
+        ]);
+      }
+
+      if (params[0] === 'p1harmony') {
+        return this.result<Row>([
+          {
+            entity_slug: 'yena',
+            payload: buildEntityDetailPayload(),
+            generated_at: NOW,
+          } as unknown as Row,
+        ]);
+      }
+
+      return this.result<Row>([]);
+    }
+
     if (normalizedSql.includes('from entity_detail_projection')) {
       if (params[0] === 'yena') {
         return this.result<Row>([
@@ -1728,6 +1807,11 @@ test('GET /v1/entities/:slug returns entity detail projection payload', async (t
   assert.equal(body.data.recent_albums[0].artwork.thumbnail_image_url, 'https://cdn.example.com/love-catcher-thumb.jpg');
   assert.equal(body.data.source_timeline[0].event_type, 'official_announcement');
   assert.equal(body.data.source_timeline[0].summary, 'ep · confirmed · 2026-03-11');
+  assert.equal(body.data.compare_candidates.length, 2);
+  assert.equal(body.data.compare_candidates[0].entity_slug, 'chuu');
+  assert.equal(body.data.related_acts.length, 1);
+  assert.equal(body.data.related_acts[0].entity_slug, 'chuu');
+  assert.equal(body.data.related_acts[0].reason.kind, 'entity_type');
 });
 
 test('GET /v1/entities/:slug suppresses same-day exact upcoming when latest release matches the scheduled date', async (t) => {
@@ -1744,6 +1828,9 @@ test('GET /v1/entities/:slug suppresses same-day exact upcoming when latest rele
   assert.equal(body.data.next_upcoming, null);
   assert.equal(body.data.latest_release.release_title, 'UNIQUE');
   assert.equal(body.data.recent_albums[0].release_title, 'UNIQUE');
+  assert.equal(body.data.compare_candidates.length, 1);
+  assert.equal(body.data.compare_candidates[0].entity_slug, 'yena');
+  assert.equal(body.data.related_acts.length, 0);
 });
 
 test('GET /v1/releases/lookup resolves legacy key to release id', async (t) => {

--- a/backend/src/routes/entities.ts
+++ b/backend/src/routes/entities.ts
@@ -61,6 +61,24 @@ type TrackingStateBlock = {
   tracking_status: string | null;
 };
 
+type CompareCandidateSummary = {
+  entity_slug: string;
+  display_name: string;
+  entity_type: string;
+  agency_name: string | null;
+};
+
+type RelatedActSummary = {
+  entity_slug: string;
+  display_name: string;
+  entity_type: string;
+  agency_name: string | null;
+  reason: {
+    kind: 'agency' | 'entity_type';
+    value: string | null;
+  };
+};
+
 type ArtworkSummary = {
   cover_image_url: string | null;
   thumbnail_image_url: string | null;
@@ -147,6 +165,8 @@ type EntityDetailPayload = {
   recent_albums: ReleaseSummary[];
   source_timeline: SourceTimelineItem[];
   artist_source_url: string | null;
+  compare_candidates: CompareCandidateSummary[];
+  related_acts: RelatedActSummary[];
 };
 
 function asNullableString(value: unknown): string | null {
@@ -589,6 +609,128 @@ function normalizeTrackingStateForSurface(tier: string | null, watchReason: stri
   };
 }
 
+function normalizeCompareCandidate(value: unknown): CompareCandidateSummary | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const entitySlug = asNullableString(value.entity_slug);
+  const displayName = asNullableString(value.display_name);
+  const entityType = asNullableString(value.entity_type);
+
+  if (!entitySlug || !displayName || !entityType) {
+    return null;
+  }
+
+  return {
+    entity_slug: entitySlug,
+    display_name: displayName,
+    entity_type: entityType,
+    agency_name: asNullableString(value.agency_name),
+  };
+}
+
+function normalizeCompareCandidateArray(value: unknown): CompareCandidateSummary[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .map(normalizeCompareCandidate)
+    .filter((item): item is CompareCandidateSummary => item !== null);
+}
+
+function normalizeRelatedActSummary(value: unknown): RelatedActSummary | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const candidate = normalizeCompareCandidate(value);
+  if (!candidate) {
+    return null;
+  }
+
+  const reasonValue = isRecord(value.reason) ? value.reason : null;
+  const reasonKind = asNullableString(reasonValue?.kind);
+  if (reasonKind !== 'agency' && reasonKind !== 'entity_type') {
+    return null;
+  }
+
+  return {
+    ...candidate,
+    reason: {
+      kind: reasonKind,
+      value: asNullableString(reasonValue?.value),
+    },
+  };
+}
+
+function normalizeRelatedActSummaryArray(value: unknown): RelatedActSummary[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .map(normalizeRelatedActSummary)
+    .filter((item): item is RelatedActSummary => item !== null);
+}
+
+function compareCandidateSummaries(left: CompareCandidateSummary, right: CompareCandidateSummary): number {
+  return left.display_name.localeCompare(right.display_name, 'en', { sensitivity: 'base' });
+}
+
+function buildCompareCandidateSummary(payload: EntityDetailPayload): CompareCandidateSummary {
+  return {
+    entity_slug: payload.identity.entity_slug,
+    display_name: payload.identity.display_name,
+    entity_type: payload.identity.entity_type,
+    agency_name: payload.identity.agency_name,
+  };
+}
+
+function buildRelatedActSummaries(
+  identity: IdentityBlock,
+  candidates: CompareCandidateSummary[],
+): RelatedActSummary[] {
+  const related: RelatedActSummary[] = [];
+  const seen = new Set<string>();
+  const currentAgency = identity.agency_name;
+
+  for (const candidate of candidates) {
+    if (currentAgency && candidate.agency_name === currentAgency) {
+      related.push({
+        ...candidate,
+        reason: {
+          kind: 'agency',
+          value: currentAgency,
+        },
+      });
+      seen.add(candidate.entity_slug);
+    }
+  }
+
+  for (const candidate of candidates) {
+    if (seen.has(candidate.entity_slug)) {
+      continue;
+    }
+
+    if (candidate.entity_type !== identity.entity_type) {
+      continue;
+    }
+
+    related.push({
+      ...candidate,
+      reason: {
+        kind: 'entity_type',
+        value: candidate.entity_type,
+      },
+    });
+    seen.add(candidate.entity_slug);
+  }
+
+  return related.slice(0, 6);
+}
+
 function normalizeEntityDetailPayload(payload: unknown, slug: string, todayIsoDate: string): EntityDetailPayload | null {
   if (!isRecord(payload)) {
     return null;
@@ -658,6 +800,8 @@ function normalizeEntityDetailPayload(payload: unknown, slug: string, todayIsoDa
     recent_albums: dedupeRecentAlbumSummaries(normalizeReleaseSummaryArray(payload.recent_albums)),
     source_timeline: normalizeSourceTimeline(payload.source_timeline),
     artist_source_url: asNullableString(payload.artist_source_url),
+    compare_candidates: normalizeCompareCandidateArray(payload.compare_candidates),
+    related_acts: normalizeRelatedActSummaryArray(payload.related_acts),
   };
 }
 
@@ -770,6 +914,27 @@ export function registerEntityRoutes(app: FastifyInstance, context: EntityRouteC
       });
     }
 
+    const compareCandidateResult = await context.db.query<EntityDetailProjectionRow>(
+      `
+        select entity_slug, payload, generated_at
+        from entity_detail_projection
+        where entity_slug <> $1
+      `,
+      [slug]
+    );
+
+    const compareCandidates = compareCandidateResult.rows
+      .map((candidateRow) =>
+        normalizeEntityDetailPayload(
+          candidateRow.payload,
+          candidateRow.entity_slug,
+          resolveTodayIsoDate(context.config.appTimezone),
+        )
+      )
+      .filter((item): item is EntityDetailPayload => item !== null)
+      .map(buildCompareCandidateSummary)
+      .sort(compareCandidateSummaries);
+
     const [latestRelease] = await hydrateReleaseSummaries(
       context.db,
       normalized.latest_release ? [normalized.latest_release] : [],
@@ -779,6 +944,8 @@ export function registerEntityRoutes(app: FastifyInstance, context: EntityRouteC
       ...normalized,
       latest_release: latestRelease ?? normalized.latest_release,
       recent_albums: recentAlbums,
+      compare_candidates: compareCandidates,
+      related_acts: buildRelatedActSummaries(normalized.identity, compareCandidates),
     };
 
     return buildReadDataEnvelope(

--- a/docs/specs/backend/shared-read-api-contracts.md
+++ b/docs/specs/backend/shared-read-api-contracts.md
@@ -321,6 +321,8 @@
 - next upcoming
 - latest release
 - recent albums
+- compare candidates
+- related acts
 - optional source timeline support
 
 ### 7.4 Response Shape
@@ -412,6 +414,26 @@
         }
       }
     ],
+    "compare_candidates": [
+      {
+        "entity_slug": "enhypen",
+        "display_name": "ENHYPEN",
+        "entity_type": "group",
+        "agency_name": "BELIFT LAB"
+      }
+    ],
+    "related_acts": [
+      {
+        "entity_slug": "boynextdoor",
+        "display_name": "BOYNEXTDOOR",
+        "entity_type": "group",
+        "agency_name": "KOZ ENTERTAINMENT",
+        "reason": {
+          "kind": "entity_type",
+          "value": "group"
+        }
+      }
+    ],
     "source_timeline": [
       {
         "event_type": "official_announcement",
@@ -443,6 +465,8 @@
 - official links는 deduped canonical URL만 준다
 - latest release와 recent album card는 `release_format`과 nested `artwork` shape를 항상 포함한다
 - recent album selection rule은 서버가 고정하며 `album` stream 기준 최신순 최대 `12`개다
+- `compare_candidates`는 현재 entity를 제외한 비교 가능한 팀 후보를 stable slug/display shape로 준다
+- `related_acts`는 서버가 reason(`agency`, `entity_type`)까지 함께 계산해서 준다
 - `source_timeline`를 shared contract로 유지하는 동안 item shape는 `event_type`, `occurred_at`, `summary`, source/date meta까지 포함한 구조로 고정한다
 
 ## 8. `GET /v1/releases/:id`

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -482,6 +482,22 @@ type EntityDetailApiResponse = {
       confidence_score?: number | null
     }>
     artist_source_url?: string | null
+    compare_candidates?: Array<{
+      entity_slug?: string
+      display_name?: string
+      entity_type?: string | null
+      agency_name?: string | null
+    }>
+    related_acts?: Array<{
+      entity_slug?: string
+      display_name?: string
+      entity_type?: string | null
+      agency_name?: string | null
+      reason?: {
+        kind?: string
+        value?: string | null
+      } | null
+    }>
   }
   error?: {
     code?: string
@@ -749,6 +765,10 @@ type RelatedActReason =
       agency: string
     }
   | {
+      kind: 'entity_type'
+      entityType: string
+    }
+  | {
       kind: 'radar_tag'
       radarTag: RelatedRadarTag
     }
@@ -758,6 +778,8 @@ type RelatedActReason =
 
 type RelatedActRecommendation = {
   group: string
+  entitySlug: string | null
+  displayName: string
   reason: RelatedActReason
   score: number
 }
@@ -829,6 +851,12 @@ type TeamCompareSnapshot = {
   latestSong: VerifiedRelease | null
   nextUpcomingSignal: UpcomingCandidateRow | null
   recentYearReleaseCount: number
+}
+
+type TeamCompareOption = {
+  group: string
+  entitySlug: string
+  displayName: string
 }
 
 type TeamDirectoryEntry = {
@@ -911,6 +939,8 @@ type TeamProfile = {
   annualReleaseTimeline: AnnualReleaseTimelineSection[]
   changeLog: ReleaseChangeLogRow[]
   nextUpcomingSignal: UpcomingCandidateRow | null
+  compareOptions: TeamCompareOption[]
+  relatedActs: RelatedActRecommendation[]
 }
 
 type CanonicalDisclosureStatus = 'missing' | 'unresolved' | 'review_needed' | 'conditional_none'
@@ -1627,6 +1657,7 @@ const TEAM_COPY = {
     relatedActsTitle: '비슷한 결로 바로 이동',
     relatedActsEmpty: '추천할 관련 팀 데이터가 아직 충분하지 않습니다.',
     relatedActsReasonAgency: '같은 소속사',
+    relatedActsReasonType: '같은 유형',
     relatedActsReasonRadarTag: '같은 레이더 태그',
     relatedActsReasonManual: '수동 추천',
     compareAction: '비교',
@@ -1764,6 +1795,7 @@ const TEAM_COPY = {
     relatedActsTitle: 'Jump into adjacent acts',
     relatedActsEmpty: 'There is not enough related-act data to recommend another team yet.',
     relatedActsReasonAgency: 'Same agency',
+    relatedActsReasonType: 'Same type',
     relatedActsReasonRadarTag: 'Same radar tag',
     relatedActsReasonManual: 'Manual pick',
     compareAction: 'Compare',
@@ -2200,7 +2232,7 @@ function App() {
   const calendarPanelRef = useRef<HTMLElement | null>(null)
   const selectedDayPanelRef = useRef<HTMLElement | null>(null)
   const activeCompareGroup =
-    selectedGroup && selectedCompareGroup && selectedCompareGroup !== selectedGroup
+    selectedEntitySlug && selectedCompareGroup && selectedCompareGroup !== selectedEntitySlug
       ? selectedCompareGroup
       : null
   const selectedReleaseRoute =
@@ -2232,7 +2264,7 @@ function App() {
 
       document.title = selectedGroup
         ? activeCompareGroup
-          ? `${selectedGroup} vs ${activeCompareGroup} | Idol Song App`
+          ? `${selectedGroup} vs ${humanizeRouteSlug(activeCompareGroup)} | Idol Song App`
           : `${selectedGroup} | Idol Song App`
         : 'Idol Song App'
     }
@@ -2266,7 +2298,7 @@ function App() {
       : selectedGroup
         ? getArtistPath(selectedGroup, activeCompareGroup)
         : selectedEntitySlug
-          ? getArtistPathBySlug(selectedEntitySlug)
+          ? getArtistPathBySlug(selectedEntitySlug, activeCompareGroup)
           : getHomePath()
     const currentLocation = `${window.location.pathname}${window.location.search}`
     if (currentLocation !== nextPath) {
@@ -2590,21 +2622,16 @@ function App() {
   })
   const selectedTeam = selectedTeamResource.team
   const selectedTeamPageGroup = selectedTeam?.group ?? selectedGroup ?? selectedTeamShellDisplayName ?? null
-  const selectedTeamLocalProfile = selectedTeamPageGroup ? teamProfileMap.get(selectedTeamPageGroup) ?? null : null
+  const compareTeamResource = useEntityDetailResource({
+    group: null,
+    entitySlug: activeCompareGroup,
+  })
+  const compareTeam = compareTeamResource.team
   const selectedTeamIsPinned = selectedTeamPageGroup ? myTeamsSet.has(selectedTeamPageGroup) : false
   const myTeamsLimitReached = myTeams.length >= MY_TEAMS_LIMIT
-  const compareTeam = activeCompareGroup ? teamProfileMap.get(activeCompareGroup) ?? null : null
-  const compareTeamOptions: TeamProfile[] = selectedTeamPageGroup
-    ? teamProfiles
-        .filter((team) => team.group !== selectedTeamPageGroup)
-        .sort((left, right) => left.displayName.localeCompare(right.displayName))
-    : []
-  const selectedTeamCompareSnapshot = selectedTeamLocalProfile
-    ? buildTeamCompareSnapshot(selectedTeamLocalProfile.group)
-    : selectedTeam
-      ? buildEntityDetailCompareSnapshot(selectedTeam)
-      : null
-  const compareTeamSnapshot = compareTeam ? buildTeamCompareSnapshot(compareTeam.group) : null
+  const compareTeamOptions: TeamCompareOption[] = selectedTeam?.compareOptions ?? []
+  const selectedTeamCompareSnapshot = selectedTeam ? buildEntityDetailCompareSnapshot(selectedTeam) : null
+  const compareTeamSnapshot = compareTeam ? buildEntityDetailCompareSnapshot(compareTeam) : null
   const selectedTeamSourceStatus = {
     source: selectedTeamResource.source,
     errorCode: selectedTeamResource.loading ? null : selectedTeamResource.errorCode,
@@ -2631,9 +2658,7 @@ function App() {
   const selectedTeamLatestHandoffs =
     selectedTeam?.latestRelease ? selectedTeam.latestRelease.musicHandoffs : undefined
   const selectedTeamLatestMvUrl = selectedTeam?.latestRelease?.youtubeMvUrl ?? ''
-  const relatedActs: RelatedActRecommendation[] = selectedTeamPageGroup
-    ? (relatedActsByGroup.get(selectedTeamPageGroup) ?? []).filter((item) => teamProfileMap.has(item.group))
-    : []
+  const relatedActs: RelatedActRecommendation[] = selectedTeam?.relatedActs ?? []
   const dashboardSectionNavigatorItems: DashboardSectionNavigatorItem[] = [
     {
       id: DASHBOARD_SECTION_NAV_IDS[0],
@@ -3789,27 +3814,27 @@ function closeReleaseDetail() {
                 <div className="team-directory related-acts-list">
                   {relatedActs.length ? (
                     relatedActs.map((item) => {
-                      const team = teamProfileMap.get(item.group)
-                      if (!team) {
-                        return null
-                      }
-
                       return (
-                        <article key={team.group} className="related-acts-card">
+                        <article key={item.entitySlug ?? item.group} className="related-acts-card">
                           <div className="related-acts-head">
-                            <TeamIdentity group={team.group} variant="list" />
+                            <TeamIdentity group={item.group} variant="list" />
                             <span className={`signal-badge signal-badge-related-${item.reason.kind}`}>
                               {formatRelatedActReasonLabel(item.reason, language)}
                             </span>
                           </div>
                           <p className="related-acts-reason">{formatRelatedActReasonDetail(item.reason, language)}</p>
                           <div className="action-row">
-                            <ActionButton variant="primary" onClick={() => openTeamPage(team.group)}>
+                            <ActionButton
+                              variant="primary"
+                              onClick={() => openTeamPage(item.group, item.entitySlug)}
+                            >
                               {teamCopy.action}
                             </ActionButton>
-                            <ActionButton variant="secondary" onClick={() => setSelectedCompareGroup(team.group)}>
-                              {teamCopy.compareAction}
-                            </ActionButton>
+                            {item.entitySlug ? (
+                              <ActionButton variant="secondary" onClick={() => setSelectedCompareGroup(item.entitySlug)}>
+                                {teamCopy.compareAction}
+                              </ActionButton>
+                            ) : null}
                           </div>
                         </article>
                       )
@@ -5408,7 +5433,7 @@ function CompareTeamView({
   secondaryTeam: TeamProfile | null
   primarySnapshot: TeamCompareSnapshot | null
   secondarySnapshot: TeamCompareSnapshot | null
-  compareOptions: TeamProfile[]
+  compareOptions: TeamCompareOption[]
   selectedCompareGroup: string | null
   language: Language
   displayDateFormatter: Intl.DateTimeFormat
@@ -5439,7 +5464,7 @@ function CompareTeamView({
           <select value={selectedCompareGroup ?? ''} onChange={(event) => onSelectCompareGroup(event.target.value || null)}>
             <option value="">{teamCopy.compareSelectPlaceholder}</option>
             {compareOptions.map((team) => (
-              <option key={team.group} value={team.group}>
+              <option key={team.entitySlug} value={team.entitySlug}>
                 {team.displayName}
               </option>
             ))}
@@ -5454,7 +5479,7 @@ function CompareTeamView({
             <article className="compare-summary-card">
               <TeamIdentity group={primaryTeam.group} variant="list" />
               <div className="action-row">
-                <ActionButton variant="secondary" onClick={() => onOpenTeamPage(primaryTeam.group)}>
+                <ActionButton variant="secondary" onClick={() => onOpenTeamPage(primaryTeam.group, primaryTeam.slug)}>
                   {teamCopy.action}
                 </ActionButton>
               </div>
@@ -5462,7 +5487,10 @@ function CompareTeamView({
             <article className="compare-summary-card">
               <TeamIdentity group={secondaryTeam.group} variant="list" />
               <div className="action-row">
-                <ActionButton variant="secondary" onClick={() => onOpenTeamPage(secondaryTeam.group)}>
+                <ActionButton
+                  variant="secondary"
+                  onClick={() => onOpenTeamPage(secondaryTeam.group, secondaryTeam.slug)}
+                >
                   {teamCopy.action}
                 </ActionButton>
               </div>
@@ -7388,6 +7416,8 @@ function formatRelatedActReasonLabel(reason: RelatedActReason, language: Languag
   switch (reason.kind) {
     case 'agency':
       return teamCopy.relatedActsReasonAgency
+    case 'entity_type':
+      return teamCopy.relatedActsReasonType
     case 'radar_tag':
       return teamCopy.relatedActsReasonRadarTag
     case 'manual_override':
@@ -7401,6 +7431,8 @@ function formatRelatedActReasonDetail(reason: RelatedActReason, language: Langua
   switch (reason.kind) {
     case 'agency':
       return `${teamCopy.relatedActsReasonAgency} · ${reason.agency}`
+    case 'entity_type':
+      return `${teamCopy.relatedActsReasonType} · ${formatEntityTypeLabel(reason.entityType, language)}`
     case 'radar_tag':
       return `${teamCopy.relatedActsReasonRadarTag} · ${formatRelatedRadarTag(reason.radarTag, language)}`
     case 'manual_override':
@@ -7849,6 +7881,8 @@ function buildSyntheticTeamProfile(group: string | null, entitySlug: string): Te
     annualReleaseTimeline: [],
     changeLog: [],
     nextUpcomingSignal: null,
+    compareOptions: [],
+    relatedActs: [],
   }
 }
 
@@ -8099,6 +8133,11 @@ function normalizeApiActType(entityType: string | null | undefined): ActType {
   }
 
   return 'group'
+}
+
+function formatEntityTypeLabel(entityType: string, language: Language) {
+  const actType = normalizeApiActType(entityType)
+  return TRANSLATIONS[language].filterOptions[actType]
 }
 
 function resolveApiDisplayGroup(entitySlug: string | null | undefined, displayName: string | null | undefined) {
@@ -9465,6 +9504,86 @@ function buildEntityDetailSourceTimeline(
     .filter((item): item is SourceTimelineItem => item !== null)
 }
 
+function normalizeEntityTypeLabel(value: string | null | undefined) {
+  const normalized = readNonEmptyString(value)?.toLowerCase()
+  if (normalized === 'solo') {
+    return 'solo'
+  }
+  if (normalized === 'unit') {
+    return 'unit'
+  }
+  return 'group'
+}
+
+function buildEntityDetailCompareOptions(
+  items: NonNullable<EntityDetailApiResponse['data']>['compare_candidates'],
+): TeamCompareOption[] {
+  if (!Array.isArray(items)) {
+    return []
+  }
+
+  return items
+    .map((item) => {
+      const entitySlug = readNonEmptyString(item.entity_slug)
+      const displayName = readNonEmptyString(item.display_name)
+      if (!entitySlug || !displayName) {
+        return null
+      }
+
+      return {
+        group: displayName,
+        entitySlug,
+        displayName,
+      } satisfies TeamCompareOption
+    })
+    .filter((item): item is TeamCompareOption => item !== null)
+    .sort((left, right) => left.displayName.localeCompare(right.displayName))
+}
+
+function buildEntityDetailRelatedActs(
+  items: NonNullable<EntityDetailApiResponse['data']>['related_acts'],
+): RelatedActRecommendation[] {
+  if (!Array.isArray(items)) {
+    return []
+  }
+
+  return items.reduce<RelatedActRecommendation[]>((recommendations, item, index) => {
+      const entitySlug = readNonEmptyString(item.entity_slug)
+      const displayName = readNonEmptyString(item.display_name)
+      if (!entitySlug || !displayName) {
+        return recommendations
+      }
+
+      const reasonKind = readNonEmptyString(item.reason?.kind)
+      let reason: RelatedActReason | null = null
+
+      if (reasonKind === 'agency') {
+        reason = {
+          kind: 'agency',
+          agency: readNonEmptyString(item.reason?.value) ?? readNonEmptyString(item.agency_name) ?? displayName,
+        }
+      } else if (reasonKind === 'entity_type') {
+        reason = {
+          kind: 'entity_type',
+          entityType: normalizeEntityTypeLabel(item.reason?.value ?? item.entity_type),
+        }
+      }
+
+      if (!reason) {
+        return recommendations
+      }
+
+      recommendations.push({
+        group: displayName,
+        entitySlug,
+        displayName,
+        reason,
+        score: items.length - index,
+      })
+      return recommendations
+    }, [])
+}
+
 function buildEntityDetailTeamProfile(
   group: string,
   entitySlug: string,
@@ -9495,6 +9614,8 @@ function buildEntityDetailTeamProfile(
     readNonEmptyString(data.official_links?.youtube) ??
     null
   const sourceTimeline = buildEntityDetailSourceTimeline(canonicalGroup, data.source_timeline)
+  const compareOptions = buildEntityDetailCompareOptions(data.compare_candidates)
+  const relatedActs = buildEntityDetailRelatedActs(data.related_acts)
 
   return {
     ...baseTeam,
@@ -9516,6 +9637,8 @@ function buildEntityDetailTeamProfile(
     upcomingSignals,
     sourceTimeline,
     nextUpcomingSignal,
+    compareOptions,
+    relatedActs,
   }
 }
 
@@ -9720,6 +9843,8 @@ function buildTeamProfiles() {
         annualReleaseTimeline,
         changeLog,
         nextUpcomingSignal: upcomingSignals[0] ?? null,
+        compareOptions: [],
+        relatedActs: [],
       }
     })
     .sort(compareTeamProfiles)
@@ -9775,9 +9900,11 @@ function buildRelatedActsByGroup() {
         return [
           {
             group: candidate.group,
+            entitySlug: candidate.slug,
+            displayName: candidate.displayName,
             reason,
             score,
-          },
+          } satisfies RelatedActRecommendation,
         ]
       })
       .sort(compareRelatedActRecommendations)
@@ -10817,8 +10944,8 @@ function readSelectedCompareGroupFromLocation() {
     return null
   }
 
-  const primaryGroup = getGroupFromPath(window.location.pathname)
-  if (!primaryGroup) {
+  const primaryEntitySlug = getEntitySlugFromPath(window.location.pathname)
+  if (!primaryEntitySlug) {
     return null
   }
 
@@ -10827,12 +10954,12 @@ function readSelectedCompareGroupFromLocation() {
     return null
   }
 
-  const resolvedGroup = resolveGroupReference(compareValue)
-  if (!resolvedGroup || resolvedGroup === primaryGroup) {
+  const compareEntitySlug = decodeURIComponent(compareValue).trim().toLowerCase()
+  if (!compareEntitySlug || compareEntitySlug === primaryEntitySlug) {
     return null
   }
 
-  return resolvedGroup
+  return compareEntitySlug
 }
 
 function readSelectedReleaseKeyFromLocation() {
@@ -10896,7 +11023,7 @@ function resolveGroupReference(value: string) {
     return null
   }
 
-  return null
+  return humanizeRouteSlug(normalized)
 }
 
 function getHomePath() {
@@ -10905,9 +11032,12 @@ function getHomePath() {
   return query ? `/?${query}` : '/'
 }
 
-function getArtistPathBySlug(entitySlug: string) {
+function getArtistPathBySlug(entitySlug: string, compareGroup?: string | null) {
   const pathname = `/artists/${entitySlug}`
   const params = appendPersistentInspectParams(new URLSearchParams())
+  if (compareGroup && compareGroup !== entitySlug) {
+    params.set('compare', compareGroup)
+  }
   const query = params.toString()
   return query ? `${pathname}?${query}` : pathname
 }
@@ -10915,8 +11045,9 @@ function getArtistPathBySlug(entitySlug: string) {
 function getArtistPath(group: string, compareGroup?: string | null) {
   const pathname = `/artists/${slugifyGroup(group)}`
   const params = appendPersistentInspectParams(new URLSearchParams())
-  if (compareGroup && compareGroup !== group) {
-    params.set('compare', slugifyGroup(compareGroup))
+  const primaryEntitySlug = slugifyGroup(group)
+  if (compareGroup && compareGroup !== primaryEntitySlug) {
+    params.set('compare', compareGroup)
   }
   const query = params.toString()
   return query ? `${pathname}?${query}` : pathname


### PR DESCRIPTION
## Summary
- extend entity detail API payloads with compare candidates and related acts
- wire web team compare and related recommendations to backend-native payloads
- update backend contract docs and route tests for the new fields

Closes #725