### PR TITLE
Retry web team detail fetch for slug routes

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -9,7 +9,7 @@
     "build": "npm run build:pages-read-bridge && tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test:search-runtime": "tsx --test ./src/lib/bridgeSearch.test.ts ./src/lib/runtimeRefresh.test.ts",
+    "test:search-runtime": "tsx --test ./src/lib/bridgeSearch.test.ts ./src/lib/entityDetailRecovery.test.ts ./src/lib/runtimeRefresh.test.ts",
     "test:pages-read-bridge": "node --test ./scripts/lib/pagesReadBridgeCalendar.test.mjs ./scripts/lib/pagesReadBridgeCoverage.test.mjs",
     "test:runtime-policy": "node --test ./scripts/lib/runtimeImportBoundary.test.mjs",
     "verify:runtime-policy": "node ./scripts/verify-runtime-policy.mjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -27,6 +27,10 @@ import {
   type SurfaceStatusSource,
 } from './lib/surfaceStatus'
 import { buildBridgeSearchApiData, type BridgeSearchIndex } from './lib/bridgeSearch'
+import {
+  buildEntityDetailRecoverySearchTerms,
+  pickEntityDetailRecoveryCandidate,
+} from './lib/entityDetailRecovery'
 import { shouldReloadForRuntimeRefresh } from './lib/runtimeRefresh'
 
 type ReleaseFact = {
@@ -8211,7 +8215,7 @@ function hashBridgeKey(value: string) {
 const SEARCH_SURFACE_TIMEOUT_MS = 4_000
 const RELEASE_DETAIL_LOOKUP_TIMEOUT_MS = 4_000
 const RELEASE_DETAIL_FETCH_TIMEOUT_MS = 4_500
-const ENTITY_DETAIL_FETCH_TIMEOUT_MS = 4_500
+const ENTITY_DETAIL_FETCH_TIMEOUT_MS = 7_000
 const CALENDAR_MONTH_FETCH_TIMEOUT_MS = 4_500
 const RADAR_FETCH_TIMEOUT_MS = 4_000
 
@@ -9663,12 +9667,12 @@ function buildEntityDetailTeamProfile(
   }
 }
 
-async function fetchEntityDetailApiSnapshot(
+async function requestEntityDetailApiSnapshot(
   entitySlug: string,
   group: string | null,
   signal: AbortSignal,
-): Promise<{ team: TeamProfile | null; errorCode: string | null; traceId: string | null }> {
-  const cacheKey = entitySlug
+  cacheKeys: string[],
+): Promise<{ team: TeamProfile | null; errorCode: string | null; traceId: string | null; resolvedEntitySlug: string }> {
   const result = await fetchApiJson<EntityDetailApiResponse>(
     `/v1/entities/${encodeURIComponent(entitySlug)}`,
     signal,
@@ -9680,16 +9684,90 @@ async function fetchEntityDetailApiSnapshot(
       team: null,
       errorCode: result.body?.error?.code ?? `entity_${result.status}`,
       traceId: result.traceId,
+      resolvedEntitySlug: entitySlug,
     }
   }
 
   const fallbackGroup = group ?? humanizeRouteSlug(entitySlug)
   const team = buildEntityDetailTeamProfile(fallbackGroup, entitySlug, result.body.data)
-  entityDetailApiSnapshotCache.set(cacheKey, team)
+  for (const nextCacheKey of cacheKeys) {
+    if (nextCacheKey) {
+      entityDetailApiSnapshotCache.set(nextCacheKey, team)
+    }
+  }
   return {
     team,
     errorCode: null,
     traceId: result.traceId,
+    resolvedEntitySlug: entitySlug,
+  }
+}
+
+async function fetchEntityDetailRecoveryCandidate(
+  entitySlug: string,
+  signal: AbortSignal,
+): Promise<{ entitySlug: string; displayName: string } | null> {
+  const searchTerms = buildEntityDetailRecoverySearchTerms(entitySlug)
+
+  for (const searchTerm of searchTerms) {
+    const params = new URLSearchParams()
+    params.set('q', searchTerm)
+    params.set('limit', '5')
+
+    const result = await fetchApiJson<SearchApiResponse>(
+      `/v1/search?${params.toString()}`,
+      signal,
+      SEARCH_SURFACE_TIMEOUT_MS,
+      `web-entity-reresolve-${entitySlug}`,
+    )
+
+    if (!result.ok || !result.body?.data) {
+      continue
+    }
+
+    const candidate = pickEntityDetailRecoveryCandidate(result.body.data.entities, entitySlug, searchTerm)
+    if (candidate) {
+      return candidate
+    }
+  }
+
+  return null
+}
+
+async function fetchEntityDetailApiSnapshot(
+  entitySlug: string,
+  group: string | null,
+  signal: AbortSignal,
+): Promise<{ team: TeamProfile | null; errorCode: string | null; traceId: string | null }> {
+  const directResult = await requestEntityDetailApiSnapshot(entitySlug, group, signal, [entitySlug])
+  if (directResult.team || group) {
+    return {
+      team: directResult.team,
+      errorCode: directResult.errorCode,
+      traceId: directResult.traceId,
+    }
+  }
+
+  const recoveryCandidate = await fetchEntityDetailRecoveryCandidate(entitySlug, signal)
+  if (!recoveryCandidate) {
+    return {
+      team: directResult.team,
+      errorCode: directResult.errorCode,
+      traceId: directResult.traceId,
+    }
+  }
+
+  const recoveredResult = await requestEntityDetailApiSnapshot(
+    recoveryCandidate.entitySlug,
+    recoveryCandidate.displayName,
+    signal,
+    [entitySlug, recoveryCandidate.entitySlug],
+  )
+
+  return {
+    team: recoveredResult.team,
+    errorCode: recoveredResult.errorCode,
+    traceId: recoveredResult.traceId,
   }
 }
 

--- a/web/src/lib/entityDetailRecovery.test.ts
+++ b/web/src/lib/entityDetailRecovery.test.ts
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  buildEntityDetailRecoverySearchTerms,
+  pickEntityDetailRecoveryCandidate,
+} from './entityDetailRecovery'
+
+test('buildEntityDetailRecoverySearchTerms keeps raw slug and humanized form', () => {
+  assert.deepEqual(buildEntityDetailRecoverySearchTerms('hearts2hearts'), ['hearts2hearts'])
+  assert.deepEqual(buildEntityDetailRecoverySearchTerms('nct-wish'), ['nct-wish', 'nct wish'])
+})
+
+test('pickEntityDetailRecoveryCandidate prefers exact slug match', () => {
+  const candidate = pickEntityDetailRecoveryCandidate(
+    [
+      {
+        entity_slug: 'aespa',
+        display_name: 'aespa',
+      },
+      {
+        entity_slug: 'hearts2hearts',
+        display_name: 'Hearts2Hearts',
+      },
+    ],
+    'hearts2hearts',
+    'hearts2hearts',
+  )
+
+  assert.deepEqual(candidate, {
+    entitySlug: 'hearts2hearts',
+    displayName: 'Hearts2Hearts',
+  })
+})
+
+test('pickEntityDetailRecoveryCandidate can recover by exact display match when slug differs', () => {
+  const candidate = pickEntityDetailRecoveryCandidate(
+    [
+      {
+        entity_slug: 'hearts2hearts',
+        display_name: 'Hearts2Hearts',
+        matched_alias: '하투하',
+      },
+    ],
+    'hearts2hearts',
+    'Hearts2Hearts',
+  )
+
+  assert.deepEqual(candidate, {
+    entitySlug: 'hearts2hearts',
+    displayName: 'Hearts2Hearts',
+  })
+})
+
+test('pickEntityDetailRecoveryCandidate returns null for unrelated entities', () => {
+  const candidate = pickEntityDetailRecoveryCandidate(
+    [
+      {
+        entity_slug: 'blackpink',
+        display_name: 'BLACKPINK',
+      },
+    ],
+    'hearts2hearts',
+    'hearts2hearts',
+  )
+
+  assert.equal(candidate, null)
+})

--- a/web/src/lib/entityDetailRecovery.ts
+++ b/web/src/lib/entityDetailRecovery.ts
@@ -1,0 +1,98 @@
+import { normalizeBridgeSearchTerm } from './bridgeSearch'
+
+type SearchEntityLike = {
+  entity_slug?: string
+  display_name?: string
+  canonical_name?: string
+  canonical_path?: string
+  matched_alias?: string | null
+}
+
+export type EntityDetailRecoveryCandidate = {
+  entitySlug: string
+  displayName: string
+}
+
+export function buildEntityDetailRecoverySearchTerms(entitySlug: string) {
+  const rawSlug = String(entitySlug ?? '').trim()
+  if (!rawSlug) {
+    return []
+  }
+
+  const humanized = rawSlug
+    .split('-')
+    .filter(Boolean)
+    .join(' ')
+    .trim()
+
+  return Array.from(new Set([rawSlug, humanized].filter(Boolean)))
+}
+
+export function pickEntityDetailRecoveryCandidate(
+  entities: SearchEntityLike[] | null | undefined,
+  entitySlug: string,
+  searchTerm: string,
+) {
+  if (!Array.isArray(entities) || !entities.length) {
+    return null
+  }
+
+  const normalizedSlug = normalizeBridgeSearchTerm(entitySlug)
+  const normalizedSearchTerm = normalizeBridgeSearchTerm(searchTerm)
+  const canonicalPath = `/artists/${entitySlug}`
+
+  const scored = entities
+    .map((item, index) => {
+      const candidateSlug = typeof item.entity_slug === 'string' ? item.entity_slug.trim() : ''
+      const displayName = typeof item.display_name === 'string' ? item.display_name.trim() : ''
+      const canonicalName = typeof item.canonical_name === 'string' ? item.canonical_name.trim() : ''
+      const matchedAlias = typeof item.matched_alias === 'string' ? item.matched_alias.trim() : ''
+      const candidatePath = typeof item.canonical_path === 'string' ? item.canonical_path.trim() : ''
+
+      if (!candidateSlug || !displayName) {
+        return null
+      }
+
+      let score = 0
+      if (normalizeBridgeSearchTerm(candidateSlug) === normalizedSlug) {
+        score = Math.max(score, 500)
+      }
+      if (candidatePath === canonicalPath) {
+        score = Math.max(score, 450)
+      }
+      if (normalizeBridgeSearchTerm(displayName) === normalizedSearchTerm) {
+        score = Math.max(score, 400)
+      }
+      if (normalizeBridgeSearchTerm(canonicalName) === normalizedSearchTerm) {
+        score = Math.max(score, 380)
+      }
+      if (normalizeBridgeSearchTerm(matchedAlias) === normalizedSearchTerm) {
+        score = Math.max(score, 360)
+      }
+
+      if (!score) {
+        return null
+      }
+
+      return {
+        entitySlug: candidateSlug,
+        displayName,
+        score,
+        index,
+      }
+    })
+    .filter((item): item is { entitySlug: string; displayName: string; score: number; index: number } => item !== null)
+    .sort((left, right) => {
+      if (right.score !== left.score) {
+        return right.score - left.score
+      }
+      return left.index - right.index
+    })
+
+  return scored[0]
+    ? {
+        entitySlug: scored[0].entitySlug,
+        displayName: scored[0].displayName,
+      }
+    : null
+}


### PR DESCRIPTION
## Summary\n- retry slug-only team detail pages via backend search resolution before surfacing backend unavailable\n- increase entity detail timeout to better tolerate cold starts\n- add web search-runtime tests for recovery candidate selection\n\n## Testing\n- cd web && npm run test:search-runtime\n- cd web && npm run build\n- cd web && npm run lint