### PR TITLE
[iOS] Clarify production install path

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -188,7 +188,8 @@ npm run ios -- \
 ```
 
 - `npm run ios`는 이제 production release install alias다.
-- `npm run ios`는 실제 앱을 여는 production install 경로로 유지한다.
+- `npm run ios`는 `expo run:ios`가 아니라, native `xcodebuild Release .app -> devicectl install -> launch` 경로를 사용한다.
+- 그래서 설치 후 앱 아이콘을 누르면 Expo dev launcher가 아니라 실제 앱 화면이 열리는 경로를 기준으로 유지한다.
 - preview/dev 빌드는 `Idol Song QA Client`, `Idol Song Dev Client`처럼 이름부터 구분되며, `npm run ios` 실행 전에 기기에 남아 있으면 best-effort로 제거한다.
 - preview dev launcher를 열고 싶을 때만 `npm run ios:preview` 또는 `npm run ios:dev`를 명시적으로 사용한다.
 
@@ -215,8 +216,9 @@ npm run ios -- \
 ```
 
 - 이 경로는 `Release` configuration을 사용한다.
+- 앱 bundle은 `xcodebuild`로 만들고 `xcrun devicectl`로 기기에 직접 설치/실행한다.
 - dev launcher를 여는 preview runtime이 아니라, 앱 아이콘을 누르면 바로 기능 화면으로 들어가는 실제 앱 경로를 기준으로 삼는다.
-- 기본적으로 Metro는 띄우지 않는다.
+- Metro는 띄우지 않는다.
 
 ### 3. production archive 생성
 

--- a/mobile/scripts/install-ios-production.sh
+++ b/mobile/scripts/install-ios-production.sh
@@ -9,10 +9,12 @@ BUNDLE_ID="${EXPO_IOS_BUNDLE_IDENTIFIER:-com.anonymous.idolsongappmobile}"
 APP_DISPLAY_NAME="${EXPO_IOS_APP_DISPLAY_NAME:-Idol Song App}"
 PRODUCT_NAME="${EXPO_IOS_PRODUCT_NAME:-IdolSongApp}"
 API_BASE_URL="${EXPO_PUBLIC_API_BASE_URL:-https://idol-song-app-production.up.railway.app}"
-PORT="8081"
-NO_BUILD_CACHE=0
+DERIVED_DATA_PATH="${ROOT_DIR}/ios/build/IdolSongAppProductionDerivedData"
+SKIP_PREBUILD=0
+CLEAN_PREBUILD=0
 NO_INSTALL=0
-NO_BUNDLER=1
+NO_LAUNCH=0
+ALLOW_PROVISIONING_UPDATES=0
 DRY_RUN=0
 SIGNING_OVERRIDE_PATH="$ROOT_DIR/ios/IdolSongAppPreview/Supporting/IdolSongAppPreview.production.signing.local.xcconfig"
 PREVIEW_BUNDLE_ID="${EXPO_IOS_PREVIEW_BUNDLE_IDENTIFIER:-}"
@@ -23,7 +25,7 @@ usage() {
 Usage:
   $(basename "$0") --device "김태훈의 iPhone" --team-id ABCDE12345 [--bundle-id com.example.idolsongapp] [--app-display-name "Idol Song App"] [--product-name IdolSongApp] [--api-base-url https://idol-song-app-production.up.railway.app]
 
-Installs the production Release build on a physical iPhone so the app opens directly instead of the Expo dev launcher.
+Builds a signed Release .app and installs it on a physical iPhone so the app opens directly instead of the Expo dev launcher.
 EOF
 }
 
@@ -77,20 +79,28 @@ while [[ $# -gt 0 ]]; do
       API_BASE_URL="${2:-}"
       shift 2
       ;;
-    --port)
-      PORT="${2:-}"
+    --derived-data-path)
+      DERIVED_DATA_PATH="${2:-}"
       shift 2
       ;;
-    --no-build-cache)
-      NO_BUILD_CACHE=1
+    --skip-prebuild)
+      SKIP_PREBUILD=1
+      shift
+      ;;
+    --clean-prebuild)
+      CLEAN_PREBUILD=1
+      shift
+      ;;
+    --allow-provisioning-updates)
+      ALLOW_PROVISIONING_UPDATES=1
       shift
       ;;
     --no-install)
       NO_INSTALL=1
       shift
       ;;
-    --with-bundler)
-      NO_BUNDLER=0
+    --no-launch)
+      NO_LAUNCH=1
       shift
       ;;
     --dry-run)
@@ -146,36 +156,87 @@ export EXPO_IOS_BUNDLE_IDENTIFIER="$BUNDLE_ID"
 export EXPO_IOS_APP_DISPLAY_NAME="$APP_DISPLAY_NAME"
 export EXPO_IOS_PRODUCT_NAME="$PRODUCT_NAME"
 
