### PR TITLE
Add title-track batch loop automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ latest/recent blocker 코호트만 빠르게 다시 돌리고 싶다면 scoped r
 ```bash
 python build_release_details_musicbrainz.py --cohorts latest,recent
 python run_mv_backfill_batch_loop.py --cohorts latest,recent --batch-size 50 --max-batches 20 --progress-every 10 --request-timeout 10 --command-timeout-seconds 180
+python run_title_track_backfill_batch_loop.py --cohorts latest,recent --batch-size 50 --max-batches 20 --progress-every 10
 ```
 
 오래 걸리는 pass를 작게 확인할 때는 progress와 row limit를 같이 건다. progress는 `stderr`로만 찍히기 때문에 기존 JSON stdout consumer는 깨지지 않는다.
@@ -221,9 +222,12 @@ python run_mv_backfill_batch_loop.py --cohorts latest,recent --batch-size 50 --m
 ```bash
 python build_release_details_musicbrainz.py --cohorts latest,recent --max-rows 25 --progress-every 5
 python run_mv_backfill_batch_loop.py --cohorts latest,recent --batch-size 25 --max-batches 12 --progress-every 5 --request-timeout 10 --command-timeout-seconds 180
+python run_title_track_backfill_batch_loop.py --cohorts latest,recent --batch-size 25 --max-batches 12 --progress-every 5
 ```
 
 `run_mv_backfill_batch_loop.py`는 latest/recent unresolved rows를 서버사이드에서 자동 batch loop로 처리한다. 실제 persisted change(`persisted_resolution_changes`) 또는 coverage lift가 난 batch만 `row_offset=0`으로 리셋해서 새 unresolved head부터 다시 먹고, 이미 반영된 head를 다시 찾기만 한 batch는 같은 snapshot 뒤쪽 chunk로 넘어간다. 전체 snapshot을 한 번 다 훑었는데 progress가 없거나 `max_batches`에 닿으면 멈추고, 마지막에 `build_mv_manual_review_queue.py`를 자동으로 다시 생성한다. `--request-timeout`은 개별 YouTube 요청, `--command-timeout-seconds`는 각 batch subprocess의 상한을 고정한다.
+
+`run_title_track_backfill_batch_loop.py`는 latest/recent unresolved title-track rows를 같은 방식으로 자동 batch loop 처리한다. 한 batch에서 실제 persisted title-track change가 나면 `row_offset=0`으로 다시 시작하고, 이미 반영된 head를 다시 계산하기만 한 batch는 같은 snapshot 뒤쪽 chunk로 넘어간다. 전체 snapshot을 한 번 다 훑었는데도 progress가 없거나 `max_batches`에 닿으면 멈추고, summary는 `backend/reports/title_track_backfill_batch_loop_report.json`에 남긴다.
 
 Neon canonical DB까지 같이 최신화하려면 아래를 이어서 실행한다.
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -589,6 +589,7 @@ latest/recent blocker 코호트만 빠르게 재생성할 때는 아래처럼 sc
 ```bash
 python3 ../build_release_details_musicbrainz.py --cohorts latest,recent
 python3 ../run_mv_backfill_batch_loop.py --cohorts latest,recent --batch-size 50 --max-batches 20 --progress-every 10 --request-timeout 10 --command-timeout-seconds 180
+python3 ../run_title_track_backfill_batch_loop.py --cohorts latest,recent --batch-size 50 --max-batches 20 --progress-every 10
 ```
 
 긴 pass를 안전하게 확인할 때는 row limit와 stderr progress를 같이 건다.
