### PR TITLE
Backfill missing team badge assets from official YouTube

### DIFF
--- a/backend/exports/non_runtime_web_snapshots/teamBadgeAssets.json
+++ b/backend/exports/non_runtime_web_snapshots/teamBadgeAssets.json
@@ -42,9 +42,30 @@
     "badge_kind": "official_channel_avatar"
   },
   {
+    "group": "ALL(H)OURS",
+    "badge_image_url": "https://yt3.googleusercontent.com/fWu6-87NDvXhuElT88HXeQYUL_npxgNwkt3ON0a8wJ6WyYcg5Bk3gF3Z2seljYY7dubQFntZ=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UC1buRciG8QIL9kRtHxI_tpw",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "ALLDAY PROJECT",
+    "badge_image_url": "https://yt3.googleusercontent.com/KlKnNaef1rJVk4GVe1wlz6ISIEvDn0iuJcsfX8IJ7KcCOLqEPiXQy9RDUgikzWPgYdwisInuxw=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCg8ZzloDPTrOiGztK0C9txQ",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
     "group": "AMPERS&ONE",
     "badge_image_url": "https://yt3.googleusercontent.com/Cld-X1XWG6BlhzwN7ZejO4rKQZChyNKY8hpDjc95sneeFlf8zH9yCm3sTCjtiBfsc2FywqnLzw=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UCH9IB4tD3U2TSjT3ZLICXTA",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "ARTMS",
+    "badge_image_url": "https://yt3.googleusercontent.com/plDKMY8MHWfkhnks3OVY9fQ9qWHXsi3bQACUHkJaQdGhqlIYME_nrxKLrfB20WqDgUnBPxer=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UChXC6ok0LaZIpf-50SIFf0Q",
     "badge_source_label": "Official YouTube channel avatar",
     "badge_kind": "official_channel_avatar"
   },
@@ -59,6 +80,13 @@
     "group": "ATEEZ",
     "badge_image_url": "https://yt3.googleusercontent.com/8ezdlFHvBROs5xd-scO3nP9j6LmmZnPYlKzuD7SFkpwDV1gKG8u-_3uIliiT8RzNzZ0u9DvR85I=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UC2e4Ukj5Pfr7cb3KpJAFBdQ",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "AtHeart",
+    "badge_image_url": "https://yt3.googleusercontent.com/U8nrIoUFiKRS-EQYrppTpTLFdL2S0WyMpub7aKe-439AXwzFhW9Wmc-AteZvYxMXt_ELOrLYZw=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCgSDdHK0MNXOHv7oBC2dHXA",
     "badge_source_label": "Official YouTube channel avatar",
     "badge_kind": "official_channel_avatar"
   },
@@ -91,6 +119,13 @@
     "badge_kind": "official_channel_avatar"
   },
   {
+    "group": "BLITZERS",
+    "badge_image_url": "https://yt3.googleusercontent.com/ytc/AIdro_kdpfzk45qlzBLA4bASJH1u5lC3WPw2GBSwXzCscEg=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCfwfC9QCYr_wxgib5dAB-mQ",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
     "group": "BOYNEXTDOOR",
     "badge_image_url": "https://yt3.googleusercontent.com/QhBJg2Djg9obHEAmP7-_BceJFY4KG0iaYWfuDGhjiURG-5CdhS_0npiZpCWvyN3Pfj9DkO8MSw=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UChhKBlh_wvspTh5n4mL0b5g",
@@ -112,6 +147,20 @@
     "badge_kind": "official_channel_avatar"
   },
   {
+    "group": "CHUNG HA",
+    "badge_image_url": "https://yt3.googleusercontent.com/zBjTczBXQiYIZwYEC8h6qrF04uMlGtCD7yUn8kfViFOlAoIKhu7ai2dh8op6_aFqr8NKrmUB=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UC9Gxb0gMCh3EPIDLQXeQUog",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "CHUU",
+    "badge_image_url": "https://yt3.googleusercontent.com/kemVwXcfboHXyLKPnpUaNoyFummTChwAGmes8Q8ZY2wGPfwZAaA1SAy85bXtKE2MEF02-hRQYIM=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCa0ylH-c4-MHZ7ih_6AHtXg",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
     "group": "cignature",
     "badge_image_url": "https://yt3.googleusercontent.com/30LF8En041JD6CCoCC9Lq-1lz3VdkCetMNwxkXuzRkTPpVEHJ2nycy-MHps8Vo0dygGYedqa=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UCaRdmTJgO6w0esJPZUOzXrw",
@@ -129,6 +178,13 @@
     "group": "CLASS:y",
     "badge_image_url": "https://yt3.googleusercontent.com/eN-lkd7e-dcCBiO790LI_w1qPY38HnkdDK61dr9Jg6eNHE9x6gri-wPHbOmw5FqxFoRBhwoKsA=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UCbCyYn2M_1ccicwj-KU7t0Q",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "CLOSE YOUR EYES",
+    "badge_image_url": "https://yt3.googleusercontent.com/zzquYCzqk4qB_XfGx3bw2aR-r-McxAOIP1cuMh0sXIcb9SmVYUjXdiStdEr89OHCEFcGO4fMXg=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCPo532dDHpbKVhJyJseLVbw",
     "badge_source_label": "Official YouTube channel avatar",
     "badge_kind": "official_channel_avatar"
   },
@@ -161,6 +217,20 @@
     "badge_kind": "official_channel_avatar"
   },
   {
+    "group": "DRIPPIN",
+    "badge_image_url": "https://yt3.googleusercontent.com/Q95lrIm35iyloY37gLqn-wafIrECa9W0k_JUlSjj9Qna1ETXBkfEieXZtiMgvU-bSooaNLW1hg=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCNf1JFLCOec-SUhREgZaR6w",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "DXMON",
+    "badge_image_url": "https://yt3.googleusercontent.com/EmC7yf0coePAVKbfDmfxpuuIVidnJ-rXuCi5SHHj36gfggLXGHNfpuAMyyduSDcIWmECu0hJxA=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCrhNp7bqMHOjVfMcyjk_J9Q",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
     "group": "ENHYPEN",
     "badge_image_url": "https://yt3.googleusercontent.com/gKp9WExdyzEEBpHM7WgVEgIhl7-yVhIAzOe1U5jJEYSYi17AbvUXyW4dGRk2KykXeCsgUhqD4A=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UCArLZtok93cO5R9RI4_Y5Jw",
@@ -171,6 +241,13 @@
     "group": "EPEX",
     "badge_image_url": "https://yt3.googleusercontent.com/i8q4Jrq13aFin04gXOZDgXI6bdPllOak0bG1xzlC52QKBBaTAe9njUayZ6-1oEHOHA6qxaPpJw=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UCKHl-9B-aa4AK5ZR9XLOg8A",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "EVNNE",
+    "badge_image_url": "https://yt3.googleusercontent.com/bccCK7GoZnIJW2j7KdSEuJSzKWqjOwLCtxowxOG2UcLDUYL8FjWosJxmIP6cpq3Ks8X95__FwDY=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCAWT2IC2TrPFNPCvkKZUFjg",
     "badge_source_label": "Official YouTube channel avatar",
     "badge_kind": "official_channel_avatar"
   },
@@ -210,6 +287,13 @@
     "badge_kind": "official_channel_avatar"
   },
   {
+    "group": "ifeye",
+    "badge_image_url": "https://yt3.googleusercontent.com/kgwXABXfEJjR2Ui8bCMFOezihv-YVOen4jYi7sXKXfnm-CvYW4FgZUUkhkz78jQWM4ZwC3JEDg=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCQ5K9InArSCtJoiUOlqu27g",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
     "group": "INFINITE",
     "badge_image_url": "https://yt3.googleusercontent.com/LJoGTgVSlHOmc9gC1qULrAGl0q0YYBv2UD77ck2g4M_dS7_RSS4oW_T9dL9C59oHrk2PnhA_Fw=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UCdzXSux7OnRD1Cml-DQ416Q",
@@ -238,6 +322,20 @@
     "badge_kind": "official_channel_avatar"
   },
   {
+    "group": "JEON SOMI",
+    "badge_image_url": "https://yt3.googleusercontent.com/pAAg3_IMU45qWBSxDrupSsQaq19-4gfERWEM6eqlbpOKoYLFUBRPZj8iM_RTw1zYkQ0TVfjagg=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCjDH1Pld9zc8pTYjbv5eM-Q",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "JUST B",
+    "badge_image_url": "https://yt3.googleusercontent.com/NxqWHzDwAylOLgm1Sc3cEyP3773hU9ONvUZofAl0uMAu9REssh0HbtzYwfhrD6IR22g6WvtA7Q=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCcpodGf_wkyawcTc-fXa82g",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
     "group": "KARD",
     "badge_image_url": "https://yt3.googleusercontent.com/nAeia3ldQiBtEhYxEQAb7Y84TyYFsKg6DvypKoF4BYuOLIWAZVXRowHYzfJdFYkk0J2HdIraGQ=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UC5OwlwvsVmf_lXHguB6OYFw",
@@ -245,9 +343,37 @@
     "badge_kind": "official_channel_avatar"
   },
   {
+    "group": "Kep1er",
+    "badge_image_url": "https://yt3.googleusercontent.com/L7N_d5rtqKhSPS14K878wpwxTC8thABdbQHbVhTV9wEIDuTFnw_xq2T64kXtSBPxj0gzSpoV=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCoQwdDRNobhnp6_wIvsE4aw",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "KickFlip",
+    "badge_image_url": "https://yt3.googleusercontent.com/xTwAhDMn0MxN9FD08hE-UDt9zwY1lvUn99MYttLASGQJc1nvLp3eGhUUjGjtdYQoPJxJviXIVA=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCmq9jjpHA69PwAwlA0DwOsg",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "KiiiKiii",
+    "badge_image_url": "https://yt3.googleusercontent.com/ytc/AIdro_kgo5-MnM8oZR7nY16V-tDL5_A6dKIJoQqTwiqSgTbZYwwthXx2pd4s6k-o2cXayo3jJA=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCcoT6JMccOgbh0Qtw_Kb3XA",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
     "group": "KISS OF LIFE",
     "badge_image_url": "https://yt3.googleusercontent.com/UZhdOaXGbF6NKRV4TSHPyr6uiLpj5gGpd1sEqjcnmCW2zKDzo64MpbJh2wKbLoKaymRfauLA=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UCvEEeBssb4XxIfWWIB8IjMw",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "KWON EUNBI",
+    "badge_image_url": "https://yt3.googleusercontent.com/qboVN73fAVmaXT8vj-BCxT58Rc_JqzCYT4pKwbfoWb30QblZVOsZ_ScQcCtrHdpTLDZaXK4t6Q=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCoCvj_VhZPOtttlJK7RCh2A",
     "badge_source_label": "Official YouTube channel avatar",
     "badge_kind": "official_channel_avatar"
   },
