### PR TITLE
Restore backend-backed release history on team pages

### DIFF
--- a/backend/src/route-contract.test.ts
+++ b/backend/src/route-contract.test.ts
@@ -9,11 +9,13 @@ import type { ReadyStatusSnapshot } from './lib/readiness.js';
 const NOW = '2026-03-08T06:00:00.000Z';
 const ENTITY_ID = '11111111-1111-4111-8111-111111111111';
 const YENA_RELEASE_ID = '22222222-2222-4222-8222-222222222222';
+const YENA_OLDER_RELEASE_ID = '22222222-2222-4222-8222-222222222223';
 const IVE_RELEASE_ID = '33333333-3333-4333-8333-333333333333';
 const MALFORMED_RELEASE_ID = '44444444-4444-4444-8444-444444444444';
 const UPCOMING_SIGNAL_ID = '55555555-5555-4555-8555-555555555555';
 const P1HARMONY_RELEASE_ID = '55555555-5555-4555-8555-555555555556';
 const P1HARMONY_UPCOMING_SIGNAL_ID = '55555555-5555-4555-8555-555555555557';
+const P1HARMONY_OLDER_RELEASE_ID = '55555555-5555-4555-8555-555555555558';
 const UPCOMING_REVIEW_ID = '66666666-6666-4666-8666-666666666666';
 const MV_REVIEW_ID = '77777777-7777-4777-8777-777777777777';
 const IVE_ENTITY_ID = '88888888-8888-4888-8888-888888888888';
@@ -1026,6 +1028,64 @@ class FakeDb {
       return this.result<Row>(rows);
     }
 
