### PR TITLE
Fix mobile handoff and team detail card regressions

### DIFF
--- a/mobile/app.config.ts
+++ b/mobile/app.config.ts
@@ -308,6 +308,9 @@ export default ({ config }: ConfigContext): ExpoConfig => {
     ios: {
       supportsTablet: true,
       bundleIdentifier: nativeIosConfig.bundleIdentifier,
+      infoPlist: {
+        LSApplicationQueriesSchemes: ['spotify', 'youtube', 'youtubemusic', 'ytmusic', 'twitter', 'x'],
+      },
       ...(nativeIosConfig.appleTeamId ? { appleTeamId: nativeIosConfig.appleTeamId } : {}),
     },
     android: {

--- a/mobile/app/(tabs)/calendar.tsx
+++ b/mobile/app/(tabs)/calendar.tsx
@@ -539,6 +539,7 @@ export default function CalendarTabScreen() {
   }
 
   function openReleaseDetail(releaseId: string) {
+    setIsSheetOpen(false);
     router.push({
       pathname: '/releases/[id]',
       params: { id: releaseId },
@@ -550,6 +551,7 @@ export default function CalendarTabScreen() {
       return;
     }
 
+    setIsSheetOpen(false);
     router.push({
       pathname: '/artists/[slug]',
       params: { slug: group },

--- a/mobile/app/artists/[slug].tsx
+++ b/mobile/app/artists/[slug].tsx
@@ -1155,6 +1155,7 @@ function createStyles(theme: ReturnType<typeof useAppTheme>) {
     },
     singleAlbumCard: {
       flexDirection: 'row',
+      alignItems: 'center',
       gap: theme.space[12],
       padding: theme.space[12],
       borderRadius: theme.radius.card,
@@ -1162,7 +1163,7 @@ function createStyles(theme: ReturnType<typeof useAppTheme>) {
     },
     singleAlbumArtwork: {
       width: 72,
-      aspectRatio: 1,
+      height: 72,
       borderRadius: theme.radius.button,
       alignItems: 'center',
       justifyContent: 'center',
@@ -1175,8 +1176,8 @@ function createStyles(theme: ReturnType<typeof useAppTheme>) {
       justifyContent: 'center',
     },
     albumCard: {
-      width: '52%',
-      minWidth: 188,
+      width: 156,
+      flexShrink: 0,
       gap: theme.space[8],
       padding: theme.space[12],
       borderRadius: theme.radius.card,
@@ -1184,7 +1185,7 @@ function createStyles(theme: ReturnType<typeof useAppTheme>) {
     },
     albumArtwork: {
       width: '100%',
-      aspectRatio: 1,
+      height: 132,
       borderRadius: theme.radius.button,
       alignItems: 'center',
       justifyContent: 'center',
@@ -1194,6 +1195,7 @@ function createStyles(theme: ReturnType<typeof useAppTheme>) {
     albumArtworkImage: {
       width: '100%',
       height: '100%',
+      resizeMode: 'cover',
     },
     albumArtworkFallback: {
       fontSize: 22,

--- a/mobile/src/components/actions/ServiceButton.tsx
+++ b/mobile/src/components/actions/ServiceButton.tsx
@@ -90,7 +90,7 @@ function ServiceButtonComponent({
               fadeDuration={0}
               onError={() => setIconLoadFailed(true)}
               source={serviceIconSource}
-              style={[styles.markIcon, styles[`${resolvedService}MarkIcon`]]}
+              style={styles.markIcon}
               testID={testID ? `${testID}-icon` : undefined}
             />
           )}
@@ -156,15 +156,15 @@ function createStyles(theme: MobileTheme) {
       textAlign: 'center',
     },
     mark: {
-      width: 24,
-      height: 24,
+      width: 28,
+      height: 28,
       alignItems: 'center',
       justifyContent: 'center',
-      borderRadius: 12,
+      borderRadius: 14,
     },
     markIcon: {
-      width: 14,
-      height: 14,
+      width: 18,
+      height: 18,
       resizeMode: 'contain',
     },
     markFallbackGlyph: {
@@ -185,9 +185,6 @@ function createStyles(theme: MobileTheme) {
     spotifyMark: {
       backgroundColor: theme.colors.service.spotify.icon,
     },
-    spotifyMarkIcon: {
-      tintColor: theme.colors.text.inverse,
-    },
     spotifyMarkFallbackGlyph: {
       color: theme.colors.text.inverse,
     },
@@ -201,9 +198,6 @@ function createStyles(theme: MobileTheme) {
     youtubeMusicMark: {
       backgroundColor: theme.colors.service.youtubeMusic.icon,
     },
-    youtubeMusicMarkIcon: {
-      tintColor: theme.colors.text.inverse,
-    },
     youtubeMusicMarkFallbackGlyph: {
       color: theme.colors.text.inverse,
     },
@@ -216,9 +210,6 @@ function createStyles(theme: MobileTheme) {
     },
     youtubeMvMark: {
       backgroundColor: theme.colors.service.youtubeMv.icon,
-    },
-    youtubeMvMarkIcon: {
-      tintColor: theme.colors.text.inverse,
     },
     youtubeMvMarkFallbackGlyph: {
       color: theme.colors.text.inverse,

--- a/mobile/src/components/calendar/DayCell.tsx
+++ b/mobile/src/components/calendar/DayCell.tsx
@@ -162,9 +162,10 @@ function createStyles(theme: MobileTheme) {
   return StyleSheet.create({
     dayCell: {
       flex: 1,
-      minHeight: 96,
-      gap: theme.space[8],
-      padding: theme.space[8],
+      minHeight: 88,
+      gap: theme.space[4],
+      paddingHorizontal: theme.space[8],
+      paddingVertical: theme.space[4],
       borderRadius: theme.radius.card,
       borderWidth: 1,
       borderColor: theme.colors.border.subtle,
@@ -190,6 +191,8 @@ function createStyles(theme: MobileTheme) {
       ...theme.typography.cardTitle,
       color: theme.colors.text.primary,
       flexShrink: 1,
+      fontSize: 18,
+      lineHeight: 22,
     },
     dayNumberSelected: {
       color: theme.colors.text.brand,
@@ -201,11 +204,11 @@ function createStyles(theme: MobileTheme) {
       alignItems: 'center',
     },
     badgePill: {
-      minHeight: 24,
-      minWidth: 24,
+      minHeight: 22,
+      minWidth: 22,
       alignItems: 'center',
       justifyContent: 'center',
-      paddingHorizontal: theme.space[8],
+      paddingHorizontal: theme.space[4],
       borderRadius: theme.radius.chip,
     },
     badgeText: {

--- a/mobile/src/features/calendarControls.test.tsx
+++ b/mobile/src/features/calendarControls.test.tsx
@@ -369,6 +369,7 @@ describe('calendar controls', () => {
       params: { id: 'yena--love-catcher--2026-03-11--album' },
     });
     expect(mockOpenXSearchHandoff).toHaveBeenCalled();
+    expect(tree.root.findAllByProps({ testID: 'calendar-bottom-sheet' })).toHaveLength(0);
   });
 
   test('renders list mode with separated verified, exact, and month-only sections', async () => {

--- a/mobile/src/services/handoff.test.ts
+++ b/mobile/src/services/handoff.test.ts
@@ -88,6 +88,7 @@ describe('mobile external handoff service', () => {
     }
 
     expect(handoff.mode).toBe('canonical');
+    expect(handoff.appUrls).toContain('spotify:album:12345');
     expect(handoff.primaryUrl).toBe('https://open.spotify.com/album/12345');
     expect(handoff.searchFallbackUrl).toBe('https://open.spotify.com/search/BLACKPINK%20DEADLINE');
     expect(handoff.browserFallbackUrl).toBe('https://open.spotify.com/search/BLACKPINK%20DEADLINE');
@@ -169,10 +170,10 @@ describe('mobile external handoff service', () => {
       ok: true,
       service: 'spotify',
       mode: 'canonical',
-      target: 'primary',
-      openedUrl: 'https://open.spotify.com/album/12345',
+      target: 'app',
+      openedUrl: 'spotify:album:12345',
     });
-    expect(opened).toEqual(['https://open.spotify.com/album/12345']);
+    expect(opened).toEqual(['spotify:album:12345']);
   });
 
   test('uses browser fallback when the primary target cannot be opened', async () => {

--- a/mobile/src/services/handoff.ts
+++ b/mobile/src/services/handoff.ts
@@ -2,7 +2,7 @@ import * as Linking from 'expo-linking';
 
 export type MusicService = 'spotify' | 'youtubeMusic' | 'youtubeMv';
 export type ServiceHandoffMode = 'canonical' | 'searchFallback';
-export type ServiceHandoffTarget = 'primary' | 'browserFallback';
+export type ServiceHandoffTarget = 'app' | 'primary' | 'browserFallback';
 export type ServiceHandoffFailureCode = 'handoff_unavailable' | 'handoff_open_failed';
 export type XSearchHandoffTarget = 'app' | 'web';
 export type XSearchQueryMode = 'entity_only' | 'release_backed';
@@ -11,6 +11,7 @@ export type ServiceHandoffResolution = {
   service: MusicService;
   mode: ServiceHandoffMode;
   query: string;
+  appUrls: string[];
   primaryUrl: string;
   browserFallbackUrl: string | null;
   searchFallbackUrl: string;
@@ -315,6 +316,70 @@ function normalizeBrowserFallbackUrl(service: MusicService, value: string | null
   return normalizeCanonicalServiceUrl(service, value);
 }
 
+function buildSpotifyAppUrls(primaryUrl: string, query: string): string[] {
+  const urls = new Set<string>();
+  const parsed = tryParseUrl(primaryUrl);
+
+  if (parsed?.hostname === 'open.spotify.com') {
+    const [kind, id] = parsed.pathname.split('/').filter(Boolean);
+    if (kind && id) {
+      urls.add(`spotify:${kind}:${id}`);
+    }
+  }
+
+  if (query) {
+    urls.add(`spotify:search:${encodeURIComponent(query)}`);
+  }
+
+  return [...urls];
+}
+
+function buildYoutubeMusicAppUrls(primaryUrl: string, query: string): string[] {
+  const urls = new Set<string>();
+  const parsed = tryParseUrl(primaryUrl);
+
+  if (parsed) {
+    urls.add(`youtubemusic://${parsed.host}${parsed.pathname}${parsed.search}`);
+    urls.add(`ytmusic://${parsed.host}${parsed.pathname}${parsed.search}`);
+  }
+
+  if (query) {
+    const searchPath = `/search?q=${encodeURIComponent(query)}`;
+    urls.add(`youtubemusic://music.youtube.com${searchPath}`);
+    urls.add(`ytmusic://music.youtube.com${searchPath}`);
+  }
+
+  return [...urls];
+}
+
+function buildYoutubeAppUrls(primaryUrl: string, query: string): string[] {
+  const urls = new Set<string>();
+  const videoId = extractYouTubeVideoId(primaryUrl);
+
+  if (videoId) {
+    urls.add(`youtube://www.youtube.com/watch?v=${videoId}`);
+  }
+
+  if (query) {
+    urls.add(`youtube://www.youtube.com/results?search_query=${encodeURIComponent(`${query} official mv`)}`);
+  }
+
+  return [...urls];
+}
+
+function buildServiceAppUrls(service: MusicService, primaryUrl: string, query: string): string[] {
+  switch (service) {
+    case 'spotify':
+      return buildSpotifyAppUrls(primaryUrl, query);
+    case 'youtubeMusic':
+      return buildYoutubeMusicAppUrls(primaryUrl, query);
+    case 'youtubeMv':
+      return buildYoutubeAppUrls(primaryUrl, query);
+    default:
+      return [];
+  }
+}
+
 export function resolveServiceHandoff(input: {
   service: MusicService;
   query: string;
@@ -331,6 +396,7 @@ export function resolveServiceHandoff(input: {
       service: input.service,
       mode: 'canonical',
       query,
+      appUrls: buildServiceAppUrls(input.service, canonicalUrl, query),
       primaryUrl: canonicalUrl,
       browserFallbackUrl:
         browserFallbackUrl && browserFallbackUrl !== canonicalUrl ? browserFallbackUrl : searchFallbackUrl,
@@ -358,6 +424,7 @@ export function resolveServiceHandoff(input: {
     service: input.service,
     mode: 'searchFallback',
     query,
+    appUrls: buildServiceAppUrls(input.service, searchFallbackUrl, query),
     primaryUrl: searchFallbackUrl,
     browserFallbackUrl: browserFallbackUrl && browserFallbackUrl !== searchFallbackUrl ? browserFallbackUrl : null,
     searchFallbackUrl,
@@ -409,6 +476,7 @@ export async function openServiceHandoff(
 
   const resolvedHandoff: ServiceHandoffResolution = handoff;
   const attempts: { target: ServiceHandoffTarget; url: string }[] = [
+    ...resolvedHandoff.appUrls.map((url) => ({ target: 'app' as const, url })),
     { target: 'primary', url: resolvedHandoff.primaryUrl },
   ];
 


### PR DESCRIPTION
## Summary\n- try installed app schemes before browser for Spotify and YouTube Music handoff\n- tighten service icon rendering and calendar interactions\n- fix oversized recent album cards in team detail\n\n## Verification\n- cd mobile && npm test -- --runInBand src/services/handoff.test.ts src/features/calendarControls.test.tsx src/features/entityDetailScreen.test.tsx\n- cd mobile && npm run typecheck\n- cd mobile && npm run lint\n- git diff --check\n\nCloses #748