@@ -262,6 +388,13 @@
     "group": "LIGHTSUM",
     "badge_image_url": "https://yt3.googleusercontent.com/7a2ALs4EWUYWKT3vhwP2CsaGzOVxYia2o-ndW6I_zhOqCSwMIfHCDPvhLiuXLH5Eh-lEMvW4Jg=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UCeQlMQ-4cedE7SNmF5JsdsA",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "Loossemble",
+    "badge_image_url": "https://yt3.googleusercontent.com/37MTPSDgyyLL8FETZajRMd6-dJNYaC47b-30raAb54YfKBLT8uAbxZkAGb8t5lpRMHeyNhBObys=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCbTzy8kj_6Kik_LFD1XyN5g",
     "badge_source_label": "Official YouTube channel avatar",
     "badge_kind": "official_channel_avatar"
   },
@@ -315,6 +448,13 @@
     "badge_kind": "official_channel_avatar"
   },
   {
+    "group": "NCT WISH",
+    "badge_image_url": "https://yt3.googleusercontent.com/84qKR6IVkVxHABf51W8u2WK_NVGZIrIPPEZwmriaLTdBce7kIv31489lHtLPpYYhkoLPnsbH=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCiZqWVAeChfqlom5ZPR3ZJA",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
     "group": "NewJeans",
     "badge_image_url": "https://yt3.googleusercontent.com/LJXS4gAz-_rkoqcgixJplCAwOLQXRNTYnGhyZQoJMZ2Uyp_akqREktZnvxbmmbES_UDp9hTT9y8=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UCMki_UkHb4qSc0qyEcOHHJw",
@@ -332,6 +472,13 @@
     "group": "NMIXX",
     "badge_image_url": "https://yt3.googleusercontent.com/UkZJRmpoFVOe3qfAT5GEB5DTNJQSVUAIkHdj5A-QtfB8kSZS8LMkYJIP8e5-gIx8D0HyhGD9mw=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UCnUAyD4t2LkvW68YrDh7fDg",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "NOMAD",
+    "badge_image_url": "https://yt3.googleusercontent.com/rsoXmClOrT6Uv9AuvXZQuSfHNUywbBUaSemFXJ_q4VS5hgie1jc6AhhyiV-EMnP7qluqPuxKfA=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCtCFxLt-bMmSnxGEbjsyg6Q",
     "badge_source_label": "Official YouTube channel avatar",
     "badge_kind": "official_channel_avatar"
   },
@@ -371,6 +518,13 @@
     "badge_kind": "official_channel_avatar"
   },
   {
+    "group": "POW",
+    "badge_image_url": "https://yt3.googleusercontent.com/UET-9siTg07_yKQqM3gipiHF1wdETu5eF2lHuCeUDnHCIe05b0sndXdCMs08GFADGSLs7zVQcvg=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCc8hWuK9dgKvB04rzZL23sQ",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
     "group": "Purple Kiss",
     "badge_image_url": "https://yt3.googleusercontent.com/AzAIT8v0YppNs7JQk4DryqX8fijJos5EVy7L9z7e9GXW1aUfoUNNNVxex4y5OECwo5BLW9iTig=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UCor8nQnEdMs4eBcU-uVBQ8g",
@@ -392,9 +546,23 @@
     "badge_kind": "official_channel_avatar"
   },
   {
+    "group": "RESCENE",
+    "badge_image_url": "https://yt3.googleusercontent.com/u04HvCKlGWkEu0XQuOdKAJOKVeVMt1PtkxI0rIfjbHUZsJhhGxXTZmPVV9ryOZK1eoCibvnR3w=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UC4jgjZ6BDua0IjI4JT7h0-A",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
     "group": "RIIZE",
     "badge_image_url": "https://yt3.googleusercontent.com/W_0y6cSRgfBNVuen8N-dlCjyUl0ty5bTSJwob0IMb9L2P-9PKhTBRDS6-_tdqlvY2mLKVHX9=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UCdVD0MsYecQaIE5Ru-pOIQQ",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "SAY MY NAME",
+    "badge_image_url": "https://yt3.googleusercontent.com/jnoOgcgRCTVSB-krPF11mSI2r7w9h_acRYAIK2ba0WA7WcQh9Iq57jtGFSgU0SG-CHTYM0MdVA=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCTItOHr70Tq_GAOACSGawPw",
     "badge_source_label": "Official YouTube channel avatar",
     "badge_kind": "official_channel_avatar"
   },
@@ -427,9 +595,37 @@
     "badge_kind": "official_channel_avatar"
   },
   {
+    "group": "TEMPEST",
+    "badge_image_url": "https://yt3.googleusercontent.com/9ye6rhhC2fS5vAXUKgifndsoCZ3PUpbEzCN9bBsOxahjZeIuN6zwCJd90yLe4r0p4rvJB3UwXA=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCCViKQ1A1tXhIVKAVEazcaA",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
     "group": "THE BOYZ",
     "badge_image_url": "https://yt3.googleusercontent.com/WZvqZ_0AtJF8BuIAU341OunWSPqZHO9JaNGC3vZaawekNBkFYLhIWXzuzMKr92IXNJ8FqfzFju0=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UCkJ1rbOrsyPfBuHNfnLPm-Q",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "The KingDom",
+    "badge_image_url": "https://yt3.googleusercontent.com/6csbcy2n_mJuh7hx-ln3Mal8vJHyRrCEnjy12rq98RmgmF5qmI_jXZACiaO2VsPOGGqBOM1VEA=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCYp2CgC9Hxj_YnliiVKlOsQ",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "TIOT",
+    "badge_image_url": "https://yt3.googleusercontent.com/yU8e1L1dHiOhTbYZymV6Q3WAHipYFVeIOYuzUycS8VR2C3iP-k-wqco40ZxYtLUBZT-unRso=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UC4AVxeN8iY5j8kzg2WE0Vng",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "TNX",
+    "badge_image_url": "https://yt3.googleusercontent.com/ytc/AIdro_myfBq5IcGJV31Us6pPPwhEwMikRVq3R3QNZ4jXC-P_Ow=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCZOA7I_vjrxLuLGatPekGoA",
     "badge_source_label": "Official YouTube channel avatar",
     "badge_kind": "official_channel_avatar"
   },
@@ -458,6 +654,13 @@
     "group": "tripleS",
     "badge_image_url": "https://yt3.googleusercontent.com/31W7xhMWM227BR_zVRAQj5OMOdEjB1edRhI2-5dmFwrzXSYXdnqYh8WMB1MoIBAqRg5DkMIoYPk=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UCJnL-TBcsYrF2SLs7tmiC8Q",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "TUNEXX",
+    "badge_image_url": "https://yt3.googleusercontent.com/Ln8aMN3UkCaEkHtMqGgFoyryv2pcdYFv7x58q5iAF477MN1H86Z-6EKlRN8dL7GDIh-I_Pzl9A=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCjyoasKZmVv1uHDIID04ivw",
     "badge_source_label": "Official YouTube channel avatar",
     "badge_kind": "official_channel_avatar"
   },
