### PR TITLE
Add badge images to backend-native mobile release payloads

### DIFF
--- a/backend/src/route-contract.test.ts
+++ b/backend/src/route-contract.test.ts
@@ -406,6 +406,8 @@ function buildReleaseDetailPayload(releaseId: string) {
       release_id: releaseId,
       entity_slug: 'ive',
       display_name: 'IVE',
+      badge_image_url: 'https://cdn.example.com/ive-badge.png',
+      representative_image_url: 'https://cdn.example.com/ive-representative.jpg',
       release_title: 'REVIVE+',
       release_date: '2026-02-23',
       stream: 'album',
@@ -2023,6 +2025,8 @@ test('GET /v1/releases/:id returns release detail payload with title tracks', as
   assert.equal(body.data.detail_metadata.provenance, 'releaseDetails.existing_row');
   assert.equal(body.data.title_track_metadata.status, 'manual_override');
   assert.equal(body.data.title_track_metadata.provenance, 'release_detail_overrides.title_tracks');
+  assert.equal(body.data.release.badge_image_url, 'https://cdn.example.com/ive-badge.png');
+  assert.equal(body.data.release.representative_image_url, 'https://cdn.example.com/ive-representative.jpg');
   assert.equal(body.data.tracks.length, 2);
   assert.equal(body.data.tracks.filter((track: { is_title_track: boolean }) => track.is_title_track).length, 2);
   assert.equal(body.data.service_links.youtube_music.status, 'manual_override');

--- a/backend/src/routes/calendar.ts
+++ b/backend/src/routes/calendar.ts
@@ -26,6 +26,8 @@ type CalendarVerifiedReleaseHydrationRow = {
   release_format: string | null;
   entity_type: string | null;
   agency_name: string | null;
+  badge_image_url: string | null;
+  representative_image_url: string | null;
 };
 
 type CalendarSummary = {
@@ -38,6 +40,8 @@ type CalendarNearestUpcoming = {
   upcoming_signal_id: string;
   entity_slug: string;
   display_name: string;
+  badge_image_url: string | null;
+  representative_image_url: string | null;
   entity_type: string | null;
   agency_name: string | null;
   tracking_status: string | null;
@@ -59,6 +63,8 @@ type CalendarVerifiedRelease = {
   release_id: string;
   entity_slug: string;
   display_name: string;
+  badge_image_url: string | null;
+  representative_image_url: string | null;
   entity_type: string | null;
   agency_name: string | null;
   release_title: string;
@@ -74,6 +80,8 @@ type CalendarUpcomingItem = {
   upcoming_signal_id: string;
   entity_slug: string;
   display_name: string;
+  badge_image_url: string | null;
+  representative_image_url: string | null;
   entity_type: string | null;
   agency_name: string | null;
   tracking_status: string | null;
@@ -182,6 +190,8 @@ function normalizeVerifiedRelease(value: unknown): CalendarVerifiedRelease | nul
     release_id: releaseId,
     entity_slug: entitySlug,
     display_name: displayName,
+    badge_image_url: asNullableString(value.badge_image_url),
+    representative_image_url: asNullableString(value.representative_image_url),
     entity_type: asNullableString(value.entity_type),
     agency_name: asNullableString(value.agency_name),
     release_title: releaseTitle,
@@ -224,6 +234,8 @@ function normalizeUpcomingItem(value: unknown): CalendarUpcomingItem | null {
     upcoming_signal_id: upcomingSignalId,
     entity_slug: entitySlug,
     display_name: displayName,
+    badge_image_url: asNullableString(value.badge_image_url),
+    representative_image_url: asNullableString(value.representative_image_url),
     entity_type: asNullableString(value.entity_type),
     agency_name: asNullableString(value.agency_name),
     tracking_status: asNullableString(value.tracking_status),
@@ -324,6 +336,8 @@ function hydrateVerifiedRelease(
 
   return {
     ...release,
+    badge_image_url: release.badge_image_url ?? row.badge_image_url,
+    representative_image_url: release.representative_image_url ?? row.representative_image_url,
     entity_type: release.entity_type ?? row.entity_type,
     agency_name: release.agency_name ?? row.agency_name,
     release_format: release.release_format ?? row.release_format,
@@ -350,7 +364,9 @@ async function hydrateVerifiedReleaseArray(
         r.artist_source_url,
         r.release_format,
         e.entity_type,
-        e.agency_name
+        e.agency_name,
+        e.badge_image_url,
+        e.representative_image_url
       from releases r
       left join entities e on e.id = r.entity_id
       where r.id = any($1::uuid[])
@@ -398,6 +414,8 @@ function toNearestUpcoming(item: CalendarUpcomingItem | null): CalendarNearestUp
     upcoming_signal_id: item.upcoming_signal_id,
     entity_slug: item.entity_slug,
     display_name: item.display_name,
+    badge_image_url: item.badge_image_url,
+    representative_image_url: item.representative_image_url,
     entity_type: item.entity_type,
     agency_name: item.agency_name,
     tracking_status: item.tracking_status,
@@ -461,10 +479,12 @@ function normalizeCalendarMonthPayload(payload: unknown): CalendarMonthData | nu
       nearestUpcoming &&
       nearestUpcoming.scheduled_date &&
       nearestUpcoming.date_precision === 'exact'
-        ? {
+          ? {
             upcoming_signal_id: nearestUpcoming.upcoming_signal_id,
             entity_slug: nearestUpcoming.entity_slug,
             display_name: nearestUpcoming.display_name,
+            badge_image_url: nearestUpcoming.badge_image_url,
+            representative_image_url: nearestUpcoming.representative_image_url,
             entity_type: nearestUpcoming.entity_type,
             agency_name: nearestUpcoming.agency_name,
             tracking_status: nearestUpcoming.tracking_status,

--- a/backend/src/routes/releases.ts
+++ b/backend/src/routes/releases.ts
@@ -20,6 +20,8 @@ type ReleaseDetailProjectionRow = {
   generated_at: Date | string;
   source_url?: string | null;
   artist_source_url?: string | null;
+  badge_image_url?: string | null;
+  representative_image_url?: string | null;
 };
 
 type ReleaseLookupQuery = {
@@ -37,6 +39,8 @@ type ReleaseCore = {
   release_id: string;
   entity_slug: string;
   display_name: string;
+  badge_image_url: string | null;
+  representative_image_url: string | null;
   release_title: string;
   release_date: string;
   stream: string;
@@ -232,6 +236,8 @@ function normalizeReleaseCore(value: unknown): ReleaseCore | null {
     release_id: releaseId,
     entity_slug: entitySlug,
     display_name: displayName,
+    badge_image_url: asNullableString(value.badge_image_url),
+    representative_image_url: asNullableString(value.representative_image_url),
     release_title: releaseTitle,
     release_date: releaseDate,
     stream,
@@ -409,12 +415,15 @@ export function registerReleaseRoutes(app: FastifyInstance, context: ReleaseRout
           rdp.normalized_release_title,
           rdp.release_date::text as release_date,
           rdp.stream,
-          rdp.payload,
-          rdp.generated_at,
-          r.source_url,
-          r.artist_source_url
+        rdp.payload,
+        rdp.generated_at,
+        r.source_url,
+        r.artist_source_url,
+        e.badge_image_url,
+        e.representative_image_url
         from release_detail_projection rdp
         left join releases r on r.id = rdp.release_id
+        left join entities e on e.id = r.entity_id
         where rdp.entity_slug = $1
           and rdp.normalized_release_title = projection_normalize_text($2)
           and rdp.stream = $4
@@ -468,12 +477,15 @@ export function registerReleaseRoutes(app: FastifyInstance, context: ReleaseRout
           rdp.normalized_release_title,
           rdp.release_date::text as release_date,
           rdp.stream,
-          rdp.payload,
-          rdp.generated_at,
-          r.source_url,
-          r.artist_source_url
+        rdp.payload,
+        rdp.generated_at,
+        r.source_url,
+        r.artist_source_url,
+        e.badge_image_url,
+        e.representative_image_url
         from release_detail_projection rdp
         left join releases r on r.id = rdp.release_id
+        left join entities e on e.id = r.entity_id
         where rdp.release_id = $1::uuid
         limit 1
       `,
@@ -494,6 +506,9 @@ export function registerReleaseRoutes(app: FastifyInstance, context: ReleaseRout
 
     data.release.source_url = data.release.source_url ?? asNullableString(row.source_url);
     data.release.artist_source_url = data.release.artist_source_url ?? asNullableString(row.artist_source_url);
+    data.release.badge_image_url = data.release.badge_image_url ?? asNullableString(row.badge_image_url);
+    data.release.representative_image_url =
+      data.release.representative_image_url ?? asNullableString(row.representative_image_url);
 
     return buildReadDataEnvelope(
       request,

--- a/mobile/app/(tabs)/calendar.tsx
+++ b/mobile/app/(tabs)/calendar.tsx
@@ -723,13 +723,13 @@ export default function CalendarTabScreen() {
       },
       serviceButtons: buildReleaseServiceButtons(release),
       sourceLinks: buildReleaseSourceLinks(release),
-      team: {
-        badgeImageUrl: undefined,
-        fallbackAssetKey: resolveBadgeFallbackAssetKey('group'),
-        meta: buildReleaseIdentityMeta(release),
-        monogram: release.displayGroup.slice(0, 2).toUpperCase(),
-        name: release.displayGroup,
-      },
+              team: {
+                badgeImageUrl: release.badgeImageUrl ?? release.representativeImageUrl,
+                fallbackAssetKey: resolveBadgeFallbackAssetKey('group'),
+                meta: buildReleaseIdentityMeta(release),
+                monogram: release.displayGroup.slice(0, 2).toUpperCase(),
+                name: release.displayGroup,
+              },
       testID: `${testPrefix}-${release.id}`,
       title: release.releaseTitle,
     };
@@ -755,12 +755,12 @@ export default function CalendarTabScreen() {
       scheduledDate: formatUpcomingLabel(event),
       sourceLinks: buildUpcomingSourceLinks(event),
       statusChip: resolveUpcomingStatusLabel(event.status),
-      team: {
-        badgeImageUrl: undefined,
-        fallbackAssetKey: resolveBadgeFallbackAssetKey('group'),
-        monogram: event.displayGroup.slice(0, 2).toUpperCase(),
-        name: event.displayGroup,
-      },
+              team: {
+                badgeImageUrl: event.badgeImageUrl ?? event.representativeImageUrl,
+                fallbackAssetKey: resolveBadgeFallbackAssetKey('group'),
+                monogram: event.displayGroup.slice(0, 2).toUpperCase(),
+                name: event.displayGroup,
+              },
       testID: `${testPrefix}-${event.id}`,
     };
   }

--- a/mobile/app/releases/[id].tsx
+++ b/mobile/app/releases/[id].tsx
@@ -597,13 +597,13 @@ export default function ReleaseDetailScreen() {
                 </Text>
               </View>
             </View>
-            <TeamIdentityRow
-              badgeImageUrl={undefined}
-              fallbackAssetKey={resolveBadgeFallbackAssetKey('group')}
-              monogram={detail.displayGroup.slice(0, 2).toUpperCase()}
-              name={detail.displayGroup}
-              testID="release-team-identity"
-            />
+        <TeamIdentityRow
+          badgeImageUrl={detail.badgeImageUrl ?? detail.representativeImageUrl}
+          fallbackAssetKey={resolveBadgeFallbackAssetKey('group')}
+          monogram={detail.displayGroup.slice(0, 2).toUpperCase()}
+          name={detail.displayGroup}
+          testID="release-team-identity"
+        />
           </View>
         }
         media={<ReleaseCover detail={detail} styles={styles} />}

--- a/mobile/src/services/backendDisplayAdapters.ts
+++ b/mobile/src/services/backendDisplayAdapters.ts
@@ -114,6 +114,9 @@ function adaptReleaseSummary(
     id: input.release_id,
     group: entitySlug,
     displayGroup: displayName,
+    badgeImageUrl: 'badge_image_url' in input ? input.badge_image_url ?? undefined : undefined,
+    representativeImageUrl:
+      'representative_image_url' in input ? input.representative_image_url ?? undefined : undefined,
     releaseTitle: input.release_title,
     releaseDate: input.release_date ?? '',
     releaseKind: normalizeReleaseKind(input.release_kind ?? null),
@@ -144,6 +147,9 @@ function adaptUpcomingEvent(
     id: input.upcoming_signal_id,
     group: entitySlug,
     displayGroup: displayName,
+    badgeImageUrl: 'badge_image_url' in input ? input.badge_image_url ?? undefined : undefined,
+    representativeImageUrl:
+      'representative_image_url' in input ? input.representative_image_url ?? undefined : undefined,
     scheduledDate: input.scheduled_date ?? undefined,
     scheduledMonth: input.scheduled_month ?? undefined,
     datePrecision: normalizeUpcomingDatePrecision(input.date_precision),
@@ -429,6 +435,8 @@ export function adaptBackendReleaseDetail(data: BackendReleaseDetailData): Relea
     id: data.release.release_id,
     group: data.release.entity_slug,
     displayGroup: data.release.display_name,
+    badgeImageUrl: data.release.badge_image_url ?? undefined,
+    representativeImageUrl: data.release.representative_image_url ?? undefined,
     releaseTitle: data.release.release_title,
     releaseDate: data.release.release_date,
     releaseKind: data.release.release_kind ?? undefined,

--- a/mobile/src/services/backendReadClient.ts
+++ b/mobile/src/services/backendReadClient.ts
@@ -19,6 +19,8 @@ export type BackendCalendarRelease = {
   release_id: string;
   entity_slug: string;
   display_name: string;
+  badge_image_url?: string | null;
+  representative_image_url?: string | null;
   release_title: string;
   release_date?: string;
   stream: string;
@@ -29,6 +31,8 @@ export type BackendCalendarUpcoming = {
   upcoming_signal_id: string;
   entity_slug: string;
   display_name: string;
+  badge_image_url?: string | null;
+  representative_image_url?: string | null;
   headline: string;
   scheduled_date?: string | null;
   scheduled_month?: string | null;
@@ -192,6 +196,8 @@ export type BackendEntityReleaseSummary = {
   stream: string;
   release_kind?: string | null;
   release_format?: string | null;
+  badge_image_url?: string | null;
+  representative_image_url?: string | null;
   representative_song_title?: string | null;
   spotify_url?: string | null;
   youtube_music_url?: string | null;
@@ -292,6 +298,8 @@ export type BackendReleaseDetailData = {
     release_id: string;
     entity_slug: string;
     display_name: string;
+    badge_image_url?: string | null;
+    representative_image_url?: string | null;
     release_title: string;
     release_date: string;
     stream: string;

--- a/mobile/src/types/displayModels.ts
+++ b/mobile/src/types/displayModels.ts
@@ -40,6 +40,8 @@ export interface ReleaseSummaryModel {
   id: string;
   group: string;
   displayGroup: string;
+  badgeImageUrl?: string;
+  representativeImageUrl?: string;
   releaseTitle: string;
   releaseDate: string;
   releaseKind?: ReleaseKind | string;
@@ -57,6 +59,8 @@ export interface UpcomingEventModel {
   id: string;
   group: string;
   displayGroup: string;
+  badgeImageUrl?: string;
+  representativeImageUrl?: string;
   scheduledDate?: string;
   scheduledMonth?: string;
   datePrecision: UpcomingDatePrecision;
@@ -80,6 +84,8 @@ export interface ReleaseDetailModel {
   id: string;
   group: string;
   displayGroup: string;
+  badgeImageUrl?: string;
+  representativeImageUrl?: string;
   releaseTitle: string;
   releaseDate: string;
   releaseKind?: string;


### PR DESCRIPTION
## Summary
- expose badge and representative image URLs in backend calendar/release payloads
- thread those fields through mobile adapters and display models
- use the images in mobile calendar and release detail surfaces

## Validation
- cd backend && npm run build
- cd backend && node --import tsx --test ./src/route-contract.test.ts
- cd mobile && npm run typecheck
- cd mobile && npm run lint
- git diff --check