-COMMAND=(
+PREBUILD_COMMAND=(
   npx
   expo
-  run:ios
-  --configuration
-  Release
-  --device
-  "$DEVICE_NAME"
-  --port
-  "$PORT"
+  prebuild
+  --platform
+  ios
 )
 
-if [[ $NO_BUNDLER -eq 1 ]]; then
-  COMMAND+=(--no-bundler)
-fi
-
-if [[ $NO_BUILD_CACHE -eq 1 ]]; then
-  COMMAND+=(--no-build-cache)
-fi
-
 if [[ $NO_INSTALL -eq 1 ]]; then
-  COMMAND+=(--no-install)
+  PREBUILD_COMMAND+=(--no-install)
 fi
+
+if [[ $CLEAN_PREBUILD -eq 1 ]]; then
+  PREBUILD_COMMAND+=(--clean)
+fi
+
+XCODEBUILD_COMMAND=(
+  xcodebuild
+  -workspace
+  "$ROOT_DIR/ios/IdolSongAppPreview.xcworkspace"
+  -scheme
+  IdolSongAppPreview
+  -configuration
+  Release
+  -destination
+  generic/platform=iOS
+  -derivedDataPath
+  "$DERIVED_DATA_PATH"
+  CODE_SIGN_STYLE=Automatic
+  DEVELOPMENT_TEAM="$TEAM_ID"
+  PRODUCT_BUNDLE_IDENTIFIER="$BUNDLE_ID"
+  APP_DISPLAY_NAME="$APP_DISPLAY_NAME"
+  PRODUCT_NAME="$PRODUCT_NAME"
+  build
+)
+
+if [[ $ALLOW_PROVISIONING_UPDATES -eq 1 ]]; then
+  XCODEBUILD_COMMAND=(-allowProvisioningUpdates "${XCODEBUILD_COMMAND[@]}")
+fi
+
+INSTALL_COMMAND=(
+  xcrun
+  devicectl
+  device
+  install
+  app
+  --device
+  "$DEVICE_NAME"
+)
+
+LAUNCH_COMMAND=(
+  xcrun
+  devicectl
+  device
+  process
+  launch
+  --device
+  "$DEVICE_NAME"
+  --terminate-existing
+  --activate
+  "$BUNDLE_ID"
+)
 
 if [[ $DRY_RUN -eq 1 ]]; then
   printf 'APP_ENV=%q EXPO_PUBLIC_API_BASE_URL=%q EXPO_IOS_APPLE_TEAM_ID=%q EXPO_IOS_BUNDLE_IDENTIFIER=%q EXPO_IOS_PREVIEW_BUNDLE_IDENTIFIER=%q EXPO_IOS_DEV_BUNDLE_IDENTIFIER=%q ' \
     "$APP_ENV" "$EXPO_PUBLIC_API_BASE_URL" "$EXPO_IOS_APPLE_TEAM_ID" "$EXPO_IOS_BUNDLE_IDENTIFIER" "$PREVIEW_BUNDLE_ID" "$DEV_BUNDLE_ID"
   printf 'EXPO_IOS_APP_DISPLAY_NAME=%q EXPO_IOS_PRODUCT_NAME=%q ' "$EXPO_IOS_APP_DISPLAY_NAME" "$EXPO_IOS_PRODUCT_NAME"
-  printf '%q ' "${COMMAND[@]}"
   printf '\n'
+  if [[ $SKIP_PREBUILD -eq 0 ]]; then
+    printf '%q ' "${PREBUILD_COMMAND[@]}"
+    printf '\n'
+  fi
+  printf '%q ' "${XCODEBUILD_COMMAND[@]}"
+  printf '\n'
+  if [[ $NO_INSTALL -eq 0 ]]; then
+    printf '%q <APP_PATH>\n' "${INSTALL_COMMAND[@]}"
+  fi
+  if [[ $NO_INSTALL -eq 0 && $NO_LAUNCH -eq 0 ]]; then
+    printf '%q ' "${LAUNCH_COMMAND[@]}"
+    printf '\n'
+  fi
   exit 0
 fi
 
@@ -192,4 +253,28 @@ cleanup_existing_client() {
 cleanup_existing_client "$PREVIEW_BUNDLE_ID"
 cleanup_existing_client "$DEV_BUNDLE_ID"
 
-"${COMMAND[@]}"
+if [[ $SKIP_PREBUILD -eq 0 ]]; then
+  "${PREBUILD_COMMAND[@]}"
+fi
+
+mkdir -p "$DERIVED_DATA_PATH"
+"${XCODEBUILD_COMMAND[@]}"
+
+APP_PATH="$DERIVED_DATA_PATH/Build/Products/Release-iphoneos/${PRODUCT_NAME}.app"
+
+if [[ ! -d "$APP_PATH" ]]; then
+  APP_PATH="$(find "$DERIVED_DATA_PATH/Build/Products/Release-iphoneos" -maxdepth 1 -type d -name '*.app' | head -n 1)"
+fi
+
+if [[ -z "$APP_PATH" || ! -d "$APP_PATH" ]]; then
+  echo "Unable to locate built .app inside $DERIVED_DATA_PATH/Build/Products/Release-iphoneos" >&2
+  exit 1
+fi
+
+if [[ $NO_INSTALL -eq 0 ]]; then
+  "${INSTALL_COMMAND[@]}" "$APP_PATH"
+fi
+
+if [[ $NO_INSTALL -eq 0 && $NO_LAUNCH -eq 0 ]]; then
+  "${LAUNCH_COMMAND[@]}"
+fi


### PR DESCRIPTION
## Summary\n- switch production iOS install flow from expo run to native xcodebuild + devicectl install/launch\n- update mobile README so the real-app install path is explicit\n\n## Testing\n- bash mobile/scripts/install-ios-production.sh --dry-run --device "김태훈의 iPhone" --team-id ABCDE12345 --bundle-id com.example.idolsongapp\n- cd mobile && npm run typecheck\n- cd mobile && npm run lint\n- git diff --check