### PR TITLE
[#787] Polish mobile nearest upcoming summary card

### DIFF
--- a/mobile/app/(tabs)/calendar.tsx
+++ b/mobile/app/(tabs)/calendar.tsx
@@ -906,6 +906,7 @@ export default function CalendarTabScreen() {
                 { key: 'upcoming-count', label: MOBILE_COPY.summary.upcoming, value: filteredSnapshot.upcomingCount },
                 {
                   key: 'nearest-upcoming',
+                  kind: 'focus',
                   label: MOBILE_COPY.summary.nearestUpcoming,
                   value: nearestUpcomingItem.value,
                   detail: nearestUpcomingItem.detail,

--- a/mobile/src/components/layout/SummaryStrip.test.tsx
+++ b/mobile/src/components/layout/SummaryStrip.test.tsx
@@ -63,6 +63,7 @@ describe('SummaryStrip', () => {
         <SummaryStrip
           items={[
             {
+              kind: 'focus',
               key: 'nearest-upcoming',
               label: '가까운 일정',
               value: 'BTS',
@@ -76,7 +77,11 @@ describe('SummaryStrip', () => {
     });
 
     const texts = tree!.root.findAllByType(Text).map((node) => node.props.children);
+    const card = tree!.root.findByProps({ testID: 'summary-item-nearest-upcoming' });
 
+    expect(card.props.style).toEqual(
+      expect.arrayContaining([expect.objectContaining({ flexBasis: '100%' })]),
+    );
     expect(texts).toContain('BTS');
     expect(texts).toContain('3월 20일');
     expect(texts).toContain('가까운 일정');

--- a/mobile/src/components/layout/SummaryStrip.tsx
+++ b/mobile/src/components/layout/SummaryStrip.tsx
@@ -12,6 +12,7 @@ import { MOBILE_TEXT_SCALE_LIMITS, isLargeTextMode } from '../../tokens/accessib
 
 export interface SummaryStripItem {
   detail?: string;
+  kind?: 'metric' | 'focus';
   key: string;
   label: string;
   value: string | number;
@@ -43,41 +44,77 @@ function SummaryStripComponent({
           key={item.key}
           style={[
             styles.card,
+            item.kind === 'focus' ? styles.focusCard : null,
             density === 'compact' ? styles.compactCard : null,
-            useFullWidthCards ? styles.fullWidthCard : null,
+            useFullWidthCards || item.kind === 'focus' ? styles.fullWidthCard : null,
           ]}
           testID={testID ? `${testID}-item-${item.key}` : undefined}
         >
-          <View style={styles.valueGroup}>
-            <Text
-              allowFontScaling
-              maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.summaryValue}
-              style={[
-                styles.value,
-                density === 'compact' ? styles.valueDense : null,
-                largeTextMode ? styles.valueCompact : null,
-              ]}
-            >
-              {item.value}
-            </Text>
-            {item.detail ? (
+          {item.kind === 'focus' ? (
+            <>
               <Text
                 allowFontScaling
                 maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.summaryLabel}
-                style={styles.detail}
+                numberOfLines={1}
+                style={styles.focusLabel}
               >
-                {item.detail}
+                {item.label}
               </Text>
-            ) : null}
-          </View>
-          <Text
-            allowFontScaling
-            maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.summaryLabel}
-            numberOfLines={density === 'compact' ? 1 : 2}
-            style={styles.label}
-          >
-            {item.label}
-          </Text>
+              <View style={styles.focusValueGroup}>
+                <Text
+                  allowFontScaling
+                  maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.summaryValue}
+                  numberOfLines={1}
+                  style={[styles.value, styles.focusValue, largeTextMode ? styles.valueCompact : null]}
+                >
+                  {item.value}
+                </Text>
+                {item.detail ? (
+                  <Text
+                    allowFontScaling
+                    maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.summaryLabel}
+                    numberOfLines={1}
+                    style={styles.focusDetail}
+                  >
+                    {item.detail}
+                  </Text>
+                ) : null}
+              </View>
+            </>
+          ) : (
+            <>
+              <View style={styles.valueGroup}>
+                <Text
+                  allowFontScaling
+                  maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.summaryValue}
+                  style={[
+                    styles.value,
+                    density === 'compact' ? styles.valueDense : null,
+                    largeTextMode ? styles.valueCompact : null,
+                  ]}
+                >
+                  {item.value}
+                </Text>
+                {item.detail ? (
+                  <Text
+                    allowFontScaling
+                    maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.summaryLabel}
+                    style={styles.detail}
+                  >
+                    {item.detail}
+                  </Text>
+                ) : null}
+              </View>
+              <Text
+                allowFontScaling
+                maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.summaryLabel}
+                numberOfLines={density === 'compact' ? 1 : 2}
+                style={styles.label}
+              >
+                {item.label}
+              </Text>
+            </>
+          )}
         </View>
       ))}
     </View>
@@ -107,6 +144,10 @@ function createStyles(theme: MobileTheme) {
       borderWidth: 1,
       borderColor: theme.colors.border.subtle,
     },
+    focusCard: {
+      minWidth: 0,
+      justifyContent: 'flex-start',
+    },
     fullWidthCard: {
       flexBasis: '100%',
     },
@@ -120,6 +161,9 @@ function createStyles(theme: MobileTheme) {
     valueGroup: {
       gap: theme.space[4],
       minHeight: 0,
+    },
+    focusValueGroup: {
+      gap: theme.space[4],
     },
     value: {
       ...sectionTitleTypography,
@@ -136,6 +180,21 @@ function createStyles(theme: MobileTheme) {
       letterSpacing: theme.typography.sectionTitle.letterSpacing,
     },
     detail: {
+      ...metaTypography,
+      color: theme.colors.text.secondary,
+      fontWeight: '600',
+    },
+    focusLabel: {
+      ...metaTypography,
+      color: theme.colors.text.secondary,
+      textTransform: 'none',
+    },
+    focusValue: {
+      fontSize: theme.typography.cardTitle.fontSize,
+      fontWeight: theme.typography.cardTitle.fontWeight,
+      letterSpacing: theme.typography.cardTitle.letterSpacing,
+    },
+    focusDetail: {
       ...metaTypography,
       color: theme.colors.text.secondary,
       fontWeight: '600',


### PR DESCRIPTION
## Summary
- replace the mobile calendar nearest-upcoming metric with a structured focus card
- keep team name and date readable without ellipsis-heavy truncation
- cover the layout with regression tests

## Verification
- npm test -- --runInBand src/components/layout/SummaryStrip.test.tsx src/features/calendarControls.test.tsx
- npm run typecheck
- npm run lint
- git diff --check