@@ -511,6 +714,20 @@
     "badge_kind": "official_channel_avatar"
   },
   {
+    "group": "WEi",
+    "badge_image_url": "https://yt3.googleusercontent.com/RGCyXjp99SpRWKeSbDFRbI9HA7cK7B28t6UG3UskIvxprJG8yWzh8BUKFXINShdCAJSY4veM=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCbTXWjND2y7zLlSKtHqiwGA",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "WHIB",
+    "badge_image_url": "https://yt3.googleusercontent.com/IoLB3V0LkVj91fXL1MZqwuZCC2iNevEkzlsZzInq34fLaUXSKJEiNYXhmv2y6tVbDkCRAaYDn7Q=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UC_isDbPZQyyQqXX-POFFPIw",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
     "group": "woo!ah!",
     "badge_image_url": "https://yt3.googleusercontent.com/EuT8DXp42k4-8G1Tv8EJ0UrbtNFnGkbrp01fuAqLVN69Jc1Ou34AfeYti8utR7oYFh7DMuLg1w=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UCNeLbWtlJzTsavMC70zY0dQ",
@@ -528,6 +745,48 @@
     "group": "xikers",
     "badge_image_url": "https://yt3.googleusercontent.com/guibzVeJuX_WUD1iyTVdOtkD8qCjMvcq1k4JsngjLgeZP086YIXZ4oDvcmojQWo0KgRY9blI=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UCPtC0MXSW40Qq7RkhsCXjUQ",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "XLOV",
+    "badge_image_url": "https://yt3.googleusercontent.com/r89AwR6X6s6R41Woe7rvSI4INfOmY6pQzwefrPGKx_GyKh20B6qknl74mIVCA94myOkPBaMm_A=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCHWhn9xw7x8NPPnV6eWQDQA",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "YENA",
+    "badge_image_url": "https://yt3.googleusercontent.com/1PO2aCez6i_TqIy1mS-h-PnvjmB46gh42Gdkj4WvGw-ZPW-irnjIGM6tNmm574COoNq398En=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCkrDEGNM3mqZXHk2MfnOjMw",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "YOUNG POSSE",
+    "badge_image_url": "https://yt3.googleusercontent.com/9ydrDmxLEzNrsx3wUo4y-qjGmggTUy5O91iwJrvp-qsXqCqstlFUujnth3RaX7m9clj0mFJbpeg=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCYvGSZPvQj09LgpcziCszyA",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "YOUNITE",
+    "badge_image_url": "https://yt3.googleusercontent.com/ytc/AIdro_lumwHjAwitSOM2pDk0cr_Nc5-Y3TfhTBUq5XAvsFS9PKk=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCtBLjxlnFpzt7Jvl_0aA7lw",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "YUJU",
+    "badge_image_url": "https://yt3.googleusercontent.com/ZFhcGw5AIVLxjPm1LJ-GdOZsIYmHFUmDAuounmhnZIP6bnlQrorXag2KP3CkS2clWY7QKooNlwE=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCt7Nlt3vXkz-NTyou5Kqp6w",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "Yves",
+    "badge_image_url": "https://yt3.googleusercontent.com/3IX22RvkkcBbMlwk4ywaXA3m6pbZt5kEVApi7vvLB31SUKTlRVoffqqqloe8Uu5uVgXvV9q3tg=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCMuK2QPg9oFJ1-veMCw3Irg",
     "badge_source_label": "Official YouTube channel avatar",
     "badge_kind": "official_channel_avatar"
   },

--- a/build_team_badge_assets.py
+++ b/build_team_badge_assets.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import html
+import json
+import re
+import urllib.request
+from pathlib import Path
+from typing import Any, Callable
+
+import non_runtime_dataset_paths
+from youtube_channel_allowlists import AGENCY_MV_CHANNELS, load_allowlists_by_group, resolve_youtube_channel_alias_urls
+
+
+ROOT = Path(__file__).resolve().parent
+PROFILES_PATH = non_runtime_dataset_paths.resolve_input_path("artistProfiles.json")
+BADGES_PATH = non_runtime_dataset_paths.resolve_input_path("teamBadgeAssets.json")
+OUTPUT_PATH = non_runtime_dataset_paths.primary_path("teamBadgeAssets.json")
+OG_IMAGE_PATTERN = re.compile(r'<meta property="og:image" content="([^"]+)"')
+AVATAR_PATTERN = re.compile(r'"avatar":\{"thumbnails":\[(.*?)\]\}')
+URL_PATTERN = re.compile(r'"url":"([^"]+)"')
+USER_AGENT = "Mozilla/5.0"
+REQUEST_TIMEOUT_SECONDS = 5
+AGENCY_CHANNEL_URLS = {
+    channel["channel_url"].rstrip("/").casefold() for channel in AGENCY_MV_CHANNELS.values()
+}
+
+FetchText = Callable[[str], str]
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def normalize_url(url: str | None) -> str | None:
+    if not url:
+        return None
+    return url.rstrip("/")
+
+
+def is_agency_channel(channel_url: str | None) -> bool:
+    normalized = normalize_url(channel_url)
+    if not normalized:
+        return False
+    return normalized.casefold() in AGENCY_CHANNEL_URLS
+
+
+def decode_html_url(value: str) -> str:
+    return html.unescape(value.replace("\\/", "/"))
+
+
+def extract_avatar_image_url(page_html: str) -> str | None:
+    normalized_html = page_html.replace("\\/", "/")
+
+    og_image_match = OG_IMAGE_PATTERN.search(normalized_html)
+    if og_image_match:
+        return decode_html_url(og_image_match.group(1))
+
+    avatar_match = AVATAR_PATTERN.search(normalized_html)
+    if not avatar_match:
+        return None
+
+    urls = [decode_html_url(match) for match in URL_PATTERN.findall(avatar_match.group(1))]
+    if not urls:
+        return None
+    return urls[-1]
+
+
+def select_team_channel_url(
+    profile: dict[str, Any],
+    allowlist_row: dict[str, Any] | None,
+) -> str | None:
+    channels = allowlist_row.get("channels") if allowlist_row else []
+    for channel in channels or []:
+        channel_url = channel.get("channel_url")
+        if not channel_url or is_agency_channel(channel_url):
+            continue
+        if channel.get("owner_type") == "team" and channel.get("display_in_team_links"):
+            return channel_url
+
+    primary_team_channel_url = allowlist_row.get("primary_team_channel_url") if allowlist_row else None
+    if primary_team_channel_url and not is_agency_channel(primary_team_channel_url):
+        return primary_team_channel_url
+
+    official_youtube_url = profile.get("official_youtube_url")
+    if official_youtube_url and not is_agency_channel(official_youtube_url):
+        return official_youtube_url
+    return None
+
+
+def resolve_badge_source_url(channel_url: str, fetcher: FetchText) -> str:
+    alias_urls = resolve_youtube_channel_alias_urls(channel_url, fetcher=fetcher)
+    for alias_url in alias_urls:
+        if "/channel/" in alias_url:
+            return alias_url
+    if alias_urls:
+        return alias_urls[0]
+    return channel_url
+
+
+def build_badge_row(group: str, channel_url: str, fetcher: FetchText) -> dict[str, str] | None:
+    try:
+        page_html = fetcher(channel_url)
+    except Exception:  # noqa: BLE001
+        return None
+
+    badge_image_url = extract_avatar_image_url(page_html)
+    if not badge_image_url:
+        return None
+
+    return {
+        "group": group,
+        "badge_image_url": badge_image_url,
+        "badge_source_url": resolve_badge_source_url(channel_url, fetcher),
+        "badge_source_label": "Official YouTube channel avatar",
+        "badge_kind": "official_channel_avatar",
+    }
+
+
+def build_badge_rows(
+    profiles: list[dict[str, Any]],
+    existing_rows: list[dict[str, Any]],
+    allowlists_by_group: dict[str, dict[str, Any]],
+    fetcher: FetchText,
+) -> tuple[list[dict[str, Any]], dict[str, int]]:
+    rows_by_group = {row["group"]: row for row in existing_rows}
+    summary = {
+        "added": 0,
+        "skipped_existing": 0,
+        "skipped_agency_only": 0,
+        "skipped_fetch_failed": 0,
+    }
+
+    for profile in profiles:
+        group = profile["group"]
+        if rows_by_group.get(group, {}).get("badge_image_url"):
+            summary["skipped_existing"] += 1
+            continue
+
+        channel_url = select_team_channel_url(profile, allowlists_by_group.get(group))
+        if not channel_url:
+            summary["skipped_agency_only"] += 1
+            continue
+
+        badge_row = build_badge_row(group, channel_url, fetcher)
+        if not badge_row:
+            summary["skipped_fetch_failed"] += 1
+            continue
+
+        rows_by_group[group] = badge_row
+        summary["added"] += 1
+
+    sorted_rows = sorted(rows_by_group.values(), key=lambda row: row["group"].casefold())
+    return sorted_rows, summary
+
+
+def write_json(rows: list[dict[str, Any]]) -> dict[str, list[str] | str]:
+    return non_runtime_dataset_paths.write_json_dataset("teamBadgeAssets.json", rows)
+
+
+def fetch_text(url: str) -> str:
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    with urllib.request.urlopen(request, timeout=REQUEST_TIMEOUT_SECONDS) as response:
+        return response.read().decode("utf-8", "ignore")
+
+
+def main() -> None:
+    profiles = load_json(PROFILES_PATH)
+    existing_rows = load_json(BADGES_PATH)
+    allowlists_by_group = load_allowlists_by_group()
+    rows, summary = build_badge_rows(profiles, existing_rows, allowlists_by_group, fetch_text)
+    io_paths = write_json(rows)
+    print(
+        json.dumps(
+            {
+                "rows": len(rows),
+                "input_profiles": str(PROFILES_PATH.relative_to(ROOT)),
+                "input_badges": str(BADGES_PATH.relative_to(ROOT)),
+                **summary,
+                **io_paths,
+            },
+            ensure_ascii=False,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/team_badge_assets.json
+++ b/team_badge_assets.json
@@ -42,9 +42,30 @@
     "badge_kind": "official_channel_avatar"
   },
   {
+    "group": "ALL(H)OURS",
+    "badge_image_url": "https://yt3.googleusercontent.com/fWu6-87NDvXhuElT88HXeQYUL_npxgNwkt3ON0a8wJ6WyYcg5Bk3gF3Z2seljYY7dubQFntZ=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UC1buRciG8QIL9kRtHxI_tpw",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "ALLDAY PROJECT",
+    "badge_image_url": "https://yt3.googleusercontent.com/KlKnNaef1rJVk4GVe1wlz6ISIEvDn0iuJcsfX8IJ7KcCOLqEPiXQy9RDUgikzWPgYdwisInuxw=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCg8ZzloDPTrOiGztK0C9txQ",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
     "group": "AMPERS&ONE",
     "badge_image_url": "https://yt3.googleusercontent.com/Cld-X1XWG6BlhzwN7ZejO4rKQZChyNKY8hpDjc95sneeFlf8zH9yCm3sTCjtiBfsc2FywqnLzw=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UCH9IB4tD3U2TSjT3ZLICXTA",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "ARTMS",
+    "badge_image_url": "https://yt3.googleusercontent.com/plDKMY8MHWfkhnks3OVY9fQ9qWHXsi3bQACUHkJaQdGhqlIYME_nrxKLrfB20WqDgUnBPxer=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UChXC6ok0LaZIpf-50SIFf0Q",
     "badge_source_label": "Official YouTube channel avatar",
     "badge_kind": "official_channel_avatar"
   },
@@ -59,6 +80,13 @@
     "group": "ATEEZ",
     "badge_image_url": "https://yt3.googleusercontent.com/8ezdlFHvBROs5xd-scO3nP9j6LmmZnPYlKzuD7SFkpwDV1gKG8u-_3uIliiT8RzNzZ0u9DvR85I=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UC2e4Ukj5Pfr7cb3KpJAFBdQ",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "AtHeart",
+    "badge_image_url": "https://yt3.googleusercontent.com/U8nrIoUFiKRS-EQYrppTpTLFdL2S0WyMpub7aKe-439AXwzFhW9Wmc-AteZvYxMXt_ELOrLYZw=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCgSDdHK0MNXOHv7oBC2dHXA",
     "badge_source_label": "Official YouTube channel avatar",
     "badge_kind": "official_channel_avatar"
   },