+    if (
+      normalizedSql.includes('from releases r') &&
+      normalizedSql.includes('inner join entities e on e.id = r.entity_id') &&
+      normalizedSql.includes('where e.slug = $1')
+    ) {
+      if (params[0] === 'yena') {
+        return this.result<Row>([
+          {
+            release_id: YENA_RELEASE_ID,
+            release_title: 'LOVE CATCHER',
+            release_date: '2026-03-11',
+            stream: 'album',
+            release_kind: 'ep',
+            release_format: 'ep',
+            source_url: 'https://musicbrainz.org/release-group/yena-love-catcher',
+            artist_source_url: 'https://www.youtube.com/@YENA_OFFICIAL',
+          } as unknown as Row,
+          {
+            release_id: YENA_OLDER_RELEASE_ID,
+            release_title: 'SMILEY',
+            release_date: '2025-02-17',
+            stream: 'album',
+            release_kind: 'single',
+            release_format: 'single',
+            source_url: 'https://musicbrainz.org/release-group/yena-smiley',
+            artist_source_url: 'https://www.youtube.com/@YENA_OFFICIAL',
+          } as unknown as Row,
+        ]);
+      }
+
+      if (params[0] === 'p1harmony') {
+        return this.result<Row>([
+          {
+            release_id: P1HARMONY_RELEASE_ID,
+            release_title: 'UNIQUE',
+            release_date: '2026-03-12',
+            stream: 'album',
+            release_kind: 'ep',
+            release_format: 'ep',
+            source_url: 'https://musicbrainz.org/release-group/p1harmony-unique',
+            artist_source_url: 'https://www.youtube.com/@P1Harmony',
+          } as unknown as Row,
+          {
+            release_id: P1HARMONY_OLDER_RELEASE_ID,
+            release_title: 'SAD SONG',
+            release_date: '2025-09-20',
+            stream: 'album',
+            release_kind: 'ep',
+            release_format: 'ep',
+            source_url: 'https://musicbrainz.org/release-group/p1harmony-sad-song',
+            artist_source_url: 'https://www.youtube.com/@P1Harmony',
+          } as unknown as Row,
+        ]);
+      }
+
+      return this.result<Row>([]);
+    }
+
     if (normalizedSql.includes('from upcoming_signals us') && normalizedSql.includes('projection_normalize_text(us.headline)')) {
       if (params[0] === '컴백') {
         return this.result<Row>([
@@ -1865,6 +1925,10 @@ test('GET /v1/entities/:slug returns entity detail projection payload', async (t
   assert.equal(body.data.latest_release.youtube_music_url, 'https://music.youtube.com/playlist?list=PLLOVECATCHER');
   assert.equal(body.data.latest_release.youtube_mv_url, null);
   assert.equal(body.data.latest_release.artwork.cover_image_url, 'https://cdn.example.com/love-catcher-cover.jpg');
+  assert.equal(body.data.release_history.length, 2);
+  assert.equal(body.data.release_history[0].release_title, 'LOVE CATCHER');
+  assert.equal(body.data.release_history[0].source_url, 'https://starnews.example/yena-love-catcher');
+  assert.equal(body.data.release_history[1].release_title, 'SMILEY');
   assert.equal(body.data.recent_albums.length, 1);
   assert.equal(body.data.recent_albums[0].release_format, 'ep');
   assert.equal(body.data.recent_albums[0].representative_song_title, 'LOVE CATCHER');
@@ -1893,6 +1957,8 @@ test('GET /v1/entities/:slug suppresses same-day exact upcoming when latest rele
   assert.equal(body.data.identity.entity_slug, 'p1harmony');
   assert.equal(body.data.next_upcoming, null);
   assert.equal(body.data.latest_release.release_title, 'UNIQUE');
+  assert.equal(body.data.release_history.length, 2);
+  assert.equal(body.data.release_history[0].release_title, 'UNIQUE');
   assert.equal(body.data.recent_albums[0].release_title, 'UNIQUE');
   assert.equal(body.data.compare_candidates.length, 1);
   assert.equal(body.data.compare_candidates[0].entity_slug, 'yena');

--- a/backend/src/routes/entities.ts
+++ b/backend/src/routes/entities.ts
@@ -163,6 +163,7 @@ type EntityDetailPayload = {
   tracking_state: TrackingStateBlock;
   next_upcoming: UpcomingSummary | null;
   latest_release: ReleaseSummary | null;
+  release_history: ReleaseSummary[];
   recent_albums: ReleaseSummary[];
   source_timeline: SourceTimelineItem[];
   artist_source_url: string | null;
@@ -811,12 +812,55 @@ function normalizeEntityDetailPayload(payload: unknown, slug: string, todayIsoDa
       normalizedLatestRelease?.release_date,
     ),
     latest_release: normalizedLatestRelease,
+    release_history: normalizeReleaseSummaryArray(payload.release_history),
     recent_albums: dedupeRecentAlbumSummaries(normalizeReleaseSummaryArray(payload.recent_albums)),
     source_timeline: normalizeSourceTimeline(payload.source_timeline),
     artist_source_url: asNullableString(payload.artist_source_url),
     compare_candidates: normalizeCompareCandidateArray(payload.compare_candidates),
     related_acts: normalizeRelatedActSummaryArray(payload.related_acts),
   };
+}
+
+async function hydrateEntityReleaseHistory(
+  db: DbQueryable,
+  slug: string,
+): Promise<ReleaseSummary[]> {
+  const result = await db.query<ReleaseSummary>(
+    `
+      select
+        r.id::text as release_id,
+        r.release_title,
+        r.release_date::text as release_date,
+        r.stream,
+        r.release_kind,
+        r.release_format,
+        null::text as representative_song_title,
+        null::text as spotify_url,
+        null::text as youtube_music_url,
+        null::text as youtube_mv_url,
+        r.source_url,
+        r.artist_source_url,
+        null::jsonb as artwork
+      from releases r
+      inner join entities e on e.id = r.entity_id
+      where e.slug = $1
+      order by
+        r.release_date desc nulls last,
+        case r.stream
+          when 'album' then 0
+          when 'song' then 1
+          else 2
+        end,
+        r.release_title asc
+    `,
+    [slug],
+  );
+
+  const normalized = result.rows
+    .map((row) => normalizeReleaseSummary(row))
+    .filter((item): item is ReleaseSummary => item !== null);
+
+  return hydrateReleaseSummaries(db, normalized);
 }
 
 export function registerEntityRoutes(app: FastifyInstance, context: EntityRouteContext): void {
@@ -953,10 +997,12 @@ export function registerEntityRoutes(app: FastifyInstance, context: EntityRouteC
       context.db,
       normalized.latest_release ? [normalized.latest_release] : [],
     );
+    const releaseHistory = await hydrateEntityReleaseHistory(context.db, slug);
     const recentAlbums = await hydrateReleaseSummaries(context.db, normalized.recent_albums);
     const data: EntityDetailPayload = {
       ...normalized,
       latest_release: latestRelease ?? normalized.latest_release,
+      release_history: releaseHistory,
       recent_albums: recentAlbums,
       compare_candidates: compareCandidates,
       related_acts: buildRelatedActSummaries(normalized.identity, compareCandidates),

--- a/docs/specs/backend/shared-read-api-contracts.md
+++ b/docs/specs/backend/shared-read-api-contracts.md
@@ -320,6 +320,7 @@
 - tracking state
 - next upcoming
 - latest release
+- release history
 - recent albums
 - compare candidates
 - related acts
@@ -397,6 +398,25 @@
         "is_placeholder": false
       }
     },
+    "release_history": [
+      {
+        "release_id": "rel_txt_example",
+        "release_title": "Example",
+        "release_date": "2026-02-27",
+        "stream": "album",
+        "release_kind": "mini",
+        "release_format": "mini",
+        "source_url": "https://musicbrainz.org/release-group/example",
+        "artist_source_url": "https://www.youtube.com/@TXT_bighit",
+        "artwork": {
+          "cover_image_url": "https://cdn.example.com/txt-example-cover.jpg",
+          "thumbnail_image_url": "https://cdn.example.com/txt-example-thumb.jpg",
+          "artwork_source_type": "releaseArtwork.cover_image_url",
+          "artwork_source_url": "https://artwork.example.com/txt-example",
+          "is_placeholder": false
+        }
+      }
+    ],
     "recent_albums": [
       {
         "release_id": "rel_txt_example",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -401,6 +401,22 @@ type ReleaseRouteSelection = {
   releaseId: string | null
 }
 
+type EntityDetailReleaseSummary = {
+  release_id?: string
+  release_title?: string
+  release_date?: string
+  stream?: string
+  release_kind?: string | null
+  release_format?: string | null
+  representative_song_title?: string | null
+  spotify_url?: string | null
+  youtube_music_url?: string | null
+  youtube_mv_url?: string | null
+  source_url?: string | null
+  artist_source_url?: string | null
+  artwork?: Record<string, unknown> | null
+}
+
 type EntityDetailApiResponse = {
   data?: {
     identity?: {
@@ -440,36 +456,9 @@ type EntityDetailApiResponse = {
       evidence_summary?: string | null
       source_count?: number | null
     } | null
-    latest_release?: {
-      release_id?: string
-      release_title?: string
-      release_date?: string
-      stream?: string
-      release_kind?: string | null
-      release_format?: string | null
-      representative_song_title?: string | null
-      spotify_url?: string | null
-      youtube_music_url?: string | null
-      youtube_mv_url?: string | null
-      source_url?: string | null
-      artist_source_url?: string | null
-      artwork?: Record<string, unknown> | null
-    } | null
-    recent_albums?: Array<{
-      release_id?: string
-      release_title?: string
-      release_date?: string
-      stream?: string
-      release_kind?: string | null
-      release_format?: string | null
-      representative_song_title?: string | null
-      spotify_url?: string | null
-      youtube_music_url?: string | null
-      youtube_mv_url?: string | null
-      source_url?: string | null
-      artist_source_url?: string | null
-      artwork?: Record<string, unknown> | null
-    }>
+    latest_release?: EntityDetailReleaseSummary | null
+    release_history?: EntityDetailReleaseSummary[]
+    recent_albums?: EntityDetailReleaseSummary[]
     source_timeline?: Array<{
       headline?: string
       source_url?: string | null
@@ -2490,18 +2479,16 @@ function App() {
       ...visibleMonthScheduledRows.map((item) => item.isoDate),
     ]),
   ).sort()
-  const weeklyDigestReferenceDate = visibleMonthVerifiedRows.at(-1)?.dateValue ?? null
-  const weeklyDigestWindowStart = weeklyDigestReferenceDate ? getDateDaysBefore(weeklyDigestReferenceDate, 6) : null
+  const weeklyDigestReferenceDate = new Date(`${todayIso}T00:00:00`)
+  const weeklyDigestWindowStart = getDateDaysBefore(weeklyDigestReferenceDate, 6)
   const weeklyDigestRows =
-    weeklyDigestReferenceDate && weeklyDigestWindowStart
-      ? buildWeeklyDigestRows(
-          visibleMonthVerifiedRows.filter((item) => {
-            const time = item.dateValue.getTime()
-            return time >= weeklyDigestWindowStart.getTime() && time <= weeklyDigestReferenceDate.getTime()
-          }),
-          WEEKLY_DIGEST_MAX_ITEMS,
-        )
-      : []
+    buildWeeklyDigestRows(
+      visibleMonthVerifiedRows.filter((item) => {
+        const time = item.dateValue.getTime()
+        return time >= weeklyDigestWindowStart.getTime() && time <= weeklyDigestReferenceDate.getTime()
+      }),
+      WEEKLY_DIGEST_MAX_ITEMS,
+    )
   const visibleDayIsos = new Set(monthDays.map((day) => day.iso))
   const isSelectedDayVisible = visibleDayIsos.has(selectedDayIso)
   const hasNoMonthMatches =
@@ -9592,14 +9579,25 @@ function buildEntityDetailTeamProfile(
   data: NonNullable<EntityDetailApiResponse['data']>,
 ): TeamProfile {
   const baseTeam = buildSyntheticTeamProfile(group, entitySlug)
-  const latestReleaseSummary = data.latest_release
   const canonicalGroup =
     readNonEmptyString(data.identity?.canonical_name) ??
     readNonEmptyString(data.identity?.display_name) ??
     group
-  const latestReleaseRecord = latestReleaseSummary
+  const releaseHistory = Array.isArray(data.release_history)
+    ? data.release_history
+        .map((item) => buildSyntheticVerifiedRelease(canonicalGroup, item))
+        .filter((item): item is VerifiedRelease => item !== null)
+    : []
+  const latestReleaseSummary = data.latest_release
+  const latestReleaseId = readNonEmptyString(latestReleaseSummary?.release_id)
+  const latestReleaseRecordFromSummary = latestReleaseSummary
     ? buildSyntheticVerifiedRelease(canonicalGroup, latestReleaseSummary)
     : null
+  const latestReleaseRecord =
+    (latestReleaseId ? releaseHistory.find((item) => item.release_id === latestReleaseId) ?? null : null) ??
+    latestReleaseRecordFromSummary ??
+    releaseHistory[0] ??
+    null
   const recentAlbums = Array.isArray(data.recent_albums)
     ? data.recent_albums
         .map((item) => buildSyntheticVerifiedRelease(canonicalGroup, item))
@@ -9620,17 +9618,17 @@ function buildEntityDetailTeamProfile(
   const relatedActs = buildEntityDetailRelatedActs(data.related_acts)
   const verifiedHistoryByKey = new Map<string, VerifiedRelease>()
 
+  for (const release of releaseHistory) {
+    verifiedHistoryByKey.set(
+      getReleaseLookupKey(canonicalGroup, release.title, release.date, release.stream),
+      release,
+    )
+  }
+
   if (latestReleaseRecord) {
     verifiedHistoryByKey.set(
       getReleaseLookupKey(canonicalGroup, latestReleaseRecord.title, latestReleaseRecord.date, latestReleaseRecord.stream),
       latestReleaseRecord,
-    )
-  }
-
-  for (const album of recentAlbums) {
-    verifiedHistoryByKey.set(
-      getReleaseLookupKey(canonicalGroup, album.title, album.date, album.stream),
-      album,
     )
   }
 


### PR DESCRIPTION
## Summary
- add backend entity release history payload and hydrate it from canonical releases
- rebuild web team pages to use release history for annual timelines and latest release source context
- anchor the weekly digest to today instead of the last visible verified row

Closes #739