### PR TITLE
Clarify iOS real-app install path

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -188,6 +188,8 @@ npm run ios -- \
 ```
 
 - `npm run ios`는 이제 production release install alias다.
+- `npm run ios`는 실제 앱을 여는 production install 경로로 유지한다.
+- preview/dev 빌드는 `Idol Song QA Client`, `Idol Song Dev Client`처럼 이름부터 구분되며, `npm run ios` 실행 전에 기기에 남아 있으면 best-effort로 제거한다.
 - preview dev launcher를 열고 싶을 때만 `npm run ios:preview` 또는 `npm run ios:dev`를 명시적으로 사용한다.
 
 ### 1. personal Apple team signing override 준비

--- a/mobile/app.config.ts
+++ b/mobile/app.config.ts
@@ -64,7 +64,7 @@ type EnvMap = Record<string, string | undefined>;
 
 const PROFILE_CONFIG: Record<MobileProfile, ProfileConfig> = {
   development: {
-    name: 'Idol Song App (Dev)',
+    name: 'Idol Song Dev Client',
     slug: 'idol-song-app-mobile-dev',
     scheme: 'idolsongapp-dev',
     iosBundleIdentifier: 'com.anonymous.idolsongappmobile.dev',
@@ -80,7 +80,7 @@ const PROFILE_CONFIG: Record<MobileProfile, ProfileConfig> = {
     },
   },
   preview: {
-    name: 'Idol Song App (Preview)',
+    name: 'Idol Song QA Client',
     slug: 'idol-song-app-mobile-preview',
     scheme: 'idolsongapp-preview',
     iosBundleIdentifier: 'com.anonymous.idolsongappmobile.preview',

--- a/mobile/scripts/install-ios-production.sh
+++ b/mobile/scripts/install-ios-production.sh
@@ -13,6 +13,8 @@ NO_INSTALL=0
 NO_BUNDLER=1
 DRY_RUN=0
 SIGNING_OVERRIDE_PATH="$ROOT_DIR/ios/IdolSongAppPreview/Supporting/IdolSongAppPreview.production.signing.local.xcconfig"
+PREVIEW_BUNDLE_ID="${EXPO_IOS_PREVIEW_BUNDLE_IDENTIFIER:-}"
+DEV_BUNDLE_ID="${EXPO_IOS_DEV_BUNDLE_IDENTIFIER:-}"
 
 usage() {
   cat <<EOF
@@ -90,6 +92,14 @@ done
 
 read_local_override
 
+if [[ -z "$PREVIEW_BUNDLE_ID" ]]; then
+  PREVIEW_BUNDLE_ID="${BUNDLE_ID}.preview"
+fi
+
+if [[ -z "$DEV_BUNDLE_ID" ]]; then
+  DEV_BUNDLE_ID="${BUNDLE_ID}.dev"
+fi
+
 if [[ $DRY_RUN -eq 0 && -z "$DEVICE_NAME" ]]; then
   echo "--device is required unless --dry-run is used." >&2
   exit 1
@@ -135,11 +145,24 @@ if [[ $NO_INSTALL -eq 1 ]]; then
 fi
 
 if [[ $DRY_RUN -eq 1 ]]; then
-  printf 'APP_ENV=%q EXPO_PUBLIC_API_BASE_URL=%q EXPO_IOS_APPLE_TEAM_ID=%q EXPO_IOS_BUNDLE_IDENTIFIER=%q ' \
-    "$APP_ENV" "$EXPO_PUBLIC_API_BASE_URL" "$EXPO_IOS_APPLE_TEAM_ID" "$EXPO_IOS_BUNDLE_IDENTIFIER"
+  printf 'APP_ENV=%q EXPO_PUBLIC_API_BASE_URL=%q EXPO_IOS_APPLE_TEAM_ID=%q EXPO_IOS_BUNDLE_IDENTIFIER=%q EXPO_IOS_PREVIEW_BUNDLE_IDENTIFIER=%q EXPO_IOS_DEV_BUNDLE_IDENTIFIER=%q ' \
+    "$APP_ENV" "$EXPO_PUBLIC_API_BASE_URL" "$EXPO_IOS_APPLE_TEAM_ID" "$EXPO_IOS_BUNDLE_IDENTIFIER" "$PREVIEW_BUNDLE_ID" "$DEV_BUNDLE_ID"
   printf '%q ' "${COMMAND[@]}"
   printf '\n'
   exit 0
 fi
+
+cleanup_existing_client() {
+  local bundle_id="$1"
+
+  if [[ -z "$bundle_id" || "$bundle_id" == "$BUNDLE_ID" ]]; then
+    return 0
+  fi
+
+  xcrun devicectl device uninstall app --device "$DEVICE_NAME" "$bundle_id" >/dev/null 2>&1 || true
+}
+
+cleanup_existing_client "$PREVIEW_BUNDLE_ID"
+cleanup_existing_client "$DEV_BUNDLE_ID"
 
 "${COMMAND[@]}"


### PR DESCRIPTION
## Summary
- rename non-production iOS app profiles so they read as QA/dev clients
- make the production install path best-effort uninstall preview/dev app ids first
- clarify docs that  is the real app install path

## Verification
- npm run typecheck
- npm run lint
- git diff --check
- bash ./scripts/install-ios-production.sh --dry-run --device "김태훈의 iPhone" --team-id ABCDE12345 --bundle-id com.example.idolsongapp