@@ -91,6 +119,13 @@
     "badge_kind": "official_channel_avatar"
   },
   {
+    "group": "BLITZERS",
+    "badge_image_url": "https://yt3.googleusercontent.com/ytc/AIdro_kdpfzk45qlzBLA4bASJH1u5lC3WPw2GBSwXzCscEg=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCfwfC9QCYr_wxgib5dAB-mQ",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
     "group": "BOYNEXTDOOR",
     "badge_image_url": "https://yt3.googleusercontent.com/QhBJg2Djg9obHEAmP7-_BceJFY4KG0iaYWfuDGhjiURG-5CdhS_0npiZpCWvyN3Pfj9DkO8MSw=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UChhKBlh_wvspTh5n4mL0b5g",
@@ -112,6 +147,20 @@
     "badge_kind": "official_channel_avatar"
   },
   {
+    "group": "CHUNG HA",
+    "badge_image_url": "https://yt3.googleusercontent.com/zBjTczBXQiYIZwYEC8h6qrF04uMlGtCD7yUn8kfViFOlAoIKhu7ai2dh8op6_aFqr8NKrmUB=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UC9Gxb0gMCh3EPIDLQXeQUog",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "CHUU",
+    "badge_image_url": "https://yt3.googleusercontent.com/kemVwXcfboHXyLKPnpUaNoyFummTChwAGmes8Q8ZY2wGPfwZAaA1SAy85bXtKE2MEF02-hRQYIM=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCa0ylH-c4-MHZ7ih_6AHtXg",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
     "group": "cignature",
     "badge_image_url": "https://yt3.googleusercontent.com/30LF8En041JD6CCoCC9Lq-1lz3VdkCetMNwxkXuzRkTPpVEHJ2nycy-MHps8Vo0dygGYedqa=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UCaRdmTJgO6w0esJPZUOzXrw",
@@ -129,6 +178,13 @@
     "group": "CLASS:y",
     "badge_image_url": "https://yt3.googleusercontent.com/eN-lkd7e-dcCBiO790LI_w1qPY38HnkdDK61dr9Jg6eNHE9x6gri-wPHbOmw5FqxFoRBhwoKsA=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UCbCyYn2M_1ccicwj-KU7t0Q",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "CLOSE YOUR EYES",
+    "badge_image_url": "https://yt3.googleusercontent.com/zzquYCzqk4qB_XfGx3bw2aR-r-McxAOIP1cuMh0sXIcb9SmVYUjXdiStdEr89OHCEFcGO4fMXg=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCPo532dDHpbKVhJyJseLVbw",
     "badge_source_label": "Official YouTube channel avatar",
     "badge_kind": "official_channel_avatar"
   },
@@ -161,6 +217,20 @@
     "badge_kind": "official_channel_avatar"
   },
   {
+    "group": "DRIPPIN",
+    "badge_image_url": "https://yt3.googleusercontent.com/Q95lrIm35iyloY37gLqn-wafIrECa9W0k_JUlSjj9Qna1ETXBkfEieXZtiMgvU-bSooaNLW1hg=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCNf1JFLCOec-SUhREgZaR6w",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "DXMON",
+    "badge_image_url": "https://yt3.googleusercontent.com/EmC7yf0coePAVKbfDmfxpuuIVidnJ-rXuCi5SHHj36gfggLXGHNfpuAMyyduSDcIWmECu0hJxA=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCrhNp7bqMHOjVfMcyjk_J9Q",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
     "group": "ENHYPEN",
     "badge_image_url": "https://yt3.googleusercontent.com/gKp9WExdyzEEBpHM7WgVEgIhl7-yVhIAzOe1U5jJEYSYi17AbvUXyW4dGRk2KykXeCsgUhqD4A=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UCArLZtok93cO5R9RI4_Y5Jw",
@@ -171,6 +241,13 @@
     "group": "EPEX",
     "badge_image_url": "https://yt3.googleusercontent.com/i8q4Jrq13aFin04gXOZDgXI6bdPllOak0bG1xzlC52QKBBaTAe9njUayZ6-1oEHOHA6qxaPpJw=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UCKHl-9B-aa4AK5ZR9XLOg8A",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "EVNNE",
+    "badge_image_url": "https://yt3.googleusercontent.com/bccCK7GoZnIJW2j7KdSEuJSzKWqjOwLCtxowxOG2UcLDUYL8FjWosJxmIP6cpq3Ks8X95__FwDY=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCAWT2IC2TrPFNPCvkKZUFjg",
     "badge_source_label": "Official YouTube channel avatar",
     "badge_kind": "official_channel_avatar"
   },
@@ -210,6 +287,13 @@
     "badge_kind": "official_channel_avatar"
   },
   {
+    "group": "ifeye",
+    "badge_image_url": "https://yt3.googleusercontent.com/kgwXABXfEJjR2Ui8bCMFOezihv-YVOen4jYi7sXKXfnm-CvYW4FgZUUkhkz78jQWM4ZwC3JEDg=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCQ5K9InArSCtJoiUOlqu27g",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
     "group": "INFINITE",
     "badge_image_url": "https://yt3.googleusercontent.com/LJoGTgVSlHOmc9gC1qULrAGl0q0YYBv2UD77ck2g4M_dS7_RSS4oW_T9dL9C59oHrk2PnhA_Fw=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UCdzXSux7OnRD1Cml-DQ416Q",
@@ -238,6 +322,20 @@
     "badge_kind": "official_channel_avatar"
   },
   {
+    "group": "JEON SOMI",
+    "badge_image_url": "https://yt3.googleusercontent.com/pAAg3_IMU45qWBSxDrupSsQaq19-4gfERWEM6eqlbpOKoYLFUBRPZj8iM_RTw1zYkQ0TVfjagg=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCjDH1Pld9zc8pTYjbv5eM-Q",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "JUST B",
+    "badge_image_url": "https://yt3.googleusercontent.com/NxqWHzDwAylOLgm1Sc3cEyP3773hU9ONvUZofAl0uMAu9REssh0HbtzYwfhrD6IR22g6WvtA7Q=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCcpodGf_wkyawcTc-fXa82g",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
     "group": "KARD",
     "badge_image_url": "https://yt3.googleusercontent.com/nAeia3ldQiBtEhYxEQAb7Y84TyYFsKg6DvypKoF4BYuOLIWAZVXRowHYzfJdFYkk0J2HdIraGQ=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UC5OwlwvsVmf_lXHguB6OYFw",
@@ -245,9 +343,37 @@
     "badge_kind": "official_channel_avatar"
   },
   {
+    "group": "Kep1er",
+    "badge_image_url": "https://yt3.googleusercontent.com/L7N_d5rtqKhSPS14K878wpwxTC8thABdbQHbVhTV9wEIDuTFnw_xq2T64kXtSBPxj0gzSpoV=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCoQwdDRNobhnp6_wIvsE4aw",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "KickFlip",
+    "badge_image_url": "https://yt3.googleusercontent.com/xTwAhDMn0MxN9FD08hE-UDt9zwY1lvUn99MYttLASGQJc1nvLp3eGhUUjGjtdYQoPJxJviXIVA=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCmq9jjpHA69PwAwlA0DwOsg",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "KiiiKiii",
+    "badge_image_url": "https://yt3.googleusercontent.com/ytc/AIdro_kgo5-MnM8oZR7nY16V-tDL5_A6dKIJoQqTwiqSgTbZYwwthXx2pd4s6k-o2cXayo3jJA=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCcoT6JMccOgbh0Qtw_Kb3XA",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
     "group": "KISS OF LIFE",
     "badge_image_url": "https://yt3.googleusercontent.com/UZhdOaXGbF6NKRV4TSHPyr6uiLpj5gGpd1sEqjcnmCW2zKDzo64MpbJh2wKbLoKaymRfauLA=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UCvEEeBssb4XxIfWWIB8IjMw",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "KWON EUNBI",
+    "badge_image_url": "https://yt3.googleusercontent.com/qboVN73fAVmaXT8vj-BCxT58Rc_JqzCYT4pKwbfoWb30QblZVOsZ_ScQcCtrHdpTLDZaXK4t6Q=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCoCvj_VhZPOtttlJK7RCh2A",
     "badge_source_label": "Official YouTube channel avatar",
     "badge_kind": "official_channel_avatar"
   },
