### PR TITLE
chore: harden enrichment batch retries

### DIFF
--- a/.github/workflows/catalog-enrichment-refresh.yml
+++ b/.github/workflows/catalog-enrichment-refresh.yml
@@ -63,8 +63,8 @@ jobs:
           python build_release_details_musicbrainz.py
           python build_release_artwork_catalog.py
           python build_entity_asset_coverage_report.py
-          python run_title_track_backfill_batch_loop.py --cohorts latest,recent --batch-size 50 --max-batches 20 --progress-every 10 --skip-acquisition
-          python run_mv_backfill_batch_loop.py --cohorts latest,recent --batch-size 50 --max-batches 20 --progress-every 10
+          python run_title_track_backfill_batch_loop.py --cohorts latest,recent --batch-size 25 --min-batch-size 10 --max-batches 40 --progress-every 10 --skip-acquisition
+          python run_mv_backfill_batch_loop.py --cohorts latest,recent --batch-size 25 --min-batch-size 10 --max-batches 40 --progress-every 10
           if [ -n "${DATABASE_URL:-}" ]; then
             python sync_release_pipeline_to_neon.py --summary-path /tmp/release-pipeline-db-sync-summary.json
             python sync_upcoming_pipeline_to_neon.py --summary-path /tmp/upcoming-pipeline-db-sync-summary.json

--- a/README.md
+++ b/README.md
@@ -213,21 +213,21 @@ latest/recent blocker 코호트만 빠르게 다시 돌리고 싶다면 scoped r
 
 ```bash
 python build_release_details_musicbrainz.py --cohorts latest,recent
-python run_mv_backfill_batch_loop.py --cohorts latest,recent --batch-size 50 --max-batches 20 --progress-every 10 --request-timeout 10 --command-timeout-seconds 180
-python run_title_track_backfill_batch_loop.py --cohorts latest,recent --batch-size 50 --max-batches 20 --progress-every 10
+python run_mv_backfill_batch_loop.py --cohorts latest,recent --batch-size 25 --min-batch-size 10 --max-batches 40 --progress-every 10 --request-timeout 10 --command-timeout-seconds 180
+python run_title_track_backfill_batch_loop.py --cohorts latest,recent --batch-size 25 --min-batch-size 10 --max-batches 40 --progress-every 10
 ```
 
 오래 걸리는 pass를 작게 확인할 때는 progress와 row limit를 같이 건다. progress는 `stderr`로만 찍히기 때문에 기존 JSON stdout consumer는 깨지지 않는다.
 
 ```bash
 python build_release_details_musicbrainz.py --cohorts latest,recent --max-rows 25 --progress-every 5
-python run_mv_backfill_batch_loop.py --cohorts latest,recent --batch-size 25 --max-batches 12 --progress-every 5 --request-timeout 10 --command-timeout-seconds 180
-python run_title_track_backfill_batch_loop.py --cohorts latest,recent --batch-size 25 --max-batches 12 --progress-every 5
+python run_mv_backfill_batch_loop.py --cohorts latest,recent --batch-size 25 --min-batch-size 10 --max-batches 12 --progress-every 5 --request-timeout 10 --command-timeout-seconds 180
+python run_title_track_backfill_batch_loop.py --cohorts latest,recent --batch-size 25 --min-batch-size 10 --max-batches 12 --progress-every 5
 ```
 
-`run_mv_backfill_batch_loop.py`는 latest/recent unresolved rows를 서버사이드에서 자동 batch loop로 처리한다. 실제 persisted change(`persisted_resolution_changes`) 또는 coverage lift가 난 batch만 `row_offset=0`으로 리셋해서 새 unresolved head부터 다시 먹고, 이미 반영된 head를 다시 찾기만 한 batch는 같은 snapshot 뒤쪽 chunk로 넘어간다. 전체 snapshot을 한 번 다 훑었는데 progress가 없거나 `max_batches`에 닿으면 멈추고, 마지막에 `build_mv_manual_review_queue.py`를 자동으로 다시 생성한다. `--request-timeout`은 개별 YouTube 요청, `--command-timeout-seconds`는 각 batch subprocess의 상한을 고정한다.
+`run_mv_backfill_batch_loop.py`는 latest/recent unresolved rows를 서버사이드에서 자동 batch loop로 처리한다. 실제 persisted change(`persisted_resolution_changes`) 또는 coverage lift가 난 batch만 `row_offset=0`으로 리셋해서 새 unresolved head부터 다시 먹고, 이미 반영된 head를 다시 찾기만 한 batch는 같은 snapshot 뒤쪽 chunk로 넘어간다. batch subprocess가 timeout 나면 `--min-batch-size`까지 batch 크기를 자동으로 줄여 같은 offset을 재시도한다. 전체 snapshot을 한 번 다 훑었는데 progress가 없거나 `max_batches`에 닿으면 멈추고, 마지막에 `build_mv_manual_review_queue.py`를 자동으로 다시 생성한다. `--request-timeout`은 개별 YouTube 요청, `--command-timeout-seconds`는 각 batch subprocess의 상한을 고정한다.
 
