### PR TITLE
Fill remaining team badge assets

### DIFF
--- a/backend/exports/non_runtime_web_snapshots/teamBadgeAssets.json
+++ b/backend/exports/non_runtime_web_snapshots/teamBadgeAssets.json
@@ -196,6 +196,13 @@
     "badge_kind": "official_channel_avatar"
   },
   {
+    "group": "CSR",
+    "badge_image_url": "https://scontent-icn2-1.cdninstagram.com/v/t51.2885-19/446555786_857741539533419_3107289545524488844_n.jpg?stp=dst-jpg_s100x100_tt6&_nc_cat=108&ccb=7-5&_nc_sid=bf7eb4&efg=eyJ2ZW5jb2RlX3RhZyI6InByb2ZpbGVfcGljLnd3dy4xMDgwLkMzIn0%3D&_nc_ohc=Y_TJmKpFr0wQ7kNvwFYWyxC&_nc_oc=AdkP4EvfVMx_bIxy1tsZ7G1llos2vitq07Y2XnPbzUK_h0RdXda2pGHrpx6NDlxYN7A&_nc_zt=24&_nc_ht=scontent-icn2-1.cdninstagram.com&_nc_ss=8&oh=00_AfzjfXFZxHQcuj_BxSz6lFIC0JChRrs7NYblYt4CjmmJGg&oe=69B94F05",
+    "badge_source_url": "https://www.instagram.com/csr.offcl",
+    "badge_source_label": "Official Instagram profile image",
+    "badge_kind": "official_social_avatar"
+  },
+  {
     "group": "DAY6",
     "badge_image_url": "https://yt3.googleusercontent.com/V1pNQjnS31WUTRZUMKaiJwajsN68Bie_SAiAepR4h5HHNk9Sw91uJm6ubXYS6OC5nZd5rDBt1dE=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UCp-pqXsizklX3ZHvLxXyhxw",
@@ -285,6 +292,13 @@
     "badge_source_url": "https://www.youtube.com/channel/UC-6L6QIx3M6O_ROf7CP-pJg",
     "badge_source_label": "Official YouTube channel avatar",
     "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "Hearts2Hearts",
+    "badge_image_url": "https://scontent-icn2-1.cdninstagram.com/v/t51.82787-19/629373161_17896862172396895_3942247668013275531_n.jpg?stp=dst-jpg_s100x100_tt6&_nc_cat=1&ccb=7-5&_nc_sid=bf7eb4&efg=eyJ2ZW5jb2RlX3RhZyI6InByb2ZpbGVfcGljLnd3dy4xMDgwLkMzIn0%3D&_nc_ohc=N0nXidYKtHgQ7kNvwGO5ymP&_nc_oc=Adm7aWwOJ02DJqXKetCQpkCQE5cHdFNsB89LlxWQZz3Y8ib0sYjsCdW8CUDr1Jxwc7A&_nc_zt=24&_nc_ht=scontent-icn2-1.cdninstagram.com&_nc_gid=fjBosh43P2XgBrurcMvbyQ&_nc_ss=8&oh=00_Afyyo-n60QWf8fUGGjOSUeqDfkOdjOw5N-tE3jX2gfr5Ig&oe=69B96137",
+    "badge_source_url": "https://www.instagram.com/hearts2hearts",
+    "badge_source_label": "Official Instagram profile image",
+    "badge_kind": "official_social_avatar"
   },
   {
     "group": "ifeye",
@@ -726,6 +740,13 @@
     "badge_source_url": "https://www.youtube.com/channel/UC_isDbPZQyyQqXX-POFFPIw",
     "badge_source_label": "Official YouTube channel avatar",
     "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "WJSN",
+    "badge_image_url": "https://scontent-icn2-1.cdninstagram.com/v/t51.2885-19/429482687_734946172132167_7267530967471263956_n.jpg?stp=dst-jpg_s100x100_tt6&_nc_cat=103&ccb=7-5&_nc_sid=bf7eb4&efg=eyJ2ZW5jb2RlX3RhZyI6InByb2ZpbGVfcGljLnd3dy43NTAuQzMifQ%3D%3D&_nc_ohc=SQ1x8ZFzDqwQ7kNvwEMgkpr&_nc_oc=AdnZ3Bkn7EEWsjGxzpB5bHEsu2OKcAZsUrM8d3swBMb_uZVRgInOvJBV19Ru37WK0NQ&_nc_zt=24&_nc_ht=scontent-icn2-1.cdninstagram.com&_nc_ss=8&oh=00_AfwtInL4U0Yi3jvEWefCDwmZVVm6opGE3XKeInLPZ8wgEA&oe=69B96E49",
+    "badge_source_url": "https://www.instagram.com/wjsn_cosmic",
+    "badge_source_label": "Official Instagram profile image",
+    "badge_kind": "official_social_avatar"
   },
   {
     "group": "woo!ah!",

--- a/build_team_badge_assets.py
+++ b/build_team_badge_assets.py
@@ -118,6 +118,31 @@ def build_badge_row(group: str, channel_url: str, fetcher: FetchText) -> dict[st
     }
 
 
+def build_social_badge_row(
+    group: str,
+    source_url: str,
+    source_label: str,
+    badge_kind: str,
+    fetcher: FetchText,
+) -> dict[str, str] | None:
+    try:
+        page_html = fetcher(source_url)
+    except Exception:  # noqa: BLE001
+        return None
+
+    badge_image_url = extract_avatar_image_url(page_html)
+    if not badge_image_url:
+        return None
+
+    return {
+        "group": group,
+        "badge_image_url": badge_image_url,
+        "badge_source_url": source_url,
+        "badge_source_label": source_label,
+        "badge_kind": badge_kind,
+    }
+
+
 def build_badge_rows(
     profiles: list[dict[str, Any]],
     existing_rows: list[dict[str, Any]],
@@ -139,13 +164,22 @@ def build_badge_rows(
             continue
 
         channel_url = select_team_channel_url(profile, allowlists_by_group.get(group))
-        if not channel_url:
-            summary["skipped_agency_only"] += 1
-            continue
-
-        badge_row = build_badge_row(group, channel_url, fetcher)
+        badge_row = build_badge_row(group, channel_url, fetcher) if channel_url else None
         if not badge_row:
-            summary["skipped_fetch_failed"] += 1
+            official_instagram_url = profile.get("official_instagram_url")
+            if official_instagram_url:
+                badge_row = build_social_badge_row(
+                    group,
+                    official_instagram_url,
+                    "Official Instagram profile image",
+                    "official_social_avatar",
+                    fetcher,
+                )
+        if not badge_row:
+            if channel_url:
+                summary["skipped_fetch_failed"] += 1
+            else:
+                summary["skipped_agency_only"] += 1
             continue
 
         rows_by_group[group] = badge_row

--- a/team_badge_assets.json
+++ b/team_badge_assets.json
@@ -196,6 +196,13 @@
     "badge_kind": "official_channel_avatar"
   },
   {
+    "group": "CSR",
+    "badge_image_url": "https://scontent-icn2-1.cdninstagram.com/v/t51.2885-19/446555786_857741539533419_3107289545524488844_n.jpg?stp=dst-jpg_s100x100_tt6&_nc_cat=108&ccb=7-5&_nc_sid=bf7eb4&efg=eyJ2ZW5jb2RlX3RhZyI6InByb2ZpbGVfcGljLnd3dy4xMDgwLkMzIn0%3D&_nc_ohc=Y_TJmKpFr0wQ7kNvwFYWyxC&_nc_oc=AdkP4EvfVMx_bIxy1tsZ7G1llos2vitq07Y2XnPbzUK_h0RdXda2pGHrpx6NDlxYN7A&_nc_zt=24&_nc_ht=scontent-icn2-1.cdninstagram.com&_nc_ss=8&oh=00_AfzjfXFZxHQcuj_BxSz6lFIC0JChRrs7NYblYt4CjmmJGg&oe=69B94F05",
+    "badge_source_url": "https://www.instagram.com/csr.offcl",
+    "badge_source_label": "Official Instagram profile image",
+    "badge_kind": "official_social_avatar"
+  },
+  {
     "group": "DAY6",
     "badge_image_url": "https://yt3.googleusercontent.com/V1pNQjnS31WUTRZUMKaiJwajsN68Bie_SAiAepR4h5HHNk9Sw91uJm6ubXYS6OC5nZd5rDBt1dE=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UCp-pqXsizklX3ZHvLxXyhxw",
@@ -285,6 +292,13 @@
     "badge_source_url": "https://www.youtube.com/channel/UC-6L6QIx3M6O_ROf7CP-pJg",
     "badge_source_label": "Official YouTube channel avatar",
     "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "Hearts2Hearts",
+    "badge_image_url": "https://scontent-icn2-1.cdninstagram.com/v/t51.82787-19/629373161_17896862172396895_3942247668013275531_n.jpg?stp=dst-jpg_s100x100_tt6&_nc_cat=1&ccb=7-5&_nc_sid=bf7eb4&efg=eyJ2ZW5jb2RlX3RhZyI6InByb2ZpbGVfcGljLnd3dy4xMDgwLkMzIn0%3D&_nc_ohc=N0nXidYKtHgQ7kNvwGO5ymP&_nc_oc=Adm7aWwOJ02DJqXKetCQpkCQE5cHdFNsB89LlxWQZz3Y8ib0sYjsCdW8CUDr1Jxwc7A&_nc_zt=24&_nc_ht=scontent-icn2-1.cdninstagram.com&_nc_gid=fjBosh43P2XgBrurcMvbyQ&_nc_ss=8&oh=00_Afyyo-n60QWf8fUGGjOSUeqDfkOdjOw5N-tE3jX2gfr5Ig&oe=69B96137",
+    "badge_source_url": "https://www.instagram.com/hearts2hearts",
+    "badge_source_label": "Official Instagram profile image",
+    "badge_kind": "official_social_avatar"
   },
   {
     "group": "ifeye",
@@ -726,6 +740,13 @@
     "badge_source_url": "https://www.youtube.com/channel/UC_isDbPZQyyQqXX-POFFPIw",
     "badge_source_label": "Official YouTube channel avatar",
     "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "WJSN",
+    "badge_image_url": "https://scontent-icn2-1.cdninstagram.com/v/t51.2885-19/429482687_734946172132167_7267530967471263956_n.jpg?stp=dst-jpg_s100x100_tt6&_nc_cat=103&ccb=7-5&_nc_sid=bf7eb4&efg=eyJ2ZW5jb2RlX3RhZyI6InByb2ZpbGVfcGljLnd3dy43NTAuQzMifQ%3D%3D&_nc_ohc=SQ1x8ZFzDqwQ7kNvwEMgkpr&_nc_oc=AdnZ3Bkn7EEWsjGxzpB5bHEsu2OKcAZsUrM8d3swBMb_uZVRgInOvJBV19Ru37WK0NQ&_nc_zt=24&_nc_ht=scontent-icn2-1.cdninstagram.com&_nc_ss=8&oh=00_AfwtInL4U0Yi3jvEWefCDwmZVVm6opGE3XKeInLPZ8wgEA&oe=69B96E49",
+    "badge_source_url": "https://www.instagram.com/wjsn_cosmic",
+    "badge_source_label": "Official Instagram profile image",
+    "badge_kind": "official_social_avatar"
   },
   {
     "group": "woo!ah!",

--- a/test_build_team_badge_assets.py
+++ b/test_build_team_badge_assets.py
@@ -81,6 +81,7 @@ class BuildTeamBadgeAssetsTest(unittest.TestCase):
             {
                 "group": "Hearts2Hearts",
                 "official_youtube_url": "https://www.youtube.com/@SMTOWN",
+                "official_instagram_url": "https://www.instagram.com/hearts2hearts",
             },
         ]
         existing_rows = [
@@ -123,7 +124,14 @@ class BuildTeamBadgeAssetsTest(unittest.TestCase):
                   </head>
                   <body>"channelId":"UCg8ZzloDPTrOiGztK0C9txQ"</body>
                 </html>
-                """
+                """,
+                "https://www.instagram.com/hearts2hearts": """
+                <html>
+                  <head>
+                    <meta property="og:image" content="https://scontent.example/hearts2hearts.jpg" />
+                  </head>
+                </html>
+                """,
             }
         )
 
@@ -131,9 +139,11 @@ class BuildTeamBadgeAssetsTest(unittest.TestCase):
 
         groups = {row["group"] for row in rows}
         self.assertIn("ALLDAY PROJECT", groups)
-        self.assertNotIn("Hearts2Hearts", {row["group"] for row in rows if row["group"] != "BTS" and row["group"] != "ALLDAY PROJECT"})
-        self.assertEqual(summary["added"], 1)
-        self.assertEqual(summary["skipped_agency_only"], 1)
+        self.assertIn("Hearts2Hearts", groups)
+        hearts_row = next(row for row in rows if row["group"] == "Hearts2Hearts")
+        self.assertEqual(hearts_row["badge_kind"], "official_social_avatar")
+        self.assertEqual(summary["added"], 2)
+        self.assertEqual(summary["skipped_agency_only"], 0)
 
 
 if __name__ == "__main__":

--- a/web/src/data/teamBadgeAssets.json
+++ b/web/src/data/teamBadgeAssets.json
@@ -196,6 +196,13 @@
     "badge_kind": "official_channel_avatar"
   },
   {
+    "group": "CSR",
+    "badge_image_url": "https://scontent-icn2-1.cdninstagram.com/v/t51.2885-19/446555786_857741539533419_3107289545524488844_n.jpg?stp=dst-jpg_s100x100_tt6&_nc_cat=108&ccb=7-5&_nc_sid=bf7eb4&efg=eyJ2ZW5jb2RlX3RhZyI6InByb2ZpbGVfcGljLnd3dy4xMDgwLkMzIn0%3D&_nc_ohc=Y_TJmKpFr0wQ7kNvwFYWyxC&_nc_oc=AdkP4EvfVMx_bIxy1tsZ7G1llos2vitq07Y2XnPbzUK_h0RdXda2pGHrpx6NDlxYN7A&_nc_zt=24&_nc_ht=scontent-icn2-1.cdninstagram.com&_nc_ss=8&oh=00_AfzjfXFZxHQcuj_BxSz6lFIC0JChRrs7NYblYt4CjmmJGg&oe=69B94F05",
+    "badge_source_url": "https://www.instagram.com/csr.offcl",
+    "badge_source_label": "Official Instagram profile image",
+    "badge_kind": "official_social_avatar"
+  },
+  {
     "group": "DAY6",
     "badge_image_url": "https://yt3.googleusercontent.com/V1pNQjnS31WUTRZUMKaiJwajsN68Bie_SAiAepR4h5HHNk9Sw91uJm6ubXYS6OC5nZd5rDBt1dE=s900-c-k-c0x00ffffff-no-rj",
     "badge_source_url": "https://www.youtube.com/channel/UCp-pqXsizklX3ZHvLxXyhxw",
@@ -285,6 +292,13 @@
     "badge_source_url": "https://www.youtube.com/channel/UC-6L6QIx3M6O_ROf7CP-pJg",
     "badge_source_label": "Official YouTube channel avatar",
     "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "Hearts2Hearts",
+    "badge_image_url": "https://scontent-icn2-1.cdninstagram.com/v/t51.82787-19/629373161_17896862172396895_3942247668013275531_n.jpg?stp=dst-jpg_s100x100_tt6&_nc_cat=1&ccb=7-5&_nc_sid=bf7eb4&efg=eyJ2ZW5jb2RlX3RhZyI6InByb2ZpbGVfcGljLnd3dy4xMDgwLkMzIn0%3D&_nc_ohc=N0nXidYKtHgQ7kNvwGO5ymP&_nc_oc=Adm7aWwOJ02DJqXKetCQpkCQE5cHdFNsB89LlxWQZz3Y8ib0sYjsCdW8CUDr1Jxwc7A&_nc_zt=24&_nc_ht=scontent-icn2-1.cdninstagram.com&_nc_gid=fjBosh43P2XgBrurcMvbyQ&_nc_ss=8&oh=00_Afyyo-n60QWf8fUGGjOSUeqDfkOdjOw5N-tE3jX2gfr5Ig&oe=69B96137",
+    "badge_source_url": "https://www.instagram.com/hearts2hearts",
+    "badge_source_label": "Official Instagram profile image",
+    "badge_kind": "official_social_avatar"
   },
   {
     "group": "ifeye",
@@ -726,6 +740,13 @@
     "badge_source_url": "https://www.youtube.com/channel/UC_isDbPZQyyQqXX-POFFPIw",
     "badge_source_label": "Official YouTube channel avatar",
     "badge_kind": "official_channel_avatar"
+  },
+  {
+    "group": "WJSN",
+    "badge_image_url": "https://scontent-icn2-1.cdninstagram.com/v/t51.2885-19/429482687_734946172132167_7267530967471263956_n.jpg?stp=dst-jpg_s100x100_tt6&_nc_cat=103&ccb=7-5&_nc_sid=bf7eb4&efg=eyJ2ZW5jb2RlX3RhZyI6InByb2ZpbGVfcGljLnd3dy43NTAuQzMifQ%3D%3D&_nc_ohc=SQ1x8ZFzDqwQ7kNvwEMgkpr&_nc_oc=AdnZ3Bkn7EEWsjGxzpB5bHEsu2OKcAZsUrM8d3swBMb_uZVRgInOvJBV19Ru37WK0NQ&_nc_zt=24&_nc_ht=scontent-icn2-1.cdninstagram.com&_nc_ss=8&oh=00_AfwtInL4U0Yi3jvEWefCDwmZVVm6opGE3XKeInLPZ8wgEA&oe=69B96E49",
+    "badge_source_url": "https://www.instagram.com/wjsn_cosmic",
+    "badge_source_label": "Official Instagram profile image",
+    "badge_kind": "official_social_avatar"
   },
   {
     "group": "woo!ah!",


### PR DESCRIPTION
## Summary\n- backfill the last remaining team badge assets via official Instagram avatars when team-owned YouTube channels are unavailable\n- mirror the completed badge dataset to backend exports and web runtime data\n- keep runtime fallback on badge -> representative image -> monogram\n\n## Verification\n- python3 -m unittest test_build_team_badge_assets.py\n- python3 -m py_compile build_team_badge_assets.py test_build_team_badge_assets.py\n- cd web && npm run build\n- cd web && npm run lint\n- git diff --check