@@ -262,6 +388,13 @@
     "group": "LIGHTSUM",
     "badge_image_url": "https://yt3.googleusercontent.com/7a2ALs4EWUYWKT3vhwP2CsaGzOVxYia2o-ndW6I_zhOqCSwMIfHCDPvhLiuXLH5Eh-lEMvW4Jg=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UCeQlMQ-4cedE7SNmF5JsdsA",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "Loossemble",
+    "badge_image_url": "https://yt3.googleusercontent.com/37MTPSDgyyLL8FETZajRMd6-dJNYaC47b-30raAb54YfKBLT8uAbxZkAGb8t5lpRMHeyNhBObys=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCbTzy8kj_6Kik_LFD1XyN5g",
     "badge_source_label": "Official YouTube channel avatar",
     "badge_kind": "official_channel_avatar"
   },
@@ -315,6 +448,13 @@
     "badge_kind": "official_channel_avatar"
   },
   {
+    "group": "NCT WISH",
+    "badge_image_url": "https://yt3.googleusercontent.com/84qKR6IVkVxHABf51W8u2WK_NVGZIrIPPEZwmriaLTdBce7kIv31489lHtLPpYYhkoLPnsbH=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCiZqWVAeChfqlom5ZPR3ZJA",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
     "group": "NewJeans",
     "badge_image_url": "https://yt3.googleusercontent.com/LJXS4gAz-_rkoqcgixJplCAwOLQXRNTYnGhyZQoJMZ2Uyp_akqREktZnvxbmmbES_UDp9hTT9y8=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UCMki_UkHb4qSc0qyEcOHHJw",
@@ -332,6 +472,13 @@
     "group": "NMIXX",
     "badge_image_url": "https://yt3.googleusercontent.com/UkZJRmpoFVOe3qfAT5GEB5DTNJQSVUAIkHdj5A-QtfB8kSZS8LMkYJIP8e5-gIx8D0HyhGD9mw=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UCnUAyD4t2LkvW68YrDh7fDg",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "NOMAD",
+    "badge_image_url": "https://yt3.googleusercontent.com/rsoXmClOrT6Uv9AuvXZQuSfHNUywbBUaSemFXJ_q4VS5hgie1jc6AhhyiV-EMnP7qluqPuxKfA=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCtCFxLt-bMmSnxGEbjsyg6Q",
     "badge_source_label": "Official YouTube channel avatar",
     "badge_kind": "official_channel_avatar"
   },
@@ -371,6 +518,13 @@
     "badge_kind": "official_channel_avatar"
   },
   {
+    "group": "POW",
+    "badge_image_url": "https://yt3.googleusercontent.com/UET-9siTg07_yKQqM3gipiHF1wdETu5eF2lHuCeUDnHCIe05b0sndXdCMs08GFADGSLs7zVQcvg=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCc8hWuK9dgKvB04rzZL23sQ",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
     "group": "Purple Kiss",
     "badge_image_url": "https://yt3.googleusercontent.com/AzAIT8v0YppNs7JQk4DryqX8fijJos5EVy7L9z7e9GXW1aUfoUNNNVxex4y5OECwo5BLW9iTig=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UCor8nQnEdMs4eBcU-uVBQ8g",
@@ -392,9 +546,23 @@
     "badge_kind": "official_channel_avatar"
   },
   {
+    "group": "RESCENE",
+    "badge_image_url": "https://yt3.googleusercontent.com/u04HvCKlGWkEu0XQuOdKAJOKVeVMt1PtkxI0rIfjbHUZsJhhGxXTZmPVV9ryOZK1eoCibvnR3w=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UC4jgjZ6BDua0IjI4JT7h0-A",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
     "group": "RIIZE",
     "badge_image_url": "https://yt3.googleusercontent.com/W_0y6cSRgfBNVuen8N-dlCjyUl0ty5bTSJwob0IMb9L2P-9PKhTBRDS6-_tdqlvY2mLKVHX9=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UCdVD0MsYecQaIE5Ru-pOIQQ",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "SAY MY NAME",
+    "badge_image_url": "https://yt3.googleusercontent.com/jnoOgcgRCTVSB-krPF11mSI2r7w9h_acRYAIK2ba0WA7WcQh9Iq57jtGFSgU0SG-CHTYM0MdVA=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCTItOHr70Tq_GAOACSGawPw",
     "badge_source_label": "Official YouTube channel avatar",
     "badge_kind": "official_channel_avatar"
   },
@@ -427,9 +595,37 @@
     "badge_kind": "official_channel_avatar"
   },
   {
+    "group": "TEMPEST",
+    "badge_image_url": "https://yt3.googleusercontent.com/9ye6rhhC2fS5vAXUKgifndsoCZ3PUpbEzCN9bBsOxahjZeIuN6zwCJd90yLe4r0p4rvJB3UwXA=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCCViKQ1A1tXhIVKAVEazcaA",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
     "group": "THE BOYZ",
     "badge_image_url": "https://yt3.googleusercontent.com/WZvqZ_0AtJF8BuIAU341OunWSPqZHO9JaNGC3vZaawekNBkFYLhIWXzuzMKr92IXNJ8FqfzFju0=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UCkJ1rbOrsyPfBuHNfnLPm-Q",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "The KingDom",
+    "badge_image_url": "https://yt3.googleusercontent.com/6csbcy2n_mJuh7hx-ln3Mal8vJHyRrCEnjy12rq98RmgmF5qmI_jXZACiaO2VsPOGGqBOM1VEA=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCYp2CgC9Hxj_YnliiVKlOsQ",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "TIOT",
+    "badge_image_url": "https://yt3.googleusercontent.com/yU8e1L1dHiOhTbYZymV6Q3WAHipYFVeIOYuzUycS8VR2C3iP-k-wqco40ZxYtLUBZT-unRso=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UC4AVxeN8iY5j8kzg2WE0Vng",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "TNX",
+    "badge_image_url": "https://yt3.googleusercontent.com/ytc/AIdro_myfBq5IcGJV31Us6pPPwhEwMikRVq3R3QNZ4jXC-P_Ow=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCZOA7I_vjrxLuLGatPekGoA",
     "badge_source_label": "Official YouTube channel avatar",
     "badge_kind": "official_channel_avatar"
   },
@@ -458,6 +654,13 @@
     "group": "tripleS",
     "badge_image_url": "https://yt3.googleusercontent.com/31W7xhMWM227BR_zVRAQj5OMOdEjB1edRhI2-5dmFwrzXSYXdnqYh8WMB1MoIBAqRg5DkMIoYPk=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UCJnL-TBcsYrF2SLs7tmiC8Q",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "TUNEXX",
+    "badge_image_url": "https://yt3.googleusercontent.com/Ln8aMN3UkCaEkHtMqGgFoyryv2pcdYFv7x58q5iAF477MN1H86Z-6EKlRN8dL7GDIh-I_Pzl9A=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCjyoasKZmVv1uHDIID04ivw",
     "badge_source_label": "Official YouTube channel avatar",
     "badge_kind": "official_channel_avatar"
   },
@@ -511,6 +714,20 @@
     "badge_kind": "official_channel_avatar"
   },
   {
+    "group": "WEi",
+    "badge_image_url": "https://yt3.googleusercontent.com/RGCyXjp99SpRWKeSbDFRbI9HA7cK7B28t6UG3UskIvxprJG8yWzh8BUKFXINShdCAJSY4veM=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCbTXWjND2y7zLlSKtHqiwGA",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "WHIB",
+    "badge_image_url": "https://yt3.googleusercontent.com/IoLB3V0LkVj91fXL1MZqwuZCC2iNevEkzlsZzInq34fLaUXSKJEiNYXhmv2y6tVbDkCRAaYDn7Q=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UC_isDbPZQyyQqXX-POFFPIw",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
     "group": "woo!ah!",
     "badge_image_url": "https://yt3.googleusercontent.com/EuT8DXp42k4-8G1Tv8EJ0UrbtNFnGkbrp01fuAqLVN69Jc1Ou34AfeYti8utR7oYFh7DMuLg1w=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UCNeLbWtlJzTsavMC70zY0dQ",
@@ -528,6 +745,48 @@
     "group": "xikers",
     "badge_image_url": "https://yt3.googleusercontent.com/guibzVeJuX_WUD1iyTVdOtkD8qCjMvcq1k4JsngjLgeZP086YIXZ4oDvcmojQWo0KgRY9blI=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UCPtC0MXSW40Qq7RkhsCXjUQ",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "XLOV",
+    "badge_image_url": "https://yt3.googleusercontent.com/r89AwR6X6s6R41Woe7rvSI4INfOmY6pQzwefrPGKx_GyKh20B6qknl74mIVCA94myOkPBaMm_A=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCHWhn9xw7x8NPPnV6eWQDQA",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "YENA",
+    "badge_image_url": "https://yt3.googleusercontent.com/1PO2aCez6i_TqIy1mS-h-PnvjmB46gh42Gdkj4WvGw-ZPW-irnjIGM6tNmm574COoNq398En=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCkrDEGNM3mqZXHk2MfnOjMw",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "YOUNG POSSE",
+    "badge_image_url": "https://yt3.googleusercontent.com/9ydrDmxLEzNrsx3wUo4y-qjGmggTUy5O91iwJrvp-qsXqCqstlFUujnth3RaX7m9clj0mFJbpeg=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCYvGSZPvQj09LgpcziCszyA",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "YOUNITE",
+    "badge_image_url": "https://yt3.googleusercontent.com/ytc/AIdro_lumwHjAwitSOM2pDk0cr_Nc5-Y3TfhTBUq5XAvsFS9PKk=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCtBLjxlnFpzt7Jvl_0aA7lw",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "YUJU",
+    "badge_image_url": "https://yt3.googleusercontent.com/ZFhcGw5AIVLxjPm1LJ-GdOZsIYmHFUmDAuounmhnZIP6bnlQrorXag2KP3CkS2clWY7QKooNlwE=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCt7Nlt3vXkz-NTyou5Kqp6w",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "Yves",
+    "badge_image_url": "https://yt3.googleusercontent.com/3IX22RvkkcBbMlwk4ywaXA3m6pbZt5kEVApi7vvLB31SUKTlRVoffqqqloe8Uu5uVgXvV9q3tg=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCMuK2QPg9oFJ1-veMCw3Irg",
     "badge_source_label": "Official YouTube channel avatar",
     "badge_kind": "official_channel_avatar"
   },