-`run_title_track_backfill_batch_loop.py`는 latest/recent unresolved title-track rows를 같은 방식으로 자동 batch loop 처리한다. 한 batch에서 실제 persisted title-track change가 나면 `row_offset=0`으로 다시 시작하고, 이미 반영된 head를 다시 계산하기만 한 batch는 같은 snapshot 뒤쪽 chunk로 넘어간다. 전체 snapshot을 한 번 다 훑었는데도 progress가 없거나 `max_batches`에 닿으면 멈추고, summary는 `backend/reports/title_track_backfill_batch_loop_report.json`에 남긴다.
+`run_title_track_backfill_batch_loop.py`는 latest/recent unresolved title-track rows를 같은 방식으로 자동 batch loop 처리한다. 한 batch에서 실제 persisted title-track change가 나면 `row_offset=0`으로 다시 시작하고, 이미 반영된 head를 다시 계산하기만 한 batch는 같은 snapshot 뒤쪽 chunk로 넘어간다. batch subprocess가 timeout 나면 `--min-batch-size`까지 batch 크기를 자동으로 줄여 같은 offset을 재시도한다. 전체 snapshot을 한 번 다 훑었는데도 progress가 없거나 `max_batches`에 닿으면 멈추고, summary는 `backend/reports/title_track_backfill_batch_loop_report.json`에 남긴다.
 
 주간 `Catalog Enrichment Refresh` workflow는 이제 latest/recent 코호트에 대해 `run_title_track_backfill_batch_loop.py`와 `run_mv_backfill_batch_loop.py`를 둘 다 자동 실행한다. 즉 title-track / MV blocker queue는 scheduled enrichment cadence에서 서버사이드로 계속 전진한다.
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -588,21 +588,21 @@ latest/recent blocker 코호트만 빠르게 재생성할 때는 아래처럼 sc
 
 ```bash
 python3 ../build_release_details_musicbrainz.py --cohorts latest,recent
-python3 ../run_mv_backfill_batch_loop.py --cohorts latest,recent --batch-size 50 --max-batches 20 --progress-every 10 --request-timeout 10 --command-timeout-seconds 180
-python3 ../run_title_track_backfill_batch_loop.py --cohorts latest,recent --batch-size 50 --max-batches 20 --progress-every 10
+python3 ../run_mv_backfill_batch_loop.py --cohorts latest,recent --batch-size 25 --min-batch-size 10 --max-batches 40 --progress-every 10 --request-timeout 10 --command-timeout-seconds 180
+python3 ../run_title_track_backfill_batch_loop.py --cohorts latest,recent --batch-size 25 --min-batch-size 10 --max-batches 40 --progress-every 10
 ```
 
 긴 pass를 안전하게 확인할 때는 row limit와 stderr progress를 같이 건다.
 
 ```bash
 python3 ../build_release_details_musicbrainz.py --cohorts latest,recent --max-rows 25 --progress-every 5
-python3 ../run_mv_backfill_batch_loop.py --cohorts latest,recent --batch-size 25 --max-batches 12 --progress-every 5 --request-timeout 10 --command-timeout-seconds 180
-python3 ../run_title_track_backfill_batch_loop.py --cohorts latest,recent --batch-size 25 --max-batches 12 --progress-every 5
+python3 ../run_mv_backfill_batch_loop.py --cohorts latest,recent --batch-size 25 --min-batch-size 10 --max-batches 12 --progress-every 5 --request-timeout 10 --command-timeout-seconds 180
+python3 ../run_title_track_backfill_batch_loop.py --cohorts latest,recent --batch-size 25 --min-batch-size 10 --max-batches 12 --progress-every 5
 ```
 
