### PR TITLE
Show team badge images in mobile month calendar cells (#797)

### DIFF
--- a/mobile/src/components/calendar/DayCell.test.tsx
+++ b/mobile/src/components/calendar/DayCell.test.tsx
@@ -20,6 +20,7 @@ describe('DayCell', () => {
           kind: 'release',
           label: 'YENA',
           monogram: 'YE',
+          imageUrl: 'https://example.com/yena.png',
         },
       ],
       overflowCount: 2,
@@ -46,6 +47,7 @@ describe('DayCell', () => {
     });
 
     const target = tree!.root.findByProps({ testID: 'calendar-day-2026-03-11' });
+    expect(tree!.root.findByProps({ testID: 'calendar-day-badge-image-release-yena' })).toBeTruthy();
     expect(target.props.accessibilityState).toEqual({ selected: true });
     expect(target.props.accessibilityLabel).toContain('3월 11일');
     expect(target.props.accessibilityLabel).toContain('확정 발매 1건');

--- a/mobile/src/components/calendar/DayCell.tsx
+++ b/mobile/src/components/calendar/DayCell.tsx
@@ -1,5 +1,6 @@
 import React, { memo, useMemo } from 'react';
 import {
+  Image,
   Pressable,
   StyleSheet,
   Text,
@@ -148,17 +149,38 @@ function DayCellComponent({
       <View style={styles.dayCellFooter}>
         <View style={styles.markerRow}>
           {cell.badges.map((badge) => {
-            const { backgroundColor } = getBadgePalette(theme, badge.kind);
+            const { backgroundColor, color } = getBadgePalette(theme, badge.kind);
             return (
               <View
                 key={badge.id}
                 style={[
-                  styles.badgeMarker,
+                  styles.badgeMarkerWrap,
                   {
                     backgroundColor,
                   },
                 ]}
-              />
+              >
+                {badge.imageUrl ? (
+                  <Image
+                    source={{ uri: badge.imageUrl }}
+                    style={styles.badgeMarkerImage}
+                    testID={`calendar-day-badge-image-${badge.id}`}
+                  />
+                ) : (
+                  <Text
+                    allowFontScaling={false}
+                    numberOfLines={1}
+                    style={[
+                      styles.badgeMarkerText,
+                      {
+                        color,
+                      },
+                    ]}
+                  >
+                    {badge.monogram.slice(0, 2)}
+                  </Text>
+                )}
+              </View>
             );
           })}
           {cell.overflowCount > 0 ? (
@@ -244,17 +266,30 @@ function createStyles(theme: MobileTheme) {
     },
     markerRow: {
       flexDirection: 'row',
-      gap: 3,
+      gap: 4,
       justifyContent: 'flex-start',
       alignItems: 'center',
-      minHeight: 10,
+      minHeight: 16,
     },
-    badgeMarker: {
-      width: 6,
-      height: 6,
-      borderRadius: theme.radius.chip,
+    badgeMarkerWrap: {
+      width: 16,
+      height: 16,
+      borderRadius: 8,
       borderWidth: 1,
       borderColor: theme.colors.surface.base,
+      overflow: 'hidden',
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    badgeMarkerImage: {
+      width: '100%',
+      height: '100%',
+    },
+    badgeMarkerText: {
+      ...theme.typography.meta,
+      fontSize: 8,
+      lineHeight: 9,
+      fontWeight: '800',
     },
     overflowPill: {
       minWidth: 16,

--- a/mobile/src/features/calendarGrid.test.ts
+++ b/mobile/src/features/calendarGrid.test.ts
@@ -7,6 +7,7 @@ function createRelease(
   group: string,
   displayGroup: string,
   releaseDate: string,
+  overrides: Partial<ReleaseSummaryModel> = {},
 ): ReleaseSummaryModel {
   return {
     id: `${group}-${releaseDate}`,
@@ -17,6 +18,7 @@ function createRelease(
     releaseKind: 'single',
     stream: 'song',
     contextTags: [],
+    ...overrides,
   };
 }
 
@@ -92,6 +94,47 @@ describe('calendar month grid', () => {
 
     expect(march8?.badges).toHaveLength(2);
     expect(march8?.overflowCount).toBe(1);
+  });
+
+  test('carries badge image urls into visible badges when available', () => {
+    const snapshot: CalendarMonthSnapshotModel = {
+      month: '2026-03',
+      releaseCount: 1,
+      upcomingCount: 1,
+      nearestUpcoming: null,
+      releases: [
+        createRelease('ALPHA', 'Alpha', '2026-03-08', {
+          badgeImageUrl: 'https://example.com/alpha.png',
+        }),
+      ],
+      exactUpcoming: [
+        {
+          id: 'beta-upcoming',
+          group: 'BETA',
+          displayGroup: 'Beta',
+          badgeImageUrl: 'https://example.com/beta.png',
+          scheduledDate: '2026-03-08',
+          datePrecision: 'exact',
+          headline: 'Beta comeback',
+          sourceType: 'official_social',
+        },
+      ],
+      monthOnlyUpcoming: [],
+    };
+
+    const grid = buildCalendarMonthGrid(snapshot, '2026-03-08', '2026-03-07');
+    const march8 = grid.weeks.flat().find((cell) => cell?.isoDate === '2026-03-08');
+
+    expect(march8?.badges).toEqual([
+      expect.objectContaining({
+        group: 'ALPHA',
+        imageUrl: 'https://example.com/alpha.png',
+      }),
+      expect.objectContaining({
+        group: 'BETA',
+        imageUrl: 'https://example.com/beta.png',
+      }),
+    ]);
   });
 
   test('supports empty-day selection and month-safe fallback selection', () => {

--- a/mobile/src/features/calendarGrid.ts
+++ b/mobile/src/features/calendarGrid.ts
@@ -69,6 +69,20 @@ function getBadgeLabel(
   );
 }
 
+function getBadgeImageUrl(
+  group: string,
+  releaseRows: ReleaseSummaryModel[],
+  upcomingRows: UpcomingEventModel[],
+): string | undefined {
+  const releaseMatch = releaseRows.find((item) => item.group === group);
+  if (releaseMatch?.badgeImageUrl || releaseMatch?.representativeImageUrl) {
+    return releaseMatch.badgeImageUrl ?? releaseMatch.representativeImageUrl;
+  }
+
+  const upcomingMatch = upcomingRows.find((item) => item.group === group);
+  return upcomingMatch?.badgeImageUrl ?? upcomingMatch?.representativeImageUrl ?? undefined;
+}
+
 function buildBadges(
   releaseRows: ReleaseSummaryModel[],
   upcomingRows: UpcomingEventModel[],
@@ -91,6 +105,7 @@ function buildBadges(
       label,
       monogram: buildTeamMonogram(label),
       kind: getBadgeKind(group, releaseRows, upcomingRows),
+      imageUrl: getBadgeImageUrl(group, releaseRows, upcomingRows),
     };
   });
 }

--- a/mobile/src/types/displayModels.ts
+++ b/mobile/src/types/displayModels.ts
@@ -160,6 +160,7 @@ export interface CalendarDayBadgeModel {
   label: string;
   monogram: string;
   kind: CalendarDayBadgeKind;
+  imageUrl?: string;
 }
 
 export interface CalendarDayCellModel {


### PR DESCRIPTION
## Summary
- carry badge image urls through mobile calendar badge models
- render tiny team badge images in month cells with monogram fallback
- add regression tests for badge propagation and rendering

## Verification
- npm test -- --runInBand src/components/calendar/DayCell.test.tsx src/features/calendarGrid.test.ts src/features/calendarControls.test.tsx
- npm run typecheck
- npm run lint
- git diff --check