--- a/test_build_team_badge_assets.py
+++ b/test_build_team_badge_assets.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import unittest
+
+from build_team_badge_assets import (
+    build_badge_row,
+    build_badge_rows,
+    extract_avatar_image_url,
+    select_team_channel_url,
+)
+
+
+def stub_fetcher_factory(pages: dict[str, str]):
+    def fetcher(url: str) -> str:
+        if url not in pages:
+            raise RuntimeError(f"missing page for {url}")
+        return pages[url]
+
+    return fetcher
+
+
+class BuildTeamBadgeAssetsTest(unittest.TestCase):
+    def test_extract_avatar_image_url_prefers_og_image(self) -> None:
+        html = """
+        <html><head>
+          <meta property="og:image" content="https://yt3.googleusercontent.com/example=s900-c-k-c0x00ffffff-no-rj" />
+        </head></html>
+        """
+        self.assertEqual(
+            extract_avatar_image_url(html),
+            "https://yt3.googleusercontent.com/example=s900-c-k-c0x00ffffff-no-rj",
+        )
+
+    def test_select_team_channel_url_skips_agency_channel(self) -> None:
+        profile = {
+            "group": "Hearts2Hearts",
+            "official_youtube_url": "https://www.youtube.com/@SMTOWN",
+        }
+        allowlist_row = {
+            "primary_team_channel_url": "https://www.youtube.com/@SMTOWN",
+            "channels": [
+                {
+                    "channel_url": "https://www.youtube.com/@SMTOWN",
+                    "owner_type": "team",
+                    "display_in_team_links": True,
+                }
+            ],
+        }
+        self.assertIsNone(select_team_channel_url(profile, allowlist_row))
+
+    def test_build_badge_row_uses_channel_alias_for_source(self) -> None:
+        channel_url = "https://www.youtube.com/@ALLDAY_PROJECT"
+        fetcher = stub_fetcher_factory(
+            {
+                channel_url: """
+                <html>
+                  <head>
+                    <meta property="og:image" content="https://yt3.googleusercontent.com/allday=s900-c-k-c0x00ffffff-no-rj" />
+                  </head>
+                  <body>
+                    "channelId":"UCg8ZzloDPTrOiGztK0C9txQ"
+                    "canonicalBaseUrl":"/@ALLDAY_PROJECT"
+                  </body>
+                </html>
+                """
+            }
+        )
+        row = build_badge_row("ALLDAY PROJECT", channel_url, fetcher)
+        self.assertIsNotNone(row)
+        self.assertEqual(
+            row["badge_source_url"],
+            "https://www.youtube.com/channel/UCg8ZzloDPTrOiGztK0C9txQ",
+        )
+
+    def test_build_badge_rows_adds_missing_team_owned_badges(self) -> None:
+        profiles = [
+            {
+                "group": "ALLDAY PROJECT",
+                "official_youtube_url": "https://www.youtube.com/@ALLDAY_PROJECT",
+            },
+            {
+                "group": "Hearts2Hearts",
+                "official_youtube_url": "https://www.youtube.com/@SMTOWN",
+            },
+        ]
+        existing_rows = [
+            {
+                "group": "BTS",
+                "badge_image_url": "https://yt3.googleusercontent.com/bts=s900-c-k-c0x00ffffff-no-rj",
+                "badge_source_url": "https://www.youtube.com/channel/UC1",
+                "badge_source_label": "Official YouTube channel avatar",
+                "badge_kind": "official_channel_avatar",
+            }
+        ]
+        allowlists_by_group = {
+            "ALLDAY PROJECT": {
+                "primary_team_channel_url": "https://www.youtube.com/@ALLDAY_PROJECT",
+                "channels": [
+                    {
+                        "channel_url": "https://www.youtube.com/@ALLDAY_PROJECT",
+                        "owner_type": "team",
+                        "display_in_team_links": True,
+                    }
+                ],
+            },
+            "Hearts2Hearts": {
+                "primary_team_channel_url": "https://www.youtube.com/@SMTOWN",
+                "channels": [
+                    {
+                        "channel_url": "https://www.youtube.com/@SMTOWN",
+                        "owner_type": "team",
+                        "display_in_team_links": True,
+                    }
+                ],
+            },
+        }
+        fetcher = stub_fetcher_factory(
+            {
+                "https://www.youtube.com/@ALLDAY_PROJECT": """
+                <html>
+                  <head>
+                    <meta property="og:image" content="https://yt3.googleusercontent.com/allday=s900-c-k-c0x00ffffff-no-rj" />
+                  </head>
+                  <body>"channelId":"UCg8ZzloDPTrOiGztK0C9txQ"</body>
+                </html>
+                """
+            }
+        )
+
+        rows, summary = build_badge_rows(profiles, existing_rows, allowlists_by_group, fetcher)
+
+        groups = {row["group"] for row in rows}
+        self.assertIn("ALLDAY PROJECT", groups)
+        self.assertNotIn("Hearts2Hearts", {row["group"] for row in rows if row["group"] != "BTS" and row["group"] != "ALLDAY PROJECT"})
+        self.assertEqual(summary["added"], 1)
+        self.assertEqual(summary["skipped_agency_only"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4812,7 +4812,7 @@ function TeamIdentity({
   group: string
   variant: 'chip' | 'list'
 }) {
-  const badgeImageUrl = getTeamBadgeImageUrl(group)
+  const identityImageUrl = getTeamBadgeImageUrl(group) ?? getTeamRepresentativeImageUrl(group)
   const badgeStyle = getTeamBadgeStyle(group)
   const displayName = getTeamDisplayName(group)
   const label = variant === 'chip' ? getCompactTeamLabel(displayName) : displayName
@@ -4824,8 +4824,8 @@ function TeamIdentity({
       aria-label={displayName}
     >
       <span className="team-badge" style={badgeStyle} aria-hidden="true">
-        {badgeImageUrl ? (
-          <img className="team-badge-image" src={badgeImageUrl} alt="" />
+        {identityImageUrl ? (
+          <img className="team-badge-image" src={identityImageUrl} alt="" />
         ) : (
           <span className="team-badge-fallback">{getTeamMonogram(group)}</span>
         )}
@@ -10818,6 +10818,10 @@ function getTeamMonogram(group: string) {
 
 function getTeamBadgeImageUrl(group: string) {
   return teamBadgeAssetByGroup.get(group)?.badge_image_url ?? null
+}
+
+function getTeamRepresentativeImageUrl(group: string) {
+  return artistProfileByGroup.get(group)?.representative_image_url ?? null
 }
 
 function getTeamBadgeSourceUrl(group: string) {

--- a/web/src/data/teamBadgeAssets.json
+++ b/web/src/data/teamBadgeAssets.json
@@ -42,9 +42,30 @@
     "badge_kind": "official_channel_avatar"
   },
   {
+    "group": "ALL(H)OURS",
+    "badge_image_url": "https://yt3.googleusercontent.com/fWu6-87NDvXhuElT88HXeQYUL_npxgNwkt3ON0a8wJ6WyYcg5Bk3gF3Z2seljYY7dubQFntZ=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UC1buRciG8QIL9kRtHxI_tpw",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "ALLDAY PROJECT",
+    "badge_image_url": "https://yt3.googleusercontent.com/KlKnNaef1rJVk4GVe1wlz6ISIEvDn0iuJcsfX8IJ7KcCOLqEPiXQy9RDUgikzWPgYdwisInuxw=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCg8ZzloDPTrOiGztK0C9txQ",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
     "group": "AMPERS&ONE",
     "badge_image_url": "https://yt3.googleusercontent.com/Cld-X1XWG6BlhzwN7ZejO4rKQZChyNKY8hpDjc95sneeFlf8zH9yCm3sTCjtiBfsc2FywqnLzw=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UCH9IB4tD3U2TSjT3ZLICXTA",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "ARTMS",
+    "badge_image_url": "https://yt3.googleusercontent.com/plDKMY8MHWfkhnks3OVY9fQ9qWHXsi3bQACUHkJaQdGhqlIYME_nrxKLrfB20WqDgUnBPxer=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UChXC6ok0LaZIpf-50SIFf0Q",
     "badge_source_label": "Official YouTube channel avatar",
     "badge_kind": "official_channel_avatar"
   },
@@ -59,6 +80,13 @@
     "group": "ATEEZ",
     "badge_image_url": "https://yt3.googleusercontent.com/8ezdlFHvBROs5xd-scO3nP9j6LmmZnPYlKzuD7SFkpwDV1gKG8u-_3uIliiT8RzNzZ0u9DvR85I=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UC2e4Ukj5Pfr7cb3KpJAFBdQ",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "AtHeart",
+    "badge_image_url": "https://yt3.googleusercontent.com/U8nrIoUFiKRS-EQYrppTpTLFdL2S0WyMpub7aKe-439AXwzFhW9Wmc-AteZvYxMXt_ELOrLYZw=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCgSDdHK0MNXOHv7oBC2dHXA",
     "badge_source_label": "Official YouTube channel avatar",
     "badge_kind": "official_channel_avatar"
   },
@@ -91,6 +119,13 @@
     "badge_kind": "official_channel_avatar"
   },
   {
+    "group": "BLITZERS",
+    "badge_image_url": "https://yt3.googleusercontent.com/ytc/AIdro_kdpfzk45qlzBLA4bASJH1u5lC3WPw2GBSwXzCscEg=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCfwfC9QCYr_wxgib5dAB-mQ",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
     "group": "BOYNEXTDOOR",
     "badge_image_url": "https://yt3.googleusercontent.com/QhBJg2Djg9obHEAmP7-_BceJFY4KG0iaYWfuDGhjiURG-5CdhS_0npiZpCWvyN3Pfj9DkO8MSw=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UChhKBlh_wvspTh5n4mL0b5g",
@@ -112,6 +147,20 @@
     "badge_kind": "official_channel_avatar"
   },
   {
+    "group": "CHUNG HA",
+    "badge_image_url": "https://yt3.googleusercontent.com/zBjTczBXQiYIZwYEC8h6qrF04uMlGtCD7yUn8kfViFOlAoIKhu7ai2dh8op6_aFqr8NKrmUB=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UC9Gxb0gMCh3EPIDLQXeQUog",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "CHUU",
+    "badge_image_url": "https://yt3.googleusercontent.com/kemVwXcfboHXyLKPnpUaNoyFummTChwAGmes8Q8ZY2wGPfwZAaA1SAy85bXtKE2MEF02-hRQYIM=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCa0ylH-c4-MHZ7ih_6AHtXg",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
     "group": "cignature",
     "badge_image_url": "https://yt3.googleusercontent.com/30LF8En041JD6CCoCC9Lq-1lz3VdkCetMNwxkXuzRkTPpVEHJ2nycy-MHps8Vo0dygGYedqa=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UCaRdmTJgO6w0esJPZUOzXrw",
@@ -129,6 +178,13 @@
     "group": "CLASS:y",
     "badge_image_url": "https://yt3.googleusercontent.com/eN-lkd7e-dcCBiO790LI_w1qPY38HnkdDK61dr9Jg6eNHE9x6gri-wPHbOmw5FqxFoRBhwoKsA=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UCbCyYn2M_1ccicwj-KU7t0Q",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "CLOSE YOUR EYES",
+    "badge_image_url": "https://yt3.googleusercontent.com/zzquYCzqk4qB_XfGx3bw2aR-r-McxAOIP1cuMh0sXIcb9SmVYUjXdiStdEr89OHCEFcGO4fMXg=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCPo532dDHpbKVhJyJseLVbw",
     "badge_source_label": "Official YouTube channel avatar",
     "badge_kind": "official_channel_avatar"
   },
@@ -161,6 +217,20 @@
     "badge_kind": "official_channel_avatar"
   },
   {
+    "group": "DRIPPIN",
+    "badge_image_url": "https://yt3.googleusercontent.com/Q95lrIm35iyloY37gLqn-wafIrECa9W0k_JUlSjj9Qna1ETXBkfEieXZtiMgvU-bSooaNLW1hg=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCNf1JFLCOec-SUhREgZaR6w",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "DXMON",
+    "badge_image_url": "https://yt3.googleusercontent.com/EmC7yf0coePAVKbfDmfxpuuIVidnJ-rXuCi5SHHj36gfggLXGHNfpuAMyyduSDcIWmECu0hJxA=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCrhNp7bqMHOjVfMcyjk_J9Q",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
     "group": "ENHYPEN",
     "badge_image_url": "https://yt3.googleusercontent.com/gKp9WExdyzEEBpHM7WgVEgIhl7-yVhIAzOe1U5jJEYSYi17AbvUXyW4dGRk2KykXeCsgUhqD4A=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UCArLZtok93cO5R9RI4_Y5Jw",
@@ -171,6 +241,13 @@
     "group": "EPEX",
     "badge_image_url": "https://yt3.googleusercontent.com/i8q4Jrq13aFin04gXOZDgXI6bdPllOak0bG1xzlC52QKBBaTAe9njUayZ6-1oEHOHA6qxaPpJw=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UCKHl-9B-aa4AK5ZR9XLOg8A",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "EVNNE",
+    "badge_image_url": "https://yt3.googleusercontent.com/bccCK7GoZnIJW2j7KdSEuJSzKWqjOwLCtxowxOG2UcLDUYL8FjWosJxmIP6cpq3Ks8X95__FwDY=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCAWT2IC2TrPFNPCvkKZUFjg",
     "badge_source_label": "Official YouTube channel avatar",
     "badge_kind": "official_channel_avatar"
   },
@@ -210,6 +287,13 @@
     "badge_kind": "official_channel_avatar"
   },
   {
+    "group": "ifeye",
+    "badge_image_url": "https://yt3.googleusercontent.com/kgwXABXfEJjR2Ui8bCMFOezihv-YVOen4jYi7sXKXfnm-CvYW4FgZUUkhkz78jQWM4ZwC3JEDg=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCQ5K9InArSCtJoiUOlqu27g",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
     "group": "INFINITE",
     "badge_image_url": "https://yt3.googleusercontent.com/LJoGTgVSlHOmc9gC1qULrAGl0q0YYBv2UD77ck2g4M_dS7_RSS4oW_T9dL9C59oHrk2PnhA_Fw=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UCdzXSux7OnRD1Cml-DQ416Q",
@@ -238,6 +322,20 @@
     "badge_kind": "official_channel_avatar"
   },
   {
+    "group": "JEON SOMI",
+    "badge_image_url": "https://yt3.googleusercontent.com/pAAg3_IMU45qWBSxDrupSsQaq19-4gfERWEM6eqlbpOKoYLFUBRPZj8iM_RTw1zYkQ0TVfjagg=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCjDH1Pld9zc8pTYjbv5eM-Q",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "JUST B",
+    "badge_image_url": "https://yt3.googleusercontent.com/NxqWHzDwAylOLgm1Sc3cEyP3773hU9ONvUZofAl0uMAu9REssh0HbtzYwfhrD6IR22g6WvtA7Q=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCcpodGf_wkyawcTc-fXa82g",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
     "group": "KARD",
     "badge_image_url": "https://yt3.googleusercontent.com/nAeia3ldQiBtEhYxEQAb7Y84TyYFsKg6DvypKoF4BYuOLIWAZVXRowHYzfJdFYkk0J2HdIraGQ=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UC5OwlwvsVmf_lXHguB6OYFw",
@@ -245,9 +343,37 @@
     "badge_kind": "official_channel_avatar"
   },
   {
+    "group": "Kep1er",
+    "badge_image_url": "https://yt3.googleusercontent.com/L7N_d5rtqKhSPS14K878wpwxTC8thABdbQHbVhTV9wEIDuTFnw_xq2T64kXtSBPxj0gzSpoV=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCoQwdDRNobhnp6_wIvsE4aw",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "KickFlip",
+    "badge_image_url": "https://yt3.googleusercontent.com/xTwAhDMn0MxN9FD08hE-UDt9zwY1lvUn99MYttLASGQJc1nvLp3eGhUUjGjtdYQoPJxJviXIVA=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCmq9jjpHA69PwAwlA0DwOsg",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "KiiiKiii",
+    "badge_image_url": "https://yt3.googleusercontent.com/ytc/AIdro_kgo5-MnM8oZR7nY16V-tDL5_A6dKIJoQqTwiqSgTbZYwwthXx2pd4s6k-o2cXayo3jJA=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCcoT6JMccOgbh0Qtw_Kb3XA",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
     "group": "KISS OF LIFE",
     "badge_image_url": "https://yt3.googleusercontent.com/UZhdOaXGbF6NKRV4TSHPyr6uiLpj5gGpd1sEqjcnmCW2zKDzo64MpbJh2wKbLoKaymRfauLA=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UCvEEeBssb4XxIfWWIB8IjMw",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "KWON EUNBI",
+    "badge_image_url": "https://yt3.googleusercontent.com/qboVN73fAVmaXT8vj-BCxT58Rc_JqzCYT4pKwbfoWb30QblZVOsZ_ScQcCtrHdpTLDZaXK4t6Q=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCoCvj_VhZPOtttlJK7RCh2A",
     "badge_source_label": "Official YouTube channel avatar",
     "badge_kind": "official_channel_avatar"
   },
@@ -262,6 +388,13 @@
     "group": "LIGHTSUM",
     "badge_image_url": "https://yt3.googleusercontent.com/7a2ALs4EWUYWKT3vhwP2CsaGzOVxYia2o-ndW6I_zhOqCSwMIfHCDPvhLiuXLH5Eh-lEMvW4Jg=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UCeQlMQ-4cedE7SNmF5JsdsA",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "Loossemble",
+    "badge_image_url": "https://yt3.googleusercontent.com/37MTPSDgyyLL8FETZajRMd6-dJNYaC47b-30raAb54YfKBLT8uAbxZkAGb8t5lpRMHeyNhBObys=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCbTzy8kj_6Kik_LFD1XyN5g",
     "badge_source_label": "Official YouTube channel avatar",
     "badge_kind": "official_channel_avatar"
   },
@@ -315,6 +448,13 @@
     "badge_kind": "official_channel_avatar"
   },
   {
+    "group": "NCT WISH",
+    "badge_image_url": "https://yt3.googleusercontent.com/84qKR6IVkVxHABf51W8u2WK_NVGZIrIPPEZwmriaLTdBce7kIv31489lHtLPpYYhkoLPnsbH=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCiZqWVAeChfqlom5ZPR3ZJA",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
     "group": "NewJeans",
     "badge_image_url": "https://yt3.googleusercontent.com/LJXS4gAz-_rkoqcgixJplCAwOLQXRNTYnGhyZQoJMZ2Uyp_akqREktZnvxbmmbES_UDp9hTT9y8=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UCMki_UkHb4qSc0qyEcOHHJw",
@@ -332,6 +472,13 @@
     "group": "NMIXX",
     "badge_image_url": "https://yt3.googleusercontent.com/UkZJRmpoFVOe3qfAT5GEB5DTNJQSVUAIkHdj5A-QtfB8kSZS8LMkYJIP8e5-gIx8D0HyhGD9mw=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UCnUAyD4t2LkvW68YrDh7fDg",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "NOMAD",
+    "badge_image_url": "https://yt3.googleusercontent.com/rsoXmClOrT6Uv9AuvXZQuSfHNUywbBUaSemFXJ_q4VS5hgie1jc6AhhyiV-EMnP7qluqPuxKfA=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCtCFxLt-bMmSnxGEbjsyg6Q",
     "badge_source_label": "Official YouTube channel avatar",
     "badge_kind": "official_channel_avatar"
   },
@@ -371,6 +518,13 @@
     "badge_kind": "official_channel_avatar"
   },
   {
+    "group": "POW",
+    "badge_image_url": "https://yt3.googleusercontent.com/UET-9siTg07_yKQqM3gipiHF1wdETu5eF2lHuCeUDnHCIe05b0sndXdCMs08GFADGSLs7zVQcvg=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCc8hWuK9dgKvB04rzZL23sQ",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
     "group": "Purple Kiss",
     "badge_image_url": "https://yt3.googleusercontent.com/AzAIT8v0YppNs7JQk4DryqX8fijJos5EVy7L9z7e9GXW1aUfoUNNNVxex4y5OECwo5BLW9iTig=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UCor8nQnEdMs4eBcU-uVBQ8g",
@@ -392,9 +546,23 @@
     "badge_kind": "official_channel_avatar"
   },
   {
+    "group": "RESCENE",
+    "badge_image_url": "https://yt3.googleusercontent.com/u04HvCKlGWkEu0XQuOdKAJOKVeVMt1PtkxI0rIfjbHUZsJhhGxXTZmPVV9ryOZK1eoCibvnR3w=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UC4jgjZ6BDua0IjI4JT7h0-A",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
     "group": "RIIZE",
     "badge_image_url": "https://yt3.googleusercontent.com/W_0y6cSRgfBNVuen8N-dlCjyUl0ty5bTSJwob0IMb9L2P-9PKhTBRDS6-_tdqlvY2mLKVHX9=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UCdVD0MsYecQaIE5Ru-pOIQQ",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "SAY MY NAME",
+    "badge_image_url": "https://yt3.googleusercontent.com/jnoOgcgRCTVSB-krPF11mSI2r7w9h_acRYAIK2ba0WA7WcQh9Iq57jtGFSgU0SG-CHTYM0MdVA=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCTItOHr70Tq_GAOACSGawPw",
     "badge_source_label": "Official YouTube channel avatar",
     "badge_kind": "official_channel_avatar"
   },
@@ -427,9 +595,37 @@
     "badge_kind": "official_channel_avatar"
   },
   {
+    "group": "TEMPEST",
+    "badge_image_url": "https://yt3.googleusercontent.com/9ye6rhhC2fS5vAXUKgifndsoCZ3PUpbEzCN9bBsOxahjZeIuN6zwCJd90yLe4r0p4rvJB3UwXA=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCCViKQ1A1tXhIVKAVEazcaA",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
     "group": "THE BOYZ",
     "badge_image_url": "https://yt3.googleusercontent.com/WZvqZ_0AtJF8BuIAU341OunWSPqZHO9JaNGC3vZaawekNBkFYLhIWXzuzMKr92IXNJ8FqfzFju0=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UCkJ1rbOrsyPfBuHNfnLPm-Q",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "The KingDom",
+    "badge_image_url": "https://yt3.googleusercontent.com/6csbcy2n_mJuh7hx-ln3Mal8vJHyRrCEnjy12rq98RmgmF5qmI_jXZACiaO2VsPOGGqBOM1VEA=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCYp2CgC9Hxj_YnliiVKlOsQ",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "TIOT",
+    "badge_image_url": "https://yt3.googleusercontent.com/yU8e1L1dHiOhTbYZymV6Q3WAHipYFVeIOYuzUycS8VR2C3iP-k-wqco40ZxYtLUBZT-unRso=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UC4AVxeN8iY5j8kzg2WE0Vng",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "TNX",
+    "badge_image_url": "https://yt3.googleusercontent.com/ytc/AIdro_myfBq5IcGJV31Us6pPPwhEwMikRVq3R3QNZ4jXC-P_Ow=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCZOA7I_vjrxLuLGatPekGoA",
     "badge_source_label": "Official YouTube channel avatar",
     "badge_kind": "official_channel_avatar"
   },
