### PR TITLE
Connect Android Firebase production config

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ scheduled automation도 cadence를 둘로 나눠서 운영한다.
 - upcoming dual-write report: `backend/reports/upcoming_pipeline_db_sync_summary.json`
 - projection refresh report: `backend/reports/projection_refresh_summary.json`
 - worker cadence topology report: `backend/reports/worker_cadence_report.json`
+- Android Firebase production config: `mobile/firebase/google-services.production.json`
 - canonical null coverage report: `backend/reports/canonical_null_coverage_report.json`
 - canonical null recheck queue: `backend/reports/canonical_null_recheck_queue.json`
 - null coverage trend report: `backend/reports/null_coverage_trend_report.json`

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -243,6 +243,31 @@ cd mobile
 cp .env.preview.tunnel.example .env
 ```
 
+## Android Firebase config
+
+production Android Firebase app는 `com.anonymous.idolsongappmobile` 패키지를 기준으로 한다.
+
+- tracked config file:
+  - `mobile/firebase/google-services.production.json`
+- Expo config wiring:
+  - production profile에서 `android.googleServicesFile`로 자동 연결
+- package sanity check:
+
+```bash
+cd mobile
+npm run verify:firebase:android
+```
+
+production config가 실제로 Firebase file을 읽는지 확인하려면:
+
+```bash
+cd mobile
+EXPO_PUBLIC_API_BASE_URL="$(gh variable get BACKEND_PUBLIC_URL --env production --repo iAmSomething/idol-song-app)" npm run config:production
+```
+
+새 Firebase Android app config를 받으면 `mobile/firebase/google-services.production.json`만 교체하면 된다.
+preview/development package(`.preview`, `.dev`)를 Firebase까지 쓰려면 각 패키지명에 맞는 별도 Android app registration이 추가로 필요하다.
+
 ## external device backend baseline
 
 single live production backend를 쓰는 기본 경로:

--- a/mobile/app.config.ts
+++ b/mobile/app.config.ts
@@ -1,3 +1,6 @@
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
 import type { ExpoConfig, ConfigContext } from 'expo/config';
 
 type MobileProfile = 'development' | 'preview' | 'production';
@@ -24,6 +27,10 @@ type ProfileConfig = {
 type NativeIosConfig = {
   bundleIdentifier: string;
   appleTeamId: string | null;
+};
+
+type AndroidFirebaseConfig = {
+  googleServicesFile: string | null;
 };
 
 type RuntimeConfig = {
@@ -196,6 +203,29 @@ function resolveNativeIosConfig(profileConfig: ProfileConfig, env: EnvMap): Nati
   };
 }
 
+function resolveAndroidFirebaseConfig(profile: MobileProfile, env: EnvMap): AndroidFirebaseConfig {
+  const overridePath = optionalString(env.EXPO_ANDROID_GOOGLE_SERVICES_FILE);
+  const defaultRelativePath = profile === 'production' ? './firebase/google-services.production.json' : null;
+  const configuredPath = overridePath ?? defaultRelativePath;
+
+  if (!configuredPath) {
+    return {
+      googleServicesFile: null,
+    };
+  }
+
+  const absolutePath = resolve(__dirname, configuredPath);
+  if (!existsSync(absolutePath)) {
+    return {
+      googleServicesFile: null,
+    };
+  }
+
+  return {
+    googleServicesFile: configuredPath,
+  };
+}
+
 function buildRuntimeConfig(profile: MobileProfile, profileConfig: ProfileConfig, env: EnvMap): RuntimeConfig {
   const apiBaseUrl = assertHttpUrl(optionalString(env.EXPO_PUBLIC_API_BASE_URL), 'EXPO_PUBLIC_API_BASE_URL');
   const analyticsWriteKey = optionalString(env.EXPO_PUBLIC_ANALYTICS_WRITE_KEY);
@@ -251,6 +281,7 @@ export default ({ config }: ConfigContext): ExpoConfig => {
   const profileConfig = PROFILE_CONFIG[profile];
   const runtimeConfig = buildRuntimeConfig(profile, profileConfig, process.env);
   const nativeIosConfig = resolveNativeIosConfig(profileConfig, process.env);
+  const androidFirebaseConfig = resolveAndroidFirebaseConfig(profile, process.env);
 
   return {
     ...config,
@@ -282,6 +313,11 @@ export default ({ config }: ConfigContext): ExpoConfig => {
     android: {
       predictiveBackGestureEnabled: false,
       package: profileConfig.androidPackage,
+      ...(androidFirebaseConfig.googleServicesFile
+        ? {
+            googleServicesFile: androidFirebaseConfig.googleServicesFile,
+          }
+        : {}),
       adaptiveIcon: {
         foregroundImage: './assets/app-icon/icon-adaptive-foreground.png',
         monochromeImage: './assets/app-icon/icon-adaptive-monochrome.png',

--- a/mobile/firebase/google-services.production.json
+++ b/mobile/firebase/google-services.production.json
@@ -1,0 +1,29 @@
+{
+  "project_info": {
+    "project_number": "364777074329",
+    "project_id": "idol-music-7094a",
+    "storage_bucket": "idol-music-7094a.firebasestorage.app"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:364777074329:android:3c06d1a2c73a4a44c8d208",
+        "android_client_info": {
+          "package_name": "com.anonymous.idolsongappmobile"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyCAEWBzDBcltekl4fT_ldEnyMxsMKRaypg"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -30,6 +30,7 @@
     "verify:qa:platforms": "cross-env EXPO_PUBLIC_API_BASE_URL=https://api.idol-song-app.example.com npm run config:preview && cross-env EXPO_PUBLIC_API_BASE_URL=https://api.idol-song-app.example.com npm run config:production && cross-env APP_ENV=preview EXPO_PUBLIC_API_BASE_URL=https://api.idol-song-app.example.com expo export --platform ios --output-dir /tmp/idol-song-app-mobile-export-ios >/dev/null && cross-env APP_ENV=preview EXPO_PUBLIC_API_BASE_URL=https://api.idol-song-app.example.com expo export --platform android --output-dir /tmp/idol-song-app-mobile-export-android >/dev/null",
     "verify:qa:full": "npm run test:qa:ui && npm run test:qa:functional && npm run test:qa:server && npm run typecheck && npm run lint && npm run verify:qa:platforms",
     "verify:runtime-policy": "jest --runInBand src/config/runtime.test.ts src/services/datasetFailurePolicy.test.ts src/features/useActiveDatasetScreen.test.tsx",
+    "verify:firebase:android": "node ./scripts/verify-android-firebase-config.mjs",
     "config:development": "cross-env APP_ENV=development expo config --json",
     "config:preview": "cross-env APP_ENV=preview expo config --json",
     "config:production": "cross-env APP_ENV=production expo config --json"

--- a/mobile/scripts/verify-android-firebase-config.mjs
+++ b/mobile/scripts/verify-android-firebase-config.mjs
@@ -1,0 +1,42 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const GOOGLE_SERVICES_PATH = path.resolve(__dirname, '../firebase/google-services.production.json');
+const EXPECTED_PACKAGE_NAME = 'com.anonymous.idolsongappmobile';
+
+const raw = JSON.parse(readFileSync(GOOGLE_SERVICES_PATH, 'utf8'));
+const packageName = raw?.client?.[0]?.client_info?.android_client_info?.package_name ?? null;
+const mobileSdkAppId = raw?.client?.[0]?.client_info?.mobilesdk_app_id ?? null;
+const projectNumber = raw?.project_info?.project_number ?? null;
+
+if (packageName !== EXPECTED_PACKAGE_NAME) {
+  throw new Error(
+    `google-services.production.json package mismatch: expected ${EXPECTED_PACKAGE_NAME}, received ${packageName ?? 'null'}`,
+  );
+}
+
+if (!mobileSdkAppId) {
+  throw new Error('google-services.production.json is missing mobilesdk_app_id');
+}
+
+if (!projectNumber) {
+  throw new Error('google-services.production.json is missing project_number');
+}
+
+console.log(
+  JSON.stringify(
+    {
+      status: 'pass',
+      package_name: packageName,
+      mobilesdk_app_id: mobileSdkAppId,
+      project_number: projectNumber,
+      source: GOOGLE_SERVICES_PATH,
+    },
+    null,
+    2,
+  ),
+);


### PR DESCRIPTION
## Summary\n- wire the provided Android Firebase config into the Expo production profile only\n- add a repository sanity check for the production google-services file\n- document the package names and Firebase config flow for mobile\n\nCloses #743