### PR TITLE
Fix web timeline and source hydration

### DIFF
--- a/backend/src/route-contract.test.ts
+++ b/backend/src/route-contract.test.ts
@@ -1165,7 +1165,10 @@ class FakeDb {
       return this.result<Row>([]);
     }
 
-    if (normalizedSql.includes('from release_detail_projection') && normalizedSql.includes('where entity_slug = $1')) {
+    if (
+      normalizedSql.includes('from release_detail_projection') &&
+      (normalizedSql.includes('where entity_slug = $1') || normalizedSql.includes('where rdp.entity_slug = $1'))
+    ) {
       if (params[0] === 'ive' && params[2] === '2026-02-23' && params[3] === 'album') {
         return this.result<Row>([
           {
@@ -1175,6 +1178,8 @@ class FakeDb {
             release_date: '2026-02-23',
             stream: 'album',
             payload: buildReleaseDetailPayload(IVE_RELEASE_ID),
+            source_url: 'https://artwork.example.com/revive-plus',
+            artist_source_url: null,
             generated_at: NOW,
           } as unknown as Row,
         ]);
@@ -1195,6 +1200,8 @@ class FakeDb {
               'unresolved',
               'manual_override',
             ),
+            source_url: 'https://artwork.example.com/deadline',
+            artist_source_url: 'https://www.youtube.com/@BLACKPINK',
             generated_at: NOW,
           } as unknown as Row,
           {
@@ -1210,6 +1217,8 @@ class FakeDb {
               'verified',
               'canonical',
             ),
+            source_url: 'https://artwork.example.com/deadline',
+            artist_source_url: 'https://www.youtube.com/@BLACKPINK',
             generated_at: NOW,
           } as unknown as Row,
         ]);
@@ -1218,7 +1227,11 @@ class FakeDb {
       return this.result<Row>([]);
     }
 
-    if (normalizedSql.includes('from release_detail_projection') && normalizedSql.includes('where release_id = $1::uuid')) {
+    if (
+      normalizedSql.includes('from release_detail_projection') &&
+      (normalizedSql.includes('where release_id = $1::uuid') ||
+        normalizedSql.includes('where rdp.release_id = $1::uuid'))
+    ) {
       const releaseId = String(params[0] ?? '');
       if (releaseId === IVE_RELEASE_ID) {
         return this.result<Row>([
@@ -1229,6 +1242,8 @@ class FakeDb {
             release_date: '2026-02-23',
             stream: 'album',
             payload: buildReleaseDetailPayload(IVE_RELEASE_ID),
+            source_url: 'https://artwork.example.com/revive-plus',
+            artist_source_url: null,
             generated_at: NOW,
           } as unknown as Row,
         ]);
@@ -1249,6 +1264,8 @@ class FakeDb {
               'verified',
               'canonical',
             ),
+            source_url: 'https://artwork.example.com/deadline',
+            artist_source_url: 'https://www.youtube.com/@BLACKPINK',
             generated_at: NOW,
           } as unknown as Row,
         ]);
@@ -1267,6 +1284,8 @@ class FakeDb {
                 release_id: 'wrong-id',
               },
             },
+            source_url: null,
+            artist_source_url: null,
             generated_at: NOW,
           } as unknown as Row,
         ]);
@@ -1275,8 +1294,55 @@ class FakeDb {
       return this.result<Row>([]);
     }
 