-`run_mv_backfill_batch_loop.py`는 latest/recent unresolved head를 batch로 반복 처리한다. 한 batch에서 실제 persisted change(`persisted_resolution_changes`)나 coverage lift가 나면 `row_offset=0`으로 다시 시작하고, 이미 반영된 row를 다시 찾기만 한 batch는 같은 snapshot에서 `row_offset += selected_rows`로 뒤쪽 chunk를 훑는다. 전체 snapshot을 한 번 다 훑었는데도 progress가 없거나 `max_batches`에 닿으면 멈추고, 마지막에 `build_mv_manual_review_queue.py`를 자동으로 다시 돌린다. 내부적으로는 `backfill_release_detail_mvs.py`를 재사용하므로 최대 2개의 title track, `official music video` suffix, no-suffix fallback, 외부 검색 단발 실패 흡수 규칙은 그대로 유지된다. `--request-timeout`은 개별 YouTube 요청의 상한, `--command-timeout-seconds`는 각 batch subprocess의 상한이다.
+`run_mv_backfill_batch_loop.py`는 latest/recent unresolved head를 batch로 반복 처리한다. 한 batch에서 실제 persisted change(`persisted_resolution_changes`)나 coverage lift가 나면 `row_offset=0`으로 다시 시작하고, 이미 반영된 row를 다시 찾기만 한 batch는 같은 snapshot에서 `row_offset += selected_rows`로 뒤쪽 chunk를 훑는다. batch subprocess가 timeout 나면 `--min-batch-size`까지 batch 크기를 자동으로 줄여 같은 offset을 재시도한다. 전체 snapshot을 한 번 다 훑었는데도 progress가 없거나 `max_batches`에 닿으면 멈추고, 마지막에 `build_mv_manual_review_queue.py`를 자동으로 다시 돌린다. 내부적으로는 `backfill_release_detail_mvs.py`를 재사용하므로 최대 2개의 title track, `official music video` suffix, no-suffix fallback, 외부 검색 단발 실패 흡수 규칙은 그대로 유지된다. `--request-timeout`은 개별 YouTube 요청의 상한, `--command-timeout-seconds`는 각 batch subprocess의 상한이다.
 
-`run_title_track_backfill_batch_loop.py`는 latest/recent unresolved title-track head를 batch로 반복 처리한다. 한 batch에서 실제 persisted title-track change(`persisted_title_track_changes`)가 나면 `row_offset=0`으로 다시 시작하고, progress가 없으면 같은 snapshot에서 `row_offset += selected_rows`로 뒤쪽 chunk를 훑는다. 전체 snapshot을 한 번 다 훑었는데도 progress가 없거나 `max_batches`에 닿으면 멈추고, summary는 `backend/reports/title_track_backfill_batch_loop_report.json`에 남긴다. 내부적으로는 `build_release_details_musicbrainz.py --cohorts ... --row-offset ... --max-rows ...`를 재사용한다.
+`run_title_track_backfill_batch_loop.py`는 latest/recent unresolved title-track head를 batch로 반복 처리한다. 한 batch에서 실제 persisted title-track change(`persisted_title_track_changes`)가 나면 `row_offset=0`으로 다시 시작하고, progress가 없으면 같은 snapshot에서 `row_offset += selected_rows`로 뒤쪽 chunk를 훑는다. batch subprocess가 timeout 나면 `--min-batch-size`까지 batch 크기를 자동으로 줄여 같은 offset을 재시도한다. 전체 snapshot을 한 번 다 훑었는데도 progress가 없거나 `max_batches`에 닿으면 멈추고, summary는 `backend/reports/title_track_backfill_batch_loop_report.json`에 남긴다. 내부적으로는 `build_release_details_musicbrainz.py --cohorts ... --row-offset ... --max-rows ...`를 재사용한다.
 
 주간 `Catalog Enrichment Refresh` workflow는 latest/recent 코호트에 대해 title-track loop와 MV loop를 같이 태운다. 즉 scheduled enrichment가 `title_track_manual_review_queue`와 `mv_manual_review_queue`를 둘 다 자동으로 계속 줄이는 경로를 갖는다.
 

--- a/docs/specs/backend/README.md
+++ b/docs/specs/backend/README.md
@@ -93,8 +93,8 @@
    - current transitional allowlist와 follow-up boundary
 29. scoped blocker rerun note
    - `build_release_details_musicbrainz.py --cohorts latest,recent` 로 latest/recent row만 재계산할 수 있다
-   - `run_mv_backfill_batch_loop.py --cohorts latest,recent --request-timeout 10 --command-timeout-seconds 180` 로 latest/recent unresolved MV row를 자동 batch loop로 밀 수 있다
-   - `run_title_track_backfill_batch_loop.py --cohorts latest,recent` 로 latest/recent unresolved title-track row를 자동 batch loop로 밀 수 있다
+   - `run_mv_backfill_batch_loop.py --cohorts latest,recent --batch-size 25 --min-batch-size 10 --request-timeout 10 --command-timeout-seconds 180` 로 latest/recent unresolved MV row를 timeout-adaptive batch loop로 밀 수 있다
+   - `run_title_track_backfill_batch_loop.py --cohorts latest,recent --batch-size 25 --min-batch-size 10` 로 latest/recent unresolved title-track row를 timeout-adaptive batch loop로 밀 수 있다
    - full snapshot은 유지하고 review queue / coverage report만 같은 execution scope로 다시 만든다
    - 긴 rerun은 `--max-rows`, `--row-offset`, `--progress-every`, `--request-timeout`, `--command-timeout-seconds` 를 같이 써서 작은 batch를 이어서 확인한다
 