@@ -458,6 +654,13 @@
     "group": "tripleS",
     "badge_image_url": "https://yt3.googleusercontent.com/31W7xhMWM227BR_zVRAQj5OMOdEjB1edRhI2-5dmFwrzXSYXdnqYh8WMB1MoIBAqRg5DkMIoYPk=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UCJnL-TBcsYrF2SLs7tmiC8Q",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "TUNEXX",
+    "badge_image_url": "https://yt3.googleusercontent.com/Ln8aMN3UkCaEkHtMqGgFoyryv2pcdYFv7x58q5iAF477MN1H86Z-6EKlRN8dL7GDIh-I_Pzl9A=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCjyoasKZmVv1uHDIID04ivw",
     "badge_source_label": "Official YouTube channel avatar",
     "badge_kind": "official_channel_avatar"
   },
@@ -511,6 +714,20 @@
     "badge_kind": "official_channel_avatar"
   },
   {
+    "group": "WEi",
+    "badge_image_url": "https://yt3.googleusercontent.com/RGCyXjp99SpRWKeSbDFRbI9HA7cK7B28t6UG3UskIvxprJG8yWzh8BUKFXINShdCAJSY4veM=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCbTXWjND2y7zLlSKtHqiwGA",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "WHIB",
+    "badge_image_url": "https://yt3.googleusercontent.com/IoLB3V0LkVj91fXL1MZqwuZCC2iNevEkzlsZzInq34fLaUXSKJEiNYXhmv2y6tVbDkCRAaYDn7Q=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UC_isDbPZQyyQqXX-POFFPIw",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
     "group": "woo!ah!",
     "badge_image_url": "https://yt3.googleusercontent.com/EuT8DXp42k4-8G1Tv8EJ0UrbtNFnGkbrp01fuAqLVN69Jc1Ou34AfeYti8utR7oYFh7DMuLg1w=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UCNeLbWtlJzTsavMC70zY0dQ",
@@ -528,6 +745,48 @@
     "group": "xikers",
     "badge_image_url": "https://yt3.googleusercontent.com/guibzVeJuX_WUD1iyTVdOtkD8qCjMvcq1k4JsngjLgeZP086YIXZ4oDvcmojQWo0KgRY9blI=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UCPtC0MXSW40Qq7RkhsCXjUQ",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "XLOV",
+    "badge_image_url": "https://yt3.googleusercontent.com/r89AwR6X6s6R41Woe7rvSI4INfOmY6pQzwefrPGKx_GyKh20B6qknl74mIVCA94myOkPBaMm_A=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCHWhn9xw7x8NPPnV6eWQDQA",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "YENA",
+    "badge_image_url": "https://yt3.googleusercontent.com/1PO2aCez6i_TqIy1mS-h-PnvjmB46gh42Gdkj4WvGw-ZPW-irnjIGM6tNmm574COoNq398En=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCkrDEGNM3mqZXHk2MfnOjMw",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "YOUNG POSSE",
+    "badge_image_url": "https://yt3.googleusercontent.com/9ydrDmxLEzNrsx3wUo4y-qjGmggTUy5O91iwJrvp-qsXqCqstlFUujnth3RaX7m9clj0mFJbpeg=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCYvGSZPvQj09LgpcziCszyA",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "YOUNITE",
+    "badge_image_url": "https://yt3.googleusercontent.com/ytc/AIdro_lumwHjAwitSOM2pDk0cr_Nc5-Y3TfhTBUq5XAvsFS9PKk=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCtBLjxlnFpzt7Jvl_0aA7lw",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "YUJU",
+    "badge_image_url": "https://yt3.googleusercontent.com/ZFhcGw5AIVLxjPm1LJ-GdOZsIYmHFUmDAuounmhnZIP6bnlQrorXag2KP3CkS2clWY7QKooNlwE=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCt7Nlt3vXkz-NTyou5Kqp6w",
+    "badge_source_label": "Official YouTube channel avatar",
+    "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "Yves",
+    "badge_image_url": "https://yt3.googleusercontent.com/3IX22RvkkcBbMlwk4ywaXA3m6pbZt5kEVApi7vvLB31SUKTlRVoffqqqloe8Uu5uVgXvV9q3tg=s900-c-k-c0x00ffffff-no-rj",
+    "badge_source_url": "https://www.youtube.com/channel/UCMuK2QPg9oFJ1-veMCw3Irg",
     "badge_source_label": "Official YouTube channel avatar",
     "badge_kind": "official_channel_avatar"
   },


### PR DESCRIPTION
## Summary
- add a team badge asset backfill script that pulls official YouTube avatars for team-owned channels
- mirror regenerated badge assets into the root seed, backend export, and web dataset
- make web TeamIdentity fall back to representative images before monogram badges

Closes #735