-    if (normalizedSql.includes('from release_detail_projection') && normalizedSql.includes('where release_id = any($1::uuid[])')) {
-      return this.result<Row>([]);
+    if (
+      normalizedSql.includes('from release_detail_projection') &&
+      (normalizedSql.includes('where release_id = any($1::uuid[])') ||
+        normalizedSql.includes('where rdp.release_id = any($1::uuid[])'))
+    ) {
+      const releaseIds = Array.isArray(params[0]) ? params[0].map((value) => String(value)) : [];
+
+      const rows = releaseIds.flatMap((releaseId) => {
+        if (releaseId === YENA_RELEASE_ID) {
+          return [
+            {
+              release_id: YENA_RELEASE_ID,
+              payload: {
+                tracks: [{ title: 'LOVE CATCHER', is_title_track: true }],
+              },
+              source_url: 'https://starnews.example/yena-love-catcher',
+              artist_source_url: 'https://www.youtube.com/@YENA_OFFICIAL',
+            } as unknown as Row,
+          ];
+        }
+
+        if (releaseId === P1HARMONY_RELEASE_ID) {
+          return [
+            {
+              release_id: P1HARMONY_RELEASE_ID,
+              payload: {
+                tracks: [{ title: 'DUH!', is_title_track: true }],
+              },
+              source_url: 'https://news.example.com/p1harmony-unique',
+              artist_source_url: 'https://www.youtube.com/@P1Harmony',
+            } as unknown as Row,
+          ];
+        }
+
+        if (releaseId === IVE_RELEASE_ID) {
+          return [
+            {
+              release_id: IVE_RELEASE_ID,
+              payload: buildReleaseDetailPayload(IVE_RELEASE_ID),
+              source_url: 'https://artwork.example.com/revive-plus',
+              artist_source_url: null,
+            } as unknown as Row,
+          ];
+        }
+
+        return [];
+      });
+
+      return this.result<Row>(rows);
     }
 
     if (normalizedSql.includes('from calendar_month_projection')) {

--- a/backend/src/routes/calendar.ts
+++ b/backend/src/routes/calendar.ts
@@ -19,6 +19,15 @@ type CalendarMonthProjectionRow = {
   generated_at: Date | string;
 };
 
+type CalendarVerifiedReleaseHydrationRow = {
+  release_id: string;
+  source_url: string | null;
+  artist_source_url: string | null;
+  release_format: string | null;
+  entity_type: string | null;
+  agency_name: string | null;
+};
+
 type CalendarSummary = {
   verified_count: number;
   exact_upcoming_count: number;
@@ -305,6 +314,81 @@ function collectVerifiedReleaseKeys(data: CalendarMonthData): Set<string> {
   return keys;
 }
 
+function hydrateVerifiedRelease(
+  release: CalendarVerifiedRelease,
+  row: CalendarVerifiedReleaseHydrationRow | undefined,
+): CalendarVerifiedRelease {
+  if (!row) {
+    return release;
+  }
+
+  return {
+    ...release,
+    entity_type: release.entity_type ?? row.entity_type,
+    agency_name: release.agency_name ?? row.agency_name,
+    release_format: release.release_format ?? row.release_format,
+    source_url: release.source_url ?? row.source_url,
+    artist_source_url: release.artist_source_url ?? row.artist_source_url,
+  };
+}
+
+async function hydrateVerifiedReleaseArray(
+  db: DbQueryable,
+  releases: CalendarVerifiedRelease[],
+): Promise<CalendarVerifiedRelease[]> {
+  const releaseIds = [...new Set(releases.map((release) => release.release_id).filter(Boolean))];
+
+  if (releaseIds.length === 0) {
+    return releases;
+  }
+
+  const result = await db.query<CalendarVerifiedReleaseHydrationRow>(
+    `
+      select
+        r.id::text as release_id,
+        r.source_url,
+        r.artist_source_url,
+        r.release_format,
+        e.entity_type,
+        e.agency_name
+      from releases r
+      left join entities e on e.id = r.entity_id
+      where r.id = any($1::uuid[])
+    `,
+    [releaseIds],
+  );
+
+  const rowsByReleaseId = new Map(
+    result.rows.map((row) => [row.release_id, row] as const),
+  );
+
+  return releases.map((release) => hydrateVerifiedRelease(release, rowsByReleaseId.get(release.release_id)));
+}
+
+async function hydrateCalendarMonthData(db: DbQueryable, data: CalendarMonthData): Promise<CalendarMonthData> {
+  const allVerified = [
+    ...data.verified_list,
+    ...data.days.flatMap((day) => day.verified_releases),
+  ];
+  const hydratedAllVerified = await hydrateVerifiedReleaseArray(db, allVerified);
+  const hydratedByKey = new Map(
+    hydratedAllVerified.map((release) => [release.release_id, release]),
+  );
+  const pickHydratedRelease = (release: CalendarVerifiedRelease) => hydratedByKey.get(release.release_id) ?? release;
+
+  const verifiedRows = data.verified_list.map(pickHydratedRelease);
+  const dayRows = data.days.map((day) => ({
+    ...day,
+    verified_releases: day.verified_releases.map(pickHydratedRelease),
+  }));
+
+  return {
+    ...data,
+    verified_list: verifiedRows,
+    days: dayRows,
+  };
+}
+
 function toNearestUpcoming(item: CalendarUpcomingItem | null): CalendarNearestUpcoming | null {
   if (!item || item.date_precision !== 'exact' || !item.scheduled_date) {
     return null;
@@ -476,11 +560,12 @@ export function registerCalendarRoutes(app: FastifyInstance, context: CalendarRo
 
     const todayIsoDate = resolveTodayIsoDate(context.config.appTimezone);
     const filteredData = filterElapsedExactUpcomingRows(data, todayIsoDate);
+    const hydratedData = await hydrateCalendarMonthData(context.db, filteredData);
 
     return buildReadDataEnvelope(
       request,
       context.config.appTimezone,
-      filteredData,
+      hydratedData,
       { month: row.month_key },
       toIsoString(row.generated_at)
     );

--- a/backend/src/routes/entities.ts
+++ b/backend/src/routes/entities.ts
@@ -126,6 +126,7 @@ type ReleaseSummary = {
   youtube_music_url: string | null;
   youtube_mv_url: string | null;
   source_url: string | null;
+  artist_source_url: string | null;
   artwork: ArtworkSummary | null;
 };
 
@@ -320,6 +321,7 @@ function normalizeReleaseSummary(value: unknown): ReleaseSummary | null {
     youtube_music_url: asNullableString(value.youtube_music_url),
     youtube_mv_url: asNullableString(value.youtube_mv_url),
     source_url: asNullableString(value.source_url),
+    artist_source_url: asNullableString(value.artist_source_url),
     artwork: normalizeArtworkSummary(value.artwork),
   };
 }
@@ -420,28 +422,37 @@ function extractRepresentativeSongTitle(tracks: unknown): string | null {
   return asNullableString(titleTrack.title);
 }
 
+type ReleaseSummaryHydrationRow = {
+  release_id: string;
+  payload: unknown;
+  source_url: string | null;
+  artist_source_url: string | null;
+};
+
 function mergeReleaseSummaryWithDetail(
   release: ReleaseSummary,
-  detailPayload: unknown,
+  detailRow: ReleaseSummaryHydrationRow | undefined,
 ): ReleaseSummary {
-  if (!isRecord(detailPayload)) {
+  if (!detailRow || !isRecord(detailRow.payload)) {
     return release;
   }
 
-  const serviceLinks = isRecord(detailPayload.service_links) ? detailPayload.service_links : null;
+  const serviceLinks = isRecord(detailRow.payload.service_links) ? detailRow.payload.service_links : null;
   const spotify = serviceLinks && isRecord(serviceLinks.spotify) ? serviceLinks.spotify : null;
   const youtubeMusic =
     serviceLinks && isRecord(serviceLinks.youtube_music) ? serviceLinks.youtube_music : null;
-  const mv = isRecord(detailPayload.mv) ? detailPayload.mv : null;
-  const artwork = normalizeArtworkSummary(detailPayload.artwork);
+  const mv = isRecord(detailRow.payload.mv) ? detailRow.payload.mv : null;
+  const artwork = normalizeArtworkSummary(detailRow.payload.artwork);
 
   return {
     ...release,
     representative_song_title:
-      extractRepresentativeSongTitle(detailPayload.tracks) ?? release.representative_song_title,
+      extractRepresentativeSongTitle(detailRow.payload.tracks) ?? release.representative_song_title,
     spotify_url: asNullableString(spotify?.url) ?? release.spotify_url,
     youtube_music_url: asNullableString(youtubeMusic?.url) ?? release.youtube_music_url,
     youtube_mv_url: asNullableString(mv?.url) ?? release.youtube_mv_url,
+    source_url: detailRow.source_url ?? release.source_url,
+    artist_source_url: detailRow.artist_source_url ?? release.artist_source_url,
     artwork: artwork ?? release.artwork,
   };
 }
@@ -456,22 +467,25 @@ async function hydrateReleaseSummaries(
     return releases;
   }
 
-  const result = await db.query<ReleaseDetailProjectionRow>(
+  const result = await db.query<ReleaseSummaryHydrationRow>(
     `
-      select release_id::text as release_id, payload
-      from release_detail_projection
-      where release_id = any($1::uuid[])
+      select
+        rdp.release_id::text as release_id,
+        rdp.payload,
+        r.source_url,
+        r.artist_source_url
+      from release_detail_projection rdp
+      left join releases r on r.id = rdp.release_id
+      where rdp.release_id = any($1::uuid[])
     `,
     [releaseIds],
   );
 
   const payloadByReleaseId = new Map(
-    result.rows.map((row) => [row.release_id, row.payload] as const),
+    result.rows.map((row) => [row.release_id, row] as const),
   );
 
-  return releases.map((release) =>
-    mergeReleaseSummaryWithDetail(release, payloadByReleaseId.get(release.release_id)),
-  );
+  return releases.map((release) => mergeReleaseSummaryWithDetail(release, payloadByReleaseId.get(release.release_id)));
 }
 
 function normalizeSourceTimeline(value: unknown): SourceTimelineItem[] {

--- a/backend/src/routes/releases.ts
+++ b/backend/src/routes/releases.ts
@@ -18,6 +18,8 @@ type ReleaseDetailProjectionRow = {
   stream: string;
   payload: unknown;
   generated_at: Date | string;
+  source_url?: string | null;
+  artist_source_url?: string | null;
 };
 
 type ReleaseLookupQuery = {
@@ -39,6 +41,8 @@ type ReleaseCore = {
   release_date: string;
   stream: string;
   release_kind: string | null;
+  source_url: string | null;
+  artist_source_url: string | null;
 };
 
 type ServiceLink = {
@@ -232,6 +236,8 @@ function normalizeReleaseCore(value: unknown): ReleaseCore | null {
     release_date: releaseDate,
     stream,
     release_kind: asNullableString(value.release_kind),
+    source_url: asNullableString(value.source_url),
+    artist_source_url: asNullableString(value.artist_source_url),
   };
 }
 
@@ -398,19 +404,22 @@ export function registerReleaseRoutes(app: FastifyInstance, context: ReleaseRout
     const result = await context.db.query<ReleaseDetailProjectionRow>(
       `
         select
-          release_id::text as release_id,
-          entity_slug,
-          normalized_release_title,
-          release_date::text as release_date,
-          stream,
-          payload,
-          generated_at
-        from release_detail_projection
-        where entity_slug = $1
-          and normalized_release_title = projection_normalize_text($2)
-          and stream = $4
-          and release_date between ($3::date - interval '1 day') and ($3::date + interval '1 day')
-        order by release_date desc
+          rdp.release_id::text as release_id,
+          rdp.entity_slug,
+          rdp.normalized_release_title,
+          rdp.release_date::text as release_date,
+          rdp.stream,
+          rdp.payload,
+          rdp.generated_at,
+          r.source_url,
+          r.artist_source_url
+        from release_detail_projection rdp
+        left join releases r on r.id = rdp.release_id
+        where rdp.entity_slug = $1
+          and rdp.normalized_release_title = projection_normalize_text($2)
+          and rdp.stream = $4
+          and rdp.release_date between ($3::date - interval '1 day') and ($3::date + interval '1 day')
+        order by rdp.release_date desc
         limit 5
       `,
       [lookup.entity_slug, lookup.normalized_release_title, lookup.release_date, lookup.stream]
@@ -454,15 +463,18 @@ export function registerReleaseRoutes(app: FastifyInstance, context: ReleaseRout
     const result = await context.db.query<ReleaseDetailProjectionRow>(
       `
         select
-          release_id::text as release_id,
-          entity_slug,
-          normalized_release_title,
-          release_date::text as release_date,
-          stream,
-          payload,
-          generated_at
-        from release_detail_projection
-        where release_id = $1::uuid
+          rdp.release_id::text as release_id,
+          rdp.entity_slug,
+          rdp.normalized_release_title,
+          rdp.release_date::text as release_date,
+          rdp.stream,
+          rdp.payload,
+          rdp.generated_at,
+          r.source_url,
+          r.artist_source_url
+        from release_detail_projection rdp
+        left join releases r on r.id = rdp.release_id
+        where rdp.release_id = $1::uuid
         limit 1
       `,
       [id]
@@ -479,6 +491,9 @@ export function registerReleaseRoutes(app: FastifyInstance, context: ReleaseRout
         release_id: row.release_id,
       });
     }
+
+    data.release.source_url = data.release.source_url ?? asNullableString(row.source_url);
+    data.release.artist_source_url = data.release.artist_source_url ?? asNullableString(row.artist_source_url);
 
     return buildReadDataEnvelope(
       request,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -452,6 +452,7 @@ type EntityDetailApiResponse = {
       youtube_music_url?: string | null
       youtube_mv_url?: string | null
       source_url?: string | null
+      artist_source_url?: string | null
       artwork?: Record<string, unknown> | null
     } | null
     recent_albums?: Array<{
@@ -466,6 +467,7 @@ type EntityDetailApiResponse = {
       youtube_music_url?: string | null
       youtube_mv_url?: string | null
       source_url?: string | null
+      artist_source_url?: string | null
       artwork?: Record<string, unknown> | null
     }>
     source_timeline?: Array<{
@@ -2488,7 +2490,7 @@ function App() {
       ...visibleMonthScheduledRows.map((item) => item.isoDate),
     ]),
   ).sort()
-  const weeklyDigestReferenceDate = visibleMonthVerifiedRows[0]?.dateValue ?? null
+  const weeklyDigestReferenceDate = visibleMonthVerifiedRows.at(-1)?.dateValue ?? null
   const weeklyDigestWindowStart = weeklyDigestReferenceDate ? getDateDaysBefore(weeklyDigestReferenceDate, 6) : null
   const weeklyDigestRows =
     weeklyDigestReferenceDate && weeklyDigestWindowStart
@@ -2519,8 +2521,8 @@ function App() {
     ? upcomingByDate.get(effectiveSelectedDayIso) ?? []
     : []
 
-  const latestRelease = visibleMonthVerifiedRows[0]
-  const earliestRelease = visibleMonthVerifiedRows.at(-1)
+  const latestRelease = visibleMonthVerifiedRows.at(-1)
+  const earliestRelease = visibleMonthVerifiedRows[0]
   const monthIndex = visibleMonthKeys.indexOf(effectiveMonthKey)
   const normalizedSearchQuery = deferredSearch.trim()
   const searchSummaryCounts = {
@@ -2555,7 +2557,7 @@ function App() {
   }
   const nearestUpcomingJumpSignal = visibleMonthScheduledRows.find((item) => item.isoDate >= todayIso) ?? null
   const currentMonthFallbackIso = pickClosestIsoDate(monthActiveDayIsos, todayIso)
-  const latestVerifiedFallbackIso = visibleMonthVerifiedRows[0]?.isoDate ?? ''
+  const latestVerifiedFallbackIso = visibleMonthVerifiedRows.at(-1)?.isoDate ?? ''
   const nearestCalendarJumpTarget: CalendarQuickJumpTarget | null =
     nearestUpcomingJumpSignal
       ? {
@@ -7953,7 +7955,7 @@ function buildSyntheticVerifiedRelease(
     group,
     artist_name_mb: group,
     artist_mbid: '',
-    artist_source: readNonEmptyString(summary?.source_url) ?? '',
+    artist_source: readNonEmptyString(summary?.artist_source_url) ?? readNonEmptyString(summary?.source_url) ?? '',
     actType: getActType(group),
     stream,
     title: releaseTitle,
@@ -9616,6 +9618,26 @@ function buildEntityDetailTeamProfile(
   const sourceTimeline = buildEntityDetailSourceTimeline(canonicalGroup, data.source_timeline)
   const compareOptions = buildEntityDetailCompareOptions(data.compare_candidates)
   const relatedActs = buildEntityDetailRelatedActs(data.related_acts)
+  const verifiedHistoryByKey = new Map<string, VerifiedRelease>()
+
+  if (latestReleaseRecord) {
+    verifiedHistoryByKey.set(
+      getReleaseLookupKey(canonicalGroup, latestReleaseRecord.title, latestReleaseRecord.date, latestReleaseRecord.stream),
+      latestReleaseRecord,
+    )
+  }
+
+  for (const album of recentAlbums) {
+    verifiedHistoryByKey.set(
+      getReleaseLookupKey(canonicalGroup, album.title, album.date, album.stream),
+      album,
+    )
+  }
+
+  const annualReleaseTimeline = buildAnnualReleaseTimelineSections(
+    [...verifiedHistoryByKey.values()].sort(compareMonthlyDashboardVerified),
+    upcomingSignals,
+  )
 
   return {
     ...baseTeam,
@@ -9634,6 +9656,7 @@ function buildEntityDetailTeamProfile(
     representativeImageUrl: readNonEmptyString(data.identity?.representative_image_url) ?? baseTeam.representativeImageUrl,
     latestRelease: latestReleaseRecord ? buildVerifiedTeamLatestRelease(latestReleaseRecord) : null,
     recentAlbums,
+    annualReleaseTimeline,
     upcomingSignals,
     sourceTimeline,
     nextUpcomingSignal,


### PR DESCRIPTION
## Summary
- hydrate entity detail, release detail, and calendar verified rows with canonical release source fields
- restore annual release timeline sections for backend-native team pages
- anchor the monthly weekly digest to the latest verified release in the month
- update backend route contract fixtures for the new hydration queries

## Verification
- cd backend && npm run build
- cd backend && node --import tsx --test ./src/route-contract.test.ts
- cd web && npm run build
- cd web && npm run lint
- git diff --check