@@ -596,9 +597,12 @@ python3 ../run_mv_backfill_batch_loop.py --cohorts latest,recent --batch-size 50
 ```bash
 python3 ../build_release_details_musicbrainz.py --cohorts latest,recent --max-rows 25 --progress-every 5
 python3 ../run_mv_backfill_batch_loop.py --cohorts latest,recent --batch-size 25 --max-batches 12 --progress-every 5 --request-timeout 10 --command-timeout-seconds 180
+python3 ../run_title_track_backfill_batch_loop.py --cohorts latest,recent --batch-size 25 --max-batches 12 --progress-every 5
 ```
 
 `run_mv_backfill_batch_loop.py`는 latest/recent unresolved head를 batch로 반복 처리한다. 한 batch에서 실제 persisted change(`persisted_resolution_changes`)나 coverage lift가 나면 `row_offset=0`으로 다시 시작하고, 이미 반영된 row를 다시 찾기만 한 batch는 같은 snapshot에서 `row_offset += selected_rows`로 뒤쪽 chunk를 훑는다. 전체 snapshot을 한 번 다 훑었는데도 progress가 없거나 `max_batches`에 닿으면 멈추고, 마지막에 `build_mv_manual_review_queue.py`를 자동으로 다시 돌린다. 내부적으로는 `backfill_release_detail_mvs.py`를 재사용하므로 최대 2개의 title track, `official music video` suffix, no-suffix fallback, 외부 검색 단발 실패 흡수 규칙은 그대로 유지된다. `--request-timeout`은 개별 YouTube 요청의 상한, `--command-timeout-seconds`는 각 batch subprocess의 상한이다.
+
+`run_title_track_backfill_batch_loop.py`는 latest/recent unresolved title-track head를 batch로 반복 처리한다. 한 batch에서 실제 persisted title-track change(`persisted_title_track_changes`)가 나면 `row_offset=0`으로 다시 시작하고, progress가 없으면 같은 snapshot에서 `row_offset += selected_rows`로 뒤쪽 chunk를 훑는다. 전체 snapshot을 한 번 다 훑었는데도 progress가 없거나 `max_batches`에 닿으면 멈추고, summary는 `backend/reports/title_track_backfill_batch_loop_report.json`에 남긴다. 내부적으로는 `build_release_details_musicbrainz.py --cohorts ... --row-offset ... --max-rows ...`를 재사용한다.
 
 ## Release Pipeline Dual-Write
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -35,7 +35,8 @@
     "curation:import": "node ./scripts/import-manual-curation-bundles.mjs",
     "same-day:acceptance": "node ./scripts/build-same-day-release-acceptance-report.mjs",
     "runtime:gate": "node ./scripts/build-runtime-gate-report.mjs",