--- a/run_mv_backfill_batch_loop.py
+++ b/run_mv_backfill_batch_loop.py
@@ -18,6 +18,10 @@ BACKFILL_SCRIPT = ROOT / "backfill_release_detail_mvs.py"
 QUEUE_SCRIPT = ROOT / "build_mv_manual_review_queue.py"
 
 
+class CommandTimedOutError(RuntimeError):
+    pass
+
+
 def parse_positive_int_arg(raw_value: str) -> int:
     try:
         parsed = int(raw_value)
@@ -76,7 +80,7 @@ def run_json_command(command: list[str], command_timeout_seconds: int) -> tuple[
             timeout=command_timeout_seconds,
         )
     except subprocess.TimeoutExpired as error:
-        raise RuntimeError(
+        raise CommandTimedOutError(
             "command timed out "
             f"(timeout={command_timeout_seconds}s): {' '.join(command)}\n"
             f"stdout:\n{error.stdout or ''}\nstderr:\n{error.stderr or ''}"
@@ -90,11 +94,18 @@ def run_json_command(command: list[str], command_timeout_seconds: int) -> tuple[
     return load_json_from_stdout(completed.stdout), completed.stderr
 
 
-def summarize_iteration(batch_index: int, row_offset: int, report: dict[str, Any], stderr: str) -> dict[str, Any]:
+def summarize_iteration(
+    batch_index: int,
+    row_offset: int,
+    batch_size: int,
+    report: dict[str, Any],
+    stderr: str,
+) -> dict[str, Any]:
     execution_scope = report.get("execution_scope", {})
     return {
         "batch_index": batch_index,
         "row_offset": row_offset,
+        "batch_size": batch_size,
         "selected_rows": execution_scope.get("selected_rows", 0),
         "scoped_rows_total": execution_scope.get("scoped_rows_total", 0),
         "resolved_now": report.get("resolved_now", 0),
@@ -111,23 +122,43 @@ def run_batch_loop(
     *,
     cohorts: str,
     batch_size: int,
+    min_batch_size: int,
     max_batches: int,
     progress_every: int,
     request_timeout_seconds: int,
     command_timeout_seconds: int,
-    batch_runner: Callable[[int], tuple[dict[str, Any], str]],
+    batch_runner: Callable[[int, int], tuple[dict[str, Any], str]],
     queue_builder: Callable[[], dict[str, Any]],
 ) -> dict[str, Any]:
     started_at = now_utc_iso()
     row_offset = 0
     batch_index = 0
     iterations: list[dict[str, Any]] = []
+    adaptive_events: list[dict[str, Any]] = []
     stop_reason = "unknown"
+    current_batch_size = batch_size
 
     while batch_index < max_batches:
+        try:
+            report, stderr = batch_runner(row_offset, current_batch_size)
+        except CommandTimedOutError as error:
+            if current_batch_size <= min_batch_size:
+                raise
+            next_batch_size = max(min_batch_size, current_batch_size // 2)
+            adaptive_events.append(
+                {
+                    "row_offset": row_offset,
+                    "previous_batch_size": current_batch_size,
+                    "next_batch_size": next_batch_size,
+                    "reason": "command_timeout",
+                    "error": str(error),
+                }
+            )
+            current_batch_size = next_batch_size
+            continue
+
         batch_index += 1
-        report, stderr = batch_runner(row_offset)
-        iteration = summarize_iteration(batch_index, row_offset, report, stderr)
+        iteration = summarize_iteration(batch_index, row_offset, current_batch_size, report, stderr)
         iterations.append(iteration)
 
         selected_rows = int(iteration["selected_rows"])
@@ -161,6 +192,7 @@ def run_batch_loop(
         "config": {
             "cohorts": [value.strip() for value in cohorts.split(",") if value.strip()],
             "batch_size": batch_size,
+            "min_batch_size": min_batch_size,
             "max_batches": max_batches,
             "progress_every": progress_every,
             "request_timeout_seconds": request_timeout_seconds,
@@ -168,6 +200,7 @@ def run_batch_loop(
         },
         "stop_reason": stop_reason,
         "batches_run": len(iterations),
+        "adaptive_events": adaptive_events,
         "total_resolved_now": total_resolved_now,
         "total_persisted_resolution_changes": total_persisted_resolution_changes,
         "total_coverage_lift": total_coverage_lift,
@@ -190,6 +223,12 @@ def main() -> None:
         type=parse_positive_int_arg,
         default=50,
         help="Number of rows to process per backfill batch.",
+    )
+    parser.add_argument(
+        "--min-batch-size",
+        type=parse_positive_int_arg,
+        default=10,
+        help="Minimum batch size to fall back to after timeout-driven retries.",
     )
     parser.add_argument(
         "--max-batches",
@@ -222,17 +261,17 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    def batch_runner(row_offset: int) -> tuple[dict[str, Any], str]:
+    def batch_runner(row_offset: int, batch_size: int) -> tuple[dict[str, Any], str]:
         command = build_backfill_command(
             args.cohorts,
-            args.batch_size,
+            batch_size,
             row_offset,
             args.progress_every,
             args.request_timeout,
         )
         print(
             "[run_mv_backfill_batch_loop] "
-            f"batch row_offset={row_offset} batch_size={args.batch_size}",
+            f"batch row_offset={row_offset} batch_size={batch_size}",
             file=sys.stderr,
             flush=True,
         )
@@ -249,6 +288,7 @@ def main() -> None:
     summary = run_batch_loop(
         cohorts=args.cohorts,
         batch_size=args.batch_size,
+        min_batch_size=args.min_batch_size,
         max_batches=args.max_batches,
         progress_every=args.progress_every,
         request_timeout_seconds=args.request_timeout,

--- a/run_title_track_backfill_batch_loop.py
+++ b/run_title_track_backfill_batch_loop.py
@@ -16,6 +16,10 @@ DEFAULT_SUMMARY_PATH = ROOT / "backend" / "reports" / "title_track_backfill_batc
 BACKFILL_SCRIPT = ROOT / "build_release_details_musicbrainz.py"
 
 
+class CommandTimedOutError(RuntimeError):
+    pass
+
+
 def parse_positive_int_arg(raw_value: str) -> int:
     try:
         parsed = int(raw_value)
@@ -75,7 +79,7 @@ def run_json_command(command: list[str], command_timeout_seconds: int) -> tuple[
             timeout=command_timeout_seconds,
         )
     except subprocess.TimeoutExpired as error:
-        raise RuntimeError(
+        raise CommandTimedOutError(
             "command timed out "
             f"(timeout={command_timeout_seconds}s): {' '.join(command)}\n"
             f"stdout:\n{error.stdout or ''}\nstderr:\n{error.stderr or ''}"
@@ -89,13 +93,20 @@ def run_json_command(command: list[str], command_timeout_seconds: int) -> tuple[
     return load_json_from_stdout(completed.stdout), completed.stderr
 
 
-def summarize_iteration(batch_index: int, row_offset: int, report: dict[str, Any], stderr: str) -> dict[str, Any]:
+def summarize_iteration(
+    batch_index: int,
+    row_offset: int,
+    batch_size: int,
+    report: dict[str, Any],
+    stderr: str,
+) -> dict[str, Any]:
     execution_scope = report.get("execution_scope", {})
     rows_with_title_track_before = int(report.get("rows_with_title_track_before") or 0)
     rows_with_title_track_after = int(report.get("rows_with_title_track_after") or 0)
     return {
         "batch_index": batch_index,
         "row_offset": row_offset,
+        "batch_size": batch_size,
         "selected_rows": execution_scope.get("selected_rows", 0),
         "scoped_rows_total": execution_scope.get("scoped_rows_total", 0),
         "rows_with_title_track_before": rows_with_title_track_before,
@@ -112,22 +123,42 @@ def run_batch_loop(
     *,
     cohorts: str,
     batch_size: int,
+    min_batch_size: int,
     max_batches: int,
     progress_every: int,
     skip_acquisition: bool,
     command_timeout_seconds: int,
-    batch_runner: Callable[[int], tuple[dict[str, Any], str]],
+    batch_runner: Callable[[int, int], tuple[dict[str, Any], str]],
 ) -> dict[str, Any]:
     started_at = now_utc_iso()
     row_offset = 0
     batch_index = 0
     iterations: list[dict[str, Any]] = []
+    adaptive_events: list[dict[str, Any]] = []
     stop_reason = "unknown"
+    current_batch_size = batch_size
 
     while batch_index < max_batches:
+        try:
+            report, stderr = batch_runner(row_offset, current_batch_size)
+        except CommandTimedOutError as error:
+            if current_batch_size <= min_batch_size:
+                raise
+            next_batch_size = max(min_batch_size, current_batch_size // 2)
+            adaptive_events.append(
+                {
+                    "row_offset": row_offset,
+                    "previous_batch_size": current_batch_size,
+                    "next_batch_size": next_batch_size,
+                    "reason": "command_timeout",
+                    "error": str(error),
+                }
+            )
+            current_batch_size = next_batch_size
+            continue
+
         batch_index += 1
-        report, stderr = batch_runner(row_offset)
-        iteration = summarize_iteration(batch_index, row_offset, report, stderr)
+        iteration = summarize_iteration(batch_index, row_offset, current_batch_size, report, stderr)
         iterations.append(iteration)
 
         selected_rows = int(iteration["selected_rows"])
@@ -156,6 +187,7 @@ def run_batch_loop(
         "config": {
             "cohorts": [value.strip() for value in cohorts.split(",") if value.strip()],
             "batch_size": batch_size,
+            "min_batch_size": min_batch_size,
             "max_batches": max_batches,
             "progress_every": progress_every,
             "skip_acquisition": skip_acquisition,
@@ -163,6 +195,7 @@ def run_batch_loop(
         },
         "stop_reason": stop_reason,
         "batches_run": len(iterations),
+        "adaptive_events": adaptive_events,
         "total_persisted_title_track_changes": sum(int(row["persisted_title_track_changes"]) for row in iterations),
         "total_auto_resolved_rows": sum(int(row["title_track_auto_resolved_rows"]) for row in iterations),
         "final_iteration": iterations[-1] if iterations else None,
@@ -183,6 +216,12 @@ def main() -> None:
         type=parse_positive_int_arg,
         default=50,
         help="Number of rows to process per title-track batch.",
+    )
+    parser.add_argument(
+        "--min-batch-size",
+        type=parse_positive_int_arg,
+        default=10,
+        help="Minimum batch size to fall back to after timeout-driven retries.",
     )
     parser.add_argument(
         "--max-batches",
@@ -214,17 +253,17 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    def batch_runner(row_offset: int) -> tuple[dict[str, Any], str]:
+    def batch_runner(row_offset: int, batch_size: int) -> tuple[dict[str, Any], str]:
         command = build_backfill_command(
             args.cohorts,
-            args.batch_size,
+            batch_size,
             row_offset,
             args.progress_every,
             args.skip_acquisition,
         )
         print(
             "[run_title_track_backfill_batch_loop] "
-            f"batch row_offset={row_offset} batch_size={args.batch_size}",
+            f"batch row_offset={row_offset} batch_size={batch_size}",
             file=sys.stderr,
             flush=True,
         )
@@ -233,6 +272,7 @@ def main() -> None:
     summary = run_batch_loop(
         cohorts=args.cohorts,
         batch_size=args.batch_size,
+        min_batch_size=args.min_batch_size,
         max_batches=args.max_batches,
         progress_every=args.progress_every,
         skip_acquisition=args.skip_acquisition,

--- a/test_run_mv_backfill_batch_loop.py
+++ b/test_run_mv_backfill_batch_loop.py
@@ -14,10 +14,10 @@ class RunMvBackfillBatchLoopTests(unittest.TestCase):
             loop.parse_positive_int_arg("0")
 
     def test_run_batch_loop_resets_offset_after_progress_and_stops_when_next_scan_has_none(self) -> None:
-        calls: list[int] = []
+        calls: list[tuple[int, int]] = []
 
-        def batch_runner(row_offset: int):
-            calls.append(row_offset)
+        def batch_runner(row_offset: int, batch_size: int):
+            calls.append((row_offset, batch_size))
             if row_offset == 0 and len(calls) == 1:
                 return (
                 {
@@ -56,6 +56,7 @@ class RunMvBackfillBatchLoopTests(unittest.TestCase):
         summary = loop.run_batch_loop(
             cohorts="latest,recent",
             batch_size=5,
+            min_batch_size=5,
             max_batches=4,
             progress_every=2,
             request_timeout_seconds=10,
@@ -64,16 +65,16 @@ class RunMvBackfillBatchLoopTests(unittest.TestCase):
             queue_builder=queue_builder,
         )
 
-        self.assertEqual(calls, [0, 0])
+        self.assertEqual(calls, [(0, 5), (0, 5)])
         self.assertEqual(summary["stop_reason"], "exhausted")
         self.assertEqual(summary["total_resolved_now"], 2)
         self.assertEqual(summary["queue_summary"]["queue_items"], 10)
 
     def test_run_batch_loop_advances_offset_during_no_progress_scan_and_stops_at_end(self) -> None:
-        calls: list[int] = []
+        calls: list[tuple[int, int]] = []
 
-        def batch_runner(row_offset: int):
-            calls.append(row_offset)
+        def batch_runner(row_offset: int, batch_size: int):
+            calls.append((row_offset, batch_size))
             return (
                 {
                     "resolved_now": 0,
@@ -93,6 +94,7 @@ class RunMvBackfillBatchLoopTests(unittest.TestCase):
         summary = loop.run_batch_loop(
             cohorts="latest,recent",
             batch_size=10,
+            min_batch_size=10,
             max_batches=5,
             progress_every=2,
             request_timeout_seconds=10,
@@ -101,12 +103,12 @@ class RunMvBackfillBatchLoopTests(unittest.TestCase):
             queue_builder=lambda: {"queue_items": 40},
         )
 
-        self.assertEqual(calls, [0, 10])
+        self.assertEqual(calls, [(0, 10), (10, 10)])
         self.assertEqual(summary["stop_reason"], "no_progress_full_scan")
         self.assertEqual(summary["batches_run"], 2)
 
     def test_run_batch_loop_stops_at_max_batches(self) -> None:
-        def batch_runner(_row_offset: int):
+        def batch_runner(_row_offset: int, _batch_size: int):
             return (
                 {
                     "resolved_now": 1,
@@ -126,6 +128,7 @@ class RunMvBackfillBatchLoopTests(unittest.TestCase):
         summary = loop.run_batch_loop(
             cohorts="latest,recent",
             batch_size=10,
+            min_batch_size=10,
             max_batches=3,
             progress_every=2,
             request_timeout_seconds=10,
@@ -139,10 +142,10 @@ class RunMvBackfillBatchLoopTests(unittest.TestCase):
         self.assertEqual(summary["total_persisted_resolution_changes"], 3)
 
     def test_run_batch_loop_moves_forward_when_resolutions_do_not_change_files(self) -> None:
-        calls: list[int] = []
+        calls: list[tuple[int, int]] = []
 
-        def batch_runner(row_offset: int):
-            calls.append(row_offset)
+        def batch_runner(row_offset: int, batch_size: int):
+            calls.append((row_offset, batch_size))
             return (
                 {
                     "resolved_now": 3,
@@ -162,6 +165,7 @@ class RunMvBackfillBatchLoopTests(unittest.TestCase):
         summary = loop.run_batch_loop(
             cohorts="latest,recent",
             batch_size=10,
+            min_batch_size=10,
             max_batches=5,
             progress_every=2,
             request_timeout_seconds=10,
@@ -170,10 +174,49 @@ class RunMvBackfillBatchLoopTests(unittest.TestCase):
             queue_builder=lambda: {"queue_items": 100},
         )
 
-        self.assertEqual(calls, [0, 10])
+        self.assertEqual(calls, [(0, 10), (10, 10)])
         self.assertEqual(summary["stop_reason"], "no_progress_full_scan")
         self.assertEqual(summary["total_resolved_now"], 6)
         self.assertEqual(summary["total_persisted_resolution_changes"], 0)
+
+    def test_run_batch_loop_retries_with_smaller_batch_size_after_timeout(self) -> None:
+        calls: list[tuple[int, int]] = []
+
+        def batch_runner(row_offset: int, batch_size: int):
+            calls.append((row_offset, batch_size))
+            if batch_size == 8:
+                raise loop.CommandTimedOutError("timed out")
+            return (
+                {
+                    "resolved_now": 0,
+                    "persisted_resolution_changes": 0,
+                    "coverage_lift": 0,
+                    "review_row_count": 3,
+                    "resolved_entities": 0,
+                    "unresolved_remainder": 7,
+                    "execution_scope": {
+                        "selected_rows": 0,
+                        "scoped_rows_total": 7,
+                    },
+                },
+                "",
+            )
+
+        summary = loop.run_batch_loop(
+            cohorts="latest,recent",
+            batch_size=8,
+            min_batch_size=4,
+            max_batches=2,
+            progress_every=2,
+            request_timeout_seconds=10,
+            command_timeout_seconds=180,
+            batch_runner=batch_runner,
+            queue_builder=lambda: {"queue_items": 7},
+        )
+
+        self.assertEqual(calls, [(0, 8), (0, 4)])
+        self.assertEqual(summary["stop_reason"], "exhausted")
+        self.assertEqual(summary["adaptive_events"][0]["next_batch_size"], 4)
 
     def test_build_backfill_command_forwards_request_timeout(self) -> None:
         command = loop.build_backfill_command(

--- a/test_run_title_track_backfill_batch_loop.py
+++ b/test_run_title_track_backfill_batch_loop.py
@@ -14,10 +14,10 @@ class RunTitleTrackBackfillBatchLoopTests(unittest.TestCase):
             loop.parse_positive_int_arg("0")
 
     def test_run_batch_loop_resets_offset_after_progress(self) -> None:
-        calls: list[int] = []
+        calls: list[tuple[int, int]] = []
 
-        def batch_runner(row_offset: int):
-            calls.append(row_offset)
+        def batch_runner(row_offset: int, batch_size: int):
+            calls.append((row_offset, batch_size))
             if len(calls) == 1:
                 return (
                     {
@@ -51,6 +51,7 @@ class RunTitleTrackBackfillBatchLoopTests(unittest.TestCase):
         summary = loop.run_batch_loop(
             cohorts="latest,recent",
             batch_size=5,
+            min_batch_size=5,
             max_batches=4,
             progress_every=2,
             skip_acquisition=False,
@@ -58,15 +59,15 @@ class RunTitleTrackBackfillBatchLoopTests(unittest.TestCase):
             batch_runner=batch_runner,
         )
 
-        self.assertEqual(calls, [0, 0])
+        self.assertEqual(calls, [(0, 5), (0, 5)])
         self.assertEqual(summary["stop_reason"], "exhausted")
         self.assertEqual(summary["total_persisted_title_track_changes"], 2)
 
     def test_run_batch_loop_advances_offset_during_no_progress_scan(self) -> None:
-        calls: list[int] = []
+        calls: list[tuple[int, int]] = []
 
-        def batch_runner(row_offset: int):
-            calls.append(row_offset)
+        def batch_runner(row_offset: int, batch_size: int):
+            calls.append((row_offset, batch_size))
             return (
                 {
                     "rows_with_title_track_before": 5,
@@ -85,6 +86,7 @@ class RunTitleTrackBackfillBatchLoopTests(unittest.TestCase):
         summary = loop.run_batch_loop(
             cohorts="latest,recent",
             batch_size=10,
+            min_batch_size=10,
             max_batches=5,
             progress_every=2,
             skip_acquisition=True,
@@ -92,9 +94,46 @@ class RunTitleTrackBackfillBatchLoopTests(unittest.TestCase):
             batch_runner=batch_runner,
         )
 
-        self.assertEqual(calls, [0, 10])
+        self.assertEqual(calls, [(0, 10), (10, 10)])
         self.assertEqual(summary["stop_reason"], "no_progress_full_scan")
         self.assertEqual(summary["batches_run"], 2)
+
+    def test_run_batch_loop_retries_with_smaller_batch_size_after_timeout(self) -> None:
+        calls: list[tuple[int, int]] = []
+
+        def batch_runner(row_offset: int, batch_size: int):
+            calls.append((row_offset, batch_size))
+            if batch_size == 8:
+                raise loop.CommandTimedOutError("timed out")
+            return (
+                {
+                    "rows_with_title_track_before": 4,
+                    "rows_with_title_track_after": 4,
+                    "title_track_auto_resolved_rows": 0,
+                    "title_track_auto_double_rows": 0,
+                    "title_track_review_queue_rows": 9,
+                    "execution_scope": {
+                        "selected_rows": 0,
+                        "scoped_rows_total": 9,
+                    },
+                },
+                "",
+            )
+
+        summary = loop.run_batch_loop(
+            cohorts="latest,recent",
+            batch_size=8,
+            min_batch_size=4,
+            max_batches=2,
+            progress_every=2,
+            skip_acquisition=True,
+            command_timeout_seconds=180,
+            batch_runner=batch_runner,
+        )
+
+        self.assertEqual(calls, [(0, 8), (0, 4)])
+        self.assertEqual(summary["stop_reason"], "exhausted")
+        self.assertEqual(summary["adaptive_events"][0]["next_batch_size"], 4)
 
     def test_build_backfill_command_forwards_row_offset_and_skip_flag(self) -> None:
         command = loop.build_backfill_command(


### PR DESCRIPTION
## Summary
- add timeout-adaptive batch sizing to MV and title-track enrichment loops
- lower scheduled catalog enrichment starting batch sizes and raise batch count to keep throughput
- document the new min batch size behavior in backend and root docs

## Testing
- source .venv/bin/activate && python -m unittest test_run_mv_backfill_batch_loop.py test_run_title_track_backfill_batch_loop.py
- cd backend && npm run workflow:verify
- source .venv/bin/activate && python run_mv_backfill_batch_loop.py --cohorts latest,recent --batch-size 10 --min-batch-size 5 --max-batches 1 --progress-every 2 --request-timeout 10 --command-timeout-seconds 180 --summary-path /tmp/mv-loop-success-smoke.json
- source .venv/bin/activate && python run_title_track_backfill_batch_loop.py --cohorts latest,recent --batch-size 10 --min-batch-size 5 --max-batches 1 --progress-every 5 --skip-acquisition --command-timeout-seconds 180 --summary-path /tmp/title-loop-success-smoke.json
- git diff --check