### PR TITLE
Improve mobile nearest upcoming summary card

### DIFF
--- a/mobile/app/(tabs)/calendar.tsx
+++ b/mobile/app/(tabs)/calendar.tsx
@@ -871,9 +871,17 @@ export default function CalendarTabScreen() {
   const selectedDaySummary = selectedDay
     ? `발매 ${selectedDay.releases.length} · 예정 ${selectedDay.exactUpcoming.length}`
     : '발매 0 · 예정 0';
-  const nearestSummary = filteredSnapshot.nearestUpcoming?.scheduledDate
-    ? `${filteredSnapshot.nearestUpcoming.displayGroup} · ${formatShortDateLabel(filteredSnapshot.nearestUpcoming.scheduledDate)}`
-    : '없음';
+  const nearestUpcomingItem = filteredSnapshot.nearestUpcoming
+    ? {
+        value: filteredSnapshot.nearestUpcoming.displayGroup,
+        detail: filteredSnapshot.nearestUpcoming.scheduledDate
+          ? formatShortDateLabel(filteredSnapshot.nearestUpcoming.scheduledDate)
+          : '날짜 미정',
+      }
+    : {
+        value: '정확한 날짜 없음',
+        detail: '없음',
+      };
   const runtimeRetryAction = datasetRiskDisclosure ? (
     <ActionButton
       accessibilityLabel="라이브 캘린더 데이터 다시 시도"
@@ -894,7 +902,12 @@ export default function CalendarTabScreen() {
               items={[
                 { key: 'release-count', label: MOBILE_COPY.summary.monthRelease, value: filteredSnapshot.releaseCount },
                 { key: 'upcoming-count', label: MOBILE_COPY.summary.upcoming, value: filteredSnapshot.upcomingCount },
-                { key: 'nearest-upcoming', label: MOBILE_COPY.summary.nearestUpcoming, value: nearestSummary },
+                {
+                  key: 'nearest-upcoming',
+                  label: MOBILE_COPY.summary.nearestUpcoming,
+                  value: nearestUpcomingItem.value,
+                  detail: nearestUpcomingItem.detail,
+                },
               ]}
               layout="wrap"
               testID="calendar-summary-strip"

--- a/mobile/src/components/layout/SummaryStrip.test.tsx
+++ b/mobile/src/components/layout/SummaryStrip.test.tsx
@@ -54,4 +54,31 @@ describe('SummaryStrip', () => {
     expect(valueText.props.maxFontSizeMultiplier).toBe(MOBILE_TEXT_SCALE_LIMITS.summaryValue);
     expect(labelText.props.maxFontSizeMultiplier).toBe(MOBILE_TEXT_SCALE_LIMITS.summaryLabel);
   });
+
+  test('renders detail text without collapsing the primary value into a single truncated line', () => {
+    let tree: renderer.ReactTestRenderer;
+
+    act(() => {
+      tree = renderer.create(
+        <SummaryStrip
+          items={[
+            {
+              key: 'nearest-upcoming',
+              label: '가까운 일정',
+              value: 'BTS',
+              detail: '3월 20일',
+            },
+          ]}
+          layout="wrap"
+          testID="summary"
+        />,
+      );
+    });
+
+    const texts = tree!.root.findAllByType(Text).map((node) => node.props.children);
+
+    expect(texts).toContain('BTS');
+    expect(texts).toContain('3월 20일');
+    expect(texts).toContain('가까운 일정');
+  });
 });

--- a/mobile/src/components/layout/SummaryStrip.tsx
+++ b/mobile/src/components/layout/SummaryStrip.tsx
@@ -11,6 +11,7 @@ import type { MobileTheme } from '../../tokens/theme';
 import { MOBILE_TEXT_SCALE_LIMITS, isLargeTextMode } from '../../tokens/accessibility';
 
 export interface SummaryStripItem {
+  detail?: string;
   key: string;
   label: string;
   value: string | number;
@@ -41,14 +42,24 @@ function SummaryStripComponent({
           style={[styles.card, useFullWidthCards ? styles.fullWidthCard : null]}
           testID={testID ? `${testID}-item-${item.key}` : undefined}
         >
-          <Text
-            allowFontScaling
-            maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.summaryValue}
-            numberOfLines={2}
-            style={[styles.value, largeTextMode ? styles.valueCompact : null]}
-          >
-            {item.value}
-          </Text>
+          <View style={styles.valueGroup}>
+            <Text
+              allowFontScaling
+              maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.summaryValue}
+              style={[styles.value, largeTextMode ? styles.valueCompact : null]}
+            >
+              {item.value}
+            </Text>
+            {item.detail ? (
+              <Text
+                allowFontScaling
+                maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.summaryLabel}
+                style={styles.detail}
+              >
+                {item.detail}
+              </Text>
+            ) : null}
+          </View>
           <Text
             allowFontScaling
             maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.summaryLabel}
@@ -89,6 +100,10 @@ function createStyles(theme: MobileTheme) {
     fullWidthCard: {
       flexBasis: '100%',
     },
+    valueGroup: {
+      gap: theme.space[4],
+      minHeight: 0,
+    },
     value: {
       ...sectionTitleTypography,
       color: theme.colors.text.primary,
@@ -97,6 +112,11 @@ function createStyles(theme: MobileTheme) {
       fontSize: theme.typography.cardTitle.fontSize,
       fontWeight: theme.typography.cardTitle.fontWeight,
       letterSpacing: theme.typography.cardTitle.letterSpacing,
+    },
+    detail: {
+      ...metaTypography,
+      color: theme.colors.text.secondary,
+      fontWeight: '600',
     },
     label: {
       ...metaTypography,


### PR DESCRIPTION
## Summary\n- replace truncated nearest-upcoming summary text with structured team/date content\n- keep summary cards readable without ellipsis in the calendar header\n\n## Verification\n- cd mobile && npm test -- --runInBand src/components/layout/SummaryStrip.test.tsx src/features/calendarControls.test.tsx\n- cd mobile && npm run typecheck\n- cd mobile && npm run lint\n- git diff --check\n\nCloses #752