### PR TITLE
Remove tool-like actions from primary mobile screens

### DIFF
--- a/mobile/app/(tabs)/calendar.tsx
+++ b/mobile/app/(tabs)/calendar.tsx
@@ -1118,33 +1118,6 @@ export default function CalendarTabScreen() {
                     ) : null}
                   </View>
                 </Pressable>
-                <Pressable
-                  accessibilityLabel="알림 설정 열기"
-                  accessibilityRole="button"
-                  onPress={() => router.push('/settings/notifications')}
-                  style={({ pressed }) => [
-                    styles.headerButton,
-                    styles.headerButtonCompact,
-                    !largeTextMode ? styles.headerButtonIconOnly : null,
-                    largeTextMode ? styles.headerButtonLargeText : null,
-                    pressed ? styles.headerButtonPressed : null,
-                  ]}
-                  testID="calendar-notifications-open"
-                >
-                  <View style={styles.headerButtonContentCompact}>
-                    <MaterialCommunityIcons color={theme.colors.text.secondary} name="bell-outline" size={16} />
-                    {largeTextMode ? (
-                      <Text
-                        allowFontScaling
-                        maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.buttonService}
-                        numberOfLines={1}
-                        style={styles.headerButtonLabel}
-                      >
-                        알림
-                      </Text>
-                    ) : null}
-                  </View>
-                </Pressable>
               </View>
             </View>
           </View>

--- a/mobile/app/(tabs)/radar.tsx
+++ b/mobile/app/(tabs)/radar.tsx
@@ -644,17 +644,6 @@ export default function RadarTabScreen() {
               필터
             </Text>
           </Pressable>
-          <Pressable
-            testID="radar-notifications-button"
-            accessibilityLabel="알림 설정 열기"
-            accessibilityRole="button"
-            onPress={() => router.push('/settings/notifications')}
-            style={({ pressed }) => [styles.appBarButton, pressed ? styles.buttonPressed : null]}
-          >
-            <Text allowFontScaling maxFontSizeMultiplier={MOBILE_TEXT_SCALE_LIMITS.buttonService} style={styles.appBarButtonLabel}>
-              알림
-            </Text>
-          </Pressable>
         </View>
 
         {dataState === 'degraded' && datasetRiskDisclosure ? (

--- a/mobile/app/(tabs)/search.tsx
+++ b/mobile/app/(tabs)/search.tsx
@@ -641,15 +641,7 @@ export default function SearchTabScreen() {
         subtitle={MOBILE_COPY.surface.searchSubtitle}
         testID="search-app-bar"
         title={MOBILE_COPY.surface.searchTitle}
-        trailingActions={[
-          {
-            key: 'notifications',
-            accessibilityLabel: '알림 설정 열기',
-            label: MOBILE_COPY.action.notifications,
-            onPress: () => router.push('/settings/notifications'),
-            testID: 'search-open-notifications-settings',
-          },
-        ]}
+        trailingActions={[]}
       />
 
       {datasetRiskDisclosure ? (

--- a/mobile/app/artists/[slug].tsx
+++ b/mobile/app/artists/[slug].tsx
@@ -548,15 +548,7 @@ export default function ArtistDetailScreen() {
         subtitle={MOBILE_COPY.action.teamPage}
         testID="entity-detail-app-bar"
         title={snapshot.team.displayName}
-        trailingActions={[
-          {
-            key: 'notifications',
-            accessibilityLabel: '알림 설정 열기',
-            label: MOBILE_COPY.action.notifications,
-            onPress: () => router.push('/settings/notifications'),
-            testID: 'entity-detail-notifications-settings',
-          },
-        ]}
+        trailingActions={[]}
       />
 
       <CompactHero

--- a/mobile/app/releases/[id].tsx
+++ b/mobile/app/releases/[id].tsx
@@ -578,17 +578,10 @@ export default function ReleaseDetailScreen() {
                     accessibilityLabel: `${detail.displayGroup} 팀 페이지 열기`,
                     label: MOBILE_COPY.action.teamPage,
                     onPress: () => router.push(`/artists/${teamDetailSlug}`),
-                    testID: 'release-appbar-team-page',
-                  },
-                ]
-              : []),
-            {
-              key: 'notifications',
-              accessibilityLabel: '알림 설정 열기',
-              label: MOBILE_COPY.action.notifications,
-              onPress: () => router.push('/settings/notifications'),
-              testID: 'release-appbar-notifications',
-            },
+                  testID: 'release-appbar-team-page',
+                },
+              ]
+            : []),
           ]
         }
       />


### PR DESCRIPTION
## Summary
- remove notification/settings style actions from the main mobile surfaces
- keep calendar, search, radar, artist, and release screens focused on core use cases
- leave existing lint warning in .expo/types/router.d.ts untouched

## Testing
- npm run typecheck
- npm run lint
- git diff --check