### PR TITLE
Relax production readiness freshness thresholds

### DIFF
--- a/backend/src/lib/readiness.ts
+++ b/backend/src/lib/readiness.ts
@@ -1,8 +1,10 @@
 import { readFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 
-const PROJECTION_FRESHNESS_PASS_LAG_MINUTES = 20;
-const PROJECTION_FRESHNESS_DEGRADED_LAG_MINUTES = 60;
+// Projection refreshes follow daily upcoming sync plus conditional release-day verification.
+// A few hours of lag should degrade readiness, not hard-fail deploy/runtime checks.
+const PROJECTION_FRESHNESS_PASS_LAG_MINUTES = 180;
+const PROJECTION_FRESHNESS_DEGRADED_LAG_MINUTES = 1440;
 
 type ReadyStatus = 'ready' | 'degraded' | 'not_ready';
 type ProjectionStatus = 'healthy' | 'degraded' | 'not_ready';

--- a/backend/src/route-contract.test.ts
+++ b/backend/src/route-contract.test.ts
@@ -1474,10 +1474,10 @@ function buildReadyStatusSnapshot(status: ReadyStatusSnapshot['status']): ReadyS
       status: status === 'not_ready' ? 'not_ready' : status === 'degraded' ? 'degraded' : 'healthy',
       generated_at: NOW,
       summary_lines: [],
-      lag_minutes: status === 'ready' ? 5 : status === 'degraded' ? 30 : 90,
+      lag_minutes: status === 'ready' ? 5 : status === 'degraded' ? 240 : 1500,
       thresholds: {
-        pass_lag_minutes: 20,
-        degraded_lag_minutes: 60,
+        pass_lag_minutes: 180,
+        degraded_lag_minutes: 1440,
       },
       row_counts: {
         entity_search_documents: 117,


### PR DESCRIPTION
## Summary
- relax projection freshness readiness thresholds so a few hours of lag degrade instead of hard-failing readiness
- keep truly stale projections in not-ready territory by moving the hard-fail boundary to one day
- update route contract expectations to match the new readiness contract

## Verification
- cd backend && npm run build
- cd backend && node --import tsx --test ./src/route-contract.test.ts
- cd backend && npm run smoke:live -- --target production --base-url https://idol-song-app-production.up.railway.app --report-path ./reports/live_backend_smoke_production_local.json
- git diff --check