### PR TITLE
Normalize official social upcoming tracking status

### DIFF
--- a/import_json_to_neon.py
+++ b/import_json_to_neon.py
@@ -1447,6 +1447,22 @@ def compare_rollup_release_refs(
                 )
 
 
+def normalize_official_social_upcoming_findings(
+    rows: Sequence[Dict[str, Any]],
+    watchlist_by_group: Dict[str, Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    normalized_rows: List[Dict[str, Any]] = []
+    for row in rows:
+        normalized = dict(row)
+        group = optional_text(normalized.get("group"))
+        watchlist_row = watchlist_by_group.get(group) if group else None
+        tracking_status = optional_text(normalized.get("tracking_status"))
+        if watchlist_row and tracking_status in (None, "", "filtered_out"):
+            normalized["tracking_status"] = optional_text(watchlist_row.get("tracking_status")) or "watch_only"
+        normalized_rows.append(normalized)
+    return normalized_rows
+
+
 def build_import_payload() -> Dict[str, Any]:
     artist_profiles = load_json(ARTIST_PROFILES_PATH)
     canonical_entity_metadata = load_json(CANONICAL_ENTITY_METADATA_PATH)
@@ -1467,6 +1483,11 @@ def build_import_payload() -> Dict[str, Any]:
     canonical_entity_metadata_by_group = {row["group"]: row for row in canonical_entity_metadata}
     team_badge_assets_by_group = {row["group"]: row for row in team_badge_assets if optional_text(row.get("group"))}
     group_metadata = build_group_metadata(release_history, releases_rollup)
+
+    official_social_upcoming_findings = normalize_official_social_upcoming_findings(
+        official_social_upcoming_findings,
+        watchlist_by_group,
+    )
 
     summary = {
         "generated_at": datetime.now(timezone.utc).isoformat(),

--- a/test_import_json_to_neon.py
+++ b/test_import_json_to_neon.py
@@ -183,7 +183,17 @@ class ImportJsonToNeonDryRunSummaryTests(unittest.TestCase):
             },
         ]
 
-        signal_rows, source_rows, signal_ids_by_dedupe = self.module.build_upcoming_rows(rows, entity_ids, summary)
+        normalized_rows = self.module.normalize_official_social_upcoming_findings(
+            rows,
+            {
+                "AB6IX": {
+                    "group": "AB6IX",
+                    "tracking_status": "watch_only",
+                }
+            },
+        )
+
+        signal_rows, source_rows, signal_ids_by_dedupe = self.module.build_upcoming_rows(normalized_rows, entity_ids, summary)
 
         self.assertEqual(len(signal_rows), 1)
         self.assertEqual(signal_rows[0]["headline"], rows[0]["headline"])
@@ -191,10 +201,42 @@ class ImportJsonToNeonDryRunSummaryTests(unittest.TestCase):
         self.assertEqual(signal_rows[0]["date_precision"], "exact")
         self.assertEqual(signal_rows[0]["date_status"], "confirmed")
         self.assertEqual(signal_rows[0]["release_format"], "album")
+        self.assertEqual(signal_rows[0]["tracking_status"], "watch_only")
         self.assertEqual(len(source_rows), 2)
         self.assertEqual(source_rows[0]["source_type"], "news_rss")
         self.assertEqual(source_rows[1]["source_type"], "official_social")
         self.assertEqual(len(signal_ids_by_dedupe), 2)
+
+    def test_normalize_official_social_upcoming_findings_reuses_watchlist_tracking_status(self):
+        rows = [
+            {
+                "group": "AB6IX",
+                "headline": "AB6IX official X announcement",
+                "tracking_status": "filtered_out",
+            },
+            {
+                "group": "TUNEXX",
+                "headline": "TUNEXX official X announcement",
+                "tracking_status": "watch_only",
+            },
+        ]
+
+        normalized_rows = self.module.normalize_official_social_upcoming_findings(
+            rows,
+            {
+                "AB6IX": {
+                    "group": "AB6IX",
+                    "tracking_status": "watch_only",
+                },
+                "TUNEXX": {
+                    "group": "TUNEXX",
+                    "tracking_status": "recent_release",
+                },
+            },
+        )
+
+        self.assertEqual(normalized_rows[0]["tracking_status"], "watch_only")
+        self.assertEqual(normalized_rows[1]["tracking_status"], "watch_only")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- normalize official-social upcoming findings against watchlist tracking status before canonical import
- preserve stronger exact-date official-social rows instead of leaving them filtered out
- add regression coverage for normalization and official-social exact-date canonicalization

## Evidence
- exact-date fixture: AB6IX / 2026-03-16 / official X now imports as a canonical upcoming signal with tracking_status=watch_only instead of filtered_out
- month-only fixture: ALL(H)OURS / 2026-03 still imports as month_only with scheduled status
- dry-run anomaly snippet: unresolved_release_mappings=1, stale_review_tasks=24

## Verification
- python3 -m unittest test_import_json_to_neon.py
- python3 -m py_compile import_json_to_neon.py test_import_json_to_neon.py
- eval "$(sed 's/^Export /export /' ~/.config/idol-song-app/neon.env)" && . .venv/bin/activate && python import_json_to_neon.py --dry-run --summary-path /tmp/idol-song-app-import-dry-run-784.json

Closes #784