-    "preview:url:sync": "node ./scripts/provision-preview-backend-url.mjs --target preview"
+    "preview:url:sync": "node ./scripts/provision-preview-backend-url.mjs --target preview",
+    "title-track:loop": "python3 ../run_title_track_backfill_batch_loop.py"
   },
   "dependencies": {
     "fastify": "^5.2.1",

--- a/backend/reports/title_track_backfill_batch_loop_report.json
+++ b/backend/reports/title_track_backfill_batch_loop_report.json
@@ -1,0 +1,75 @@
+{
+  "started_at": "2026-03-13T05:24:15.087478Z",
+  "finished_at": "2026-03-13T05:24:15.989127Z",
+  "config": {
+    "cohorts": [
+      "latest",
+      "recent"
+    ],
+    "batch_size": 3,
+    "max_batches": 2,
+    "progress_every": 1,
+    "skip_acquisition": true,
+    "command_timeout_seconds": 180
+  },
+  "stop_reason": "max_batches",
+  "batches_run": 2,
+  "total_persisted_title_track_changes": 0,
+  "total_auto_resolved_rows": 0,
+  "final_iteration": {
+    "batch_index": 2,
+    "row_offset": 3,
+    "selected_rows": 3,
+    "scoped_rows_total": 816,
+    "rows_with_title_track_before": 3,
+    "rows_with_title_track_after": 3,
+    "persisted_title_track_changes": 0,
+    "title_track_auto_resolved_rows": 0,
+    "title_track_auto_double_rows": 0,
+    "title_track_review_queue_rows": 0,
+    "stderr_lines": [
+      "[build_release_details_musicbrainz] processing 3/816 scoped rows (row_offset=3, progress_every=1)",
+      "[build_release_details_musicbrainz] 1/3 &TEAM / 君にカエル (Maybe) / 2024-04-28 / song",
+      "[build_release_details_musicbrainz] 2/3 &TEAM / 五月雨 (Samidare) / 2024-05-07 / song",
+      "[build_release_details_musicbrainz] 3/3 &TEAM / 声変わり / 2024-07-18 / song"
+    ]
+  },
+  "iterations": [
+    {
+      "batch_index": 1,
+      "row_offset": 0,
+      "selected_rows": 3,
+      "scoped_rows_total": 816,
+      "rows_with_title_track_before": 2,
+      "rows_with_title_track_after": 2,
+      "persisted_title_track_changes": 0,
+      "title_track_auto_resolved_rows": 0,
+      "title_track_auto_double_rows": 0,
+      "title_track_review_queue_rows": 1,
+      "stderr_lines": [
+        "[build_release_details_musicbrainz] processing 3/816 scoped rows (row_offset=0, progress_every=1)",
+        "[build_release_details_musicbrainz] 1/3 &TEAM / Blind Love / 2023-05-07 / song",
+        "[build_release_details_musicbrainz] 2/3 &TEAM / First Howling : WE / 2023-06-14 / album",
+        "[build_release_details_musicbrainz] 3/3 &TEAM / First Howling : NOW / 2023-11-15 / album"
+      ]
+    },
+    {
+      "batch_index": 2,
+      "row_offset": 3,
+      "selected_rows": 3,
+      "scoped_rows_total": 816,
+      "rows_with_title_track_before": 3,
+      "rows_with_title_track_after": 3,
+      "persisted_title_track_changes": 0,
+      "title_track_auto_resolved_rows": 0,
+      "title_track_auto_double_rows": 0,
+      "title_track_review_queue_rows": 0,
+      "stderr_lines": [
+        "[build_release_details_musicbrainz] processing 3/816 scoped rows (row_offset=3, progress_every=1)",
+        "[build_release_details_musicbrainz] 1/3 &TEAM / 君にカエル (Maybe) / 2024-04-28 / song",
+        "[build_release_details_musicbrainz] 2/3 &TEAM / 五月雨 (Samidare) / 2024-05-07 / song",
+        "[build_release_details_musicbrainz] 3/3 &TEAM / 声変わり / 2024-07-18 / song"
+      ]
+    }
+  ]
+}

--- a/build_release_details_musicbrainz.py
+++ b/build_release_details_musicbrainz.py
@@ -112,12 +112,23 @@ def parse_positive_int_arg(raw_value: str) -> int:
     return parsed
 
 
+def parse_non_negative_int_arg(raw_value: str) -> int:
+    try:
+        parsed = int(raw_value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("must be a non-negative integer") from error
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("must be a non-negative integer")
+    return parsed
+
+
 def enrich_execution_scope(
     execution_scope: Optional[Dict],
     total_scoped_rows: int,
     selected_rows: int,
     max_rows: Optional[int],
     progress_every: int,
+    row_offset: int,
 ) -> Dict:
     scope = dict(execution_scope or {})
     scope["scoped_rows_total"] = total_scoped_rows
@@ -125,6 +136,7 @@ def enrich_execution_scope(
     if max_rows is not None:
         scope["max_rows"] = max_rows
     scope["progress_every"] = progress_every
+    scope["row_offset"] = row_offset
     return scope
 
 
@@ -2317,6 +2329,12 @@ def main() -> None:
         help="Limit the current scoped rebuild to the first N matching rows for safer targeted reruns.",
     )
     parser.add_argument(
+        "--row-offset",
+        type=parse_non_negative_int_arg,
+        default=0,
+        help="Skip the first N scoped rows before applying --max-rows for batch-based reruns.",
+    )
+    parser.add_argument(
         "--progress-every",
         type=parse_positive_int_arg,
         default=25,
@@ -2347,6 +2365,8 @@ def main() -> None:
         if matches_execution_scope(item, scoped_groups, scoped_cohorts, reference_date)
     ]
     total_scoped_rows = len(scoped_items)
+    if args.row_offset:
+        scoped_items = scoped_items[args.row_offset :]
     if args.max_rows is not None:
         scoped_items = scoped_items[: args.max_rows]
     scoped_keys = {
@@ -2364,12 +2384,13 @@ def main() -> None:
         selected_rows=len(scoped_items),
         max_rows=args.max_rows,
         progress_every=args.progress_every,
+        row_offset=args.row_offset,
     )
     print(
         (
             "[build_release_details_musicbrainz] "
             f"processing {len(scoped_items)}/{total_scoped_rows} scoped rows "
-            f"(progress_every={args.progress_every})"
+            f"(row_offset={args.row_offset}, progress_every={args.progress_every})"
         ),
         file=sys.stderr,
         flush=True,

--- a/docs/specs/backend/README.md
+++ b/docs/specs/backend/README.md
@@ -94,6 +94,7 @@
 29. scoped blocker rerun note
    - `build_release_details_musicbrainz.py --cohorts latest,recent` 로 latest/recent row만 재계산할 수 있다
    - `run_mv_backfill_batch_loop.py --cohorts latest,recent --request-timeout 10 --command-timeout-seconds 180` 로 latest/recent unresolved MV row를 자동 batch loop로 밀 수 있다
+   - `run_title_track_backfill_batch_loop.py --cohorts latest,recent` 로 latest/recent unresolved title-track row를 자동 batch loop로 밀 수 있다
    - full snapshot은 유지하고 review queue / coverage report만 같은 execution scope로 다시 만든다
    - 긴 rerun은 `--max-rows`, `--row-offset`, `--progress-every`, `--request-timeout`, `--command-timeout-seconds` 를 같이 써서 작은 batch를 이어서 확인한다
 

--- a/run_title_track_backfill_batch_loop.py
+++ b/run_title_track_backfill_batch_loop.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+
+ROOT = Path(__file__).resolve().parent
+DEFAULT_SUMMARY_PATH = ROOT / "backend" / "reports" / "title_track_backfill_batch_loop_report.json"
+BACKFILL_SCRIPT = ROOT / "build_release_details_musicbrainz.py"
+
+
+def parse_positive_int_arg(raw_value: str) -> int:
+    try:
+        parsed = int(raw_value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("must be a positive integer") from error
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return parsed
+
+
+def now_utc_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def load_json_from_stdout(stdout: str) -> dict[str, Any]:
+    try:
+        payload = json.loads(stdout)
+    except json.JSONDecodeError as error:
+        raise RuntimeError(f"command did not emit valid JSON stdout: {error}") from error
+    if not isinstance(payload, dict):
+        raise RuntimeError("command did not emit a JSON object")
+    return payload
+
+
+def build_backfill_command(
+    cohorts: str,
+    batch_size: int,
+    row_offset: int,
+    progress_every: int,
+    skip_acquisition: bool,
+) -> list[str]:
+    command = [
+        sys.executable,
+        str(BACKFILL_SCRIPT),
+        "--cohorts",
+        cohorts,
+        "--max-rows",
+        str(batch_size),
+        "--row-offset",
+        str(row_offset),
+        "--progress-every",
+        str(progress_every),
+    ]
+    if skip_acquisition:
+        command.append("--skip-acquisition")
+    return command
+
+
+def run_json_command(command: list[str], command_timeout_seconds: int) -> tuple[dict[str, Any], str]:
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=command_timeout_seconds,
+        )
+    except subprocess.TimeoutExpired as error:
+        raise RuntimeError(
+            "command timed out "
+            f"(timeout={command_timeout_seconds}s): {' '.join(command)}\n"
+            f"stdout:\n{error.stdout or ''}\nstderr:\n{error.stderr or ''}"
+        ) from error
+    if completed.returncode != 0:
+        raise RuntimeError(
+            "command failed "
+            f"(exit={completed.returncode}): {' '.join(command)}\n"
+            f"stderr:\n{completed.stderr}\nstdout:\n{completed.stdout}"
+        )
+    return load_json_from_stdout(completed.stdout), completed.stderr
+
+
+def summarize_iteration(batch_index: int, row_offset: int, report: dict[str, Any], stderr: str) -> dict[str, Any]:
+    execution_scope = report.get("execution_scope", {})
+    rows_with_title_track_before = int(report.get("rows_with_title_track_before") or 0)
+    rows_with_title_track_after = int(report.get("rows_with_title_track_after") or 0)
+    return {
+        "batch_index": batch_index,
+        "row_offset": row_offset,
+        "selected_rows": execution_scope.get("selected_rows", 0),
+        "scoped_rows_total": execution_scope.get("scoped_rows_total", 0),
+        "rows_with_title_track_before": rows_with_title_track_before,
+        "rows_with_title_track_after": rows_with_title_track_after,
+        "persisted_title_track_changes": max(rows_with_title_track_after - rows_with_title_track_before, 0),
+        "title_track_auto_resolved_rows": int(report.get("title_track_auto_resolved_rows") or 0),
+        "title_track_auto_double_rows": int(report.get("title_track_auto_double_rows") or 0),
+        "title_track_review_queue_rows": int(report.get("title_track_review_queue_rows") or 0),
+        "stderr_lines": [line for line in stderr.splitlines() if line.strip()],
+    }
+
+
+def run_batch_loop(
+    *,
+    cohorts: str,
+    batch_size: int,
+    max_batches: int,
+    progress_every: int,
+    skip_acquisition: bool,
+    command_timeout_seconds: int,
+    batch_runner: Callable[[int], tuple[dict[str, Any], str]],
+) -> dict[str, Any]:
+    started_at = now_utc_iso()
+    row_offset = 0
+    batch_index = 0
+    iterations: list[dict[str, Any]] = []
+    stop_reason = "unknown"
+
+    while batch_index < max_batches:
+        batch_index += 1
+        report, stderr = batch_runner(row_offset)
+        iteration = summarize_iteration(batch_index, row_offset, report, stderr)
+        iterations.append(iteration)
+
+        selected_rows = int(iteration["selected_rows"])
+        scoped_rows_total = int(iteration["scoped_rows_total"])
+        persisted_title_track_changes = int(iteration["persisted_title_track_changes"])
+
+        if selected_rows == 0:
+            stop_reason = "exhausted"
+            break
+
+        if persisted_title_track_changes > 0:
+            row_offset = 0
+            continue
+
+        next_row_offset = row_offset + selected_rows
+        if next_row_offset >= scoped_rows_total:
+            stop_reason = "no_progress_full_scan"
+            break
+        row_offset = next_row_offset
+    else:
+        stop_reason = "max_batches"
+
+    summary = {
+        "started_at": started_at,
+        "finished_at": now_utc_iso(),
+        "config": {
+            "cohorts": [value.strip() for value in cohorts.split(",") if value.strip()],
+            "batch_size": batch_size,
+            "max_batches": max_batches,
+            "progress_every": progress_every,
+            "skip_acquisition": skip_acquisition,
+            "command_timeout_seconds": command_timeout_seconds,
+        },
+        "stop_reason": stop_reason,
+        "batches_run": len(iterations),
+        "total_persisted_title_track_changes": sum(int(row["persisted_title_track_changes"]) for row in iterations),
+        "total_auto_resolved_rows": sum(int(row["title_track_auto_resolved_rows"]) for row in iterations),
+        "final_iteration": iterations[-1] if iterations else None,
+        "iterations": iterations,
+    }
+    return summary
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--cohorts",
+        default="latest,recent",
+        help="Comma-separated release cohorts to backfill in the automated loop.",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=parse_positive_int_arg,
+        default=50,
+        help="Number of rows to process per title-track batch.",
+    )
+    parser.add_argument(
+        "--max-batches",
+        type=parse_positive_int_arg,
+        default=20,
+        help="Maximum number of title-track batch invocations before stopping.",
+    )
+    parser.add_argument(
+        "--progress-every",
+        type=parse_positive_int_arg,
+        default=25,
+        help="Forwarded to build_release_details_musicbrainz.py for stderr progress output.",
+    )
+    parser.add_argument(
+        "--command-timeout-seconds",
+        type=parse_positive_int_arg,
+        default=180,
+        help="Hard timeout in seconds for each batch subprocess.",
+    )
+    parser.add_argument(
+        "--skip-acquisition",
+        action="store_true",
+        help="Forward --skip-acquisition to the underlying release detail builder.",
+    )
+    parser.add_argument(
+        "--summary-path",
+        default=str(DEFAULT_SUMMARY_PATH),
+        help="Where to write the loop summary JSON.",
+    )
+    args = parser.parse_args()
+
+    def batch_runner(row_offset: int) -> tuple[dict[str, Any], str]:
+        command = build_backfill_command(
+            args.cohorts,
+            args.batch_size,
+            row_offset,
+            args.progress_every,
+            args.skip_acquisition,
+        )
+        print(
+            "[run_title_track_backfill_batch_loop] "
+            f"batch row_offset={row_offset} batch_size={args.batch_size}",
+            file=sys.stderr,
+            flush=True,
+        )
+        return run_json_command(command, args.command_timeout_seconds)
+
+    summary = run_batch_loop(
+        cohorts=args.cohorts,
+        batch_size=args.batch_size,
+        max_batches=args.max_batches,
+        progress_every=args.progress_every,
+        skip_acquisition=args.skip_acquisition,
+        command_timeout_seconds=args.command_timeout_seconds,
+        batch_runner=batch_runner,
+    )
+
+    summary_path = Path(args.summary_path)
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    summary_path.write_text(json.dumps(summary, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(summary, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/test_build_release_details_musicbrainz.py
+++ b/test_build_release_details_musicbrainz.py
@@ -25,6 +25,13 @@ class BuildReleaseDetailsMusicBrainzTitleTrackTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             builder.parse_scoped_cohorts("latest,foo")
 
+    def test_parse_non_negative_int_arg_accepts_zero(self) -> None:
+        self.assertEqual(builder.parse_non_negative_int_arg("0"), 0)
+
+    def test_parse_non_negative_int_arg_rejects_negative_values(self) -> None:
+        with self.assertRaises(argparse.ArgumentTypeError):
+            builder.parse_non_negative_int_arg("-1")
+
     def test_matches_execution_scope_respects_cohort_filter(self) -> None:
         item = {
             "group": "YENA",
@@ -58,6 +65,7 @@ class BuildReleaseDetailsMusicBrainzTitleTrackTests(unittest.TestCase):
             selected_rows=3,
             max_rows=3,
             progress_every=2,
+            row_offset=5,
         )
 
         self.assertEqual(
@@ -68,6 +76,7 @@ class BuildReleaseDetailsMusicBrainzTitleTrackTests(unittest.TestCase):
                 "selected_rows": 3,
                 "max_rows": 3,
                 "progress_every": 2,
+                "row_offset": 5,
             },
         )
 

--- a/test_run_title_track_backfill_batch_loop.py
+++ b/test_run_title_track_backfill_batch_loop.py
@@ -1,0 +1,130 @@
+import unittest
+from subprocess import TimeoutExpired
+from unittest.mock import patch
+
+import run_title_track_backfill_batch_loop as loop
+
+
+class RunTitleTrackBackfillBatchLoopTests(unittest.TestCase):
+    def test_parse_positive_int_arg_accepts_positive_value(self) -> None:
+        self.assertEqual(loop.parse_positive_int_arg("3"), 3)
+
+    def test_parse_positive_int_arg_rejects_zero(self) -> None:
+        with self.assertRaises(Exception):
+            loop.parse_positive_int_arg("0")
+
+    def test_run_batch_loop_resets_offset_after_progress(self) -> None:
+        calls: list[int] = []
+
+        def batch_runner(row_offset: int):
+            calls.append(row_offset)
+            if len(calls) == 1:
+                return (
+                    {
+                        "rows_with_title_track_before": 2,
+                        "rows_with_title_track_after": 4,
+                        "title_track_auto_resolved_rows": 2,
+                        "title_track_auto_double_rows": 0,
+                        "title_track_review_queue_rows": 10,
+                        "execution_scope": {
+                            "selected_rows": 5,
+                            "scoped_rows_total": 12,
+                        },
+                    },
+                    "[progress]\n",
+                )
+            return (
+                {
+                    "rows_with_title_track_before": 4,
+                    "rows_with_title_track_after": 4,
+                    "title_track_auto_resolved_rows": 0,
+                    "title_track_auto_double_rows": 0,
+                    "title_track_review_queue_rows": 10,
+                    "execution_scope": {
+                        "selected_rows": 0,
+                        "scoped_rows_total": 10,
+                    },
+                },
+                "",
+            )
+
+        summary = loop.run_batch_loop(
+            cohorts="latest,recent",
+            batch_size=5,
+            max_batches=4,
+            progress_every=2,
+            skip_acquisition=False,
+            command_timeout_seconds=180,
+            batch_runner=batch_runner,
+        )
+
+        self.assertEqual(calls, [0, 0])
+        self.assertEqual(summary["stop_reason"], "exhausted")
+        self.assertEqual(summary["total_persisted_title_track_changes"], 2)
+
+    def test_run_batch_loop_advances_offset_during_no_progress_scan(self) -> None:
+        calls: list[int] = []
+
+        def batch_runner(row_offset: int):
+            calls.append(row_offset)
+            return (
+                {
+                    "rows_with_title_track_before": 5,
+                    "rows_with_title_track_after": 5,
+                    "title_track_auto_resolved_rows": 0,
+                    "title_track_auto_double_rows": 0,
+                    "title_track_review_queue_rows": 20,
+                    "execution_scope": {
+                        "selected_rows": 10,
+                        "scoped_rows_total": 20,
+                    },
+                },
+                "",
+            )
+
+        summary = loop.run_batch_loop(
+            cohorts="latest,recent",
+            batch_size=10,
+            max_batches=5,
+            progress_every=2,
+            skip_acquisition=True,
+            command_timeout_seconds=180,
+            batch_runner=batch_runner,
+        )
+
+        self.assertEqual(calls, [0, 10])
+        self.assertEqual(summary["stop_reason"], "no_progress_full_scan")
+        self.assertEqual(summary["batches_run"], 2)
+
+    def test_build_backfill_command_forwards_row_offset_and_skip_flag(self) -> None:
+        command = loop.build_backfill_command(
+            "latest,recent",
+            batch_size=10,
+            row_offset=20,
+            progress_every=2,
+            skip_acquisition=True,
+        )
+
+        self.assertIn("--row-offset", command)
+        self.assertIn("20", command)
+        self.assertIn("--skip-acquisition", command)
+
+    @patch.object(loop.subprocess, "run")
+    def test_run_json_command_raises_timeout_error(self, mock_run: object) -> None:
+        mock_run.side_effect = TimeoutExpired(
+            cmd=["python", "fake.py"],
+            timeout=30,
+            output="partial stdout",
+            stderr="partial stderr",
+        )
+
+        with self.assertRaises(RuntimeError) as error:
+            loop.run_json_command(["python", "fake.py"], command_timeout_seconds=30)
+
+        self.assertIn("command timed out", str(error.exception))
+        self.assertIn("partial stdout", str(error.exception))
+        self.assertIn("partial stderr", str(error.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary\n- add row-offset support to scoped title-track rebuilds\n- add a server-side title-track batch loop patterned after the MV loop\n- document and expose the loop from the backend toolchain\n\n## Verification\n- source .venv/bin/activate && python -m unittest test_build_release_details_musicbrainz.py test_run_title_track_backfill_batch_loop.py\n- source .venv/bin/activate && python run_title_track_backfill_batch_loop.py --cohorts latest,recent --batch-size 3 --max-batches 2 --progress-every 1 --skip-acquisition\n- git diff --check